### PR TITLE
Fix login and register for Nhost with React-Query example

### DIFF
--- a/examples/nhost-react-query/pages/login.tsx
+++ b/examples/nhost-react-query/pages/login.tsx
@@ -19,9 +19,10 @@ export default function LoginPage(): ReactElement {
   }, [removeRedirectTo, user, redirectTo])
 
   console.warn('user in login')
-  if (user === null) {
-    return <FullPageLoader />
-  }
+  // remove this as the login page is never shown
+  // if (user === null) {
+  //   return <FullPageLoader />
+  // }
 
   return !user ? (
     <Layout>

--- a/examples/nhost-react-query/src/modules/auth/register/RegisterForm.tsx
+++ b/examples/nhost-react-query/src/modules/auth/register/RegisterForm.tsx
@@ -9,7 +9,7 @@ const RegisterForm = (): ReactElement => {
 
   const onSubmit = async ({ email, password }: FormData): Promise<void> => {
     try {
-      await auth.register(email, password)
+      await auth.register({email, password})
       router.push('/')
     } catch (e) {
       // TODO use i18n to handle multilingual


### PR DESCRIPTION
Fixed two minor issues in the Nhost with React-Query example example:

- The register form was not passing the `email` and `password` to the `auth.register` function correctly.
- The login form is never shown due to the `user === null` check