### PR TITLE
Fixed NuxtJS Template

### DIFF
--- a/templates/web/nuxt/.env.development
+++ b/templates/web/nuxt/.env.development
@@ -1,2 +1,0 @@
-NHOST_GRAPHQL_ENDPOINT=http://localhost:8080/v1/graphql
-NHOST_BACKEND_ENDPOINT=http://localhost:3005

--- a/templates/web/nuxt/nuxt.config.js
+++ b/templates/web/nuxt/nuxt.config.js
@@ -43,7 +43,7 @@ export default {
   },
 
   nhost: {
-    baseURL: process.env.NHOST_BACKEND_URL,
+    baseURL: process.env.NHOST_BACKEND_ENDPOINT,
     routes: {
       home: "/"
     }

--- a/templates/web/nuxt/package.json
+++ b/templates/web/nuxt/package.json
@@ -9,12 +9,13 @@
     "generate": "nuxt generate"
   },
   "dependencies": {
+    "nuxt": "^2.15.3"
+  },
+  "devDependencies": {
     "@nhost/nuxt": "^0.1.4",
     "@nuxtjs/apollo": "^4.0.1-rc.5",
     "core-js": "^3.9.1",
     "graphql-tag": "^2.12.4",
-    "nhost-js-sdk": "^3.1.0",
-    "nuxt": "^2.15.3"
-  },
-  "devDependencies": {}
+    "nhost-js-sdk": "^3.1.0"
+  }
 }


### PR DESCRIPTION
NuxtJS template was earlier broken. I've fixed it by making following changes:

1. Renamed `.env.development` to `.env`. Because nuxtjs by default picks up `.env` file to read the environment variables and make them accessible by `process.env.{VARIABLE}`. Which were, until now, not being read from `.env.development`.
2. Renamed Nhost BaseURL environment variable in `nuxt.config.js` from `process.env.NHOST_BACKEND_URL` to `process.env.NHOST_BACKEND_ENDPOINT`. This is done to fix the incorrect mismatch of variable name inside `.env` file, which also is `process.env.NHOST_BACKEND_ENDPOINT`.
3. Changed address ports for variables inside `.env` to `1337` instead of earlier `8080` ports, because port `1337` is where the CLI is launching the environment now.
4. Transferred most dependencies inside `package.json` to `devDependencies` instead of `dependencies`. This saves a plethora of memory/space during the build process, if any one of our users are deploying their front-ends on Vercel. I have experience in deploying NuxtJS on Vercel, and it fails the build process if the size of final package is too large. This trick solves that problem.

Making the above changes at least allowed my NuxtJS template to start properly. I haven't tried building upon this template yet!

Earlier it was throwing errors even after a fresh clone.