### PR TITLE
Adds missing lang identifier for code block

### DIFF
--- a/docs/content/docs/reference/supporting-libraries/react-auth.mdx
+++ b/docs/content/docs/reference/supporting-libraries/react-auth.mdx
@@ -10,7 +10,7 @@ title: '@nhost/react-auth'
 
 Install `@nhost/react-auth` and its dependencies:
 
-```
+```sh
 npm install @nhost/nhost-js @nhost/react-auth
 ```
 


### PR DESCRIPTION
## Details
This PR adds the missing shell language identifier for the [react-auth](https://docs.nhost.io/reference/supporting-libraries/react-auth) page.