### PR TITLE
Fix useNhostAuth typings

### DIFF
--- a/.changeset/eleven-forks-relate.md
+++ b/.changeset/eleven-forks-relate.md
@@ -1,0 +1,6 @@
+---
+'@nhost/react-auth': patch
+---
+
+Correct Nhost context type
+`const { user } = useNhostAuth()`: user type was `null`. It is now `User | null`.

--- a/package.json
+++ b/package.json
@@ -19,7 +19,7 @@
     "prepare": "pnpm create-config",
     "build": "pnpm turbo run build --scope='@nhost/*' --no-deps --include-dependencies",
     "build:docs": "pnpm run build --filter=nhost-documentation",
-    "clean:all": "pnpm clean && rm -rf ./{{packages,examples}/*,docs}/node_modules node_modules",
+    "clean:all": "pnpm clean && rm -rf ./{{packages,examples}/*,docs}/{.nhost,node_modules} node_modules",
     "clean": "rm -rf ./{{packages,examples}/*,docs}/{dist,.next,.turbo,coverage}",
     "ci": "pnpm turbo run build test --concurrency=4 --scope='@nhost/*' && pnpm run lint",
     "ci:version": "changeset version && pnpm install --frozen-lockfile false",

--- a/packages/react-auth/package.json
+++ b/packages/react-auth/package.json
@@ -55,6 +55,7 @@
     "react-dom": "^16.0.0 || ^17.0.0 || ^18.0.0"
   },
   "devDependencies": {
+    "@nhost/hasura-auth-js": "workspace:*",
     "@types/react": "^17.0.38",
     "react": "^17.0.2",
     "react-dom": "^17.0.2"

--- a/packages/react-auth/src/index.tsx
+++ b/packages/react-auth/src/index.tsx
@@ -1,8 +1,14 @@
 import React, { createContext, ReactNode, useContext, useEffect, useState } from 'react'
 
+import type { User } from '@nhost/hasura-auth-js'
 import { NhostClient } from '@nhost/nhost-js'
 
-export const AuthContext = createContext({
+type NhostContext = {
+  isLoading: boolean
+  isAuthenticated: boolean
+  user: User | null
+}
+export const AuthContext = createContext<NhostContext>({
   user: null,
   isLoading: true,
   isAuthenticated: false
@@ -15,7 +21,7 @@ export function NhostAuthProvider({
   children: ReactNode
   nhost: NhostClient
 }) {
-  const [authContext, setAuthContext] = useState({
+  const [authContext, setAuthContext] = useState<NhostContext>({
     user: null,
     isLoading: true,
     isAuthenticated: false

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -293,6 +293,7 @@ importers:
 
   packages/react-auth:
     specifiers:
+      '@nhost/hasura-auth-js': workspace:*
       '@nhost/nhost-js': workspace:*
       '@types/react': ^17.0.38
       react: ^17.0.2
@@ -300,6 +301,7 @@ importers:
     dependencies:
       '@nhost/nhost-js': link:../nhost-js
     devDependencies:
+      '@nhost/hasura-auth-js': link:../hasura-auth-js
       '@types/react': 17.0.39
       react: 17.0.2
       react-dom: 17.0.2_react@17.0.2


### PR DESCRIPTION
Close #187 

Another minor point: `pnpm run clean:all` now also removes the `.nhost` folders