### PR TITLE
refactor(hasura-storage-js): rename `storage.getUrl` to `storage.getPublicUrl`

### DIFF
--- a/.changeset/long-cars-melt.md
+++ b/.changeset/long-cars-melt.md
@@ -1,0 +1,7 @@
+---
+'@nhost/hasura-storage-js': patch
+---
+
+Rename `storage.getUrl` to `storage.getPublicUrl`
+It aims to make a clear distinction between `storage.getPublicUrl` and `storage.getPresginedUrl`
+`storage.getUrl` is now deprecated.

--- a/docs/content/docs/reference/sdk/storage.mdx
+++ b/docs/content/docs/reference/sdk/storage.mdx
@@ -19,12 +19,12 @@ const { fileMetadata, error } = await nhost.storage.upload({ file })
 
 ---
 
-## `nhost.storage.getUrl()`
+## `nhost.storage.getPublicUrl()`
 
 Get the public URL of a file. To access the file via public URL, the file must have the `select` permission for the `public` role.
 
 ```js
-const url = nhost.storage.getUrl({ fileId })
+const url = nhost.storage.getPublicUrl({ fileId })
 ```
 
 ---

--- a/packages/hasura-storage-js/src/hasura-storage-client.ts
+++ b/packages/hasura-storage-js/src/hasura-storage-client.ts
@@ -48,14 +48,23 @@ export class HasuraStorageClient {
 
   /**
    *
-   * Use `.getUrl` to direct file URL to a file.
-   *
-   * @example
-   *
-   * storage.getUrl({ fileId: 'uuid' })
+   * @deprecated use `.getPublicUrl` instead
    *
    */
   getUrl(params: StorageGetUrlParams): string {
+    return this.getPublicUrl(params)
+  }
+
+  /**
+   *
+   * Use `.getPublicUrl` to direct file URL to a file.
+   *
+   * @example
+   *
+   * storage.getPublicUrl({ fileId: 'uuid' })
+   *
+   */
+  getPublicUrl(params: StorageGetUrlParams): string {
     const { fileId } = params
     return `${this.url}/files/${fileId}`
   }


### PR DESCRIPTION
It aims to make a clear distinction between `storage.getPublicUrl` and `storage.getPresginedUrl`
`storage.getUrl` is now deprecated.


fix #178