### PR TITLE
fix: current options when sign in with a provider

### DIFF
--- a/packages/hasura-auth-js/src/hasura-auth-client.ts
+++ b/packages/hasura-auth-js/src/hasura-auth-client.ts
@@ -222,8 +222,14 @@ export class HasuraAuthClient {
     provider?: string
   }> {
     if ('provider' in params) {
-      const { provider } = params
-      const providerUrl = `${this.url}/signin/provider/${provider}`
+      const { provider, options } = params
+
+      let providerUrl = `${this.url}/signin/provider/${provider}`
+
+      // add redirect url if exists
+      if (options?.redirectTo) {
+        providerUrl += `?redirectTo=${options.redirectTo}`
+      }
 
       if (isBrowser()) {
         window.location.href = providerUrl

--- a/packages/hasura-auth-js/src/utils/types.ts
+++ b/packages/hasura-auth-js/src/utils/types.ts
@@ -92,12 +92,12 @@ export type Provider =
 export interface SignInWithProviderOptions {
   provider: Provider
   options?: {
-    locale?: string
-    allowedRoles?: string[]
-    defaultRole?: string
-    displayName?: string
+    // locale?: string
+    // allowedRoles?: string[]
+    // defaultRole?: string
+    // displayName?: string
     redirectTo?: string
-    metadata?: Record<string, unknown>
+    // metadata?: Record<string, unknown>
   }
 }
 


### PR DESCRIPTION
We currently only support setting the `redirectTo` option for providers.

This PR removed the options that do not work and adds the `redirectTo` option correctly to the provider sign-in URL.

See code from Haura Auth here: https://github.com/nhost/hasura-auth/blob/main/src/routes/signin/providers/utils.ts#L255-L268