### PR TITLE
fix: change target ES module build target to es2019

### DIFF
--- a/.changeset/eight-scissors-turn.md
+++ b/.changeset/eight-scissors-turn.md
@@ -1,0 +1,8 @@
+---
+'@nhost/hasura-auth-js': patch
+'@nhost/hasura-storage-js': patch
+'@nhost/nhost-js': patch
+---
+
+Change target ES module build target to es2019
+Some systems based on older versions of Webpack or Babel don't support the current esbuild configuration e.g, [this issue](https://github.com/nhost/nhost/issues/275).

--- a/.config/esbuild.lib.js
+++ b/.config/esbuild.lib.js
@@ -25,6 +25,6 @@ esbuild
     platform: 'browser',
     format: 'esm',
     sourcemap: true,
-    target: 'esnext'
+    target: 'es2019'
   })
   .catch(() => process.exit(1))

--- a/packages/hasura-auth-js/package.json
+++ b/packages/hasura-auth-js/package.json
@@ -32,16 +32,16 @@
     "verify:fix": "run-p prettier:fix lint:fix"
   },
   "main": "src/index.ts",
-  "exports": {
-    ".": {
-      "import": {
-        "node": "./dist/index.cjs.js",
-        "default": "./dist/index.es.js"
-      },
-      "require": "./dist/index.cjs.js"
-    }
-  },
   "publishConfig": {
+    "exports": {
+      ".": {
+        "import": {
+          "node": "./dist/index.cjs.js",
+          "default": "./dist/index.es.js"
+        },
+        "require": "./dist/index.cjs.js"
+      }
+    },
     "access": "public",
     "main": "dist/index.cjs.js",
     "module": "dist/index.es.js",

--- a/packages/hasura-storage-js/package.json
+++ b/packages/hasura-storage-js/package.json
@@ -30,16 +30,16 @@
     "verify:fix": "run-p prettier:fix lint:fix"
   },
   "main": "src/index.ts",
-  "exports": {
-    ".": {
-      "import": {
-        "node": "./dist/index.cjs.js",
-        "default": "./dist/index.es.js"
-      },
-      "require": "./dist/index.cjs.js"
-    }
-  },
   "publishConfig": {
+    "exports": {
+      ".": {
+        "import": {
+          "node": "./dist/index.cjs.js",
+          "default": "./dist/index.es.js"
+        },
+        "require": "./dist/index.cjs.js"
+      }
+    },
     "access": "public",
     "main": "dist/index.cjs.js",
     "module": "dist/index.es.js",

--- a/packages/nhost-js/package.json
+++ b/packages/nhost-js/package.json
@@ -21,16 +21,16 @@
     "url": "git+https://github.com/nhost/nhost.git"
   },
   "main": "src/index.ts",
-  "exports": {
-    ".": {
-      "import": {
-        "node": "./dist/index.cjs.js",
-        "default": "./dist/index.es.js"
-      },
-      "require": "./dist/index.cjs.js"
-    }
-  },
   "publishConfig": {
+    "exports": {
+      ".": {
+        "import": {
+          "node": "./dist/index.cjs.js",
+          "default": "./dist/index.es.js"
+        },
+        "require": "./dist/index.cjs.js"
+      }
+    },
     "access": "public",
     "main": "dist/index.cjs.js",
     "module": "dist/index.es.js",


### PR DESCRIPTION
Some systems based on older versions of Webpack or Babel don't support the current esbuild configuration e.g, [this issue](https://github.com/nhost/nhost/issues/275).