### PR TITLE
feat: admin secret for storage

### DIFF
--- a/.changeset/famous-laws-sit.md
+++ b/.changeset/famous-laws-sit.md
@@ -1,0 +1,5 @@
+---
+'@nhost/hasura-storage-js': minor
+---
+
+Introducing `setAdminSecret` to allow users of the SDK to use `x-hasura-admin-secret` request header in storage related functions

--- a/packages/hasura-storage-js/src/hasura-storage-api.ts
+++ b/packages/hasura-storage-js/src/hasura-storage-api.ts
@@ -1,6 +1,5 @@
 /* eslint-disable @typescript-eslint/no-unsafe-assignment */
 import axios, { AxiosInstance } from 'axios'
-
 import {
   ApiDeleteParams,
   ApiDeleteResponse,
@@ -10,10 +9,12 @@ import {
   ApiUploadResponse,
   UploadHeaders
 } from './utils/types'
+
 export class HasuraStorageApi {
   private url: string
   private httpClient: AxiosInstance
-  private accessToken: string | undefined
+  private accessToken?: string
+  private adminSecret?: string
 
   constructor({ url }: { url: string }) {
     this.url = url
@@ -66,8 +67,28 @@ export class HasuraStorageApi {
     }
   }
 
-  setAccessToken(accessToken: string | undefined) {
+  /**
+   * Set the access token to use for authentication.
+   *
+   * @param accessToken Access token
+   * @returns Hasura Storage API instance
+   */
+  setAccessToken(accessToken?: string): HasuraStorageApi {
     this.accessToken = accessToken
+
+    return this
+  }
+
+  /**
+   * Set the admin secret to use for authentication.
+   *
+   * @param adminSecret Hasura admin secret
+   * @returns Hasura Storage API instance
+   */
+  setAdminSecret(adminSecret?: string): HasuraStorageApi {
+    this.adminSecret = adminSecret
+
+    return this
   }
 
   private generateUploadHeaders(params: ApiUploadParams): UploadHeaders {
@@ -83,10 +104,21 @@ export class HasuraStorageApi {
     if (name) {
       uploadheaders['x-nhost-file-name'] = name
     }
+
     return uploadheaders
   }
 
   private generateAuthHeaders() {
+    if (!this.adminSecret) {
+      return null
+    }
+
+    if (this.adminSecret) {
+      return {
+        'x-hasura-admin-secret': this.adminSecret
+      }
+    }
+
     if (!this.accessToken) {
       return null
     }

--- a/packages/hasura-storage-js/src/hasura-storage-client.ts
+++ b/packages/hasura-storage-js/src/hasura-storage-client.ts
@@ -1,3 +1,4 @@
+import { HasuraStorageApi } from './hasura-storage-api'
 import {
   StorageDeleteParams,
   StorageDeleteResponse,
@@ -7,7 +8,6 @@ import {
   StorageUploadParams,
   StorageUploadResponse
 } from './utils/types'
-import { HasuraStorageApi } from './hasura-storage-api'
 
 export class HasuraStorageClient {
   private url: string
@@ -113,7 +113,27 @@ export class HasuraStorageClient {
     return { error: null }
   }
 
-  setAccessToken(accessToken: string | undefined): void {
+  /**
+   * Set the access token to use for authentication.
+   *
+   * @param accessToken Access token
+   * @returns Hasura Storage Client instance
+   */
+  setAccessToken(accessToken?: string): HasuraStorageClient {
     this.api.setAccessToken(accessToken)
+
+    return this
+  }
+
+  /**
+   * Set the admin secret to use for authentication.
+   *
+   * @param adminSecret Hasura admin secret
+   * @returns Hasura Storage Client instance
+   */
+  setAdminSecret(adminSecret?: string): HasuraStorageClient {
+    this.api.setAdminSecret(adminSecret)
+
+    return this
   }
 }


### PR DESCRIPTION
This PR aims to make `x-hasura-admin-secret` request header configuration available when using storage related functions (upload, delete, etc.). This would allow users of the SDK leverage our functions where file management should be restricted to administrators only.

Comments were also added to `setAccessToken` and `setAdminSecret` functions. The way these setters work has also been slightly changed.

Initial approach:
```js
// ... rest of the code ...
nhost.storage.setAdminSecret('my-admin-secret');

const { fileMetadata, error } = await nhost.storage.upload({
  /* ... */
});
```

Final approach:
```js
// ... rest of the code ...
const { fileMetadata, error } = await nhost.storage
  .setAdminSecret('my-admin-secret')
  .upload({
    /* ... */
  });
```

**Note: It's worth mentioning that it's not mandatory to use "final approach", both of these will work.**