### PR TITLE
fix: keep location.hash in email redirections

### DIFF
--- a/packages/core/src/machines/index.ts
+++ b/packages/core/src/machines/index.ts
@@ -645,7 +645,9 @@ export const createAuthMachine = ({
                   refreshToken
                 })
                 // * remove hash from the current url after consumming the token
-                window.history.pushState({}, '', location.pathname)
+                // TODO remove the hash. For the moment, it is kept to avoid regression from the current SDK.
+                // * Then, only `refreshToken` will be in the hash, while `type` will be sent by hasura-auth as a query parameter
+                // window.history.pushState({}, '', location.pathname)
                 const channel = new BroadcastChannel('nhost')
                 // TODO broadcat session instead of token
                 channel.postMessage(refreshToken)


### PR DESCRIPTION
In the next cycle, hasura-auth will only send the refresh token in the hash, and will add the
redirection type as a query parameter. We will then be able to remove/hide the hash from the url as
soon as the refresh token has been used