### PR TITLE
Deprecate `useAuthLoading` and introduce `useAuthenticationStatus`

### DIFF
--- a/.changeset/red-tables-punch.md
+++ b/.changeset/red-tables-punch.md
@@ -12,7 +12,7 @@ As a result, when a user loads the page while he previously authenticated, the h
 | `false`   | `false`         |
 | `false`   | `true`          |
 
-The interpediate (`false`, `false`) is incorrect and is causing issues when using an authentication gate.
+The intermediate (`false`, `false`) is incorrect and is causing issues when using an authentication gate.
 
 It is therefore recommended to stop using `useAuthLoading`, and to use `useAuthenticationStatus` instead, in order to keep the loading state and the authentication in sync within the same hook.
 

--- a/.changeset/red-tables-punch.md
+++ b/.changeset/red-tables-punch.md
@@ -1,0 +1,25 @@
+---
+'@nhost/react': minor
+---
+
+Deprecate `useAuthLoading` and introduce `useAuthenticationStatus`
+When using both `useAuthLoading` and `useAuthenticated` together, the hooks rerender independently from each other.
+As a result, when a user loads the page while he previously authenticated, the hooks values were chronologically:
+
+| isLoading | isAuthenticated |
+| --------- | --------------- |
+| `true`    | `false`         |
+| `false`   | `false`         |
+| `false`   | `true`          |
+
+The interpediate (`false`, `false`) is incorrect and is causing issues when using an authentication gate.
+
+It is therefore recommended to stop using `useAuthLoading`, and to use `useAuthenticationStatus` instead, in order to keep the loading state and the authentication in sync within the same hook.
+
+Usage:
+
+```js
+const { isLoading, isAuthenticated } = useAuthenticationStatus()
+```
+
+Fixes [this issue](https://github.com/nhost/nhost/issues/302)

--- a/docs/content/docs/reference/react/hooks.mdx
+++ b/docs/content/docs/reference/react/hooks.mdx
@@ -218,20 +218,19 @@ const Component = () => {
 
 ## Authentication status
 
-### `useAuthLoading`
+### `useAuthenticationStatus`
 
 The Nhost client may need some initial steps to determine the authentication status during startup, like fetching a new JWT from an existing refresh token.
 
-`useAuthLoading` will return `true` until the authentication status is known.
+`isLoading` will return `true` until the authentication status is known.
 
 #### Usage
 
 ```jsx
-import { useAuthLoading, useAuthenticated } from '@nhost/react'
+import { useAuthenticationStatus } from '@nhost/react'
 
 const Component = () => {
-  const isLoading = useAuthLoading()
-  const isAuthenticated = useAuthenticated()
+  const { isLoading, isAuthenticated } = useAuthenticationStatus()
   if (isLoading) return <div>Loading Nhost authentication status...</div>
   else if (isAuthenticated) return <div>User is authenticated</div>
   else return <div>Public section</div>

--- a/docs/content/docs/reference/react/protecting-routes.mdx
+++ b/docs/content/docs/reference/react/protecting-routes.mdx
@@ -8,11 +8,10 @@ You can protect routes by creating an `AuthGate` component when using `@nhost/re
 
 ```jsx
 import { Redirect } from 'react-router-dom'
-import { useAuthLoading, useAuthenticated } from '@nhost/react'
+import { useAuthenticationStatus } from '@nhost/react'
 
 export function AuthGate(children) {
-  const isLoading = useAuthLoading()
-  const isAuthenticated = useAuthenticated()
+  const { isLoading, isAuthenticated } = useAuthenticationStatus()
 
   if (isLoading) {
     return <div>Loading...</div>

--- a/examples/nextjs/components/Header.tsx
+++ b/examples/nextjs/components/Header.tsx
@@ -7,7 +7,8 @@ export default function Header() {
       <nav>
         <Link href="/">Index</Link> <br />
         <Link href="/second">Second</Link> <br />
-        <Link href="/third">Third</Link> <br />
+        <Link href="/third">SSR auth-guarded page</Link> <br />
+        <Link href="/client-side-auth-guard">CSR auth-guarded page</Link> <br />
       </nav>
     </header>
   )

--- a/examples/nextjs/components/protected-route.tsx
+++ b/examples/nextjs/components/protected-route.tsx
@@ -1,40 +1,21 @@
----
-title: 'Protecting routes'
----
-
-Create a `auth-protected.js` file:
-
-```jsx
 import { useRouter } from 'next/router'
+
 import { useAuthenticationStatus } from '@nhost/nextjs'
 
 export function authProtected(Comp) {
   return function AuthProtected(props) {
     const router = useRouter()
     const { isLoading, isAuthenticated } = useAuthenticationStatus()
-
+    console.log('Authentication guard: check auth status', { isLoading, isAuthenticated })
     if (isLoading) {
       return <div>Loading...</div>
     }
 
     if (!isAuthenticated) {
-      router.push('/login')
+      router.push('/')
       return null
     }
 
     return <Comp {...props} />
   }
 }
-```
-
-Then wrap the Next.js page with `authProtected` to only allow signed in users to access the page.
-
-```js
-import { authProtected } from '<some-path>/auth-protected'
-
-function Index() {
-  return <div>Only signed in users can access this page.</div>
-}
-
-export default authProtected(Index)
-```

--- a/examples/nextjs/pages/client-side-auth-guard.tsx
+++ b/examples/nextjs/pages/client-side-auth-guard.tsx
@@ -1,0 +1,17 @@
+import React from 'react'
+
+import { useAccessToken } from '@nhost/nextjs'
+
+import { authProtected } from '../components/protected-route'
+
+const ClientSideAuthPage: React.FC = () => {
+  const accessToken = useAccessToken()
+  return (
+    <div>
+      <h1>Client-side rendered page only accessible to authenticated users</h1>
+      <div>Access token: {accessToken}</div>
+    </div>
+  )
+}
+
+export default authProtected(ClientSideAuthPage)

--- a/examples/nextjs/pages/third.tsx
+++ b/examples/nextjs/pages/third.tsx
@@ -2,8 +2,9 @@ import { NextPageContext } from 'next'
 import React from 'react'
 
 import { NhostSession } from '@nhost/core'
-import { getNhostSession, useAccessToken, useAuthenticated } from '@nhost/nextjs'
+import { getNhostSession, useAccessToken } from '@nhost/nextjs'
 
+import { authProtected } from '../components/protected-route'
 import { BACKEND_URL } from '../helpers'
 
 export async function getServerSideProps(context: NextPageContext) {
@@ -17,15 +18,12 @@ export async function getServerSideProps(context: NextPageContext) {
 
 const RefetchPage: React.FC<{ initial: NhostSession }> = () => {
   const accessToken = useAccessToken()
-  const isAuthenticated = useAuthenticated()
-  if (!isAuthenticated) return <div>User it not authenticated </div>
   return (
     <div>
-      <h1>Third page</h1>
-      User is authenticated: {isAuthenticated ? 'yes' : 'no'}
+      <h1>SSR page only accessible to authenticated users</h1>
       <div>Access token: {accessToken}</div>
     </div>
   )
 }
 
-export default RefetchPage
+export default authProtected(RefetchPage)

--- a/examples/react-apollo/src/components/auth-gates.tsx
+++ b/examples/react-apollo/src/components/auth-gates.tsx
@@ -1,9 +1,8 @@
 import { Navigate, useLocation } from 'react-router-dom'
-import { useAuthenticated, useAuthLoading } from '@nhost/react'
+import { useAuthenticationStatus } from '@nhost/react'
 
 export const AuthGate: React.FC = ({ children }) => {
-  const isAuthenticated = useAuthenticated()
-  const isLoading = useAuthLoading()
+  const { isLoading, isAuthenticated } = useAuthenticationStatus()
   const location = useLocation()
   if (isLoading) {
     return <div>Loading...</div>
@@ -17,8 +16,7 @@ export const AuthGate: React.FC = ({ children }) => {
 }
 
 export const PublicGate: React.FC = ({ children }) => {
-  const isAuthenticated = useAuthenticated()
-  const isLoading = useAuthLoading()
+  const { isLoading, isAuthenticated } = useAuthenticationStatus()
   const location = useLocation()
   if (isLoading) {
     return <div>Loading...</div>

--- a/packages/react/src/hooks/common.ts
+++ b/packages/react/src/hooks/common.ts
@@ -24,18 +24,24 @@ export const useNhostBackendUrl = () => {
   return nhost.auth.client.backendUrl.replace('/v1/auth', '')
 }
 
+/**
+ * @deprecated When using both useAuthLoading and useAuthenticated together, their initial state will change three times: (true,false) -> (false,false) -> (false,true). Use useAuthenticationStatus instead.
+ */
 export const useAuthLoading = () => {
   const service = useAuthInterpreter()
-  const [isLoading, setIsLoading] = useState(!service.status || !service?.state?.hasTag('ready'))
-  useEffect(() => {
-    const subscription = service.subscribe((state) => {
-      const newValue = !state.hasTag('ready')
-      setIsLoading(newValue)
-    })
-    return subscription.unsubscribe
-  }, [service])
+  return useSelector(service, (state) => !state.hasTag('ready'))
+}
 
-  return isLoading
+export const useAuthenticationStatus = () => {
+  const service = useAuthInterpreter()
+  return useSelector(
+    service,
+    (state) => ({
+      isAuthenticated: state.matches({ authentication: 'signedIn' }),
+      isLoading: !state.hasTag('ready')
+    }),
+    (a, b) => a.isAuthenticated === b.isAuthenticated && a.isLoading === b.isLoading
+  )
 }
 
 export const useAuthenticated = () => {

--- a/packages/react/src/hooks/deprecated.ts
+++ b/packages/react/src/hooks/deprecated.ts
@@ -1,14 +1,13 @@
 import { useMemo } from 'react'
 
-import { useAuthenticated, useAuthLoading } from './common'
+import { useAuthenticationStatus } from './common'
 import { useUserData } from './user'
 
 /**
- * @deprecated This hooks ensures backward compatibility with `@nhost/react-auth`, which is deprecated
+ * @deprecated This hook ensures backward compatibility with `@nhost/react-auth`, which is deprecated
  */
 export const useNhostAuth = () => {
-  const isLoading = useAuthLoading()
-  const isAuthenticated = useAuthenticated()
+  const { isLoading, isAuthenticated } = useAuthenticationStatus()
   const user = useUserData()
   return useMemo(() => ({ isLoading, isAuthenticated, user }), [isLoading, isAuthenticated, user])
 }

--- a/packages/react/src/hooks/registration.ts
+++ b/packages/react/src/hooks/registration.ts
@@ -3,7 +3,7 @@ import { useMemo } from 'react'
 import { SignUpOptions } from '@nhost/core'
 import { useSelector } from '@xstate/react'
 
-import { useAuthenticated, useAuthInterpreter, useAuthLoading } from './common'
+import { useAuthenticationStatus, useAuthInterpreter } from './common'
 
 export const useSignUpEmailPassword = (
   stateEmail?: string,
@@ -18,8 +18,7 @@ export const useSignUpEmailPassword = (
     (state) => state.context.errors.registration,
     (a, b) => a?.error === b?.error
   )
-  const loading = useAuthLoading()
-  const isSuccess = useAuthenticated()
+  const { isLoading: loading, isAuthenticated: isSuccess } = useAuthenticationStatus()
   const isLoading = useMemo(() => loading && !isSuccess, [loading, isSuccess])
   const needsEmailVerification =
     !!service.status &&


### PR DESCRIPTION
When using both `useAuthLoading` and `useAuthenticated` together, the hooks rerender independently from each other.
As a result, when a user loads the page while he previously authenticated, the hooks values were chronologically:

| isLoading | isAuthenticated |
| --------- | --------------- |
| `true`    | `false`         |
| `false`   | `false`         |
| `false`   | `true`          |

The intermediate (`false`, `false`) is incorrect and is causing issues when using an authentication gate.

It is therefore recommended to stop using `useAuthLoading`, and to use `useAuthenticationStatus` instead, in order to keep the loading state and the authentication in sync within the same hook.

Usage:

```js
const { isLoading, isAuthenticated } = useAuthenticationStatus()
```

Fixes [this issue](https://github.com/nhost/nhost/issues/302)
