### PR TITLE
Fix a type in react documentation

### DIFF
--- a/docs/content/docs/reference/react/hooks.mdx
+++ b/docs/content/docs/reference/react/hooks.mdx
@@ -445,7 +445,7 @@ const Avatar = () => {
 ### Display name
 
 ```jsx
-import { displayName } from '@nhost/react'
+import { useDisplayName } from '@nhost/react'
 
 const Avatar = () => {
   const displayName = useDisplayName()


### PR DESCRIPTION
Fix a typo in the `nhsot/react` documentation in the code example. 

The imported hook had a wrong name