### PR TITLE
fix: apollo context headers in http requests

### DIFF
--- a/packages/apollo/src/index.ts
+++ b/packages/apollo/src/index.ts
@@ -112,6 +112,7 @@ export const createApolloClient = ({
 
   const apolloClientOptions: ApolloClientOptions<any> = {
     cache: cache || new InMemoryCache(),
+    link: authLink.concat(httplink),
     ssrMode: !isBrowser,
     defaultOptions: {
       watchQuery: {


### PR DESCRIPTION
Headers such has `x-hasura-role` were not making it into the apollo requests.