### PR TITLE
Keep authentication status and access token in sync

### DIFF
--- a/.changeset/old-poets-design.md
+++ b/.changeset/old-poets-design.md
@@ -1,0 +1,10 @@
+---
+'@nhost/core': patch
+'@nhost/hasura-auth-js': patch
+'@nhost/nhost-js': patch
+---
+
+Keep authentication status and access token in sync
+The authentication events where not set correctly, leading the main Nhost client not to update internal states of storage/graphql/functions sub-clients when using non-react clients.
+The use of private fields (`#`) is also avoided as they conflict with the use of proxies in Vue, leading to errors in the upcoming Vue library.
+Fixes #373 and #378

--- a/packages/core/src/client.ts
+++ b/packages/core/src/client.ts
@@ -61,15 +61,17 @@ export class AuthClient {
   set interpreter(interpreter: AuthInterpreter | undefined) {
     this._interpreter = interpreter
     if (interpreter) {
-      console.log('INTERPRETER!!!!')
       this._subscriptions.forEach((fn) => fn(this))
     }
   }
 
   onStart(fn: (client: AuthClient) => void) {
     if (this.interpreter) {
+      // * The interpreter is already available: we can add the listener straight ahead
       fn(this)
     } else {
+      // * The interpreter is not yet available: we add the listener to a queue that will be started when setting the interpreter
+      // * Note: in React, the Xstate interpreter does not start from the global state, but from the root component
       this._subscriptions.add(fn)
     }
   }

--- a/packages/nhost-js/src/core/nhost-client.ts
+++ b/packages/nhost-js/src/core/nhost-client.ts
@@ -60,20 +60,22 @@ export class NhostClient {
       url: `${backendUrl}/v1/graphql`
     })
 
-    // set current token if token is already accessable
+    // * Set current token if token is already accessable
     this.storage.setAccessToken(this.auth.getAccessToken())
     this.functions.setAccessToken(this.auth.getAccessToken())
     this.graphql.setAccessToken(this.auth.getAccessToken())
 
     this.auth.client.onStart(() => {
-      // update access token for clients
+      // * Set access token when signing out
       this.auth.onAuthStateChanged((_event, session) => {
-        this.storage.setAccessToken(session?.accessToken)
-        this.functions.setAccessToken(session?.accessToken)
-        this.graphql.setAccessToken(session?.accessToken)
+        if (_event === 'SIGNED_OUT') {
+          this.storage.setAccessToken(undefined)
+          this.functions.setAccessToken(undefined)
+          this.graphql.setAccessToken(undefined)
+        }
       })
 
-      // update access token for clients
+      // * Update access token for clients, including when signin in
       this.auth.onTokenChanged((session) => {
         this.storage.setAccessToken(session?.accessToken)
         this.functions.setAccessToken(session?.accessToken)


### PR DESCRIPTION
The authentication events where not set correctly, leading the main Nhost client not to update internal states of storage/graphql/functions sub-clients when using non-react clients.
The use of private fields (`#`) is also avoided as they conflict with the use of proxies in Vue, leading to errors in the upcoming Vue library.
Fixes #373 and #378