### PR TITLE
fix: getNhostSession typing improvements, missing TSDoc

### DIFF
--- a/.changeset/thirty-scissors-pull.md
+++ b/.changeset/thirty-scissors-pull.md
@@ -1,0 +1,6 @@
+---
+'@nhost/nextjs': patch
+---
+
+- fixed typings of `getNhostSession` function (thanks to [zerosym](https://github.com/zerosym))
+- added missing TSdoc to `getNhostSession` function

--- a/packages/nextjs/package.json
+++ b/packages/nextjs/package.json
@@ -62,6 +62,7 @@
   "devDependencies": {
     "@nhost/core": "workspace:^",
     "@nhost/react": "workspace:^",
+    "@types/cookies": "^0.7.7",
     "next": "12.0.10",
     "react": "^17.0.2",
     "react-dom": "^17.0.2",

--- a/packages/nextjs/src/get-session.ts
+++ b/packages/nextjs/src/get-session.ts
@@ -1,13 +1,50 @@
 import Cookies from 'cookies'
-import { NextPageContext } from 'next'
+import { GetServerSidePropsContext, NextPageContext } from 'next'
 
 import { NHOST_JWT_EXPIRES_AT_KEY, NHOST_REFRESH_TOKEN_KEY, NhostSession } from '@nhost/core'
 
 import { refresh } from './utils'
 
+/**
+ * Refreshes the access token if there is any and returns the Nhost session.
+ *
+ * @example
+ * ### Using an arrow function
+ *
+ * ```js
+ * export const getServerSideProps: GetServerSideProps = async (context) => {
+ *   const nhostSession = await getNhostSession(BACKEND_URL, context)
+ *
+ *   return {
+ *     props: {
+ *       nhostSession
+ *     }
+ *   }
+ * }
+ * ```
+ *
+ * @example
+ * ### Using a regular function
+ *
+ * ```js
+ * export async function getServerSideProps(context: GetServerSidePropsContext) { // or NextPageContext
+ *   const nhostSession = await getNhostSession(BACKEND_URL, context)
+ *
+ *   return {
+ *     props: {
+ *       nhostSession
+ *     }
+ *   }
+ * }
+ * ```
+ *
+ * @param backendUrl - URL of your Nhost application
+ * @param context - Next.js context
+ * @returns Nhost session
+ */
 export const getNhostSession = async (
   backendUrl: string,
-  context: NextPageContext
+  context: NextPageContext | GetServerSidePropsContext
 ): Promise<NhostSession | null> => {
   let session: NhostSession | null = null
   if (context.req && context.res) {

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -205,6 +205,7 @@ importers:
       '@nhost/core': workspace:^
       '@nhost/nhost-js': workspace:^
       '@nhost/react': workspace:^
+      '@types/cookies': ^0.7.7
       cookies: ^0.8.0
       next: 12.0.10
       react: ^17.0.2
@@ -216,6 +217,7 @@ importers:
     devDependencies:
       '@nhost/core': link:../core
       '@nhost/react': link:../react
+      '@types/cookies': 0.7.7
       next: 12.0.10_33bdac975a6e334c49640fab91e2abb4
       react: 17.0.2
       react-dom: 17.0.2_react@17.0.2
@@ -2711,6 +2713,45 @@ packages:
       '@babel/types': 7.17.0
     dev: true
 
+  /@types/body-parser/1.19.2:
+    resolution: {integrity: sha512-ALYone6pm6QmwZoAgeyNksccT9Q4AWZQ6PvfwR37GT6r6FWUPguq6sUmNGSMV2Wr761oQoBxwGGa6DR5o1DC9g==}
+    dependencies:
+      '@types/connect': 3.4.35
+      '@types/node': 17.0.21
+    dev: true
+
+  /@types/connect/3.4.35:
+    resolution: {integrity: sha512-cdeYyv4KWoEgpBISTxWvqYsVy444DOqehiF3fM3ne10AmJ62RSyNkUnxMJXHQWRQQX2eR94m5y1IZyDwBjV9FQ==}
+    dependencies:
+      '@types/node': 17.0.21
+    dev: true
+
+  /@types/cookies/0.7.7:
+    resolution: {integrity: sha512-h7BcvPUogWbKCzBR2lY4oqaZbO3jXZksexYJVFvkrFeLgbZjQkU4x8pRq6eg2MHXQhY0McQdqmmsxRWlVAHooA==}
+    dependencies:
+      '@types/connect': 3.4.35
+      '@types/express': 4.17.13
+      '@types/keygrip': 1.0.2
+      '@types/node': 17.0.21
+    dev: true
+
+  /@types/express-serve-static-core/4.17.28:
+    resolution: {integrity: sha512-P1BJAEAW3E2DJUlkgq4tOL3RyMunoWXqbSCygWo5ZIWTjUgN1YnaXWW4VWl/oc8vs/XoYibEGBKP0uZyF4AHig==}
+    dependencies:
+      '@types/node': 17.0.21
+      '@types/qs': 6.9.7
+      '@types/range-parser': 1.2.4
+    dev: true
+
+  /@types/express/4.17.13:
+    resolution: {integrity: sha512-6bSZTPaTIACxn48l50SR+axgrqm6qXFIxrdAKaG6PaJk3+zuUr35hBlgT7vOmJcum+OEaIBLtHV/qloEAFITeA==}
+    dependencies:
+      '@types/body-parser': 1.19.2
+      '@types/express-serve-static-core': 4.17.28
+      '@types/qs': 6.9.7
+      '@types/serve-static': 1.13.10
+    dev: true
+
   /@types/faker/5.5.9:
     resolution: {integrity: sha512-uCx6mP3UY5SIO14XlspxsGjgaemrxpssJI0Ol+GfhxtcKpv9pgRZYsS4eeKeHVLje6Qtc8lGszuBI461+gVZBA==}
     dev: true
@@ -2770,11 +2811,19 @@ packages:
   /@types/json5/0.0.29:
     resolution: {integrity: sha1-7ihweulOEdK4J7y+UnC86n8+ce4=}
 
+  /@types/keygrip/1.0.2:
+    resolution: {integrity: sha512-GJhpTepz2udxGexqos8wgaBx4I/zWIDPh/KOGEwAqtuGDkOUJu5eFvwmdBX4AmB8Odsr+9pHCQqiAqDL/yKMKw==}
+    dev: true
+
   /@types/mdast/3.0.10:
     resolution: {integrity: sha512-W864tg/Osz1+9f4lrGTZpCSO5/z4608eUp19tbozkq2HJK6i3z1kT0H9tlADXuYIb1YYOBByU4Jsqkk75q48qA==}
     dependencies:
       '@types/unist': 2.0.6
     dev: false
+
+  /@types/mime/1.3.2:
+    resolution: {integrity: sha512-YATxVxgRqNH6nHEIsvg6k2Boc1JHI9ZbH5iWFFv/MTkchz3b1ieGDa5T0a9RznNdI0KhVbdbWSN+KWWrQZRxTw==}
+    dev: true
 
   /@types/minimist/1.2.2:
     resolution: {integrity: sha512-jhuKLIRrhvCPLqwPcx6INqmKeiA5EWrsCOPhrlFSrbrmU4ZMPjj5Ul/oLCMDO98XRUIwVm78xICz4EPCektzeQ==}
@@ -2807,6 +2856,14 @@ packages:
   /@types/prop-types/15.7.4:
     resolution: {integrity: sha512-rZ5drC/jWjrArrS8BR6SIr4cWpW09RNTYt9AMZo3Jwwif+iacXAqgVjm0B0Bv/S1jhDXKHqRVNCbACkJ89RAnQ==}
 
+  /@types/qs/6.9.7:
+    resolution: {integrity: sha512-FGa1F62FT09qcrueBA6qYTrJPVDzah9a+493+o2PCXsesWHIn27G98TsSMs3WPNbZIEj4+VJf6saSFpvD+3Zsw==}
+    dev: true
+
+  /@types/range-parser/1.2.4:
+    resolution: {integrity: sha512-EEhsLsD6UsDM1yFhAvy0Cjr6VwmpMWqFBCb9w07wVugF7w9nfajxLuVmngTIpgS6svCnm6Vaw+MZhoDCKnOfsw==}
+    dev: true
+
   /@types/react-redux/7.1.23:
     resolution: {integrity: sha512-D02o3FPfqQlfu2WeEYwh3x2otYd2Dk1o8wAfsA0B1C2AJEFxE663Ozu7JzuWbznGgW248NaOF6wsqCGNq9d3qw==}
     dependencies:
@@ -2828,6 +2885,13 @@ packages:
 
   /@types/semver/6.2.3:
     resolution: {integrity: sha512-KQf+QAMWKMrtBMsB8/24w53tEsxllMj6TuA80TT/5igJalLI/zm0L3oXRbIAl4Ohfc85gyHX/jhMwsVkmhLU4A==}
+    dev: true
+
+  /@types/serve-static/1.13.10:
+    resolution: {integrity: sha512-nCkHGI4w7ZgAdNkrEu0bv+4xNV/XDqW+DydknebMOQwkpDGx8G+HTlj7R7ABI8i8nKxVw0wtKPi1D+lPOkh4YQ==}
+    dependencies:
+      '@types/mime': 1.3.2
+      '@types/node': 17.0.21
     dev: true
 
   /@types/stack-utils/2.0.1:


### PR DESCRIPTION
This PR fixes #371 and also adds the missing TSDoc to the exposed `getNhostSession` function.