### PR TITLE
Docs: edit link instead of blob

### DIFF
--- a/docs/docusaurus.config.js
+++ b/docs/docusaurus.config.js
@@ -34,7 +34,7 @@ const config = {
           sidebarPath: require.resolve('./sidebars.js'),
           remarkPlugins: [require('mdx-mermaid')],
           // Please change this to your repo.
-          editUrl: 'https://github.com/nhost/nhost/blob/main/docs/',
+          editUrl: 'https://github.com/nhost/nhost/edit/main/docs/',
         },
         theme: {
           customCss: require.resolve('./src/css/custom.css'),


### PR DESCRIPTION
Updated edit link to link to edit page instead of blob page.