### PR TITLE
Update Docs README.md

### DIFF
--- a/docs/README.md
+++ b/docs/README.md
@@ -24,7 +24,7 @@ $ pnpm build
 
 This command generates static content into the `build` directory and can be served using any static contents hosting service.
 
-### Serve
+### Serve
 
 ```bash
 $ pnpm serve


### PR DESCRIPTION
Mac put this weird whitespace-like character here, therefore the README was rendered incorrectly.