### PR TITLE
fix: invalid password and email errors on sign up

### DIFF
--- a/.changeset/tricky-drinks-laugh.md
+++ b/.changeset/tricky-drinks-laugh.md
@@ -1,0 +1,7 @@
+---
+'@nhost/core': patch
+---
+
+Fix invalid password and email errors on sign up
+When signin up, an invalid password was returning the `invalid-email` error, and an invalid email was returning `invalid-password`.
+This is now in order.

--- a/packages/core/src/machines/index.ts
+++ b/packages/core/src/machines/index.ts
@@ -528,10 +528,10 @@ export const createAuthMachine = ({
           errors: ({ errors: { registration, ...errors } }) => errors
         }),
         saveInvalidSignUpPassword: assign({
-          errors: ({ errors }) => ({ ...errors, registration: INVALID_EMAIL_ERROR })
+          errors: ({ errors }) => ({ ...errors, registration: INVALID_PASSWORD_ERROR })
         }),
         saveInvalidSignUpEmail: assign({
-          errors: ({ errors }) => ({ ...errors, registration: INVALID_PASSWORD_ERROR })
+          errors: ({ errors }) => ({ ...errors, registration: INVALID_EMAIL_ERROR })
         }),
         saveNoMfaTicketError: assign({
           errors: ({ errors }) => ({ ...errors, registration: NO_MFA_TICKET_ERROR })


### PR DESCRIPTION
When signin up, an invalid password was returning the `invalid-email` error, and an invalid email was returning `invalid-password`.