### PR TITLE
fix: fix and improve `nhost.auth.refreshSession`

### DIFF
--- a/.changeset/calm-insects-vanish.md
+++ b/.changeset/calm-insects-vanish.md
@@ -1,0 +1,8 @@
+---
+'@nhost/core': patch
+'@nhost/hasura-auth-js': patch
+---
+
+fix and improve `nhost.auth.refreshSession`
+`nhost.auth.refreshSession` is now functional and returns possible errors, or the user session if the token has been sucessfully refreshed.
+If the user was previously not authenticated, it will sign them in. See [#286](https://github.com/nhost/nhost/issues/286)

--- a/packages/core/src/errors.ts
+++ b/packages/core/src/errors.ts
@@ -1,5 +1,6 @@
 export const NETWORK_ERROR_CODE = 0
 export const VALIDATION_ERROR_CODE = 10
+export const STATE_ERROR_CODE = 20
 
 export type ErrorPayload = {
   error: string
@@ -37,4 +38,17 @@ export const NO_MFA_TICKET_ERROR: ValidationErrorPayload = {
   status: VALIDATION_ERROR_CODE,
   error: 'no-mfa-ticket',
   message: 'No MFA ticket has been provided'
+}
+
+export const NO_REFRESH_TOKEN: ValidationErrorPayload = {
+  status: VALIDATION_ERROR_CODE,
+  error: 'no-refresh-token',
+  message: 'No refresh token has been provided'
+}
+
+export const TOKEN_REFRESHER_RUNNING_ERROR: ErrorPayload = {
+  status: STATE_ERROR_CODE,
+  error: 'refresher-already-running',
+  message:
+    'The token refresher is already running. You must wait until is has finished before submitting a new token.'
 }

--- a/packages/core/src/machines/index.ts
+++ b/packages/core/src/machines/index.ts
@@ -457,6 +457,7 @@ export const createAuthMachine = ({
                   target: ['#nhost.authentication.signedIn', 'idle.noErrors']
                 },
                 onError: [
+                  // TODO save error
                   { cond: 'isSignedIn', target: 'idle.error' },
                   {
                     target: ['#nhost.authentication.signedOut', 'idle.error']

--- a/packages/hasura-auth-js/src/hasura-auth-client.ts
+++ b/packages/hasura-auth-js/src/hasura-auth-client.ts
@@ -8,7 +8,9 @@ import {
   createResetPasswordMachine,
   createSendVerificationEmailMachine,
   encodeQueryParameters,
-  rewriteRedirectTo
+  NO_REFRESH_TOKEN,
+  rewriteRedirectTo,
+  TOKEN_REFRESHER_RUNNING_ERROR
 } from '@nhost/core'
 
 import { getSession, isBrowser, localStorageGetter, localStorageSetter } from './utils/helpers'
@@ -567,24 +569,34 @@ export class HasuraAuthClient {
    *
    * @docs https://docs.nhost.io/TODO
    */
-  async refreshSession(refreshToken?: string): Promise<void> {
+  async refreshSession(refreshToken?: string): Promise<{
+    session: Session | null
+    error: ApiError | null
+  }> {
     try {
       const interpreter = await this.waitUntilReady()
-      if (interpreter.state.matches({ token: 'idle' })) return
+      if (interpreter.state.matches({ token: 'idle' }))
+        return { session: null, error: TOKEN_REFRESHER_RUNNING_ERROR }
       return new Promise((resolve) => {
         const token = refreshToken || interpreter.state.context.refreshToken.value
-        if (!token) return resolve()
+        if (!token) return resolve({ session: null, error: NO_REFRESH_TOKEN })
         interpreter?.onTransition((state) => {
-          if (state.matches({ token: { idle: 'error' } })) resolve()
-          else if (state.event.type === 'TOKEN_CHANGED') resolve()
+          if (state.matches({ token: { idle: 'error' } }))
+            resolve({
+              session: null,
+              // * TODO get the error from xstate once it is implemented
+              error: { status: 400, message: 'Invalid refresh token' }
+            })
+          else if (state.event.type === 'TOKEN_CHANGED')
+            resolve({ session: getSession(state.context), error: null })
         })
         interpreter.send({
           type: 'TRY_TOKEN',
           token
         })
       })
-    } catch {
-      return
+    } catch (error: any) {
+      return { session: null, error: error.message }
     }
   }
 


### PR DESCRIPTION
`nhost.auth.refreshSession` is now functional and returns possible errors, or the user session if the token has been sucessfully refreshed.
If the user was previously not authenticated, it will sign them in. See [#286](https://github.com/nhost/nhost/issues/286)