### PR TITLE
fix: improve reliability of the token refresher

### DIFF
--- a/.changeset/twelve-gifts-count.md
+++ b/.changeset/twelve-gifts-count.md
@@ -1,0 +1,13 @@
+---
+'@nhost/core': patch
+---
+
+Improve reliability of the token refresher
+The token refresher had an unreliable behaviour, leading to too many refreshes, or refreshes that are missed, leading to an expired access token (JWT).
+
+The internal refresher rules have been made more explicit in the code. Every second, this runs:
+
+- If the client defined a `refreshIntervalTime` and the interval between when the last access token has been created and now is more than this value, then it triggers a refresh
+- If the access token expires in less than five minutes, then it triggers a refresh
+
+If a refresh fails, then it switches to a specific rule: it will make an attempt to refresh the token every five seconds

--- a/packages/core/src/client.ts
+++ b/packages/core/src/client.ts
@@ -1,6 +1,5 @@
 import { interpret } from 'xstate'
 
-import { MIN_TOKEN_REFRESH_INTERVAL } from './constants'
 import { AuthMachine, AuthMachineOptions, createAuthMachine } from './machines'
 import { defaultClientStorageGetter, defaultClientStorageSetter } from './storage'
 import type { AuthInterpreter } from './types'
@@ -20,7 +19,7 @@ export class AuthClient {
     clientUrl = (typeof window !== 'undefined' && window.location?.origin) || '',
     clientStorageGetter = defaultClientStorageGetter,
     clientStorageSetter = defaultClientStorageSetter,
-    refreshIntervalTime = MIN_TOKEN_REFRESH_INTERVAL,
+    refreshIntervalTime,
     autoSignIn = true,
     autoRefreshToken = true,
     start = true

--- a/packages/core/src/constants.ts
+++ b/packages/core/src/constants.ts
@@ -3,15 +3,16 @@ export const NHOST_JWT_EXPIRES_AT_KEY = 'nhostRefreshTokenExpiresAt'
 
 export const MIN_PASSWORD_LENGTH = 3
 
-// * Minimum time in seconds before the JWT expiration and the first refresh attempt
-export const TOKEN_REFRESH_MARGIN = 900
+/**
+ * Minimum time in seconds between now and the JWT expiration time before the JWT is refreshed
+ * For instance, if set to 60, the client will refresh the JWT one minute before it expires
+ */
+export const TOKEN_REFRESH_MARGIN = 300 // five minutes
 
-// * Minimum time in seconds for a refresh regardless ot the JWT expiration
-export const MIN_TOKEN_REFRESH_INTERVAL = 60
+/** Number of seconds before retrying a token refresh after an error */
+export const REFRESH_TOKEN_RETRY_INTERVAL = 5
 
-// * Number of seconds before retrying a token refresh after an error
-export const REFRESH_TOKEN_RETRY_INTERVAL = 10
-
-// * Maximum number of attempts to refresh a token before stopping the timer and logging out
+// TODO not implemented yet
 // TODO try when offline for a long time: maybe we could keep state as 'signedIn'
+/** Maximum number of attempts to refresh a token before stopping the timer and logging out */
 export const REFRESH_TOKEN_RETRY_MAX_ATTEMPTS = 30

--- a/packages/core/src/machines/context.ts
+++ b/packages/core/src/machines/context.ts
@@ -11,8 +11,9 @@ export type AuthContext = {
     expiresAt: Date
   }
   refreshTimer: {
-    elapsed: number
+    startedAt: Date | null
     attempts: number
+    lastAttempt: Date | null
   }
   refreshToken: {
     value: string | null
@@ -28,8 +29,9 @@ export const INITIAL_MACHINE_CONTEXT: AuthContext = {
     expiresAt: new Date()
   },
   refreshTimer: {
-    elapsed: 0,
-    attempts: 0
+    startedAt: null,
+    attempts: 0,
+    lastAttempt: null
   },
   refreshToken: {
     value: null

--- a/packages/core/src/machines/index.typegen.ts
+++ b/packages/core/src/machines/index.typegen.ts
@@ -50,7 +50,7 @@ export interface Typegen0 {
       | 'error.platform.signInMfaTotp'
     saveMfaTicket: 'done.invoke.authenticateUserWithPassword'
     saveRegisrationError: 'error.platform.registerUser'
-    tickRefreshTimer: 'xstate.after(1000)#nhost.authentication.signedIn.refreshTimer.running.pending'
+    saveRefreshAttempt: 'error.platform.refreshToken'
     reportSignedOut: '' | 'error.platform.authenticateWithToken'
     resetAuthenticationError: 'xstate.init'
     clearContext: 'xstate.init'
@@ -136,12 +136,13 @@ export interface Typegen0 {
     }
     'error.platform.signInMfaTotp': { type: 'error.platform.signInMfaTotp'; data: unknown }
     'error.platform.registerUser': { type: 'error.platform.registerUser'; data: unknown }
-    'xstate.after(1000)#nhost.authentication.signedIn.refreshTimer.running.pending': {
-      type: 'xstate.after(1000)#nhost.authentication.signedIn.refreshTimer.running.pending'
-    }
+    'error.platform.refreshToken': { type: 'error.platform.refreshToken'; data: unknown }
     'error.platform.authenticateWithToken': {
       type: 'error.platform.authenticateWithToken'
       data: unknown
+    }
+    'xstate.after(1000)#nhost.authentication.signedIn.refreshTimer.running.pending': {
+      type: 'xstate.after(1000)#nhost.authentication.signedIn.refreshTimer.running.pending'
     }
     'error.platform.autoSignIn': { type: 'error.platform.autoSignIn'; data: unknown }
     'xstate.init': { type: 'xstate.init' }
@@ -165,7 +166,6 @@ export interface Typegen0 {
       data: unknown
       __tip: 'See the XState TS docs to learn how to strongly type this.'
     }
-    'error.platform.refreshToken': { type: 'error.platform.refreshToken'; data: unknown }
   }
   invokeSrcNameMap: {
     autoSignIn: 'done.invoke.autoSignIn'


### PR DESCRIPTION
The token refresher had an unreliable behaviour, leading to too many refreshes, or refreshes that are missed, leading to an expired access token (JWT).

The internal refresher rules have been made more explicit in the code. Every second, this runs:

- If the client defined a `refreshIntervalTime` and the interval between when the last access token has been created and now is more than this value, then it triggers a refresh
- If the access token expires in less than five minutes, then it triggers a refresh

If a refresh fails, then it switches to a specific rule: it will make an attempt to refresh the token every five seconds
