### PR TITLE
Rename `autoLogin` to `autoSignIn`, and deprecate `autoLogin`

### DIFF
--- a/.changeset/stupid-singers-provide.md
+++ b/.changeset/stupid-singers-provide.md
@@ -1,0 +1,7 @@
+---
+'@nhost/hasura-auth-js': patch
+'@nhost/nhost-js': patch
+---
+
+Rename `autoLogin` to `autoSignIn`, and deprecate `autoLogin`
+Thourought Nhost, we use the term `sign in` rather than `login`. This version reflect this terminology in the `NhostClient` options

--- a/docs/docs/reference/react/getting-started.md
+++ b/docs/docs/reference/react/getting-started.md
@@ -60,7 +60,7 @@ ReactDOM.render(
 ```js
 const nhost = new NhostClient({
   backendUrl,
-  autoLogin,
+  autoSignIn,
   autoRefreshToken,
   clientStorageGetter,
   clientStorageSetter,
@@ -70,7 +70,7 @@ const nhost = new NhostClient({
 | Name                  | Type                                | Default            | Notes                                                                                                                                                                                                                                          |
 | --------------------- | ----------------------------------- | ------------------ | ---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
 | `backendUrl`          | string                              |                    | The Nhost app url, for instance `https://my-app.nhost.run`. When using the CLI, its value is `http://localhost:1337`                                                                                                                           |
-| `autoLogin`           | boolean                             | `true`             | If set to `true`, the client will detect credentials in the current URL that could have been sent during an email verification or an Oauth authentication. It will also automatically authenticate all the active tabs in the current browser. |
+| `autoSignIn`          | boolean                             | `true`             | If set to `true`, the client will detect credentials in the current URL that could have been sent during an email verification or an Oauth authentication. It will also automatically authenticate all the active tabs in the current browser. |
 | `autoRefreshToken`    | boolean                             | `true`             | If set to `true`, the JWT (access token) will be automatically refreshed before it expires.                                                                                                                                                    |
 | `clientStorageGetter` | (key:string) => string \| null      | use `localStorage` | Nhost stores a refresh token in `localStorage` so the session can be restored when starting the browser.                                                                                                                                       |
 | `clientStorageGetter` | (key: string, value: string \| null | use `localStorage` |                                                                                                                                                                                                                                                |

--- a/packages/hasura-auth-js/src/hasura-auth-client.ts
+++ b/packages/hasura-auth-js/src/hasura-auth-client.ts
@@ -60,7 +60,8 @@ export class HasuraAuthClient {
   constructor({
     url,
     autoRefreshToken = true,
-    autoLogin = true,
+    autoSignIn = true,
+    autoLogin,
     clientStorage,
     clientStorageType = 'web',
     clientStorageGetter,
@@ -72,7 +73,7 @@ export class HasuraAuthClient {
     this._client = new Client({
       backendUrl: url,
       autoRefreshToken,
-      autoSignIn: autoLogin,
+      autoSignIn: typeof autoLogin === 'boolean' ? autoLogin : autoSignIn,
       start,
       clientStorageGetter:
         clientStorageGetter || localStorageGetter(clientStorageType, clientStorage),

--- a/packages/hasura-auth-js/src/utils/types.ts
+++ b/packages/hasura-auth-js/src/utils/types.ts
@@ -24,8 +24,10 @@ export interface NhostAuthConstructorParams {
   clientStorageSetter?: StorageSetter
   /** When set to true, will automatically refresh token before it expires */
   autoRefreshToken?: boolean
-  /** When set to true, will parse the url on startup to check if it contains a refresh token to start the session with */
+  /** @deprecated use autoSignIn instead */
   autoLogin?: boolean
+  /** When set to true, will parse the url on startup to check if it contains a refresh token to start the session with */
+  autoSignIn?: boolean
   start?: boolean
   Client?: typeof AuthClient
 }

--- a/packages/nhost-js/src/core/nhost-client.ts
+++ b/packages/nhost-js/src/core/nhost-client.ts
@@ -30,7 +30,7 @@ export class NhostClient {
     clientStorage,
     clientStorageType,
     autoRefreshToken,
-    autoLogin,
+    autoSignIn,
     start = true,
     Client
   }: NhostClientConstructorParams) {
@@ -43,7 +43,7 @@ export class NhostClient {
       clientStorage,
       clientStorageType,
       autoRefreshToken,
-      autoLogin,
+      autoSignIn,
       start,
       Client
     })


### PR DESCRIPTION
Thourought Nhost, we use the term `sign in` rather than `login`. This version reflect this terminology in the `NhostClient` options
