### PR TITLE
fix: get the refresh token in the right place in the url

### DIFF
--- a/.changeset/bright-apples-sparkle.md
+++ b/.changeset/bright-apples-sparkle.md
@@ -1,0 +1,5 @@
+---
+'@nhost/core': patch
+---
+
+Clean `refreshToken` and `type` from the url when the user is already signed in

--- a/.changeset/quick-swans-care.md
+++ b/.changeset/quick-swans-care.md
@@ -1,0 +1,6 @@
+---
+'@nhost/nextjs': patch
+---
+
+Get the refresh token in the right place in the url
+Hasura-auth puts the refresh token in the url as `refreshToken`, but it is not stored using the same key in localStorage / the cookie. This fix makes the right correspondance between the two.

--- a/examples/nextjs/nhost/config.yaml
+++ b/examples/nextjs/nhost/config.yaml
@@ -7,7 +7,7 @@ services:
     environment:
       hasura_graphql_enable_remote_schema_permissions: false
   auth:
-    version: 0.4.2
+    version: 0.7.1
 auth:
   access_control:
     email:

--- a/examples/react-apollo/nhost/config.yaml
+++ b/examples/react-apollo/nhost/config.yaml
@@ -7,7 +7,7 @@ services:
     environment:
       hasura_graphql_enable_remote_schema_permissions: false
   auth:
-    version: 0.6.3
+    version: 0.7.1
 auth:
   access_control:
     email:

--- a/packages/core/src/machines/index.ts
+++ b/packages/core/src/machines/index.ts
@@ -353,7 +353,7 @@ export const createAuthMachine = ({
             signedIn: {
               tags: ['ready'],
               type: 'parallel',
-              entry: 'reportSignedIn',
+              entry: ['reportSignedIn', 'cleanUrl'],
               on: {
                 SIGNOUT: '#nhost.authentication.signedOut.signingOut',
                 DEANONYMIZE: {
@@ -567,6 +567,17 @@ export const createAuthMachine = ({
             return { value: null }
           }
         }),
+
+        // * Clean the browser url when `autoSignIn` is activated
+        cleanUrl: () => {
+          if (autoSignIn && getParameterByName('refreshToken')) {
+            // * Remove the refresh token from the URL
+            removeParameterFromWindow('refreshToken')
+            removeParameterFromWindow('type')
+          }
+        },
+
+        // * Broadcast the token to other tabs when `autoSignIn` is activated
         broadcastToken: (context) => {
           if (autoSignIn) {
             try {
@@ -687,8 +698,6 @@ export const createAuthMachine = ({
                 // ? Which takes precedence? localStorage or the url?
                 refreshToken = urlToken
               }
-              // * Remove the refresh token from the URL
-              removeParameterFromWindow('refreshToken')
             } else {
               const error = getParameterByName('error')
               if (error) {

--- a/packages/core/src/machines/index.typegen.ts
+++ b/packages/core/src/machines/index.typegen.ts
@@ -72,6 +72,16 @@ export interface Typegen0 {
       | 'done.invoke.signInMfaTotp'
       | 'done.invoke.registerUser'
       | 'done.invoke.authenticateWithToken'
+    cleanUrl:
+      | 'SESSION_UPDATE'
+      | ''
+      | 'done.invoke.authenticatePasswordlessSmsOtp'
+      | 'done.invoke.authenticateUserWithPassword'
+      | 'done.invoke.signInToken'
+      | 'done.invoke.authenticateAnonymously'
+      | 'done.invoke.signInMfaTotp'
+      | 'done.invoke.registerUser'
+      | 'done.invoke.authenticateWithToken'
   }
   internalEvents: {
     'done.invoke.authenticatePasswordlessSmsOtp': {


### PR DESCRIPTION
- Get the refresh token in the right place in the url
Hasura-auth puts the refresh token in the url as `refreshToken`, but it is not stored using the same key in localStorage / the cookie. This fix makes the right correspondance between the two.
- Clean `refreshToken` and `type` from the url when the user is already signed in
- Bump hasura-auth versions in the examples