### PR TITLE
Adds environment variables to auth service

### DIFF
--- a/examples/docker-compose/docker-compose.yaml
+++ b/examples/docker-compose/docker-compose.yaml
@@ -56,6 +56,9 @@ services:
       AUTH_CLIENT_URL: ${AUTH_CLIENT_URL:-http://localhost:3000}
       AUTH_SMTP_HOST: mailhog
       AUTH_SMTP_PORT: 1025
+      AUTH_SMTP_USER: user
+      AUTH_SMTP_PASS: password
+      AUTH_SMTP_SENDER: mail@example.com
     expose: 
       - 4000
     healthcheck:


### PR DESCRIPTION
I ran into an issue where I couldn't sign up users because the auth service wasn't able to connect to mailhog.
That caused the auth service to not send an email and not respond to the HTTP request.

fixes #499 

I'm wondering if anyone else had this issue. If I'm the only one then maybe this PR is obsolete.