### PR TITLE
refactor: stop using next-transpile-modules

### DIFF
--- a/examples/nextjs/next.config.js
+++ b/examples/nextjs/next.config.js
@@ -5,13 +5,4 @@ const withBundleAnalyzer = require('@next/bundle-analyzer')({
   enabled: process.env.ANALYZE === 'true'
 })
 
-const pkg = require('./package.json')
-// * Only required to make it work with the monorepo. Is not required otherwise
-const withTM = require('next-transpile-modules')(
-  // * All references to workspace packages are transpiled
-  Object.entries(pkg.dependencies)
-    .filter(([, version]) => version.startsWith('workspace'))
-    .map(([name]) => name)
-)
-
-module.exports = withBundleAnalyzer(withTM(nextConfig))
+module.exports = withBundleAnalyzer(nextConfig)

--- a/examples/nextjs/package.json
+++ b/examples/nextjs/package.json
@@ -35,7 +35,6 @@
     "@types/react": "18.0.8",
     "@xstate/inspect": "^0.6.2",
     "eslint-config-next": "12.0.10",
-    "next-transpile-modules": "^9.0.0",
     "typescript": "4.5.5",
     "ws": "^8.5.0",
     "xstate": "^4.31.0"

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -1,4 +1,4 @@
-lockfileVersion: 5.4
+lockfileVersion: 5.3
 
 overrides:
   graphql: 15.7.2
@@ -44,7 +44,7 @@ importers:
       wait-on: ^6.0.1
     devDependencies:
       '@babel/core': 7.17.10
-      '@babel/eslint-parser': 7.17.0_ore52sp75uhoubdikfje6htfpm
+      '@babel/eslint-parser': 7.17.0_7449dd49ffed0eea046851524f1e657b
       '@babel/plugin-syntax-flow': 7.16.7_@babel+core@7.17.10
       '@babel/plugin-transform-react-jsx': 7.17.3_@babel+core@7.17.10
       '@changesets/cli': 2.22.0
@@ -52,13 +52,13 @@ importers:
       '@trivago/prettier-plugin-sort-imports': 3.2.0_prettier@2.6.2
       '@types/jest': 27.5.0
       '@types/node': 17.0.31
-      '@typescript-eslint/eslint-plugin': 5.22.0_w4ajklk3bpbkv4oq2x7ogihpc4
-      '@typescript-eslint/parser': 5.22.0_sdq423wcawycjzugemfabbjutq
+      '@typescript-eslint/eslint-plugin': 5.22.0_b700952d5b0bc2aaf1d0d5fee320ef17
+      '@typescript-eslint/parser': 5.22.0_eslint@8.14.0+typescript@4.5.5
       '@vitejs/plugin-react': 1.3.2
       eslint: 8.14.0
-      eslint-config-react-app: 7.0.1_iilo2pjbcpzhr6eqe5ncsrl6jq
-      eslint-plugin-flowtype: 8.0.3_bnjl7sn2qxwsoaiqrpavakq354
-      eslint-plugin-import: 2.26.0_as7czvxgrvaa35lzxztolpnp5a
+      eslint-config-react-app: 7.0.1_4216ed3d2113f278f890275a29457e4c
+      eslint-plugin-flowtype: 8.0.3_0b52bfc9ba85ed2701108bc1502a1bef
+      eslint-plugin-import: 2.26.0_eslint@8.14.0
       eslint-plugin-jsx-a11y: 6.5.1_eslint@8.14.0
       eslint-plugin-node: 11.1.0_eslint@8.14.0
       eslint-plugin-promise: 6.0.0_eslint@8.14.0
@@ -69,7 +69,7 @@ importers:
       jest: 27.5.1
       npm-run-all: 4.1.5
       prettier: 2.6.2
-      ts-jest: 27.1.4_qibfzi6pqxnvkzgq6a2hlm326a
+      ts-jest: 27.1.4_82025ca3cf85db5564d0f03475b37af0
       tsconfig-paths-jest: 0.0.1
       turbo: 1.2.5
       typedoc: 0.22.15_typescript@4.5.5
@@ -97,19 +97,19 @@ importers:
       swagger-ui-react: ^4.10.3
       typescript: ^4.6.3
     dependencies:
-      '@docusaurus/core': 2.0.0-beta.18_fdtqczkawcrswx4npptvkurkw4
-      '@docusaurus/plugin-sitemap': 2.0.0-beta.18_fdtqczkawcrswx4npptvkurkw4
-      '@docusaurus/preset-classic': 2.0.0-beta.18_fdtqczkawcrswx4npptvkurkw4
+      '@docusaurus/core': 2.0.0-beta.18_66c8c36abcfdbeab71528ce4b75c41f7
+      '@docusaurus/plugin-sitemap': 2.0.0-beta.18_66c8c36abcfdbeab71528ce4b75c41f7
+      '@docusaurus/preset-classic': 2.0.0-beta.18_66c8c36abcfdbeab71528ce4b75c41f7
       '@mdx-js/react': 1.6.22_react@17.0.2
       clsx: 1.1.1
-      mdx-mermaid: 1.2.2_c22t5semscxhgv3n3sjop6jcyy
+      mdx-mermaid: 1.2.2_mermaid@8.14.0+react@17.0.2
       mermaid: 8.14.0
       prism-react-renderer: 1.3.1_react@17.0.2
       react: 17.0.2
       react-dom: 17.0.2_react@17.0.2
-      swagger-ui-react: 4.10.3_sfoxds7t5ydpegc3knd667wn6m
+      swagger-ui-react: 4.10.3_react-dom@17.0.2+react@17.0.2
     devDependencies:
-      '@docusaurus/module-type-aliases': 2.0.0-beta.18_sfoxds7t5ydpegc3knd667wn6m
+      '@docusaurus/module-type-aliases': 2.0.0-beta.18_react-dom@17.0.2+react@17.0.2
       '@tsconfig/docusaurus': 1.0.5
       '@types/swagger-ui-react': 4.1.1
       typescript: 4.6.3
@@ -144,7 +144,6 @@ importers:
       eslint-config-next: 12.0.10
       graphql: 15.7.2
       next: 12.1.6
-      next-transpile-modules: ^9.0.0
       react: 18.1.0
       react-dom: 18.1.0
       react-icons: ^4.3.1
@@ -152,16 +151,16 @@ importers:
       ws: ^8.5.0
       xstate: ^4.31.0
     dependencies:
-      '@apollo/client': 3.6.2_ryheervzrbnxhj6xtqeq4kzpce
-      '@mantine/core': 4.2.2_zg4p567angkgzzlgt52zcfrhle
+      '@apollo/client': 3.6.2_graphql@15.7.2+react@18.1.0
+      '@mantine/core': 4.2.2_c9b8fefbe069946ce5669f7591162759
       '@mantine/hooks': 4.2.2_react@18.1.0
-      '@mantine/next': 4.2.2_2difmhutoxsf46pey4x65e3hyi
-      '@mantine/notifications': 4.2.2_v5dmohwpkggin643o3ukrg3qbi
+      '@mantine/next': 4.2.2_d0d0561e9375e45e79e4c72fee9367c2
+      '@mantine/notifications': 4.2.2_af46c71ecf518c86fb9b76e8a89b700a
       '@nhost/nextjs': link:../../packages/nextjs
       '@nhost/react': link:../../packages/react
       '@nhost/react-apollo': link:../../packages/react-apollo
       graphql: 15.7.2
-      next: 12.1.6_ef5jwxihqo6n7gxfmzogljlgcm
+      next: 12.1.6_react-dom@18.1.0+react@18.1.0
       react: 18.1.0
       react-dom: 18.1.0_react@18.1.0
       react-icons: 4.3.1_react@18.1.0
@@ -170,8 +169,7 @@ importers:
       '@types/node': 17.0.23
       '@types/react': 18.0.8
       '@xstate/inspect': 0.6.5_ws@8.5.0+xstate@4.31.0
-      eslint-config-next: 12.0.10_otyth6o2424wisqc4eno5l4teu
-      next-transpile-modules: 9.0.0
+      eslint-config-next: 12.0.10_next@12.1.6+typescript@4.5.5
       typescript: 4.5.5
       ws: 8.5.0
       xstate: 4.31.0
@@ -199,11 +197,11 @@ importers:
       vite: ^2.9.7
       xstate: ^4.31.0
     dependencies:
-      '@apollo/client': 3.6.2_ryheervzrbnxhj6xtqeq4kzpce
-      '@mantine/core': 4.2.2_zg4p567angkgzzlgt52zcfrhle
+      '@apollo/client': 3.6.2_graphql@15.7.2+react@18.1.0
+      '@mantine/core': 4.2.2_ea9d0c51a4562a6544166c6277bf397c
       '@mantine/hooks': 4.2.2_react@18.1.0
-      '@mantine/notifications': 4.2.2_v5dmohwpkggin643o3ukrg3qbi
-      '@mantine/prism': 4.2.2_v5dmohwpkggin643o3ukrg3qbi
+      '@mantine/notifications': 4.2.2_af46c71ecf518c86fb9b76e8a89b700a
+      '@mantine/prism': 4.2.2_af46c71ecf518c86fb9b76e8a89b700a
       '@nhost/react': link:../../packages/react
       '@nhost/react-apollo': link:../../packages/react-apollo
       graphql: 15.7.2
@@ -211,7 +209,7 @@ importers:
       react-dom: 18.1.0_react@18.1.0
       react-icons: 4.3.1_react@18.1.0
       react-router: 6.3.0_react@18.1.0
-      react-router-dom: 6.3.0_ef5jwxihqo6n7gxfmzogljlgcm
+      react-router-dom: 6.3.0_react-dom@18.1.0+react@18.1.0
     devDependencies:
       '@types/react': 18.0.8
       '@types/react-dom': 18.0.3
@@ -255,8 +253,8 @@ importers:
       typescript: ^4.6.3
       vite: ^2.9.7
     dependencies:
-      '@apollo/client': 3.5.10_yaujofatqqw66zcfkmual2ppy4
-      '@headlessui/react': 1.5.0_sfoxds7t5ydpegc3knd667wn6m
+      '@apollo/client': 3.5.10_graphql@15.7.2+react@17.0.2
+      '@headlessui/react': 1.5.0_react-dom@17.0.2+react@17.0.2
       '@heroicons/react': 1.0.6_react@17.0.2
       '@nhost/react': link:../../packages/react
       '@nhost/react-apollo': link:../../packages/react-apollo
@@ -268,14 +266,14 @@ importers:
       pretty-bytes: 5.6.0
       react: 17.0.2
       react-dom: 17.0.2_react@17.0.2
-      react-router-dom: 6.3.0_sfoxds7t5ydpegc3knd667wn6m
+      react-router-dom: 6.3.0_react-dom@17.0.2+react@17.0.2
       tailwindcss: 3.0.24
     devDependencies:
-      '@graphql-codegen/cli': 2.6.2_gmfj57eud24hcocpgi4qxibj74
+      '@graphql-codegen/cli': 2.6.2_330a9efc941eb871384f32390ba029ff
       '@graphql-codegen/introspection': 2.1.1_graphql@15.7.2
       '@graphql-codegen/typescript': 2.4.8_graphql@15.7.2
       '@graphql-codegen/typescript-operations': 2.3.5_graphql@15.7.2
-      '@graphql-codegen/typescript-react-apollo': 3.2.11_uiakrmibzyjojycqgq5qw35buq
+      '@graphql-codegen/typescript-react-apollo': 3.2.11_a200a8b101ce12e4e050343b0b6fa1a4
       '@types/express': 4.17.13
       '@types/jest': 26.0.24
       '@types/node': 12.20.48
@@ -302,7 +300,7 @@ importers:
       graphql: 15.7.2
       graphql-ws: 5.7.0_graphql@15.7.2
     devDependencies:
-      '@apollo/client': 3.6.2_ln7i2g2ohihrgsg7myx26qasgy
+      '@apollo/client': 3.6.2_graphql-ws@5.7.0+graphql@15.7.2
 
   packages/core:
     specifiers:
@@ -339,7 +337,7 @@ importers:
       commander: 9.2.0
       just-kebab-case: 4.0.1
       prettier: 2.6.2
-      valtio: 1.6.0
+      valtio: 1.6.0_vite@2.9.7
     devDependencies:
       '@swc/core': 1.2.171
       '@types/jest': 27.4.1
@@ -347,9 +345,9 @@ importers:
       '@types/prettier': 2.6.0
       jest: 27.5.1_ts-node@10.7.0
       rimraf: 3.0.2
-      ts-jest: 27.1.4_tgc6da2oqazvrn56dzwolsqo5i
-      ts-node: 10.7.0_tzixnl2p2257qb6vfbxvuwk7q4
-      tsup: 5.12.6_r2f2fcz3zztmgx5yz2r3q5xsqi
+      ts-jest: 27.1.4_7040bf7e0d8786507314c0c39bfde1b1
+      ts-node: 10.7.0_9e5176af4fd6bbf807d5286f5a595f87
+      tsup: 5.12.6_ts-node@10.7.0+typescript@4.6.3
       typescript: 4.6.3
 
   packages/hasura-auth-js:
@@ -407,7 +405,7 @@ importers:
       '@nhost/docgen': link:../docgen
       '@nhost/react': link:../react
       '@types/cookies': 0.7.7
-      next: 12.0.10_sfoxds7t5ydpegc3knd667wn6m
+      next: 12.0.10_9b0027aae606c22bf55a7fd89836f009
       react: 17.0.2
       react-dom: 17.0.2_react@17.0.2
 
@@ -444,7 +442,7 @@ importers:
     dependencies:
       '@nhost/core': link:../core
       '@nhost/nhost-js': link:../nhost-js
-      '@xstate/react': 2.0.1_mxz6tg6ny5uzqitzb7bw7ikoo4
+      '@xstate/react': 2.0.1_65f3e99bcdc7699822790fc36fa14e77
       immer: 9.0.12
       jwt-decode: 3.1.2
       xstate: 4.31.0
@@ -465,7 +463,7 @@ importers:
     dependencies:
       '@nhost/apollo': link:../apollo
     devDependencies:
-      '@apollo/client': 3.6.2_ryheervzrbnxhj6xtqeq4kzpce
+      '@apollo/client': 3.6.2_graphql@15.7.2+react@18.1.0
       '@nhost/react': link:../react
       '@types/react': 18.0.8
       graphql: 15.7.2
@@ -618,7 +616,7 @@ packages:
       '@jridgewell/trace-mapping': 0.3.9
     dev: true
 
-  /@apollo/client/3.5.10_yaujofatqqw66zcfkmual2ppy4:
+  /@apollo/client/3.5.10_graphql@15.7.2+react@17.0.2:
     resolution: {integrity: sha512-tL3iSpFe9Oldq7gYikZK1dcYxp1c01nlSwtsMz75382HcI6fvQXyFXUCJTTK3wgO2/ckaBvRGw7VqjFREdVoRw==}
     peerDependencies:
       graphql: ^14.0.0 || ^15.0.0 || ^16.0.0
@@ -649,7 +647,7 @@ packages:
       zen-observable-ts: 1.2.3
     dev: false
 
-  /@apollo/client/3.6.2_ln7i2g2ohihrgsg7myx26qasgy:
+  /@apollo/client/3.6.2_graphql-ws@5.7.0+graphql@15.7.2:
     resolution: {integrity: sha512-DNWyl+NNU2VsfHtXwOr4rV9hnQFPkl2/dNXeouhk9q7bXCWdEh3K8YTt/frULGVKbQjtnlPmz8C+LFI/JZ2N3w==}
     peerDependencies:
       graphql: ^14.0.0 || ^15.0.0 || ^16.0.0
@@ -681,7 +679,7 @@ packages:
       zen-observable-ts: 1.2.3
     dev: true
 
-  /@apollo/client/3.6.2_ryheervzrbnxhj6xtqeq4kzpce:
+  /@apollo/client/3.6.2_graphql@15.7.2+react@18.1.0:
     resolution: {integrity: sha512-DNWyl+NNU2VsfHtXwOr4rV9hnQFPkl2/dNXeouhk9q7bXCWdEh3K8YTt/frULGVKbQjtnlPmz8C+LFI/JZ2N3w==}
     peerDependencies:
       graphql: ^14.0.0 || ^15.0.0 || ^16.0.0
@@ -821,7 +819,7 @@ packages:
       - supports-color
     dev: false
 
-  /@babel/eslint-parser/7.17.0_ore52sp75uhoubdikfje6htfpm:
+  /@babel/eslint-parser/7.17.0_7449dd49ffed0eea046851524f1e657b:
     resolution: {integrity: sha512-PUEJ7ZBXbRkbq3qqM/jZ2nIuakUBqCYc7Qf52Lj7dlZ6zERnqisdHioL0l4wwQZnmskMeasqUNzLBFKs3nylXA==}
     engines: {node: ^10.13.0 || ^12.13.0 || >=14.0.0}
     peerDependencies:
@@ -3477,7 +3475,7 @@ packages:
     resolution: {integrity: sha512-1kkV7tkAsiuEd0shunYRByKJe3xQDG2q7wYg24SOw1nV9/2lwEd4WrUYRJC/ukGTl2/kHeFxsaUvtiOy0y6fFA==}
     dev: false
 
-  /@docsearch/react/3.0.0_sfoxds7t5ydpegc3knd667wn6m:
+  /@docsearch/react/3.0.0_react-dom@17.0.2+react@17.0.2:
     resolution: {integrity: sha512-yhMacqS6TVQYoBh/o603zszIb5Bl8MIXuOc6Vy617I74pirisDzzcNh0NEaYQt50fVVR3khUbeEhUEWEWipESg==}
     peerDependencies:
       '@types/react': '>= 16.8.0 < 18.0.0'
@@ -3494,7 +3492,7 @@ packages:
       - '@algolia/client-search'
     dev: false
 
-  /@docusaurus/core/2.0.0-beta.18_fdtqczkawcrswx4npptvkurkw4:
+  /@docusaurus/core/2.0.0-beta.18_66c8c36abcfdbeab71528ce4b75c41f7:
     resolution: {integrity: sha512-puV7l+0/BPSi07Xmr8tVktfs1BzhC8P5pm6Bs2CfvysCJ4nefNCD1CosPc1PGBWy901KqeeEJ1aoGwj9tU3AUA==}
     engines: {node: '>=14'}
     hasBin: true
@@ -3514,7 +3512,7 @@ packages:
       '@babel/traverse': 7.17.9
       '@docusaurus/cssnano-preset': 2.0.0-beta.18
       '@docusaurus/logger': 2.0.0-beta.18
-      '@docusaurus/mdx-loader': 2.0.0-beta.18_sfoxds7t5ydpegc3knd667wn6m
+      '@docusaurus/mdx-loader': 2.0.0-beta.18_react-dom@17.0.2+react@17.0.2
       '@docusaurus/react-loadable': 5.5.2_react@17.0.2
       '@docusaurus/utils': 2.0.0-beta.18
       '@docusaurus/utils-common': 2.0.0-beta.18
@@ -3522,7 +3520,7 @@ packages:
       '@slorber/static-site-generator-webpack-plugin': 4.0.4
       '@svgr/webpack': 6.2.1
       autoprefixer: 10.4.4_postcss@8.4.12
-      babel-loader: 8.2.5_vs5hf2sl7hjtttp43d2vzw3qay
+      babel-loader: 8.2.5_acba72ea4bf9d339cdfcd8f55cdb7006
       babel-plugin-dynamic-import-node: 2.3.0
       boxen: 6.2.1
       chokidar: 3.5.3
@@ -3533,7 +3531,7 @@ packages:
       copy-webpack-plugin: 10.2.4_webpack@5.72.0
       core-js: 3.22.1
       css-loader: 6.7.1_webpack@5.72.0
-      css-minimizer-webpack-plugin: 3.4.1_tejugib4y3rw5hvgnfmxavjvsu
+      css-minimizer-webpack-plugin: 3.4.1_clean-css@5.3.0+webpack@5.72.0
       cssnano: 5.1.7_postcss@8.4.12
       del: 6.0.0
       detect-port: 1.3.0
@@ -3551,16 +3549,16 @@ packages:
       mini-css-extract-plugin: 2.6.0_webpack@5.72.0
       nprogress: 0.2.0
       postcss: 8.4.12
-      postcss-loader: 6.2.1_ophkbroklgd6jdvupnp5h6xq4i
+      postcss-loader: 6.2.1_postcss@8.4.12+webpack@5.72.0
       prompts: 2.4.2
       react: 17.0.2
-      react-dev-utils: 12.0.1_4dvvomwfbhpgf7xcm7gogbdvgu
+      react-dev-utils: 12.0.1_509a9d40d32ea50a4d33125362dc897b
       react-dom: 17.0.2_react@17.0.2
-      react-helmet-async: 1.3.0_sfoxds7t5ydpegc3knd667wn6m
+      react-helmet-async: 1.3.0_react-dom@17.0.2+react@17.0.2
       react-loadable: /@docusaurus/react-loadable/5.5.2_react@17.0.2
-      react-loadable-ssr-addon-v5-slorber: 1.0.1_5grs2dwrf6hqtfkptfcfoiy4bu
+      react-loadable-ssr-addon-v5-slorber: 1.0.1_e9a32d0ed12f8f09954f994457231c0d
       react-router: 5.3.1_react@17.0.2
-      react-router-config: 5.1.1_53jg2tb4f34fvmclurfotx7m6y
+      react-router-config: 5.1.1_react-router@5.3.1+react@17.0.2
       react-router-dom: 5.3.1_react@17.0.2
       remark-admonitions: 1.2.1
       rtl-detect: 1.0.4
@@ -3570,7 +3568,7 @@ packages:
       terser-webpack-plugin: 5.3.1_webpack@5.72.0
       tslib: 2.3.1
       update-notifier: 5.1.0
-      url-loader: 4.1.1_csgzzuwaerdr4d7s3u52mzcn7m
+      url-loader: 4.1.1_file-loader@6.2.0+webpack@5.72.0
       wait-on: 6.0.1
       webpack: 5.72.0
       webpack-bundle-analyzer: 4.5.0
@@ -3609,7 +3607,7 @@ packages:
       tslib: 2.3.1
     dev: false
 
-  /@docusaurus/mdx-loader/2.0.0-beta.18_sfoxds7t5ydpegc3knd667wn6m:
+  /@docusaurus/mdx-loader/2.0.0-beta.18_react-dom@17.0.2+react@17.0.2:
     resolution: {integrity: sha512-pOmAQM4Y1jhuZTbEhjh4ilQa74Mh6Q0pMZn1xgIuyYDdqvIOrOlM/H0i34YBn3+WYuwsGim4/X0qynJMLDUA4A==}
     engines: {node: '>=14'}
     peerDependencies:
@@ -3632,7 +3630,7 @@ packages:
       stringify-object: 3.3.0
       tslib: 2.3.1
       unist-util-visit: 2.0.3
-      url-loader: 4.1.1_csgzzuwaerdr4d7s3u52mzcn7m
+      url-loader: 4.1.1_file-loader@6.2.0+webpack@5.72.0
       webpack: 5.72.0
     transitivePeerDependencies:
       - '@swc/core'
@@ -3642,7 +3640,7 @@ packages:
       - webpack-cli
     dev: false
 
-  /@docusaurus/module-type-aliases/2.0.0-beta.18_sfoxds7t5ydpegc3knd667wn6m:
+  /@docusaurus/module-type-aliases/2.0.0-beta.18_react-dom@17.0.2+react@17.0.2:
     resolution: {integrity: sha512-e6mples8FZRyT7QyqidGS6BgkROjM+gljJsdOqoctbtBp+SZ5YDjwRHOmoY7eqEfsQNOaFZvT2hK38ui87hCRA==}
     peerDependencies:
       react: '*'
@@ -3654,23 +3652,23 @@ packages:
       '@types/react-router-dom': 5.3.3
       react: 17.0.2
       react-dom: 17.0.2_react@17.0.2
-      react-helmet-async: 1.3.0_sfoxds7t5ydpegc3knd667wn6m
+      react-helmet-async: 1.3.0_react-dom@17.0.2+react@17.0.2
     transitivePeerDependencies:
       - '@swc/core'
       - esbuild
       - uglify-js
       - webpack-cli
 
-  /@docusaurus/plugin-content-blog/2.0.0-beta.18_fdtqczkawcrswx4npptvkurkw4:
+  /@docusaurus/plugin-content-blog/2.0.0-beta.18_66c8c36abcfdbeab71528ce4b75c41f7:
     resolution: {integrity: sha512-qzK83DgB+mxklk3PQC2nuTGPQD/8ogw1nXSmaQpyXAyhzcz4CXAZ9Swl/Ee9A/bvPwQGnSHSP3xqIYl8OkFtfw==}
     engines: {node: '>=14'}
     peerDependencies:
       react: ^16.8.4 || ^17.0.0
       react-dom: ^16.8.4 || ^17.0.0
     dependencies:
-      '@docusaurus/core': 2.0.0-beta.18_fdtqczkawcrswx4npptvkurkw4
+      '@docusaurus/core': 2.0.0-beta.18_66c8c36abcfdbeab71528ce4b75c41f7
       '@docusaurus/logger': 2.0.0-beta.18
-      '@docusaurus/mdx-loader': 2.0.0-beta.18_sfoxds7t5ydpegc3knd667wn6m
+      '@docusaurus/mdx-loader': 2.0.0-beta.18_react-dom@17.0.2+react@17.0.2
       '@docusaurus/utils': 2.0.0-beta.18
       '@docusaurus/utils-common': 2.0.0-beta.18
       '@docusaurus/utils-validation': 2.0.0-beta.18
@@ -3701,16 +3699,16 @@ packages:
       - webpack-cli
     dev: false
 
-  /@docusaurus/plugin-content-docs/2.0.0-beta.18_fdtqczkawcrswx4npptvkurkw4:
+  /@docusaurus/plugin-content-docs/2.0.0-beta.18_66c8c36abcfdbeab71528ce4b75c41f7:
     resolution: {integrity: sha512-z4LFGBJuzn4XQiUA7OEA2SZTqlp+IYVjd3NrCk/ZUfNi1tsTJS36ATkk9Y6d0Nsp7K2kRXqaXPsz4adDgeIU+Q==}
     engines: {node: '>=14'}
     peerDependencies:
       react: ^16.8.4 || ^17.0.0
       react-dom: ^16.8.4 || ^17.0.0
     dependencies:
-      '@docusaurus/core': 2.0.0-beta.18_fdtqczkawcrswx4npptvkurkw4
+      '@docusaurus/core': 2.0.0-beta.18_66c8c36abcfdbeab71528ce4b75c41f7
       '@docusaurus/logger': 2.0.0-beta.18
-      '@docusaurus/mdx-loader': 2.0.0-beta.18_sfoxds7t5ydpegc3knd667wn6m
+      '@docusaurus/mdx-loader': 2.0.0-beta.18_react-dom@17.0.2+react@17.0.2
       '@docusaurus/utils': 2.0.0-beta.18
       '@docusaurus/utils-validation': 2.0.0-beta.18
       combine-promises: 1.1.0
@@ -3740,15 +3738,15 @@ packages:
       - webpack-cli
     dev: false
 
-  /@docusaurus/plugin-content-pages/2.0.0-beta.18_fdtqczkawcrswx4npptvkurkw4:
+  /@docusaurus/plugin-content-pages/2.0.0-beta.18_66c8c36abcfdbeab71528ce4b75c41f7:
     resolution: {integrity: sha512-CJ2Xeb9hQrMeF4DGywSDVX2TFKsQpc8ZA7czyeBAAbSFsoRyxXPYeSh8aWljqR4F1u/EKGSKy0Shk/D4wumaHw==}
     engines: {node: '>=14'}
     peerDependencies:
       react: ^16.8.4 || ^17.0.0
       react-dom: ^16.8.4 || ^17.0.0
     dependencies:
-      '@docusaurus/core': 2.0.0-beta.18_fdtqczkawcrswx4npptvkurkw4
-      '@docusaurus/mdx-loader': 2.0.0-beta.18_sfoxds7t5ydpegc3knd667wn6m
+      '@docusaurus/core': 2.0.0-beta.18_66c8c36abcfdbeab71528ce4b75c41f7
+      '@docusaurus/mdx-loader': 2.0.0-beta.18_react-dom@17.0.2+react@17.0.2
       '@docusaurus/utils': 2.0.0-beta.18
       '@docusaurus/utils-validation': 2.0.0-beta.18
       fs-extra: 10.1.0
@@ -3773,19 +3771,19 @@ packages:
       - webpack-cli
     dev: false
 
-  /@docusaurus/plugin-debug/2.0.0-beta.18_fdtqczkawcrswx4npptvkurkw4:
+  /@docusaurus/plugin-debug/2.0.0-beta.18_66c8c36abcfdbeab71528ce4b75c41f7:
     resolution: {integrity: sha512-inLnLERgG7q0WlVmK6nYGHwVqREz13ivkynmNygEibJZToFRdgnIPW+OwD8QzgC5MpQTJw7+uYjcitpBumy1Gw==}
     engines: {node: '>=14'}
     peerDependencies:
       react: ^16.8.4 || ^17.0.0
       react-dom: ^16.8.4 || ^17.0.0
     dependencies:
-      '@docusaurus/core': 2.0.0-beta.18_fdtqczkawcrswx4npptvkurkw4
+      '@docusaurus/core': 2.0.0-beta.18_66c8c36abcfdbeab71528ce4b75c41f7
       '@docusaurus/utils': 2.0.0-beta.18
       fs-extra: 10.1.0
       react: 17.0.2
       react-dom: 17.0.2_react@17.0.2
-      react-json-view: 1.21.3_sfoxds7t5ydpegc3knd667wn6m
+      react-json-view: 1.21.3_react-dom@17.0.2+react@17.0.2
       tslib: 2.3.1
     transitivePeerDependencies:
       - '@parcel/css'
@@ -3805,14 +3803,14 @@ packages:
       - webpack-cli
     dev: false
 
-  /@docusaurus/plugin-google-analytics/2.0.0-beta.18_fdtqczkawcrswx4npptvkurkw4:
+  /@docusaurus/plugin-google-analytics/2.0.0-beta.18_66c8c36abcfdbeab71528ce4b75c41f7:
     resolution: {integrity: sha512-s9dRBWDrZ1uu3wFXPCF7yVLo/+5LUFAeoxpXxzory8gn9GYDt8ZDj80h5DUyCLxiy72OG6bXWNOYS/Vc6cOPXQ==}
     engines: {node: '>=14'}
     peerDependencies:
       react: ^16.8.4 || ^17.0.0
       react-dom: ^16.8.4 || ^17.0.0
     dependencies:
-      '@docusaurus/core': 2.0.0-beta.18_fdtqczkawcrswx4npptvkurkw4
+      '@docusaurus/core': 2.0.0-beta.18_66c8c36abcfdbeab71528ce4b75c41f7
       '@docusaurus/utils-validation': 2.0.0-beta.18
       react: 17.0.2
       react-dom: 17.0.2_react@17.0.2
@@ -3833,14 +3831,14 @@ packages:
       - webpack-cli
     dev: false
 
-  /@docusaurus/plugin-google-gtag/2.0.0-beta.18_fdtqczkawcrswx4npptvkurkw4:
+  /@docusaurus/plugin-google-gtag/2.0.0-beta.18_66c8c36abcfdbeab71528ce4b75c41f7:
     resolution: {integrity: sha512-h7vPuLVo/9pHmbFcvb4tCpjg4SxxX4k+nfVDyippR254FM++Z/nA5pRB0WvvIJ3ZTe0ioOb5Wlx2xdzJIBHUNg==}
     engines: {node: '>=14'}
     peerDependencies:
       react: ^16.8.4 || ^17.0.0
       react-dom: ^16.8.4 || ^17.0.0
     dependencies:
-      '@docusaurus/core': 2.0.0-beta.18_fdtqczkawcrswx4npptvkurkw4
+      '@docusaurus/core': 2.0.0-beta.18_66c8c36abcfdbeab71528ce4b75c41f7
       '@docusaurus/utils-validation': 2.0.0-beta.18
       react: 17.0.2
       react-dom: 17.0.2_react@17.0.2
@@ -3861,14 +3859,14 @@ packages:
       - webpack-cli
     dev: false
 
-  /@docusaurus/plugin-sitemap/2.0.0-beta.18_fdtqczkawcrswx4npptvkurkw4:
+  /@docusaurus/plugin-sitemap/2.0.0-beta.18_66c8c36abcfdbeab71528ce4b75c41f7:
     resolution: {integrity: sha512-Klonht0Ye3FivdBpS80hkVYNOH+8lL/1rbCPEV92rKhwYdwnIejqhdKct4tUTCl8TYwWiyeUFQqobC/5FNVZPQ==}
     engines: {node: '>=14'}
     peerDependencies:
       react: ^16.8.4 || ^17.0.0
       react-dom: ^16.8.4 || ^17.0.0
     dependencies:
-      '@docusaurus/core': 2.0.0-beta.18_fdtqczkawcrswx4npptvkurkw4
+      '@docusaurus/core': 2.0.0-beta.18_66c8c36abcfdbeab71528ce4b75c41f7
       '@docusaurus/utils': 2.0.0-beta.18
       '@docusaurus/utils-common': 2.0.0-beta.18
       '@docusaurus/utils-validation': 2.0.0-beta.18
@@ -3893,24 +3891,24 @@ packages:
       - webpack-cli
     dev: false
 
-  /@docusaurus/preset-classic/2.0.0-beta.18_fdtqczkawcrswx4npptvkurkw4:
+  /@docusaurus/preset-classic/2.0.0-beta.18_66c8c36abcfdbeab71528ce4b75c41f7:
     resolution: {integrity: sha512-TfDulvFt/vLWr/Yy7O0yXgwHtJhdkZ739bTlFNwEkRMAy8ggi650e52I1I0T79s67llecb4JihgHPW+mwiVkCQ==}
     engines: {node: '>=14'}
     peerDependencies:
       react: ^16.8.4 || ^17.0.0
       react-dom: ^16.8.4 || ^17.0.0
     dependencies:
-      '@docusaurus/core': 2.0.0-beta.18_fdtqczkawcrswx4npptvkurkw4
-      '@docusaurus/plugin-content-blog': 2.0.0-beta.18_fdtqczkawcrswx4npptvkurkw4
-      '@docusaurus/plugin-content-docs': 2.0.0-beta.18_fdtqczkawcrswx4npptvkurkw4
-      '@docusaurus/plugin-content-pages': 2.0.0-beta.18_fdtqczkawcrswx4npptvkurkw4
-      '@docusaurus/plugin-debug': 2.0.0-beta.18_fdtqczkawcrswx4npptvkurkw4
-      '@docusaurus/plugin-google-analytics': 2.0.0-beta.18_fdtqczkawcrswx4npptvkurkw4
-      '@docusaurus/plugin-google-gtag': 2.0.0-beta.18_fdtqczkawcrswx4npptvkurkw4
-      '@docusaurus/plugin-sitemap': 2.0.0-beta.18_fdtqczkawcrswx4npptvkurkw4
-      '@docusaurus/theme-classic': 2.0.0-beta.18_fdtqczkawcrswx4npptvkurkw4
-      '@docusaurus/theme-common': 2.0.0-beta.18_fdtqczkawcrswx4npptvkurkw4
-      '@docusaurus/theme-search-algolia': 2.0.0-beta.18_fdtqczkawcrswx4npptvkurkw4
+      '@docusaurus/core': 2.0.0-beta.18_66c8c36abcfdbeab71528ce4b75c41f7
+      '@docusaurus/plugin-content-blog': 2.0.0-beta.18_66c8c36abcfdbeab71528ce4b75c41f7
+      '@docusaurus/plugin-content-docs': 2.0.0-beta.18_66c8c36abcfdbeab71528ce4b75c41f7
+      '@docusaurus/plugin-content-pages': 2.0.0-beta.18_66c8c36abcfdbeab71528ce4b75c41f7
+      '@docusaurus/plugin-debug': 2.0.0-beta.18_66c8c36abcfdbeab71528ce4b75c41f7
+      '@docusaurus/plugin-google-analytics': 2.0.0-beta.18_66c8c36abcfdbeab71528ce4b75c41f7
+      '@docusaurus/plugin-google-gtag': 2.0.0-beta.18_66c8c36abcfdbeab71528ce4b75c41f7
+      '@docusaurus/plugin-sitemap': 2.0.0-beta.18_66c8c36abcfdbeab71528ce4b75c41f7
+      '@docusaurus/theme-classic': 2.0.0-beta.18_66c8c36abcfdbeab71528ce4b75c41f7
+      '@docusaurus/theme-common': 2.0.0-beta.18_66c8c36abcfdbeab71528ce4b75c41f7
+      '@docusaurus/theme-search-algolia': 2.0.0-beta.18_66c8c36abcfdbeab71528ce4b75c41f7
       react: 17.0.2
       react-dom: 17.0.2_react@17.0.2
     transitivePeerDependencies:
@@ -3942,18 +3940,18 @@ packages:
       react: 17.0.2
     dev: false
 
-  /@docusaurus/theme-classic/2.0.0-beta.18_fdtqczkawcrswx4npptvkurkw4:
+  /@docusaurus/theme-classic/2.0.0-beta.18_66c8c36abcfdbeab71528ce4b75c41f7:
     resolution: {integrity: sha512-WJWofvSGKC4Luidk0lyUwkLnO3DDynBBHwmt4QrV+aAVWWSOHUjA2mPOF6GLGuzkZd3KfL9EvAfsU0aGE1Hh5g==}
     engines: {node: '>=14'}
     peerDependencies:
       react: ^16.8.4 || ^17.0.0
       react-dom: ^16.8.4 || ^17.0.0
     dependencies:
-      '@docusaurus/core': 2.0.0-beta.18_fdtqczkawcrswx4npptvkurkw4
-      '@docusaurus/plugin-content-blog': 2.0.0-beta.18_fdtqczkawcrswx4npptvkurkw4
-      '@docusaurus/plugin-content-docs': 2.0.0-beta.18_fdtqczkawcrswx4npptvkurkw4
-      '@docusaurus/plugin-content-pages': 2.0.0-beta.18_fdtqczkawcrswx4npptvkurkw4
-      '@docusaurus/theme-common': 2.0.0-beta.18_fdtqczkawcrswx4npptvkurkw4
+      '@docusaurus/core': 2.0.0-beta.18_66c8c36abcfdbeab71528ce4b75c41f7
+      '@docusaurus/plugin-content-blog': 2.0.0-beta.18_66c8c36abcfdbeab71528ce4b75c41f7
+      '@docusaurus/plugin-content-docs': 2.0.0-beta.18_66c8c36abcfdbeab71528ce4b75c41f7
+      '@docusaurus/plugin-content-pages': 2.0.0-beta.18_66c8c36abcfdbeab71528ce4b75c41f7
+      '@docusaurus/theme-common': 2.0.0-beta.18_66c8c36abcfdbeab71528ce4b75c41f7
       '@docusaurus/theme-translations': 2.0.0-beta.18
       '@docusaurus/utils': 2.0.0-beta.18
       '@docusaurus/utils-common': 2.0.0-beta.18
@@ -3986,17 +3984,17 @@ packages:
       - webpack-cli
     dev: false
 
-  /@docusaurus/theme-common/2.0.0-beta.18_fdtqczkawcrswx4npptvkurkw4:
+  /@docusaurus/theme-common/2.0.0-beta.18_66c8c36abcfdbeab71528ce4b75c41f7:
     resolution: {integrity: sha512-3pI2Q6ttScDVTDbuUKAx+TdC8wmwZ2hfWk8cyXxksvC9bBHcyzXhSgcK8LTsszn2aANyZ3e3QY2eNSOikTFyng==}
     engines: {node: '>=14'}
     peerDependencies:
       react: ^16.8.4 || ^17.0.0
       react-dom: ^16.8.4 || ^17.0.0
     dependencies:
-      '@docusaurus/module-type-aliases': 2.0.0-beta.18_sfoxds7t5ydpegc3knd667wn6m
-      '@docusaurus/plugin-content-blog': 2.0.0-beta.18_fdtqczkawcrswx4npptvkurkw4
-      '@docusaurus/plugin-content-docs': 2.0.0-beta.18_fdtqczkawcrswx4npptvkurkw4
-      '@docusaurus/plugin-content-pages': 2.0.0-beta.18_fdtqczkawcrswx4npptvkurkw4
+      '@docusaurus/module-type-aliases': 2.0.0-beta.18_react-dom@17.0.2+react@17.0.2
+      '@docusaurus/plugin-content-blog': 2.0.0-beta.18_66c8c36abcfdbeab71528ce4b75c41f7
+      '@docusaurus/plugin-content-docs': 2.0.0-beta.18_66c8c36abcfdbeab71528ce4b75c41f7
+      '@docusaurus/plugin-content-pages': 2.0.0-beta.18_66c8c36abcfdbeab71528ce4b75c41f7
       clsx: 1.1.1
       parse-numeric-range: 1.3.0
       prism-react-renderer: 1.3.1_react@17.0.2
@@ -4020,18 +4018,18 @@ packages:
       - webpack-cli
     dev: false
 
-  /@docusaurus/theme-search-algolia/2.0.0-beta.18_fdtqczkawcrswx4npptvkurkw4:
+  /@docusaurus/theme-search-algolia/2.0.0-beta.18_66c8c36abcfdbeab71528ce4b75c41f7:
     resolution: {integrity: sha512-2w97KO/gnjI49WVtYQqENpQ8iO1Sem0yaTxw7/qv/ndlmIAQD0syU4yx6GsA7bTQCOGwKOWWzZSetCgUmTnWgA==}
     engines: {node: '>=14'}
     peerDependencies:
       react: ^16.8.4 || ^17.0.0
       react-dom: ^16.8.4 || ^17.0.0
     dependencies:
-      '@docsearch/react': 3.0.0_sfoxds7t5ydpegc3knd667wn6m
-      '@docusaurus/core': 2.0.0-beta.18_fdtqczkawcrswx4npptvkurkw4
+      '@docsearch/react': 3.0.0_react-dom@17.0.2+react@17.0.2
+      '@docusaurus/core': 2.0.0-beta.18_66c8c36abcfdbeab71528ce4b75c41f7
       '@docusaurus/logger': 2.0.0-beta.18
-      '@docusaurus/plugin-content-docs': 2.0.0-beta.18_fdtqczkawcrswx4npptvkurkw4
-      '@docusaurus/theme-common': 2.0.0-beta.18_fdtqczkawcrswx4npptvkurkw4
+      '@docusaurus/plugin-content-docs': 2.0.0-beta.18_66c8c36abcfdbeab71528ce4b75c41f7
+      '@docusaurus/theme-common': 2.0.0-beta.18_66c8c36abcfdbeab71528ce4b75c41f7
       '@docusaurus/theme-translations': 2.0.0-beta.18
       '@docusaurus/utils': 2.0.0-beta.18
       '@docusaurus/utils-validation': 2.0.0-beta.18
@@ -4126,7 +4124,7 @@ packages:
       resolve-pathname: 3.0.0
       shelljs: 0.8.5
       tslib: 2.3.1
-      url-loader: 4.1.1_csgzzuwaerdr4d7s3u52mzcn7m
+      url-loader: 4.1.1_file-loader@6.2.0+webpack@5.72.0
       webpack: 5.72.0
     transitivePeerDependencies:
       - '@swc/core'
@@ -4154,7 +4152,7 @@ packages:
     resolution: {integrity: sha512-igX9a37DR2ZPGYtV6suZ6whr8pTFtyHL3K/oLUotxpSVO2ASaprmAe2Dkq7tBo7CRY7MMDrAa9nuQP9/YG8FxQ==}
     dev: false
 
-  /@emotion/react/11.7.1_ci6b7qrbzfuzg4ahcdqxg6om2y:
+  /@emotion/react/11.7.1_@types+react@18.0.8+react@18.1.0:
     resolution: {integrity: sha512-DV2Xe3yhkF1yT4uAUoJcYL1AmrnO5SVsdfvu+fBuS7IbByDeTVx9+wFmvx9Idzv7/78+9Mgx2Hcmr7Fex3tIyw==}
     peerDependencies:
       '@babel/core': ^7.0.0
@@ -4166,6 +4164,30 @@ packages:
       '@types/react':
         optional: true
     dependencies:
+      '@babel/runtime': 7.17.9
+      '@emotion/cache': 11.7.1
+      '@emotion/serialize': 1.0.2
+      '@emotion/sheet': 1.1.0
+      '@emotion/utils': 1.0.0
+      '@emotion/weak-memoize': 0.2.5
+      '@types/react': 18.0.8
+      hoist-non-react-statics: 3.3.2
+      react: 18.1.0
+    dev: false
+
+  /@emotion/react/11.7.1_e307289084c0d0f4b25b50629c6033a9:
+    resolution: {integrity: sha512-DV2Xe3yhkF1yT4uAUoJcYL1AmrnO5SVsdfvu+fBuS7IbByDeTVx9+wFmvx9Idzv7/78+9Mgx2Hcmr7Fex3tIyw==}
+    peerDependencies:
+      '@babel/core': ^7.0.0
+      '@types/react': '*'
+      react: '>=16.8.0'
+    peerDependenciesMeta:
+      '@babel/core':
+        optional: true
+      '@types/react':
+        optional: true
+    dependencies:
+      '@babel/core': 7.17.10
       '@babel/runtime': 7.17.9
       '@emotion/cache': 11.7.1
       '@emotion/serialize': 1.0.2
@@ -4217,7 +4239,7 @@ packages:
     resolution: {integrity: sha512-6U71C2Wp7r5XtFtQzYrW5iKFT67OixrSxjI4MptCHzdSVlgabczzqLe0ZSgnub/5Kp4hSbpDB1tMytZY9pwxxA==}
     dev: false
 
-  /@endemolshinegroup/cosmiconfig-typescript-loader/3.0.2_5roa5pjqgcqkkeethcdwmsg7dm:
+  /@endemolshinegroup/cosmiconfig-typescript-loader/3.0.2_ec5c0ebd3030a0a5109338876648df1b:
     resolution: {integrity: sha512-QRVtqJuS1mcT56oHpVegkKBlgtWjXw/gHNWO3eL9oyB5Sc7HBoc2OLG/nYpVfT/Jejvo3NUrD0Udk7XgoyDKkA==}
     engines: {node: '>=10.0.0'}
     peerDependencies:
@@ -4241,7 +4263,7 @@ packages:
       graphql: 15.7.2
     dev: true
 
-  /@envelop/disable-introspection/3.3.1_carat5v6daninklp6tmzaivxae:
+  /@envelop/disable-introspection/3.3.1_102209f6be181a86a96ff4d99022b701:
     resolution: {integrity: sha512-THR8UnRQQB5nCLmITXvebwXwSHvFjS+ThA3RRVXpFX9EupMbTFN5a4NHty7+BYD798c3VrBZ/InbMlEWqw1c9g==}
     peerDependencies:
       '@envelop/core': ^2.3.1
@@ -4251,7 +4273,7 @@ packages:
       graphql: 15.7.2
     dev: true
 
-  /@envelop/parser-cache/4.3.1_carat5v6daninklp6tmzaivxae:
+  /@envelop/parser-cache/4.3.1_102209f6be181a86a96ff4d99022b701:
     resolution: {integrity: sha512-IqerCVjvVTiGvSZ8qSpdEc55hhiuekufJd0+ldWtyMPznhMaYOzpLifFUhjhhD7004eJM17n9vjJQFa7fIGz8Q==}
     peerDependencies:
       '@envelop/core': ^2.3.1
@@ -4270,7 +4292,7 @@ packages:
       graphql: 15.7.2
     dev: true
 
-  /@envelop/validation-cache/4.3.1_carat5v6daninklp6tmzaivxae:
+  /@envelop/validation-cache/4.3.1_102209f6be181a86a96ff4d99022b701:
     resolution: {integrity: sha512-lmtu9idhdWqbYkcFoFsL1ED4y38DLvj6EDEwE9tULXWuZm4WWmlNQAmKHAwB1d3kGVQAMtxM59crkOOJGRBgHQ==}
     peerDependencies:
       '@envelop/core': ^2.3.1
@@ -4307,7 +4329,7 @@ packages:
     resolution: {integrity: sha512-k2Ty1JcVojjJFwrg/ThKi2ujJ7XNLYaFGNB/bWT9wGR+oSMJHMa5w+CUq6p/pVrKeNNgA7pCqEcjSnHVoqJQFw==}
     dev: true
 
-  /@graphql-codegen/cli/2.6.2_gmfj57eud24hcocpgi4qxibj74:
+  /@graphql-codegen/cli/2.6.2_330a9efc941eb871384f32390ba029ff:
     resolution: {integrity: sha512-UO75msoVgvLEvfjCezM09cQQqp32+mR8Ma1ACsBpr7nroFvHbgcu2ulx1cMovg4sxDBCsvd9Eq/xOOMpARUxtw==}
     hasBin: true
     peerDependencies:
@@ -4322,8 +4344,8 @@ packages:
       '@graphql-tools/graphql-file-loader': 7.3.11_graphql@15.7.2
       '@graphql-tools/json-file-loader': 7.3.11_graphql@15.7.2
       '@graphql-tools/load': 7.5.10_graphql@15.7.2
-      '@graphql-tools/prisma-loader': 7.1.13_mzhmhjtioioqsihdrkhoc5w2oa
-      '@graphql-tools/url-loader': 7.9.14_mzhmhjtioioqsihdrkhoc5w2oa
+      '@graphql-tools/prisma-loader': 7.1.13_664ec3a668721d0920e38a8ee176da70
+      '@graphql-tools/url-loader': 7.9.14_664ec3a668721d0920e38a8ee176da70
       '@graphql-tools/utils': 8.6.9_graphql@15.7.2
       ansi-escapes: 4.3.2
       chalk: 4.1.2
@@ -4337,7 +4359,7 @@ packages:
       glob: 7.2.0
       globby: 11.1.0
       graphql: 15.7.2
-      graphql-config: 4.3.0_gmfj57eud24hcocpgi4qxibj74
+      graphql-config: 4.3.0_330a9efc941eb871384f32390ba029ff
       inquirer: 8.2.2
       is-glob: 4.0.3
       json-to-pretty-yaml: 1.2.2
@@ -4362,7 +4384,6 @@ packages:
       - typescript
       - utf-8-validate
       - zen-observable
-      - zenObservable
     dev: true
 
   /@graphql-codegen/core/2.5.1_graphql@15.7.2:
@@ -4428,7 +4449,7 @@ packages:
       - supports-color
     dev: true
 
-  /@graphql-codegen/typescript-react-apollo/3.2.11_uiakrmibzyjojycqgq5qw35buq:
+  /@graphql-codegen/typescript-react-apollo/3.2.11_a200a8b101ce12e4e050343b0b6fa1a4:
     resolution: {integrity: sha512-Bfo7/OprnWk/srhA/3I0cKySg/SyVPX3ZoxzTk6ChYVBsy69jKDkdPWwlmE7Fjfv7+5G+xXb99OoqUUgBLma3w==}
     peerDependencies:
       graphql: ^0.8.0 || ^0.9.0 || ^0.10.0 || ^0.11.0 || ^0.12.0 || ^0.13.0 || ^14.0.0 || ^15.0.0 || ^16.0.0
@@ -4653,12 +4674,12 @@ packages:
       tslib: 2.3.1
     dev: true
 
-  /@graphql-tools/prisma-loader/7.1.13_mzhmhjtioioqsihdrkhoc5w2oa:
+  /@graphql-tools/prisma-loader/7.1.13_664ec3a668721d0920e38a8ee176da70:
     resolution: {integrity: sha512-rctgCI11ZjPJd4ncNTV7mmjV2WN2LRL3aTuTJWHjudO+iJPgoWyor0idl+aP0fOX2GnDK7zASmWwVShuGBJb9g==}
     peerDependencies:
       graphql: ^14.0.0 || ^15.0.0 || ^16.0.0
     dependencies:
-      '@graphql-tools/url-loader': 7.9.14_mzhmhjtioioqsihdrkhoc5w2oa
+      '@graphql-tools/url-loader': 7.9.14_664ec3a668721d0920e38a8ee176da70
       '@graphql-tools/utils': 8.6.9_graphql@15.7.2
       '@types/js-yaml': 4.0.5
       '@types/json-stable-stringify': 1.0.34
@@ -4713,7 +4734,7 @@ packages:
       value-or-promise: 1.0.11
     dev: true
 
-  /@graphql-tools/url-loader/7.9.14_mzhmhjtioioqsihdrkhoc5w2oa:
+  /@graphql-tools/url-loader/7.9.14_664ec3a668721d0920e38a8ee176da70:
     resolution: {integrity: sha512-7IXiqUYp0cHeM+qvgjM4jAq8uJhl3PDdQYkyIj5wzZ7XjrkdV3JjPt0cHj2IBIeEwQJOjEKNeFYXjOlg73guCQ==}
     peerDependencies:
       graphql: ^14.0.0 || ^15.0.0 || ^16.0.0
@@ -4777,9 +4798,9 @@ packages:
       graphql: ^15.2.0 || ^16.0.0
     dependencies:
       '@envelop/core': 2.3.1_graphql@15.7.2
-      '@envelop/disable-introspection': 3.3.1_carat5v6daninklp6tmzaivxae
-      '@envelop/parser-cache': 4.3.1_carat5v6daninklp6tmzaivxae
-      '@envelop/validation-cache': 4.3.1_carat5v6daninklp6tmzaivxae
+      '@envelop/disable-introspection': 3.3.1_102209f6be181a86a96ff4d99022b701
+      '@envelop/parser-cache': 4.3.1_102209f6be181a86a96ff4d99022b701
+      '@envelop/validation-cache': 4.3.1_102209f6be181a86a96ff4d99022b701
       '@graphql-tools/schema': 8.3.10_graphql@15.7.2
       '@graphql-tools/utils': 8.6.9_graphql@15.7.2
       '@graphql-typed-document-node/core': 3.1.1_graphql@15.7.2
@@ -4823,7 +4844,7 @@ packages:
     dependencies:
       '@hapi/hoek': 9.3.0
 
-  /@headlessui/react/1.5.0_sfoxds7t5ydpegc3knd667wn6m:
+  /@headlessui/react/1.5.0_react-dom@17.0.2+react@17.0.2:
     resolution: {integrity: sha512-aaRnYxBb3MU2FNJf3Ut9RMTUqqU3as0aI1lQhgo2n9Fa67wRu14iOGqx93xB+uMNVfNwZ5B3y/Ndm7qZGuFeMQ==}
     engines: {node: '>=10'}
     peerDependencies:
@@ -5152,7 +5173,7 @@ packages:
     resolution: {integrity: sha512-nkalE/f1RvRGChwBnEIoBfSEYOXnCRdleKuv6+lePbMDrMZXeDQnqak5XDOeBgrPPyPfAdcCu/B5z+v3VhplGg==}
     dev: false
 
-  /@mantine/core/4.2.2_zg4p567angkgzzlgt52zcfrhle:
+  /@mantine/core/4.2.2_c9b8fefbe069946ce5669f7591162759:
     resolution: {integrity: sha512-K8m9oNUs1dqE9qoqXcjrum0rCpG+M9245Q7Qh1FezOPyrdUcfSFVvfrBguuGnWtQXOm0EpWwG7Wqj4uojgjQng==}
     peerDependencies:
       '@mantine/hooks': 4.2.2
@@ -5160,13 +5181,33 @@ packages:
       react-dom: '>=16.8.0'
     dependencies:
       '@mantine/hooks': 4.2.2_react@18.1.0
-      '@mantine/styles': 4.2.2_i6xcbgvvylvakhe2evaee3dlf4
+      '@mantine/styles': 4.2.2_47ae209ab5c2ea051c9a2540426c6b2f
       '@popperjs/core': 2.11.5
       '@radix-ui/react-scroll-area': 0.1.4_react@18.1.0
       react: 18.1.0
       react-dom: 18.1.0_react@18.1.0
-      react-popper: 2.3.0_42yiot2n2wjamynwfzzmd7tk3i
-      react-textarea-autosize: 8.3.3_ci6b7qrbzfuzg4ahcdqxg6om2y
+      react-popper: 2.3.0_e6b0874f4dd5920661b62e72c1fe6ada
+      react-textarea-autosize: 8.3.3_@types+react@18.0.8+react@18.1.0
+    transitivePeerDependencies:
+      - '@babel/core'
+      - '@types/react'
+    dev: false
+
+  /@mantine/core/4.2.2_ea9d0c51a4562a6544166c6277bf397c:
+    resolution: {integrity: sha512-K8m9oNUs1dqE9qoqXcjrum0rCpG+M9245Q7Qh1FezOPyrdUcfSFVvfrBguuGnWtQXOm0EpWwG7Wqj4uojgjQng==}
+    peerDependencies:
+      '@mantine/hooks': 4.2.2
+      react: '>=16.8.0'
+      react-dom: '>=16.8.0'
+    dependencies:
+      '@mantine/hooks': 4.2.2_react@18.1.0
+      '@mantine/styles': 4.2.2_b49546c5ecaa39f6ec18d9e420cad0ed
+      '@popperjs/core': 2.11.5
+      '@radix-ui/react-scroll-area': 0.1.4_react@18.1.0
+      react: 18.1.0
+      react-dom: 18.1.0_react@18.1.0
+      react-popper: 2.3.0_e6b0874f4dd5920661b62e72c1fe6ada
+      react-textarea-autosize: 8.3.3_@types+react@18.0.8+react@18.1.0
     transitivePeerDependencies:
       - '@babel/core'
       - '@types/react'
@@ -5180,15 +5221,15 @@ packages:
       react: 18.1.0
     dev: false
 
-  /@mantine/next/4.2.2_2difmhutoxsf46pey4x65e3hyi:
+  /@mantine/next/4.2.2_d0d0561e9375e45e79e4c72fee9367c2:
     resolution: {integrity: sha512-KuRZHzQ6Asp5y78JqBZlwxXjmxbC27tFCwqDTDD4X6ypsdEqILgxSyBC1um+kFzi5hfauftLQ5Q8FGdiEtPfsA==}
     peerDependencies:
       next: '*'
       react: '>=16.8.0'
       react-dom: '>=16.8.0'
     dependencies:
-      '@mantine/ssr': 4.2.2_i6xcbgvvylvakhe2evaee3dlf4
-      next: 12.1.6_ef5jwxihqo6n7gxfmzogljlgcm
+      '@mantine/ssr': 4.2.2_47ae209ab5c2ea051c9a2540426c6b2f
+      next: 12.1.6_react-dom@18.1.0+react@18.1.0
       react: 18.1.0
       react-dom: 18.1.0_react@18.1.0
     transitivePeerDependencies:
@@ -5197,7 +5238,7 @@ packages:
       - '@types/react'
     dev: false
 
-  /@mantine/notifications/4.2.2_v5dmohwpkggin643o3ukrg3qbi:
+  /@mantine/notifications/4.2.2_af46c71ecf518c86fb9b76e8a89b700a:
     resolution: {integrity: sha512-QC0j74jcQs0zsljgjEb8UicsIFfxKayZRVlEefrBzJUbm89bs+TOzHugL2GL+IMJ1WSQKTI9YWvGXVbf8ZCzww==}
     peerDependencies:
       '@mantine/core': 4.2.2
@@ -5205,14 +5246,14 @@ packages:
       react: '>=16.8.0'
       react-dom: '>=16.8.0'
     dependencies:
-      '@mantine/core': 4.2.2_zg4p567angkgzzlgt52zcfrhle
+      '@mantine/core': 4.2.2_c9b8fefbe069946ce5669f7591162759
       '@mantine/hooks': 4.2.2_react@18.1.0
       react: 18.1.0
       react-dom: 18.1.0_react@18.1.0
-      react-transition-group: 4.4.2_ef5jwxihqo6n7gxfmzogljlgcm
+      react-transition-group: 4.4.2_react-dom@18.1.0+react@18.1.0
     dev: false
 
-  /@mantine/prism/4.2.2_v5dmohwpkggin643o3ukrg3qbi:
+  /@mantine/prism/4.2.2_af46c71ecf518c86fb9b76e8a89b700a:
     resolution: {integrity: sha512-I3S7xAX74EQD8LNO/FuyR5EHNAhcNaWcXcEQZZITTYKbUv3/ieAcV8k5DybWa2FbFtVEhCSTrT+9YIjhIcGWOA==}
     peerDependencies:
       '@mantine/core': 4.2.2
@@ -5220,25 +5261,25 @@ packages:
       react: '>=16.8.0'
       react-dom: '>=16.8.0'
     dependencies:
-      '@mantine/core': 4.2.2_zg4p567angkgzzlgt52zcfrhle
+      '@mantine/core': 4.2.2_ea9d0c51a4562a6544166c6277bf397c
       '@mantine/hooks': 4.2.2_react@18.1.0
       prism-react-renderer: 1.3.1_react@18.1.0
       react: 18.1.0
       react-dom: 18.1.0_react@18.1.0
     dev: false
 
-  /@mantine/ssr/4.2.2_i6xcbgvvylvakhe2evaee3dlf4:
+  /@mantine/ssr/4.2.2_47ae209ab5c2ea051c9a2540426c6b2f:
     resolution: {integrity: sha512-xZV+kAgiDIGoxTRXJFoY8LqjxTzmvX1YxRO5QCK0Ky7JuA/iiCwSDsHf5fRqGj6e/ZNJh0MHr/M52PdpYBrpuQ==}
     peerDependencies:
       react: '>=16.8.0'
       react-dom: '>=16.8.0'
     dependencies:
       '@emotion/cache': 11.7.1
-      '@emotion/react': 11.7.1_ci6b7qrbzfuzg4ahcdqxg6om2y
+      '@emotion/react': 11.7.1_@types+react@18.0.8+react@18.1.0
       '@emotion/serialize': 1.0.2
       '@emotion/server': 11.4.0
       '@emotion/utils': 1.0.0
-      '@mantine/styles': 4.2.2_i6xcbgvvylvakhe2evaee3dlf4
+      '@mantine/styles': 4.2.2_47ae209ab5c2ea051c9a2540426c6b2f
       csstype: 3.0.9
       html-react-parser: 1.3.0_react@18.1.0
       react: 18.1.0
@@ -5249,14 +5290,33 @@ packages:
       - '@types/react'
     dev: false
 
-  /@mantine/styles/4.2.2_i6xcbgvvylvakhe2evaee3dlf4:
+  /@mantine/styles/4.2.2_47ae209ab5c2ea051c9a2540426c6b2f:
     resolution: {integrity: sha512-0aPm0Zc3zFOGOT1ZGAShBg+/rE+hMU81ZJk4guEWv1j8snoqg55y9G9mIpfsgffkQc0NhkGAX++CAA/0BBSxFQ==}
     peerDependencies:
       react: '>=16.8.0'
       react-dom: '>=16.8.0'
     dependencies:
       '@emotion/cache': 11.7.1
-      '@emotion/react': 11.7.1_ci6b7qrbzfuzg4ahcdqxg6om2y
+      '@emotion/react': 11.7.1_@types+react@18.0.8+react@18.1.0
+      '@emotion/serialize': 1.0.2
+      '@emotion/utils': 1.0.0
+      clsx: 1.1.1
+      csstype: 3.0.9
+      react: 18.1.0
+      react-dom: 18.1.0_react@18.1.0
+    transitivePeerDependencies:
+      - '@babel/core'
+      - '@types/react'
+    dev: false
+
+  /@mantine/styles/4.2.2_b49546c5ecaa39f6ec18d9e420cad0ed:
+    resolution: {integrity: sha512-0aPm0Zc3zFOGOT1ZGAShBg+/rE+hMU81ZJk4guEWv1j8snoqg55y9G9mIpfsgffkQc0NhkGAX++CAA/0BBSxFQ==}
+    peerDependencies:
+      react: '>=16.8.0'
+      react-dom: '>=16.8.0'
+    dependencies:
+      '@emotion/cache': 11.7.1
+      '@emotion/react': 11.7.1_e307289084c0d0f4b25b50629c6033a9
       '@emotion/serialize': 1.0.2
       '@emotion/utils': 1.0.0
       clsx: 1.1.1
@@ -5352,7 +5412,6 @@ packages:
       url-regex-safe: 3.0.0_re2@1.17.4
       video-extensions: 1.2.0
     transitivePeerDependencies:
-      - bluebird
       - bufferutil
       - canvas
       - supports-color
@@ -5801,10 +5860,8 @@ packages:
       zen-observable:
         optional: true
     dependencies:
-      any-observable: 0.3.0_rxjs@6.6.7
+      any-observable: 0.3.0
       rxjs: 6.6.7
-    transitivePeerDependencies:
-      - zenObservable
     dev: true
 
   /@sideway/address/4.1.4:
@@ -6605,7 +6662,7 @@ packages:
       '@types/yargs-parser': 21.0.0
     dev: true
 
-  /@typescript-eslint/eslint-plugin/5.22.0_w4ajklk3bpbkv4oq2x7ogihpc4:
+  /@typescript-eslint/eslint-plugin/5.22.0_b700952d5b0bc2aaf1d0d5fee320ef17:
     resolution: {integrity: sha512-YCiy5PUzpAeOPGQ7VSGDEY2NeYUV1B0swde2e0HzokRsHBYjSdF6DZ51OuRZxVPHx0032lXGLvOMls91D8FXlg==}
     engines: {node: ^12.22.0 || ^14.17.0 || >=16.0.0}
     peerDependencies:
@@ -6616,10 +6673,10 @@ packages:
       typescript:
         optional: true
     dependencies:
-      '@typescript-eslint/parser': 5.22.0_sdq423wcawycjzugemfabbjutq
+      '@typescript-eslint/parser': 5.22.0_eslint@8.14.0+typescript@4.5.5
       '@typescript-eslint/scope-manager': 5.22.0
-      '@typescript-eslint/type-utils': 5.22.0_sdq423wcawycjzugemfabbjutq
-      '@typescript-eslint/utils': 5.22.0_sdq423wcawycjzugemfabbjutq
+      '@typescript-eslint/type-utils': 5.22.0_eslint@8.14.0+typescript@4.5.5
+      '@typescript-eslint/utils': 5.22.0_eslint@8.14.0+typescript@4.5.5
       debug: 4.3.4
       eslint: 8.14.0
       functional-red-black-tree: 1.0.1
@@ -6632,13 +6689,13 @@ packages:
       - supports-color
     dev: true
 
-  /@typescript-eslint/experimental-utils/5.22.0_sdq423wcawycjzugemfabbjutq:
+  /@typescript-eslint/experimental-utils/5.22.0_eslint@8.14.0+typescript@4.5.5:
     resolution: {integrity: sha512-rKxoCUtAHwEH6IcAoVpqipY6Th+YKW7WFspAKu0IFdbdKZpveFBeqxxE9Xn+GWikhq1o03V3VXbxIe+GdhggiQ==}
     engines: {node: ^12.22.0 || ^14.17.0 || >=16.0.0}
     peerDependencies:
       eslint: ^6.0.0 || ^7.0.0 || ^8.0.0
     dependencies:
-      '@typescript-eslint/utils': 5.22.0_sdq423wcawycjzugemfabbjutq
+      '@typescript-eslint/utils': 5.22.0_eslint@8.14.0+typescript@4.5.5
       eslint: 8.14.0
     transitivePeerDependencies:
       - supports-color
@@ -6664,7 +6721,7 @@ packages:
       - supports-color
     dev: true
 
-  /@typescript-eslint/parser/5.22.0_sdq423wcawycjzugemfabbjutq:
+  /@typescript-eslint/parser/5.22.0_eslint@8.14.0+typescript@4.5.5:
     resolution: {integrity: sha512-piwC4krUpRDqPaPbFaycN70KCP87+PC5WZmrWs+DlVOxxmF+zI6b6hETv7Quy4s9wbkV16ikMeZgXsvzwI3icQ==}
     engines: {node: ^12.22.0 || ^14.17.0 || >=16.0.0}
     peerDependencies:
@@ -6700,7 +6757,7 @@ packages:
       '@typescript-eslint/visitor-keys': 5.22.0
     dev: true
 
-  /@typescript-eslint/type-utils/5.22.0_sdq423wcawycjzugemfabbjutq:
+  /@typescript-eslint/type-utils/5.22.0_eslint@8.14.0+typescript@4.5.5:
     resolution: {integrity: sha512-iqfLZIsZhK2OEJ4cQ01xOq3NaCuG5FQRKyHicA3xhZxMgaxQazLUHbH/B2k9y5i7l3+o+B5ND9Mf1AWETeMISA==}
     engines: {node: ^12.22.0 || ^14.17.0 || >=16.0.0}
     peerDependencies:
@@ -6710,7 +6767,7 @@ packages:
       typescript:
         optional: true
     dependencies:
-      '@typescript-eslint/utils': 5.22.0_sdq423wcawycjzugemfabbjutq
+      '@typescript-eslint/utils': 5.22.0_eslint@8.14.0+typescript@4.5.5
       debug: 4.3.4
       eslint: 8.14.0
       tsutils: 3.21.0_typescript@4.5.5
@@ -6771,7 +6828,7 @@ packages:
       - supports-color
     dev: true
 
-  /@typescript-eslint/utils/5.22.0_sdq423wcawycjzugemfabbjutq:
+  /@typescript-eslint/utils/5.22.0_eslint@8.14.0+typescript@4.5.5:
     resolution: {integrity: sha512-HodsGb037iobrWSUMS7QH6Hl1kppikjA1ELiJlNSTYf/UdMEwzgj0WIp+lBNb6WZ3zTwb0tEz51j0Wee3iJ3wQ==}
     engines: {node: ^12.22.0 || ^14.17.0 || >=16.0.0}
     peerDependencies:
@@ -6959,7 +7016,7 @@ packages:
       xstate: 4.31.0
     dev: true
 
-  /@xstate/react/2.0.1_mxz6tg6ny5uzqitzb7bw7ikoo4:
+  /@xstate/react/2.0.1_65f3e99bcdc7699822790fc36fa14e77:
     resolution: {integrity: sha512-sT3hxyzNBw+bm7uT3BP+uXzN0MnRqiaj/U9Yl4OYaMAUJXWsRvSA/ipL7EDf0gVLRGrRhJTCsC0cjWaduAAqnw==}
     peerDependencies:
       '@xstate/fsm': ^1.6.5
@@ -6972,7 +7029,7 @@ packages:
         optional: true
     dependencies:
       react: 18.1.0
-      use-isomorphic-layout-effect: 1.1.2_ci6b7qrbzfuzg4ahcdqxg6om2y
+      use-isomorphic-layout-effect: 1.1.2_@types+react@18.0.8+react@18.1.0
       use-subscription: 1.5.1_react@18.1.0
       xstate: 4.31.0
     transitivePeerDependencies:
@@ -7238,19 +7295,9 @@ packages:
     engines: {node: '>=12'}
     dev: false
 
-  /any-observable/0.3.0_rxjs@6.6.7:
+  /any-observable/0.3.0:
     resolution: {integrity: sha512-/FQM1EDkTsf63Ub2C6O7GuYFDsSXUwsaZDurV0np41ocwq0jthUAYCmhBX9f+KwlaCgIuWyr/4WlUQUBfKfZog==}
     engines: {node: '>=6'}
-    peerDependencies:
-      rxjs: '*'
-      zenObservable: '*'
-    peerDependenciesMeta:
-      rxjs:
-        optional: true
-      zenObservable:
-        optional: true
-    dependencies:
-      rxjs: 6.6.7
     dev: true
 
   /any-promise/1.3.0:
@@ -7463,7 +7510,7 @@ packages:
       - supports-color
     dev: true
 
-  /babel-loader/8.2.5_vs5hf2sl7hjtttp43d2vzw3qay:
+  /babel-loader/8.2.5_acba72ea4bf9d339cdfcd8f55cdb7006:
     resolution: {integrity: sha512-OSiFfH89LrEMiWd4pLNqGz4CwJDtbs2ZVc+iGu2HrkRfPxId9F2anQj38IxWpmRfsUY0aBZYi1EFcd3mhtRMLQ==}
     engines: {node: '>= 8.9'}
     peerDependencies:
@@ -7768,8 +7815,6 @@ packages:
       qs: 6.9.7
       raw-body: 2.4.3
       type-is: 1.6.18
-    transitivePeerDependencies:
-      - supports-color
 
   /bonjour-service/1.0.11:
     resolution: {integrity: sha512-drMprzr2rDTCtgEE3VgdA9uUFaUHF+jXduwYSThHJnKMYM+FhI9Z3ph+TX3xy0LtgYHae6CHYPJ/2UnK8nQHcA==}
@@ -7945,8 +7990,6 @@ packages:
       ssri: 8.0.1
       tar: 6.1.11
       unique-filename: 1.1.1
-    transitivePeerDependencies:
-      - bluebird
     dev: true
 
   /cacheable-request/6.1.0:
@@ -8437,8 +8480,6 @@ packages:
       on-headers: 1.0.2
       safe-buffer: 5.1.2
       vary: 1.1.2
-    transitivePeerDependencies:
-      - supports-color
     dev: false
 
   /concat-map/0.0.1:
@@ -8695,7 +8736,7 @@ packages:
       webpack: 5.72.0
     dev: false
 
-  /css-minimizer-webpack-plugin/3.4.1_tejugib4y3rw5hvgnfmxavjvsu:
+  /css-minimizer-webpack-plugin/3.4.1_clean-css@5.3.0+webpack@5.72.0:
     resolution: {integrity: sha512-1u6D71zeIfgngN2XNRJefc/hY7Ybsxd74Jm4qngIXyUEk7fss3VUzuHxLAq/R8NAba4QU9OUSaMZlbpRc7bM4Q==}
     engines: {node: '>= 12.13.0'}
     peerDependencies:
@@ -9423,21 +9464,11 @@ packages:
 
   /debug/2.6.9:
     resolution: {integrity: sha512-bC7ElrdJaJnPbAP+1EotYvqZsb3ecl5wi6Bfi6BJTUcNowp6cvspg0jXznRTKDjm/E7AdgFBVeAPVMNcKGsHMA==}
-    peerDependencies:
-      supports-color: '*'
-    peerDependenciesMeta:
-      supports-color:
-        optional: true
     dependencies:
       ms: 2.0.0
 
   /debug/3.2.7:
     resolution: {integrity: sha512-CFjzYYAi4ThfiQvizrFQevTTXHtnCqWfe7x1AhgEscTz6ZbLbfoLRLPugTQyBth6f8ZERVUSyWHFD/7Wu4t1XQ==}
-    peerDependencies:
-      supports-color: '*'
-    peerDependenciesMeta:
-      supports-color:
-        optional: true
     dependencies:
       ms: 2.1.3
 
@@ -9601,8 +9632,6 @@ packages:
     dependencies:
       address: 1.1.2
       debug: 2.6.9
-    transitivePeerDependencies:
-      - supports-color
     dev: false
 
   /detect-port/1.3.0:
@@ -9612,8 +9641,6 @@ packages:
     dependencies:
       address: 1.1.2
       debug: 2.6.9
-    transitivePeerDependencies:
-      - supports-color
     dev: false
 
   /detective/5.2.0:
@@ -10421,7 +10448,7 @@ packages:
       source-map: 0.6.1
     dev: true
 
-  /eslint-config-next/12.0.10_otyth6o2424wisqc4eno5l4teu:
+  /eslint-config-next/12.0.10_next@12.1.6+typescript@4.5.5:
     resolution: {integrity: sha512-l1er6mwSo1bltjLwmd71p5BdT6k/NQxV1n4lKZI6xt3MDMrq7ChUBr+EecxOry8GC/rCRUtPpH8Ygs0BJc5YLg==}
     peerDependencies:
       eslint: ^7.23.0 || ^8.0.0
@@ -10435,51 +10462,44 @@ packages:
       '@rushstack/eslint-patch': 1.1.3
       '@typescript-eslint/parser': 5.20.0_typescript@4.5.5
       eslint-import-resolver-node: 0.3.6
-      eslint-import-resolver-typescript: 2.7.1_fkfqfehjtk7sk2efaqbgxsuasa
-      eslint-plugin-import: 2.26.0_t635sbcxoyku2geeidgiikfvme
+      eslint-import-resolver-typescript: 2.7.1_eslint-plugin-import@2.26.0
+      eslint-plugin-import: 2.26.0
       eslint-plugin-jsx-a11y: 6.5.1
       eslint-plugin-react: 7.29.4
       eslint-plugin-react-hooks: 4.4.0
-      next: 12.1.6_ef5jwxihqo6n7gxfmzogljlgcm
+      next: 12.1.6_react-dom@18.1.0+react@18.1.0
       typescript: 4.5.5
     transitivePeerDependencies:
-      - eslint-import-resolver-webpack
       - supports-color
     dev: true
 
-  /eslint-config-react-app/7.0.1_iilo2pjbcpzhr6eqe5ncsrl6jq:
+  /eslint-config-react-app/7.0.1_4216ed3d2113f278f890275a29457e4c:
     resolution: {integrity: sha512-K6rNzvkIeHaTd8m/QEh1Zko0KI7BACWkkneSs6s9cKZC/J27X3eZR6Upt1jkmZ/4FK+XUOPPxMEN7+lbUXfSlA==}
     engines: {node: '>=14.0.0'}
     peerDependencies:
       eslint: ^8.0.0
-      typescript: '*'
-    peerDependenciesMeta:
-      typescript:
-        optional: true
     dependencies:
       '@babel/core': 7.17.10
-      '@babel/eslint-parser': 7.17.0_ore52sp75uhoubdikfje6htfpm
+      '@babel/eslint-parser': 7.17.0_7449dd49ffed0eea046851524f1e657b
       '@rushstack/eslint-patch': 1.1.3
-      '@typescript-eslint/eslint-plugin': 5.22.0_w4ajklk3bpbkv4oq2x7ogihpc4
-      '@typescript-eslint/parser': 5.22.0_sdq423wcawycjzugemfabbjutq
+      '@typescript-eslint/eslint-plugin': 5.22.0_b700952d5b0bc2aaf1d0d5fee320ef17
+      '@typescript-eslint/parser': 5.22.0_eslint@8.14.0+typescript@4.5.5
       babel-preset-react-app: 10.0.1
       confusing-browser-globals: 1.0.11
       eslint: 8.14.0
-      eslint-plugin-flowtype: 8.0.3_bnjl7sn2qxwsoaiqrpavakq354
-      eslint-plugin-import: 2.26.0_as7czvxgrvaa35lzxztolpnp5a
-      eslint-plugin-jest: 25.7.0_gpyzlsvrtrblrtzdjncmeriqjy
+      eslint-plugin-flowtype: 8.0.3_0b52bfc9ba85ed2701108bc1502a1bef
+      eslint-plugin-import: 2.26.0_eslint@8.14.0
+      eslint-plugin-jest: 25.7.0_33f195cab19c42b8cf234b44c245104e
       eslint-plugin-jsx-a11y: 6.5.1_eslint@8.14.0
       eslint-plugin-react: 7.29.4_eslint@8.14.0
       eslint-plugin-react-hooks: 4.5.0_eslint@8.14.0
-      eslint-plugin-testing-library: 5.3.1_sdq423wcawycjzugemfabbjutq
-      typescript: 4.5.5
+      eslint-plugin-testing-library: 5.3.1_eslint@8.14.0+typescript@4.5.5
     transitivePeerDependencies:
       - '@babel/plugin-syntax-flow'
       - '@babel/plugin-transform-react-jsx'
-      - eslint-import-resolver-typescript
-      - eslint-import-resolver-webpack
       - jest
       - supports-color
+      - typescript
     dev: true
 
   /eslint-import-resolver-node/0.3.6:
@@ -10487,11 +10507,9 @@ packages:
     dependencies:
       debug: 3.2.7
       resolve: 1.22.0
-    transitivePeerDependencies:
-      - supports-color
     dev: true
 
-  /eslint-import-resolver-typescript/2.7.1_fkfqfehjtk7sk2efaqbgxsuasa:
+  /eslint-import-resolver-typescript/2.7.1_eslint-plugin-import@2.26.0:
     resolution: {integrity: sha512-00UbgGwV8bSgUv34igBDbTOtKhqoRMy9bFjNehT40bXg6585PNIct8HhXZ0SybqB9rWtXj9crcku8ndDn/gIqQ==}
     engines: {node: '>=4'}
     peerDependencies:
@@ -10499,7 +10517,7 @@ packages:
       eslint-plugin-import: '*'
     dependencies:
       debug: 4.3.4
-      eslint-plugin-import: 2.26.0_t635sbcxoyku2geeidgiikfvme
+      eslint-plugin-import: 2.26.0
       glob: 7.2.0
       is-glob: 4.0.3
       resolve: 1.22.0
@@ -10508,57 +10526,12 @@ packages:
       - supports-color
     dev: true
 
-  /eslint-module-utils/2.7.3_jbyz37hizqiddyo5guvrx6copq:
+  /eslint-module-utils/2.7.3:
     resolution: {integrity: sha512-088JEC7O3lDZM9xGe0RerkOMd0EjFl+Yvd1jPWIkMT5u3H9+HC34mWWPnqPrN13gieT9pBOO+Qt07Nb/6TresQ==}
     engines: {node: '>=4'}
-    peerDependencies:
-      '@typescript-eslint/parser': '*'
-      eslint-import-resolver-node: '*'
-      eslint-import-resolver-typescript: '*'
-      eslint-import-resolver-webpack: '*'
-    peerDependenciesMeta:
-      '@typescript-eslint/parser':
-        optional: true
-      eslint-import-resolver-node:
-        optional: true
-      eslint-import-resolver-typescript:
-        optional: true
-      eslint-import-resolver-webpack:
-        optional: true
     dependencies:
-      '@typescript-eslint/parser': 5.20.0_typescript@4.5.5
       debug: 3.2.7
-      eslint-import-resolver-node: 0.3.6
-      eslint-import-resolver-typescript: 2.7.1_fkfqfehjtk7sk2efaqbgxsuasa
       find-up: 2.1.0
-    transitivePeerDependencies:
-      - supports-color
-    dev: true
-
-  /eslint-module-utils/2.7.3_wex3ustmkv4ospy3s77r6ihlwq:
-    resolution: {integrity: sha512-088JEC7O3lDZM9xGe0RerkOMd0EjFl+Yvd1jPWIkMT5u3H9+HC34mWWPnqPrN13gieT9pBOO+Qt07Nb/6TresQ==}
-    engines: {node: '>=4'}
-    peerDependencies:
-      '@typescript-eslint/parser': '*'
-      eslint-import-resolver-node: '*'
-      eslint-import-resolver-typescript: '*'
-      eslint-import-resolver-webpack: '*'
-    peerDependenciesMeta:
-      '@typescript-eslint/parser':
-        optional: true
-      eslint-import-resolver-node:
-        optional: true
-      eslint-import-resolver-typescript:
-        optional: true
-      eslint-import-resolver-webpack:
-        optional: true
-    dependencies:
-      '@typescript-eslint/parser': 5.22.0_sdq423wcawycjzugemfabbjutq
-      debug: 3.2.7
-      eslint-import-resolver-node: 0.3.6
-      find-up: 2.1.0
-    transitivePeerDependencies:
-      - supports-color
     dev: true
 
   /eslint-plugin-es/3.0.1_eslint@8.14.0:
@@ -10572,7 +10545,7 @@ packages:
       regexpp: 3.2.0
     dev: true
 
-  /eslint-plugin-flowtype/8.0.3_bnjl7sn2qxwsoaiqrpavakq354:
+  /eslint-plugin-flowtype/8.0.3_0b52bfc9ba85ed2701108bc1502a1bef:
     resolution: {integrity: sha512-dX8l6qUL6O+fYPtpNRideCFSpmWOUVx5QcaGLVqe/vlDiBSe4vYljDWDETwnyFzpl7By/WVIu6rcrniCgH9BqQ==}
     engines: {node: '>=12.0.0'}
     peerDependencies:
@@ -10587,24 +10560,40 @@ packages:
       string-natural-compare: 3.0.1
     dev: true
 
-  /eslint-plugin-import/2.26.0_as7czvxgrvaa35lzxztolpnp5a:
+  /eslint-plugin-import/2.26.0:
     resolution: {integrity: sha512-hYfi3FXaM8WPLf4S1cikh/r4IxnO6zrhZbEGz2b660EJRbuxgpDS5gkCuYgGWg2xxh2rBuIr4Pvhve/7c31koA==}
     engines: {node: '>=4'}
     peerDependencies:
-      '@typescript-eslint/parser': '*'
       eslint: ^2 || ^3 || ^4 || ^5 || ^6 || ^7.2.0 || ^8
-    peerDependenciesMeta:
-      '@typescript-eslint/parser':
-        optional: true
     dependencies:
-      '@typescript-eslint/parser': 5.22.0_sdq423wcawycjzugemfabbjutq
+      array-includes: 3.1.4
+      array.prototype.flat: 1.3.0
+      debug: 2.6.9
+      doctrine: 2.1.0
+      eslint-import-resolver-node: 0.3.6
+      eslint-module-utils: 2.7.3
+      has: 1.0.3
+      is-core-module: 2.9.0
+      is-glob: 4.0.3
+      minimatch: 3.1.2
+      object.values: 1.1.5
+      resolve: 1.22.0
+      tsconfig-paths: 3.14.1
+    dev: true
+
+  /eslint-plugin-import/2.26.0_eslint@8.14.0:
+    resolution: {integrity: sha512-hYfi3FXaM8WPLf4S1cikh/r4IxnO6zrhZbEGz2b660EJRbuxgpDS5gkCuYgGWg2xxh2rBuIr4Pvhve/7c31koA==}
+    engines: {node: '>=4'}
+    peerDependencies:
+      eslint: ^2 || ^3 || ^4 || ^5 || ^6 || ^7.2.0 || ^8
+    dependencies:
       array-includes: 3.1.4
       array.prototype.flat: 1.3.0
       debug: 2.6.9
       doctrine: 2.1.0
       eslint: 8.14.0
       eslint-import-resolver-node: 0.3.6
-      eslint-module-utils: 2.7.3_wex3ustmkv4ospy3s77r6ihlwq
+      eslint-module-utils: 2.7.3
       has: 1.0.3
       is-core-module: 2.9.0
       is-glob: 4.0.3
@@ -10612,43 +10601,9 @@ packages:
       object.values: 1.1.5
       resolve: 1.22.0
       tsconfig-paths: 3.14.1
-    transitivePeerDependencies:
-      - eslint-import-resolver-typescript
-      - eslint-import-resolver-webpack
-      - supports-color
     dev: true
 
-  /eslint-plugin-import/2.26.0_t635sbcxoyku2geeidgiikfvme:
-    resolution: {integrity: sha512-hYfi3FXaM8WPLf4S1cikh/r4IxnO6zrhZbEGz2b660EJRbuxgpDS5gkCuYgGWg2xxh2rBuIr4Pvhve/7c31koA==}
-    engines: {node: '>=4'}
-    peerDependencies:
-      '@typescript-eslint/parser': '*'
-      eslint: ^2 || ^3 || ^4 || ^5 || ^6 || ^7.2.0 || ^8
-    peerDependenciesMeta:
-      '@typescript-eslint/parser':
-        optional: true
-    dependencies:
-      '@typescript-eslint/parser': 5.20.0_typescript@4.5.5
-      array-includes: 3.1.4
-      array.prototype.flat: 1.3.0
-      debug: 2.6.9
-      doctrine: 2.1.0
-      eslint-import-resolver-node: 0.3.6
-      eslint-module-utils: 2.7.3_jbyz37hizqiddyo5guvrx6copq
-      has: 1.0.3
-      is-core-module: 2.9.0
-      is-glob: 4.0.3
-      minimatch: 3.1.2
-      object.values: 1.1.5
-      resolve: 1.22.0
-      tsconfig-paths: 3.14.1
-    transitivePeerDependencies:
-      - eslint-import-resolver-typescript
-      - eslint-import-resolver-webpack
-      - supports-color
-    dev: true
-
-  /eslint-plugin-jest/25.7.0_gpyzlsvrtrblrtzdjncmeriqjy:
+  /eslint-plugin-jest/25.7.0_33f195cab19c42b8cf234b44c245104e:
     resolution: {integrity: sha512-PWLUEXeeF7C9QGKqvdSbzLOiLTx+bno7/HC9eefePfEb257QFHg7ye3dh80AZVkaa/RQsBB1Q/ORQvg2X7F0NQ==}
     engines: {node: ^12.13.0 || ^14.15.0 || >=16.0.0}
     peerDependencies:
@@ -10661,8 +10616,8 @@ packages:
       jest:
         optional: true
     dependencies:
-      '@typescript-eslint/eslint-plugin': 5.22.0_w4ajklk3bpbkv4oq2x7ogihpc4
-      '@typescript-eslint/experimental-utils': 5.22.0_sdq423wcawycjzugemfabbjutq
+      '@typescript-eslint/eslint-plugin': 5.22.0_b700952d5b0bc2aaf1d0d5fee320ef17
+      '@typescript-eslint/experimental-utils': 5.22.0_eslint@8.14.0+typescript@4.5.5
       eslint: 8.14.0
       jest: 27.5.1
     transitivePeerDependencies:
@@ -10804,13 +10759,13 @@ packages:
       eslint: 8.14.0
     dev: true
 
-  /eslint-plugin-testing-library/5.3.1_sdq423wcawycjzugemfabbjutq:
+  /eslint-plugin-testing-library/5.3.1_eslint@8.14.0+typescript@4.5.5:
     resolution: {integrity: sha512-OfF4dlG/q6ck6DL3P8Z0FPdK0dU5K57gsBu7eUcaVbwYKaNzjgejnXiM9CCUevppORkvfek+9D3Uj/9ZZ8Vz8g==}
     engines: {node: ^12.22.0 || ^14.17.0 || >=16.0.0, npm: '>=6'}
     peerDependencies:
       eslint: ^7.5.0 || ^8.0.0
     dependencies:
-      '@typescript-eslint/utils': 5.22.0_sdq423wcawycjzugemfabbjutq
+      '@typescript-eslint/utils': 5.22.0_eslint@8.14.0+typescript@4.5.5
       eslint: 8.14.0
     transitivePeerDependencies:
       - supports-color
@@ -11044,8 +10999,6 @@ packages:
       type-is: 1.6.18
       utils-merge: 1.0.1
       vary: 1.1.2
-    transitivePeerDependencies:
-      - supports-color
 
   /extend-shallow/2.0.1:
     resolution: {integrity: sha1-Ua99YUrZqfYQ6huvu5idaxxWiQ8=}
@@ -11246,8 +11199,6 @@ packages:
       parseurl: 1.3.3
       statuses: 1.5.0
       unpipe: 1.0.0
-    transitivePeerDependencies:
-      - supports-color
 
   /find-cache-dir/3.3.2:
     resolution: {integrity: sha512-wXZV5emFEjrridIgED11OoUKLxiYjAcqot/NJdAkOhlJ+vGzwhOAfcG5OX1jP+S0PcjEn8bdMJv+g2jwQ3Onig==}
@@ -11326,7 +11277,7 @@ packages:
       debug:
         optional: true
 
-  /fork-ts-checker-webpack-plugin/6.5.1_4dvvomwfbhpgf7xcm7gogbdvgu:
+  /fork-ts-checker-webpack-plugin/6.5.1_509a9d40d32ea50a4d33125362dc897b:
     resolution: {integrity: sha512-x1wumpHOEf4gDROmKTaB6i4/Q6H3LwmjVO7fIX47vBwlZbtPjU33hgoMuD/Q/y6SU8bnuYSoN6ZQOLshGp0T/g==}
     engines: {node: '>=10', yarn: '>=1.0.0'}
     peerDependencies:
@@ -11346,6 +11297,7 @@ packages:
       chokidar: 3.5.3
       cosmiconfig: 6.0.0
       deepmerge: 4.2.2
+      eslint: 8.14.0
       fs-extra: 9.1.0
       glob: 7.2.0
       memfs: 3.4.1
@@ -11680,18 +11632,18 @@ packages:
       lodash: 4.17.21
     dev: false
 
-  /graphql-config/4.3.0_gmfj57eud24hcocpgi4qxibj74:
+  /graphql-config/4.3.0_330a9efc941eb871384f32390ba029ff:
     resolution: {integrity: sha512-Uiu3X7+s5c056WyrvdZVz2vG1fhAipMlYmtiCU/4Z2mX79OXDr1SqIon2MprC/pExIWJfAQZCcjYDY76fPBUQg==}
     engines: {node: '>= 10.0.0'}
     peerDependencies:
       graphql: ^0.11.0 || ^0.12.0 || ^0.13.0 || ^14.0.0 || ^15.0.0 || ^16.0.0
     dependencies:
-      '@endemolshinegroup/cosmiconfig-typescript-loader': 3.0.2_5roa5pjqgcqkkeethcdwmsg7dm
+      '@endemolshinegroup/cosmiconfig-typescript-loader': 3.0.2_ec5c0ebd3030a0a5109338876648df1b
       '@graphql-tools/graphql-file-loader': 7.3.11_graphql@15.7.2
       '@graphql-tools/json-file-loader': 7.3.11_graphql@15.7.2
       '@graphql-tools/load': 7.5.10_graphql@15.7.2
       '@graphql-tools/merge': 8.2.10_graphql@15.7.2
-      '@graphql-tools/url-loader': 7.9.14_mzhmhjtioioqsihdrkhoc5w2oa
+      '@graphql-tools/url-loader': 7.9.14_664ec3a668721d0920e38a8ee176da70
       '@graphql-tools/utils': 8.6.9_graphql@15.7.2
       cosmiconfig: 7.0.1
       cosmiconfig-toml-loader: 1.0.0
@@ -12045,7 +11997,6 @@ packages:
       lodash: 4.17.21
       matcher: 4.0.0
     transitivePeerDependencies:
-      - bluebird
       - bufferutil
       - canvas
       - supports-color
@@ -12750,7 +12701,6 @@ packages:
       re2: 1.17.4
       url-regex-safe: 3.0.0_re2@1.17.4
     transitivePeerDependencies:
-      - bluebird
       - supports-color
     dev: true
 
@@ -13047,7 +12997,7 @@ packages:
       pretty-format: 27.5.1
       slash: 3.0.0
       strip-json-comments: 3.1.1
-      ts-node: 10.7.0_tzixnl2p2257qb6vfbxvuwk7q4
+      ts-node: 10.7.0_9e5176af4fd6bbf807d5286f5a595f87
     transitivePeerDependencies:
       - bufferutil
       - canvas
@@ -13815,7 +13765,6 @@ packages:
       rxjs: 6.6.7
     transitivePeerDependencies:
       - zen-observable
-      - zenObservable
     dev: true
 
   /load-json-file/4.0.0:
@@ -14104,7 +14053,6 @@ packages:
       socks-proxy-agent: 6.2.0
       ssri: 8.0.1
     transitivePeerDependencies:
-      - bluebird
       - supports-color
     dev: true
 
@@ -14183,7 +14131,7 @@ packages:
     resolution: {integrity: sha1-/oWy7HWlkDfyrf7BAP1sYBdhFS4=}
     dev: false
 
-  /mdx-mermaid/1.2.2_c22t5semscxhgv3n3sjop6jcyy:
+  /mdx-mermaid/1.2.2_mermaid@8.14.0+react@17.0.2:
     resolution: {integrity: sha512-izl9Vaus0fJHJb6IGgcGZ79LpfFACfn28ExPXKL815RTMT9bgDRIAubufZUCgoCAAv/2S1VTxJLWTwbck4TpLA==}
     peerDependencies:
       mermaid: '>= 8.11.0 < 8.12.0'
@@ -14329,7 +14277,7 @@ packages:
     engines: {node: '>=4'}
     dev: true
 
-  /mini-create-react-context/0.4.1_at7mkepldmzoo6silmqc5bca74:
+  /mini-create-react-context/0.4.1_prop-types@15.8.1+react@17.0.2:
     resolution: {integrity: sha512-YWCYEmd5CQeHGSAKrYvXgmzzkrvssZcuuQDDeqkT+PziKGMgE+0MCCtcKbROzocGBG1meBLl2FotlRwf4gAzbQ==}
     peerDependencies:
       prop-types: ^15.0.0
@@ -14538,14 +14486,7 @@ packages:
   /neo-async/2.6.2:
     resolution: {integrity: sha512-Yd3UES5mWCSqR+qNT93S3UoYUkqAZ9lLg8a7g9rimsWmYGK8cVToA4/sF3RrshdyV3sAGMXVUmpMYOw+dLpOuw==}
 
-  /next-transpile-modules/9.0.0:
-    resolution: {integrity: sha512-VCNFOazIAnXn1hvgYYSTYMnoWgKgwlYh4lm1pKbSfiB3kj5ZYLcKVhfh3jkPOg1cnd9DP+pte9yCUocdPEUBTQ==}
-    dependencies:
-      enhanced-resolve: 5.9.3
-      escalade: 3.1.1
-    dev: true
-
-  /next/12.0.10_sfoxds7t5ydpegc3knd667wn6m:
+  /next/12.0.10_9b0027aae606c22bf55a7fd89836f009:
     resolution: {integrity: sha512-1y3PpGzpb/EZzz1jgne+JfZXKAVJUjYXwxzrADf/LWN+8yi9o79vMLXpW3mevvCHkEF2sBnIdjzNn16TJrINUw==}
     engines: {node: '>=12.22.0'}
     hasBin: true
@@ -14568,7 +14509,7 @@ packages:
       postcss: 8.4.5
       react: 17.0.2
       react-dom: 17.0.2_react@17.0.2
-      styled-jsx: 5.0.0_react@17.0.2
+      styled-jsx: 5.0.0_@babel+core@7.17.10+react@17.0.2
       use-subscription: 1.5.1_react@17.0.2
     optionalDependencies:
       '@next/swc-android-arm64': 12.0.10
@@ -14587,7 +14528,7 @@ packages:
       - babel-plugin-macros
     dev: true
 
-  /next/12.1.6_ef5jwxihqo6n7gxfmzogljlgcm:
+  /next/12.1.6_react-dom@18.1.0+react@18.1.0:
     resolution: {integrity: sha512-cebwKxL3/DhNKfg9tPZDQmbRKjueqykHHbgaoG4VBRH3AHQJ2HO0dbKFiS1hPhe1/qgc2d/hFeadsbPicmLD+A==}
     engines: {node: '>=12.22.0'}
     hasBin: true
@@ -14681,7 +14622,6 @@ packages:
       tar: 6.1.11
       which: 2.0.2
     transitivePeerDependencies:
-      - bluebird
       - supports-color
     dev: true
 
@@ -15255,8 +15195,6 @@ packages:
       async: 2.6.4
       debug: 3.2.7
       mkdirp: 0.5.6
-    transitivePeerDependencies:
-      - supports-color
     dev: false
 
   /postcss-calc/8.2.4_postcss@8.4.12:
@@ -15378,11 +15316,11 @@ packages:
         optional: true
     dependencies:
       lilconfig: 2.0.5
-      ts-node: 10.7.0_tzixnl2p2257qb6vfbxvuwk7q4
+      ts-node: 10.7.0_9e5176af4fd6bbf807d5286f5a595f87
       yaml: 1.10.2
     dev: true
 
-  /postcss-loader/6.2.1_ophkbroklgd6jdvupnp5h6xq4i:
+  /postcss-loader/6.2.1_postcss@8.4.12+webpack@5.72.0:
     resolution: {integrity: sha512-WbbYpmAaKcux/P66bZ40bpWsBucjx/TTgVVzRZ9yUO8yQfVBlameJ0ZGVaPfH64hNSBh63a+ICP5nqOpBA0w+Q==}
     engines: {node: '>= 12.13.0'}
     peerDependencies:
@@ -15838,11 +15776,6 @@ packages:
 
   /promise-inflight/1.0.1:
     resolution: {integrity: sha1-mEcocL8igTL8vdhoEputEsPAKeM=}
-    peerDependencies:
-      bluebird: '*'
-    peerDependenciesMeta:
-      bluebird:
-        optional: true
     dev: true
 
   /promise-retry/2.0.1:
@@ -16029,7 +15962,6 @@ packages:
       nan: 2.15.0
       node-gyp: 8.4.1
     transitivePeerDependencies:
-      - bluebird
       - supports-color
     dev: true
 
@@ -16062,7 +15994,7 @@ packages:
       react: 17.0.2
     dev: false
 
-  /react-dev-utils/12.0.1_4dvvomwfbhpgf7xcm7gogbdvgu:
+  /react-dev-utils/12.0.1_509a9d40d32ea50a4d33125362dc897b:
     resolution: {integrity: sha512-84Ivxmr17KjUupyqzFode6xKhjwuEJDROWKJy/BthkL7Wn6NJ8h4WE6k/exAv6ImS+0oZLRRW5j/aINMHyeGeQ==}
     engines: {node: '>=14'}
     dependencies:
@@ -16075,7 +16007,7 @@ packages:
       escape-string-regexp: 4.0.0
       filesize: 8.0.7
       find-up: 5.0.0
-      fork-ts-checker-webpack-plugin: 6.5.1_4dvvomwfbhpgf7xcm7gogbdvgu
+      fork-ts-checker-webpack-plugin: 6.5.1_509a9d40d32ea50a4d33125362dc897b
       global-modules: 2.0.0
       globby: 11.1.0
       gzip-size: 6.0.0
@@ -16092,7 +16024,6 @@ packages:
       text-table: 0.2.0
     transitivePeerDependencies:
       - eslint
-      - supports-color
       - typescript
       - vue-template-compiler
       - webpack
@@ -16124,7 +16055,7 @@ packages:
   /react-fast-compare/3.2.0:
     resolution: {integrity: sha512-rtGImPZ0YyLrscKI9xTpV8psd6I8VAtjKCzQDlzyDvqJA8XOW78TXYQwNRNd8g8JZnDu8q9Fu/1v4HPAVwVdHA==}
 
-  /react-helmet-async/1.3.0_sfoxds7t5ydpegc3knd667wn6m:
+  /react-helmet-async/1.3.0_react-dom@17.0.2+react@17.0.2:
     resolution: {integrity: sha512-9jZ57/dAn9t3q6hneQS0wukqC2ENOBgMNVEhb/ZG9ZSxUetzVIw4iAmEU38IaVg3QGYauQPhSeUTuIUtFglWpg==}
     peerDependencies:
       react: ^16.6.0 || ^17.0.0 || ^18.0.0
@@ -16155,7 +16086,7 @@ packages:
       invariant: 2.2.4
     dev: false
 
-  /react-immutable-pure-component/2.2.2_xuna42ff4dsik7bgiahtwx36tu:
+  /react-immutable-pure-component/2.2.2_bd1a0e68a5e0e4857c26400f3b5f7e9d:
     resolution: {integrity: sha512-vkgoMJUDqHZfXXnjVlG3keCxSO/U6WeDQ5/Sl0GK2cH8TOxEzQ5jXqDXHEL/jqk6fsNxV05oH5kD7VNMUE2k+A==}
     peerDependencies:
       immutable: '>= 2 || >= 4.0.0-rc'
@@ -16184,7 +16115,7 @@ packages:
   /react-is/17.0.2:
     resolution: {integrity: sha512-w2GsyukL62IJnlaff/nRegPQR94C/XXamvMWmSHRJ4y7Ts/4ocGRmTHvOs8PSE6pB3dWOrD/nueuU5sduBsQ4w==}
 
-  /react-json-view/1.21.3_sfoxds7t5ydpegc3knd667wn6m:
+  /react-json-view/1.21.3_react-dom@17.0.2+react@17.0.2:
     resolution: {integrity: sha512-13p8IREj9/x/Ye4WI/JpjhoIwuzEgUAtgJZNBJckfzJt1qyh24BdTm6UQNGnyTq9dapQdrqvquZTo3dz1X6Cjw==}
     peerDependencies:
       react: ^17.0.0 || ^16.3.0 || ^15.5.4
@@ -16205,7 +16136,7 @@ packages:
     resolution: {integrity: sha512-fBASbA6LnOU9dOU2eW7aQ8xmYBSXUIWr+UmF9b1efZBazGNO+rcXT/icdKnYm2pTwcRylVUYwW7H1PHfLekVzA==}
     dev: false
 
-  /react-loadable-ssr-addon-v5-slorber/1.0.1_5grs2dwrf6hqtfkptfcfoiy4bu:
+  /react-loadable-ssr-addon-v5-slorber/1.0.1_e9a32d0ed12f8f09954f994457231c0d:
     resolution: {integrity: sha512-lq3Lyw1lGku8zUEJPDxsNm1AfYHBrO9Y1+olAYwpUJ2IGFBskM0DMKok97A6LWUpHm+o7IvQBOWu9MLenp9Z+A==}
     engines: {node: '>=10.13.0'}
     peerDependencies:
@@ -16217,7 +16148,7 @@ packages:
       webpack: 5.72.0
     dev: false
 
-  /react-popper/2.3.0_42yiot2n2wjamynwfzzmd7tk3i:
+  /react-popper/2.3.0_e6b0874f4dd5920661b62e72c1fe6ada:
     resolution: {integrity: sha512-e1hj8lL3uM+sgSR4Lxzn5h1GxBlpa4CQz0XLF8kx4MDrDRWY0Ena4c97PUeSX9i5W3UAfDP0z0FXCTQkoXUl3Q==}
     peerDependencies:
       '@popperjs/core': ^2.0.0
@@ -16235,7 +16166,7 @@ packages:
     resolution: {integrity: sha512-kzmNjIgU32mO4mmH5+iUyrqlpFQhF8K2k7eZ4fdLSOPFrD1XgEuSBv9LDEgxRXTMBqMd8ppT0x6TIzqE5pdGdw==}
     dev: false
 
-  /react-redux/7.2.8_sfoxds7t5ydpegc3knd667wn6m:
+  /react-redux/7.2.8_react-dom@17.0.2+react@17.0.2:
     resolution: {integrity: sha512-6+uDjhs3PSIclqoCk0kd6iX74gzrGc3W5zcAjbrFgEdIjRSQObdIwfx80unTkVUYvbQ95Y8Av3OvFHq1w5EOUw==}
     peerDependencies:
       react: ^16.8.3 || ^17 || ^18
@@ -16262,7 +16193,7 @@ packages:
     engines: {node: '>=0.10.0'}
     dev: true
 
-  /react-router-config/5.1.1_53jg2tb4f34fvmclurfotx7m6y:
+  /react-router-config/5.1.1_react-router@5.3.1+react@17.0.2:
     resolution: {integrity: sha512-DuanZjaD8mQp1ppHjgnnUnyOlqYXZVjnov/JzFhjLEwd3Z4dYjMSnqrEzzGThH47vpCOqPPwJM2FtthLeJ8Pbg==}
     peerDependencies:
       react: '>=15'
@@ -16288,19 +16219,7 @@ packages:
       tiny-warning: 1.0.3
     dev: false
 
-  /react-router-dom/6.3.0_ef5jwxihqo6n7gxfmzogljlgcm:
-    resolution: {integrity: sha512-uaJj7LKytRxZNQV8+RbzJWnJ8K2nPsOOEuX7aQstlMZKQT0164C+X2w6bnkqU3sjtLvpd5ojrezAyfZ1+0sStw==}
-    peerDependencies:
-      react: '>=16.8'
-      react-dom: '>=16.8'
-    dependencies:
-      history: 5.3.0
-      react: 18.1.0
-      react-dom: 18.1.0_react@18.1.0
-      react-router: 6.3.0_react@18.1.0
-    dev: false
-
-  /react-router-dom/6.3.0_sfoxds7t5ydpegc3knd667wn6m:
+  /react-router-dom/6.3.0_react-dom@17.0.2+react@17.0.2:
     resolution: {integrity: sha512-uaJj7LKytRxZNQV8+RbzJWnJ8K2nPsOOEuX7aQstlMZKQT0164C+X2w6bnkqU3sjtLvpd5ojrezAyfZ1+0sStw==}
     peerDependencies:
       react: '>=16.8'
@@ -16312,6 +16231,18 @@ packages:
       react-router: 6.3.0_react@17.0.2
     dev: false
 
+  /react-router-dom/6.3.0_react-dom@18.1.0+react@18.1.0:
+    resolution: {integrity: sha512-uaJj7LKytRxZNQV8+RbzJWnJ8K2nPsOOEuX7aQstlMZKQT0164C+X2w6bnkqU3sjtLvpd5ojrezAyfZ1+0sStw==}
+    peerDependencies:
+      react: '>=16.8'
+      react-dom: '>=16.8'
+    dependencies:
+      history: 5.3.0
+      react: 18.1.0
+      react-dom: 18.1.0_react@18.1.0
+      react-router: 6.3.0_react@18.1.0
+    dev: false
+
   /react-router/5.3.1_react@17.0.2:
     resolution: {integrity: sha512-v+zwjqb7bakqgF+wMVKlAPTca/cEmPOvQ9zt7gpSNyPXau1+0qvuYZ5BWzzNDP1y6s15zDwgb9rPN63+SIniRQ==}
     peerDependencies:
@@ -16321,7 +16252,7 @@ packages:
       history: 4.10.1
       hoist-non-react-statics: 3.3.2
       loose-envify: 1.4.0
-      mini-create-react-context: 0.4.1_at7mkepldmzoo6silmqc5bca74
+      mini-create-react-context: 0.4.1_prop-types@15.8.1+react@17.0.2
       path-to-regexp: 1.8.0
       prop-types: 15.8.1
       react: 17.0.2
@@ -16361,7 +16292,7 @@ packages:
       refractor: 3.6.0
     dev: false
 
-  /react-textarea-autosize/8.3.3_ci6b7qrbzfuzg4ahcdqxg6om2y:
+  /react-textarea-autosize/8.3.3_@types+react@18.0.8+react@18.1.0:
     resolution: {integrity: sha512-2XlHXK2TDxS6vbQaoPbMOfQ8GK7+irc2fVK6QFIcC8GOnH3zI/v481n+j1L0WaPVvKxwesnY93fEfH++sus2rQ==}
     engines: {node: '>=10'}
     peerDependencies:
@@ -16370,7 +16301,7 @@ packages:
       '@babel/runtime': 7.17.9
       react: 18.1.0
       use-composed-ref: 1.2.1_react@18.1.0
-      use-latest: 1.2.0_ci6b7qrbzfuzg4ahcdqxg6om2y
+      use-latest: 1.2.0_@types+react@18.0.8+react@18.1.0
     transitivePeerDependencies:
       - '@types/react'
     dev: false
@@ -16389,7 +16320,7 @@ packages:
       - '@types/react'
     dev: false
 
-  /react-transition-group/4.4.2_ef5jwxihqo6n7gxfmzogljlgcm:
+  /react-transition-group/4.4.2_react-dom@18.1.0+react@18.1.0:
     resolution: {integrity: sha512-/RNYfRAMlZwDSr6z4zNKV6xu53/e2BuaBbGhbyYIXTrmgu/bGHzmqOs7mJSJBHy9Ud+ApHx3QjrkKSp1pxvlFg==}
     peerDependencies:
       react: '>=16.6.0'
@@ -17069,8 +17000,6 @@ packages:
       on-finished: 2.3.0
       range-parser: 1.2.1
       statuses: 1.5.0
-    transitivePeerDependencies:
-      - supports-color
 
   /sentence-case/3.0.4:
     resolution: {integrity: sha512-8LS0JInaQMCRoQ7YUytAo/xUu5W2XnQxV2HI/6uM6U7CITS1RqPElr30V6uIqyMKM9lJGRVFy5/4CuzcixNYSg==}
@@ -17116,8 +17045,6 @@ packages:
       http-errors: 1.6.3
       mime-types: 2.1.35
       parseurl: 1.3.3
-    transitivePeerDependencies:
-      - supports-color
     dev: false
 
   /serve-static/1.14.2:
@@ -17128,8 +17055,6 @@ packages:
       escape-html: 1.0.3
       parseurl: 1.3.3
       send: 0.17.2
-    transitivePeerDependencies:
-      - supports-color
 
   /set-blocking/2.0.0:
     resolution: {integrity: sha1-BF+XgtARrppoA93TgrJDkrPYkPc=}
@@ -17642,7 +17567,7 @@ packages:
       inline-style-parser: 0.1.1
     dev: false
 
-  /styled-jsx/5.0.0_react@17.0.2:
+  /styled-jsx/5.0.0_@babel+core@7.17.10+react@17.0.2:
     resolution: {integrity: sha512-qUqsWoBquEdERe10EW8vLp3jT25s/ssG1/qX5gZ4wu15OZpmSMFI2v+fWlRhLfykA5rFtlJ1ME8A8pm/peV4WA==}
     engines: {node: '>= 12.0.0'}
     peerDependencies:
@@ -17655,6 +17580,7 @@ packages:
       babel-plugin-macros:
         optional: true
     dependencies:
+      '@babel/core': 7.17.10
       react: 17.0.2
     dev: true
 
@@ -17780,7 +17706,7 @@ packages:
       - encoding
     dev: false
 
-  /swagger-ui-react/4.10.3_sfoxds7t5ydpegc3knd667wn6m:
+  /swagger-ui-react/4.10.3_react-dom@17.0.2+react@17.0.2:
     resolution: {integrity: sha512-rxLVM8hv6aH+8BEJuyfejt2BweV2TLB8KiifE/8CAk96PoDyQeCTnLgivTdXIuDqdSSSajlzTq0ccw0QMYQbvA==}
     peerDependencies:
       react: '>=17.0.0'
@@ -17806,9 +17732,9 @@ packages:
       react-debounce-input: 3.2.4_react@17.0.2
       react-dom: 17.0.2_react@17.0.2
       react-immutable-proptypes: 2.2.0_immutable@3.8.2
-      react-immutable-pure-component: 2.2.2_xuna42ff4dsik7bgiahtwx36tu
+      react-immutable-pure-component: 2.2.2_bd1a0e68a5e0e4857c26400f3b5f7e9d
       react-inspector: 5.1.1_react@17.0.2
-      react-redux: 7.2.8_sfoxds7t5ydpegc3knd667wn6m
+      react-redux: 7.2.8_react-dom@17.0.2+react@17.0.2
       react-syntax-highlighter: 15.5.0_react@17.0.2
       redux: 4.2.0
       redux-immutable: 4.0.0_immutable@3.8.2
@@ -18125,7 +18051,42 @@ packages:
       tslib: 2.3.1
     dev: false
 
-  /ts-jest/27.1.4_qibfzi6pqxnvkzgq6a2hlm326a:
+  /ts-jest/27.1.4_7040bf7e0d8786507314c0c39bfde1b1:
+    resolution: {integrity: sha512-qjkZlVPWVctAezwsOD1OPzbZ+k7zA5z3oxII4dGdZo5ggX/PL7kvwTM0pXTr10fAtbiVpJaL3bWd502zAhpgSQ==}
+    engines: {node: ^10.13.0 || ^12.13.0 || ^14.15.0 || >=15.0.0}
+    hasBin: true
+    peerDependencies:
+      '@babel/core': '>=7.0.0-beta.0 <8'
+      '@types/jest': ^27.0.0
+      babel-jest: '>=27.0.0 <28'
+      esbuild: '*'
+      jest: ^27.0.0
+      typescript: '>=3.8 <5.0'
+    peerDependenciesMeta:
+      '@babel/core':
+        optional: true
+      '@types/jest':
+        optional: true
+      babel-jest:
+        optional: true
+      esbuild:
+        optional: true
+    dependencies:
+      '@babel/core': 7.17.10
+      '@types/jest': 27.4.1
+      bs-logger: 0.2.6
+      fast-json-stable-stringify: 2.1.0
+      jest: 27.5.1_ts-node@10.7.0
+      jest-util: 27.5.1
+      json5: 2.2.1
+      lodash.memoize: 4.1.2
+      make-error: 1.3.6
+      semver: 7.3.7
+      typescript: 4.6.3
+      yargs-parser: 20.2.9
+    dev: true
+
+  /ts-jest/27.1.4_82025ca3cf85db5564d0f03475b37af0:
     resolution: {integrity: sha512-qjkZlVPWVctAezwsOD1OPzbZ+k7zA5z3oxII4dGdZo5ggX/PL7kvwTM0pXTr10fAtbiVpJaL3bWd502zAhpgSQ==}
     engines: {node: ^10.13.0 || ^12.13.0 || ^14.15.0 || >=15.0.0}
     hasBin: true
@@ -18160,40 +18121,6 @@ packages:
       yargs-parser: 20.2.9
     dev: true
 
-  /ts-jest/27.1.4_tgc6da2oqazvrn56dzwolsqo5i:
-    resolution: {integrity: sha512-qjkZlVPWVctAezwsOD1OPzbZ+k7zA5z3oxII4dGdZo5ggX/PL7kvwTM0pXTr10fAtbiVpJaL3bWd502zAhpgSQ==}
-    engines: {node: ^10.13.0 || ^12.13.0 || ^14.15.0 || >=15.0.0}
-    hasBin: true
-    peerDependencies:
-      '@babel/core': '>=7.0.0-beta.0 <8'
-      '@types/jest': ^27.0.0
-      babel-jest: '>=27.0.0 <28'
-      esbuild: '*'
-      jest: ^27.0.0
-      typescript: '>=3.8 <5.0'
-    peerDependenciesMeta:
-      '@babel/core':
-        optional: true
-      '@types/jest':
-        optional: true
-      babel-jest:
-        optional: true
-      esbuild:
-        optional: true
-    dependencies:
-      '@types/jest': 27.4.1
-      bs-logger: 0.2.6
-      fast-json-stable-stringify: 2.1.0
-      jest: 27.5.1_ts-node@10.7.0
-      jest-util: 27.5.1
-      json5: 2.2.1
-      lodash.memoize: 4.1.2
-      make-error: 1.3.6
-      semver: 7.3.7
-      typescript: 4.6.3
-      yargs-parser: 20.2.9
-    dev: true
-
   /ts-log/2.2.4:
     resolution: {integrity: sha512-DEQrfv6l7IvN2jlzc/VTdZJYsWUnQNCsueYjMkC/iXoEoi5fNan6MjeDqkvhfzbmHgdz9UxDUluX3V5HdjTydQ==}
     dev: true
@@ -18205,7 +18132,7 @@ packages:
       code-block-writer: 11.0.0
     dev: true
 
-  /ts-node/10.7.0_tzixnl2p2257qb6vfbxvuwk7q4:
+  /ts-node/10.7.0_9e5176af4fd6bbf807d5286f5a595f87:
     resolution: {integrity: sha512-TbIGS4xgJoX2i3do417KSaep1uRAW/Lu+WAL2doDHC0D6ummjirVOXU5/7aiZotbQ5p1Zp9tP7U6cYhA0O7M8A==}
     hasBin: true
     peerDependencies:
@@ -18281,7 +18208,7 @@ packages:
     engines: {node: '>=0.6.x'}
     dev: false
 
-  /tsup/5.12.6_r2f2fcz3zztmgx5yz2r3q5xsqi:
+  /tsup/5.12.6_ts-node@10.7.0+typescript@4.6.3:
     resolution: {integrity: sha512-tpePOgdMRKRgazF+ujq9k1Fo44PUFUJJjRLtxq87pQrYW/Ub/fu1GpFGLzdUF9qjJ4FX1ykhf2d9mWCNy+jAtg==}
     hasBin: true
     peerDependencies:
@@ -18730,7 +18657,7 @@ packages:
     dependencies:
       punycode: 2.1.1
 
-  /url-loader/4.1.1_csgzzuwaerdr4d7s3u52mzcn7m:
+  /url-loader/4.1.1_file-loader@6.2.0+webpack@5.72.0:
     resolution: {integrity: sha512-3BTV812+AVHHOJQO8O5MkWgZ5aosP7GnROJwvzLS9hWDj00lZ6Z0wNak423Lp9PBZN05N+Jk/N5Si8jRAlGyWA==}
     engines: {node: '>= 10.13.0'}
     peerDependencies:
@@ -18797,7 +18724,7 @@ packages:
       react: 18.1.0
     dev: false
 
-  /use-isomorphic-layout-effect/1.1.2_ci6b7qrbzfuzg4ahcdqxg6om2y:
+  /use-isomorphic-layout-effect/1.1.2_@types+react@18.0.8+react@18.1.0:
     resolution: {integrity: sha512-49L8yCO3iGT/ZF9QttjwLF/ZD9Iwto5LnH5LmEdk/6cFmXddqi2ulF0edxTwjj+7mqvpVVGQWvbXZdn32wRSHA==}
     peerDependencies:
       '@types/react': '*'
@@ -18822,7 +18749,7 @@ packages:
       react: 17.0.2
     dev: false
 
-  /use-latest/1.2.0_ci6b7qrbzfuzg4ahcdqxg6om2y:
+  /use-latest/1.2.0_@types+react@18.0.8+react@18.1.0:
     resolution: {integrity: sha512-d2TEuG6nSLKQLAfW3By8mKr8HurOlTkul0sOpxbClIv4SQ4iOd7BYr7VIzdbktUCnv7dua/60xzd8igMU6jmyw==}
     peerDependencies:
       '@types/react': '*'
@@ -18833,7 +18760,7 @@ packages:
     dependencies:
       '@types/react': 18.0.8
       react: 18.1.0
-      use-isomorphic-layout-effect: 1.1.2_ci6b7qrbzfuzg4ahcdqxg6om2y
+      use-isomorphic-layout-effect: 1.1.2_@types+react@18.0.8+react@18.1.0
     dev: false
 
   /use-latest/1.2.0_react@17.0.2:
@@ -18934,7 +18861,7 @@ packages:
       spdx-expression-parse: 3.0.1
     dev: true
 
-  /valtio/1.6.0:
+  /valtio/1.6.0_vite@2.9.7:
     resolution: {integrity: sha512-I/AUMRGlGpskbTdwYbiJutMKq4AHPgV8GWMwvPPQ6jdAhlWO4gheK4bTKZ22Ff5ONXjjZE8mQ0vL5l0em4wJGg==}
     engines: {node: '>=12.7.0'}
     peerDependencies:
@@ -18960,6 +18887,7 @@ packages:
     dependencies:
       proxy-compare: 2.1.0
       use-sync-external-store: 1.0.0
+      vite: 2.9.7
     dev: false
 
   /value-equal/1.0.1:


### PR DESCRIPTION
It is not required in the new monorepo setup