### PR TITLE
accept query parameters from both relative `redirectTo` URLs and the client URL

### DIFF
--- a/.changeset/hip-ants-fly.md
+++ b/.changeset/hip-ants-fly.md
@@ -4,4 +4,4 @@
 
 Accept query parameters from both relative `redirectTo` URLs and the client URL
 URLs where malformed When the client URL was defining query parameters and a relative `redirectTo` URL was passed on as an option.
-It is not possible to define query parameters in both the base client URL and the relative `redirectTo`
+It is now possible to define query parameters in both the base client URL and the relative `redirectTo`

--- a/.changeset/hip-ants-fly.md
+++ b/.changeset/hip-ants-fly.md
@@ -1,0 +1,7 @@
+---
+'@nhost/core': patch
+---
+
+Accept query parameters from both relative `redirectTo` URLs and the client URL
+URLs where malformed When the client URL was defining query parameters and a relative `redirectTo` URL was passed on as an option.
+It is not possible to define query parameters in both the base client URL and the relative `redirectTo`

--- a/packages/core/src/utils.ts
+++ b/packages/core/src/utils.ts
@@ -18,30 +18,29 @@ export const encodeQueryParameters = (baseUrl: string, parameters?: Record<strin
 }
 
 export const rewriteRedirectTo = <T extends RedirectOption>(clientUrl: string, options?: T) => {
-  if (options?.redirectTo) {
-    const baseClientUrl = new URL(clientUrl)
-    const clientParams = Object.fromEntries(new URLSearchParams(baseClientUrl.search))
-    const url = new URL(
-      options.redirectTo.startsWith('/')
-        ? baseClientUrl.origin + options.redirectTo
-        : options.redirectTo
-    )
-    const additionalParams = new URLSearchParams(url.search)
-    let combinedParams = Object.fromEntries(additionalParams)
-
-    if (options.redirectTo.startsWith('/')) {
-      combinedParams = { ...clientParams, ...combinedParams }
-    }
-    let pathName = baseClientUrl.pathname
-    if (url.pathname.length > 1) {
-      pathName += url.pathname.slice(1)
-    }
-    return {
-      ...options,
-      redirectTo: encodeQueryParameters(url.origin + pathName, combinedParams)
-    }
-  } else {
+  if (!options?.redirectTo) {
     return options
+  }
+  const baseClientUrl = new URL(clientUrl)
+  const clientParams = Object.fromEntries(new URLSearchParams(baseClientUrl.search))
+  const url = new URL(
+    options.redirectTo.startsWith('/')
+      ? baseClientUrl.origin + options.redirectTo
+      : options.redirectTo
+  )
+  const additionalParams = new URLSearchParams(url.search)
+  let combinedParams = Object.fromEntries(additionalParams)
+
+  if (options.redirectTo.startsWith('/')) {
+    combinedParams = { ...clientParams, ...combinedParams }
+  }
+  let pathName = baseClientUrl.pathname
+  if (url.pathname.length > 1) {
+    pathName += url.pathname.slice(1)
+  }
+  return {
+    ...options,
+    redirectTo: encodeQueryParameters(url.origin + pathName, combinedParams)
   }
 }
 

--- a/packages/core/src/utils.ts
+++ b/packages/core/src/utils.ts
@@ -17,15 +17,33 @@ export const encodeQueryParameters = (baseUrl: string, parameters?: Record<strin
   else return baseUrl
 }
 
-export const rewriteRedirectTo = <T extends RedirectOption>(clientUrl: string, options?: T) =>
-  options?.redirectTo
-    ? {
-        ...options,
-        redirectTo: options?.redirectTo?.startsWith('/')
-          ? clientUrl + options.redirectTo
-          : options?.redirectTo
-      }
-    : options
+export const rewriteRedirectTo = <T extends RedirectOption>(clientUrl: string, options?: T) => {
+  if (options?.redirectTo) {
+    const baseClientUrl = new URL(clientUrl)
+    const clientParams = Object.fromEntries(new URLSearchParams(baseClientUrl.search))
+    const url = new URL(
+      options.redirectTo.startsWith('/')
+        ? baseClientUrl.origin + options.redirectTo
+        : options.redirectTo
+    )
+    const additionalParams = new URLSearchParams(url.search)
+    let combinedParams = Object.fromEntries(additionalParams)
+
+    if (options.redirectTo.startsWith('/')) {
+      combinedParams = { ...clientParams, ...combinedParams }
+    }
+    let pathName = baseClientUrl.pathname
+    if (url.pathname.length > 1) {
+      pathName += url.pathname.slice(1)
+    }
+    return {
+      ...options,
+      redirectTo: encodeQueryParameters(url.origin + pathName, combinedParams)
+    }
+  } else {
+    return options
+  }
+}
 
 export function getParameterByName(name: string, url?: string) {
   if (!url) {

--- a/packages/core/tests/utils.test.ts
+++ b/packages/core/tests/utils.test.ts
@@ -1,0 +1,70 @@
+import { RedirectOption } from '../src/types'
+import { rewriteRedirectTo } from '../src/utils'
+
+test(`should not add redirectTo when none is given`, async () => {
+  expect(rewriteRedirectTo('https://frontend.com', {})).toEqual({})
+  expect(rewriteRedirectTo('https://frontend.com')).toBeUndefined()
+})
+
+test(`should append redirectTo with the clientUrl prefix`, async () => {
+  const options: RedirectOption = { redirectTo: '/index' }
+
+  const result = rewriteRedirectTo('https://frontend.com', options)
+  expect(result.redirectTo).toEqual('https://frontend.com/index')
+})
+
+test(`should add the query parameters of the clientUrl`, async () => {
+  const options: RedirectOption = { redirectTo: '/index' }
+
+  const result = rewriteRedirectTo('https://frontend.com?key=value', options)
+  expect(result.redirectTo).toEqual('https://frontend.com/index?key=value')
+})
+
+test(`should add the query parameters of the custom redirection`, async () => {
+  const options: RedirectOption = { redirectTo: '/index?key=value' }
+
+  const result = rewriteRedirectTo('https://frontend.com', options)
+  expect(result.redirectTo).toEqual('https://frontend.com/index?key=value')
+})
+
+test(`should override the query parameter initially set in the clientUrl`, async () => {
+  const options: RedirectOption = { redirectTo: '/index?key=newValue' }
+
+  const result = rewriteRedirectTo('https://frontend.com?key=original', options)
+  expect(result.redirectTo).toEqual('https://frontend.com/index?key=newValue')
+})
+
+test(`should combine query parameters from both clientUrl and redirection`, async () => {
+  const options: RedirectOption = { redirectTo: '/index?a=valueA' }
+
+  const result = rewriteRedirectTo('https://frontend.com?b=valueB', options)
+  expect(result.redirectTo).toEqual('https://frontend.com/index?b=valueB&a=valueA')
+})
+
+test(`should ignore the original clientUrl when an absolute URL is given`, async () => {
+  const options: RedirectOption = { redirectTo: 'https://another.com/index' }
+
+  const result = rewriteRedirectTo('https://frontend.com', options)
+  expect(result.redirectTo).toEqual('https://another.com/index')
+})
+
+test(`should ignore the original query parameters when an absolute URL is given`, async () => {
+  const options: RedirectOption = { redirectTo: 'https://another.com/index' }
+
+  const result = rewriteRedirectTo('https://frontend.com?key=value', options)
+  expect(result.redirectTo).toEqual('https://another.com/index')
+})
+
+test(`should keep the trailing / in the clientUrl`, async () => {
+  const options: RedirectOption = { redirectTo: '/' }
+
+  const result = rewriteRedirectTo('https://frontend.com/', options)
+  expect(result.redirectTo).toEqual('https://frontend.com/')
+})
+
+test(`should extend to a relative URL when the clientUrl ends with a slash`, async () => {
+  const options: RedirectOption = { redirectTo: '/nested' }
+
+  const result = rewriteRedirectTo('https://frontend.com/main/', options)
+  expect(result.redirectTo).toEqual('https://frontend.com/main/nested')
+})


### PR DESCRIPTION
URLs where malformed When the client URL was defining query parameters and a relative `redirectTo` URL was passed on as an option.
It is now possible to define query parameters in both the base client URL and the relative `redirectTo`
