### PR TITLE
🐛 imports from @apollo/client/core for vue

### DIFF
--- a/.changeset/cool-shrimps-reply.md
+++ b/.changeset/cool-shrimps-reply.md
@@ -1,0 +1,6 @@
+---
+'@nhost/apollo': patch
+---
+
+Import the apollo client from `@apollo/client/core` instead of `@apollo/client`
+It avoids uncessary dependency to React when not using it e.g. Vue when using bundlers that import the library as a whole.

--- a/config/vite.lib.config.js
+++ b/config/vite.lib.config.js
@@ -53,6 +53,7 @@ export default defineConfig({
         globals: {
           'graphql/language/printer': 'graphql/language/printer',
           '@apollo/client': '@apollo/client',
+          '@apollo/client/core': '@apollo/client/core',
           '@apollo/client/link/context': '@apollo/client/link/context',
           '@apollo/client/link/subscriptions': '@apollo/client/link/subscriptions',
           '@apollo/client/utilities': '@apollo/client/utilities',

--- a/docs/docs/platform/quickstarts/vue.mdx
+++ b/docs/docs/platform/quickstarts/vue.mdx
@@ -514,7 +514,7 @@ composable to execute that query when the user submits the form from the profile
 
 ```markup title="src/pages/profile.vue"
 <script setup lang="ts">
-  import { gql } from '@apollo/client'
+  import { gql } from '@apollo/client/core'
   import { useNhostClient, useUserData } from '@nhost/vue'
   import { useMutation } from '@vue/apollo-composable'
   import { ref } from 'vue'
@@ -600,7 +600,7 @@ Finally, to add real-time caching, synchronizing, and updating server state in y
 First add the following GraphQL subscription to retrieve the current user data component:
 
 ```ts title="src/pages/profile.vue"
-import { gql } from '@apollo/client'
+import { gql } from '@apollo/client/core'
 
 const GET_USER_SUBSCRIPTION = gql`
   subscription GetUser($id: uuid!) {
@@ -627,7 +627,7 @@ Finally, we can run our GraphQL subscription using the `useSubscription` composa
 
 ```markup title="src/pages/profile.vue"
 <script setup lang="ts">
-  import { gql } from '@apollo/client'
+  import { gql } from '@apollo/client/core'
   import { useNhostClient, useUserId } from '@nhost/vue'
   import { useMutation, useSubscription } from '@vue/apollo-composable'
   import { computed, ref } from 'vue'

--- a/docs/docs/reference/vue/apollo.mdx
+++ b/docs/docs/reference/vue/apollo.mdx
@@ -57,7 +57,7 @@ You can now use all [Apollo Vue composables](https://v4.apollo.vuejs.org/guide-c
 ```html
 <script setup>
   import { useQuery } from '@vue/apollo-composable'
-  import { gql } from '@apollo/client'
+  import { gql } from '@apollo/client/core'
 
   const { loading, result, error } = useQuery(gql`
     query Books {

--- a/examples/vue-apollo/src/pages/ApolloPage.vue
+++ b/examples/vue-apollo/src/pages/ApolloPage.vue
@@ -15,7 +15,7 @@
 <script lang="ts">
 import { computed, defineComponent } from 'vue'
 
-import { gql } from '@apollo/client'
+import { gql } from '@apollo/client/core'
 import { useAuthenticated } from '@nhost/vue'
 import { useQuery } from '@vue/apollo-composable'
 

--- a/examples/vue-quickstart/src/pages/profile.vue
+++ b/examples/vue-quickstart/src/pages/profile.vue
@@ -1,5 +1,5 @@
 <script setup lang="ts">
-import { gql } from '@apollo/client'
+import { gql } from '@apollo/client/core'
 import { useNhostClient, useUserId } from '@nhost/vue'
 import { useMutation, useSubscription } from '@vue/apollo-composable'
 import { computed, ref } from 'vue'

--- a/packages/apollo/src/index.ts
+++ b/packages/apollo/src/index.ts
@@ -7,7 +7,7 @@ import {
   RequestHandler,
   split,
   WatchQueryFetchPolicy
-} from '@apollo/client'
+} from '@apollo/client/core'
 import { setContext } from '@apollo/client/link/context'
 import { GraphQLWsLink } from '@apollo/client/link/subscriptions'
 import { getMainDefinition } from '@apollo/client/utilities'


### PR DESCRIPTION
This fixes a bug where it's required to have react in a vue project.
@apollo/client exports code related to react.
@apollo/client/core does not not.

Ref: https://github.com/apollographql/apollo-client/blob/main/src/index.ts

Edit:
I'm not sure what I saw. There must have been a `feat/vue` branch here very recently. Let me know if I should re-branch this to `bug/apollo-imports` or so