### PR TITLE
fix: Package bundling / Node.js environment

### DIFF
--- a/.changeset/fair-brooms-sniff.md
+++ b/.changeset/fair-brooms-sniff.md
@@ -1,0 +1,15 @@
+---
+'@nhost/apollo': patch
+'@nhost/core': patch
+'@nhost/hasura-auth-js': patch
+'@nhost/hasura-storage-js': patch
+'@nhost/nextjs': patch
+'@nhost/nhost-js': patch
+'@nhost/react': patch
+'@nhost/react-apollo': patch
+'@nhost/react-auth': patch
+'@nhost/vue': patch
+---
+
+fix: ESM related issues in Node environments
+chore: Improved the way different formats are exposed via `exports` field in package.js

--- a/config/vite.lib.config.js
+++ b/config/vite.lib.config.js
@@ -44,7 +44,7 @@ export default defineConfig({
     lib: {
       entry,
       name: pkg.name,
-      fileName: 'index',
+      fileName: (format) => (format === 'cjs' ? `index.cjs.js` : `index.mjs`),
       formats: ['cjs', 'es']
     },
     rollupOptions: {

--- a/config/vite.lib.umd.config.js
+++ b/config/vite.lib.umd.config.js
@@ -1,8 +1,6 @@
-import fs from 'fs'
 import path from 'path'
 
 import { defineConfig } from 'vite'
-import dts from 'vite-plugin-dts'
 import tsconfigPaths from 'vite-tsconfig-paths'
 
 import baseLibConfig from './vite.lib.config'
@@ -13,19 +11,7 @@ const pkg = require(path.join(PWD, 'package.json'))
 const deps = [...Object.keys(Object.assign({}, pkg.peerDependencies))]
 
 export default defineConfig({
-  plugins: [
-    tsconfigPaths(),
-    dts({
-      exclude: ['**/*.spec.ts', '**/*.test.ts', '**/tests/**'],
-      afterBuild: () => {
-        const types = fs.readdirSync(path.join(PWD, 'umd/src'))
-        types.forEach((file) => {
-          fs.renameSync(path.join(PWD, 'umd/src', file), path.join(PWD, 'umd', file))
-        })
-        fs.rmdirSync(path.join(PWD, 'umd/src'))
-      }
-    })
-  ],
+  plugins: [tsconfigPaths()],
   build: {
     ...(baseLibConfig.build || {}),
     outDir: 'umd',

--- a/config/vite.react.umd.config.js
+++ b/config/vite.react.umd.config.js
@@ -1,8 +1,6 @@
-import fs from 'fs'
 import path from 'path'
 
 import { defineConfig } from 'vite'
-import dts from 'vite-plugin-dts'
 import tsconfigPaths from 'vite-tsconfig-paths'
 
 import react from '@vitejs/plugin-react'
@@ -15,20 +13,7 @@ const pkg = require(path.join(PWD, 'package.json'))
 const deps = [...Object.keys(Object.assign({}, pkg.peerDependencies))]
 
 export default defineConfig({
-  plugins: [
-    react(),
-    tsconfigPaths(),
-    dts({
-      exclude: ['**/*.spec.ts', '**/*.test.ts', '**/tests/**'],
-      afterBuild: () => {
-        const types = fs.readdirSync(path.join(PWD, 'umd/src'))
-        types.forEach((file) => {
-          fs.renameSync(path.join(PWD, 'umd/src', file), path.join(PWD, 'umd', file))
-        })
-        fs.rmdirSync(path.join(PWD, 'umd/src'))
-      }
-    })
-  ],
+  plugins: [react(), tsconfigPaths()],
   build: {
     ...(baseLibConfig.build || {}),
     outDir: 'umd',

--- a/config/vite.vue.umd.config.js
+++ b/config/vite.vue.umd.config.js
@@ -1,8 +1,6 @@
-import fs from 'fs'
 import path from 'path'
 
 import { defineConfig } from 'vite'
-import dts from 'vite-plugin-dts'
 import tsconfigPaths from 'vite-tsconfig-paths'
 
 import vue from '@vitejs/plugin-vue'
@@ -15,20 +13,7 @@ const pkg = require(path.join(PWD, 'package.json'))
 const deps = [...Object.keys(Object.assign({}, pkg.peerDependencies))]
 
 export default defineConfig({
-  plugins: [
-    vue(),
-    tsconfigPaths(),
-    dts({
-      exclude: ['**/*.spec.ts', '**/*.test.ts', '**/tests/**'],
-      afterBuild: () => {
-        const types = fs.readdirSync(path.join(PWD, 'umd/src'))
-        types.forEach((file) => {
-          fs.renameSync(path.join(PWD, 'umd/src', file), path.join(PWD, 'umd', file))
-        })
-        fs.rmdirSync(path.join(PWD, 'umd/src'))
-      }
-    })
-  ],
+  plugins: [vue(), tsconfigPaths()],
   build: {
     ...(baseLibConfig.build || {}),
     outDir: 'umd',

--- a/docs/docs/reference/docgen/javascript/nhost-js/content/nhost-graphql-client/content/01-request.mdx
+++ b/docs/docs/reference/docgen/javascript/nhost-js/content/nhost-graphql-client/content/01-request.mdx
@@ -4,7 +4,7 @@ title: request()
 sidebar_label: request()
 slug: /reference/javascript/nhost-js/graphql/request
 description: Use `nhost.graphql.request` to send a GraphQL request. For more serious GraphQL usage in your app we recommend using a GraphQL client such as Apollo Client (https://www.apollographql.com/docs/react).
-custom_edit_url: https://github.com/nhost/nhost/edit/main/packages/nhost-js/src/clients/graphql.ts#L56
+custom_edit_url: https://github.com/nhost/nhost/edit/main/packages/nhost-js/src/clients/graphql.ts#L55
 ---
 
 # `request()`

--- a/docs/docs/reference/docgen/javascript/nhost-js/content/nhost-graphql-client/content/02-get-url.mdx
+++ b/docs/docs/reference/docgen/javascript/nhost-js/content/nhost-graphql-client/content/02-get-url.mdx
@@ -4,7 +4,7 @@ title: getUrl()
 sidebar_label: getUrl()
 slug: /reference/javascript/nhost-js/graphql/get-url
 description: Use `nhost.graphql.getUrl` to get the GraphQL URL.
-custom_edit_url: https://github.com/nhost/nhost/edit/main/packages/nhost-js/src/clients/graphql.ts#L119
+custom_edit_url: https://github.com/nhost/nhost/edit/main/packages/nhost-js/src/clients/graphql.ts#L118
 ---
 
 # `getUrl()`

--- a/docs/docs/reference/docgen/javascript/nhost-js/content/nhost-graphql-client/content/03-set-access-token.mdx
+++ b/docs/docs/reference/docgen/javascript/nhost-js/content/nhost-graphql-client/content/03-set-access-token.mdx
@@ -4,7 +4,7 @@ title: setAccessToken()
 sidebar_label: setAccessToken()
 slug: /reference/javascript/nhost-js/graphql/set-access-token
 description: Use `nhost.graphql.setAccessToken` to a set an access token to be used in subsequent graphql requests. Note that if you're signin in users with `nhost.auth.signIn()` the access token will be set automatically.
-custom_edit_url: https://github.com/nhost/nhost/edit/main/packages/nhost-js/src/clients/graphql.ts#L133
+custom_edit_url: https://github.com/nhost/nhost/edit/main/packages/nhost-js/src/clients/graphql.ts#L132
 ---
 
 # `setAccessToken()`

--- a/docs/docs/reference/docgen/javascript/nhost-js/content/nhost-graphql-client/index.mdx
+++ b/docs/docs/reference/docgen/javascript/nhost-js/content/nhost-graphql-client/index.mdx
@@ -4,7 +4,7 @@ title: NhostGraphqlClient
 sidebar_label: GraphQL
 description: No description provided.
 slug: /reference/javascript/nhost-js/graphql
-custom_edit_url: https://github.com/nhost/nhost/edit/main/packages/nhost-js/src/clients/graphql.ts#L21
+custom_edit_url: https://github.com/nhost/nhost/edit/main/packages/nhost-js/src/clients/graphql.ts#L20
 ---
 
 # `NhostGraphqlClient`

--- a/docs/docs/reference/docgen/javascript/nhost-js/types/nhost-graphql-constructor-params.mdx
+++ b/docs/docs/reference/docgen/javascript/nhost-js/types/nhost-graphql-constructor-params.mdx
@@ -4,7 +4,7 @@ title: NhostGraphqlConstructorParams
 sidebar_label: NhostGraphqlConstructorParams
 description: No description provided.
 displayed_sidebar: referenceSidebar
-custom_edit_url: https://github.com/nhost/nhost/edit/main/packages/nhost-js/src/clients/graphql.ts#L7
+custom_edit_url: https://github.com/nhost/nhost/edit/main/packages/nhost-js/src/clients/graphql.ts#L6
 ---
 
 # `NhostGraphqlConstructorParams`

--- a/packages/apollo/package.json
+++ b/packages/apollo/package.json
@@ -22,7 +22,7 @@
     "url": "https://github.com/nhost/nhost.git"
   },
   "main": "dist/index.cjs.js",
-  "module": "dist/index.es.js",
+  "module": "dist/index.mjs",
   "types": "dist/index.d.ts",
   "source": "src/index.ts",
   "files": [
@@ -32,8 +32,11 @@
   ],
   "exports": {
     ".": {
-      "import": "./dist/index.es.js",
-      "require": "./dist/index.cjs.js"
+      "node": {
+        "import": "./dist/index.mjs",
+        "require": "./dist/index.cjs.js"
+      },
+      "default": "./dist/index.es.js"
     }
   },
   "publishConfig": {
@@ -42,7 +45,7 @@
   "scripts": {
     "dev": "vite build --config ../../config/vite.lib.dev.config.js",
     "build": "run-p build:lib build:umd",
-    "build:lib": "vite build --config ../../config/vite.lib.config.js",
+    "build:lib": "vite build --config ../../config/vite.lib.config.js && cp dist/index.mjs dist/index.es.js && cp dist/index.mjs.map dist/index.es.js.map",
     "build:umd": "vite build --config ../../config/vite.lib.umd.config.js",
     "test": "vitest run --config ../../config/vite.lib.config.js",
     "test:watch": "vitest --config ../../config/vite.lib.config.js",

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -21,7 +21,7 @@
     "url": "https://github.com/nhost/nhost.git"
   },
   "main": "dist/index.cjs.js",
-  "module": "dist/index.es.js",
+  "module": "dist/index.mjs",
   "types": "dist/index.d.ts",
   "source": "src/index.ts",
   "files": [
@@ -31,8 +31,11 @@
   ],
   "exports": {
     ".": {
-      "import": "./dist/index.es.js",
-      "require": "./dist/index.cjs.js"
+      "node": {
+        "import": "./dist/index.mjs",
+        "require": "./dist/index.cjs.js"
+      },
+      "default": "./dist/index.es.js"
     }
   },
   "publishConfig": {
@@ -41,7 +44,7 @@
   "scripts": {
     "dev": "vite build --config ../../config/vite.lib.dev.config.js",
     "build": "run-p build:lib build:umd",
-    "build:lib": "vite build --config ../../config/vite.lib.config.js",
+    "build:lib": "vite build --config ../../config/vite.lib.config.js && cp dist/index.mjs dist/index.es.js && cp dist/index.mjs.map dist/index.es.js.map",
     "build:umd": "vite build --config ../../config/vite.lib.umd.config.js",
     "test": "vitest run --config ../../config/vite.lib.config.js",
     "test:watch": "vitest --config ../../config/vite.lib.config.js",

--- a/packages/hasura-auth-js/package.json
+++ b/packages/hasura-auth-js/package.json
@@ -20,7 +20,7 @@
     "url": "https://github.com/nhost/nhost.git"
   },
   "main": "dist/index.cjs.js",
-  "module": "dist/index.es.js",
+  "module": "dist/index.mjs",
   "types": "dist/index.d.ts",
   "source": "src/index.ts",
   "files": [
@@ -30,8 +30,11 @@
   ],
   "exports": {
     ".": {
-      "import": "./dist/index.es.js",
-      "require": "./dist/index.cjs.js"
+      "node": {
+        "import": "./dist/index.mjs",
+        "require": "./dist/index.cjs.js"
+      },
+      "default": "./dist/index.es.js"
     }
   },
   "publishConfig": {
@@ -40,7 +43,7 @@
   "scripts": {
     "dev": "vite build --config ../../config/vite.lib.dev.config.js",
     "build": "run-p build:lib build:umd",
-    "build:lib": "vite build",
+    "build:lib": "vite build && cp dist/index.mjs dist/index.es.js && cp dist/index.mjs.map dist/index.es.js.map",
     "build:umd": "vite build --config ../../config/vite.lib.umd.config.js",
     "test": "vitest run",
     "test:watch": "vitest",

--- a/packages/hasura-storage-js/package.json
+++ b/packages/hasura-storage-js/package.json
@@ -18,7 +18,7 @@
     "url": "https://github.com/nhost/hasura-storage-js.git"
   },
   "main": "dist/index.cjs.js",
-  "module": "dist/index.es.js",
+  "module": "dist/index.mjs",
   "types": "dist/index.d.ts",
   "source": "src/index.ts",
   "files": [
@@ -28,8 +28,11 @@
   ],
   "exports": {
     ".": {
-      "import": "./dist/index.es.js",
-      "require": "./dist/index.cjs.js"
+      "node": {
+        "import": "./dist/index.mjs",
+        "require": "./dist/index.cjs.js"
+      },
+      "default": "./dist/index.es.js"
     }
   },
   "publishConfig": {
@@ -38,7 +41,7 @@
   "scripts": {
     "dev": "vite build --config ../../config/vite.lib.dev.config.js",
     "build": "run-p build:lib build:umd",
-    "build:lib": "vite build --config ../../config/vite.lib.config.js",
+    "build:lib": "vite build --config ../../config/vite.lib.config.js && cp dist/index.mjs dist/index.es.js && cp dist/index.mjs.map dist/index.es.js.map",
     "build:umd": "vite build --config ../../config/vite.lib.umd.config.js",
     "test": "vitest run --config ../../config/vite.lib.config.js",
     "test:watch": "vitest --config ../../config/vite.lib.config.js",

--- a/packages/nextjs/package.json
+++ b/packages/nextjs/package.json
@@ -24,7 +24,7 @@
     "url": "https://github.com/nhost/nhost.git"
   },
   "main": "dist/index.cjs.js",
-  "module": "dist/index.es.js",
+  "module": "dist/index.mjs",
   "types": "dist/index.d.ts",
   "source": "src/index.ts",
   "files": [
@@ -34,8 +34,11 @@
   ],
   "exports": {
     ".": {
-      "import": "./dist/index.es.js",
-      "require": "./dist/index.cjs.js"
+      "node": {
+        "import": "./dist/index.mjs",
+        "require": "./dist/index.cjs.js"
+      },
+      "default": "./dist/index.es.js"
     }
   },
   "publishConfig": {
@@ -44,7 +47,7 @@
   "scripts": {
     "dev": "vite build --config ../../config/vite.react.dev.config.js",
     "build": "run-p build:lib build:umd",
-    "build:lib": "vite build --config ../../config/vite.react.config.js",
+    "build:lib": "vite build --config ../../config/vite.react.config.js && cp dist/index.mjs dist/index.es.js && cp dist/index.mjs.map dist/index.es.js.map",
     "build:umd": "vite build --config ../../config/vite.react.umd.config.js",
     "test": "vitest run --config ../../config/vite.react.config.js",
     "test:watch": "vitest --config ../../config/vite.react.config.js",

--- a/packages/nhost-js/package.json
+++ b/packages/nhost-js/package.json
@@ -21,7 +21,7 @@
     "url": "git+https://github.com/nhost/nhost.git"
   },
   "main": "dist/index.cjs.js",
-  "module": "dist/index.es.js",
+  "module": "dist/index.mjs",
   "types": "dist/index.d.ts",
   "source": "src/index.ts",
   "files": [
@@ -31,8 +31,11 @@
   ],
   "exports": {
     ".": {
-      "import": "./dist/index.es.js",
-      "require": "./dist/index.cjs.js"
+      "node": {
+        "import": "./dist/index.mjs",
+        "require": "./dist/index.cjs.js"
+      },
+      "default": "./dist/index.es.js"
     }
   },
   "publishConfig": {
@@ -41,7 +44,7 @@
   "scripts": {
     "dev": "vite build --config ../../config/vite.lib.dev.config.js",
     "build": "run-p build:lib build:umd",
-    "build:lib": "vite build --config ../../config/vite.lib.config.js",
+    "build:lib": "vite build --config ../../config/vite.lib.config.js && cp dist/index.mjs dist/index.es.js && cp dist/index.mjs.map dist/index.es.js.map",
     "build:umd": "vite build --config ../../config/vite.lib.umd.config.js",
     "test": "vitest run --config ../../config/vite.lib.config.js",
     "test:watch": "vitest --config ../../config/vite.lib.config.js",

--- a/packages/nhost-js/src/clients/graphql.ts
+++ b/packages/nhost-js/src/clients/graphql.ts
@@ -1,6 +1,5 @@
 import axios, { AxiosInstance, AxiosRequestConfig, AxiosRequestHeaders } from 'axios'
-import type { DocumentNode } from 'graphql'
-import { print } from 'graphql/language/printer'
+import { DocumentNode, print } from 'graphql'
 
 import { GraphqlRequestResponse, GraphqlResponse } from '../types'
 

--- a/packages/react-apollo/package.json
+++ b/packages/react-apollo/package.json
@@ -23,7 +23,7 @@
     "url": "git+https://github.com/nhost/nhost.git"
   },
   "main": "dist/index.cjs.js",
-  "module": "dist/index.es.js",
+  "module": "dist/index.mjs",
   "types": "dist/index.d.ts",
   "source": "src/index.ts",
   "files": [
@@ -33,8 +33,11 @@
   ],
   "exports": {
     ".": {
-      "import": "./dist/index.es.js",
-      "require": "./dist/index.cjs.js"
+      "node": {
+        "import": "./dist/index.mjs",
+        "require": "./dist/index.cjs.js"
+      },
+      "default": "./dist/index.es.js"
     }
   },
   "publishConfig": {
@@ -43,7 +46,7 @@
   "scripts": {
     "dev": "vite build --config ../../config/vite.react.dev.config.js",
     "build": "run-p build:lib build:umd",
-    "build:lib": "vite build --config ../../config/vite.react.config.js",
+    "build:lib": "vite build --config ../../config/vite.react.config.js && cp dist/index.mjs dist/index.es.js && cp dist/index.mjs.map dist/index.es.js.map",
     "build:umd": "vite build --config ../../config/vite.react.umd.config.js",
     "test": "vitest run --config ../../config/vite.react.config.js",
     "test:watch": "vitest --config ../../config/vite.react.config.js",

--- a/packages/react-auth/package.json
+++ b/packages/react-auth/package.json
@@ -22,7 +22,7 @@
     "url": "git+https://github.com/nhost/nhost.git"
   },
   "main": "dist/index.cjs.js",
-  "module": "dist/index.es.js",
+  "module": "dist/index.mjs",
   "types": "dist/index.d.ts",
   "source": "src/index.tsx",
   "files": [
@@ -32,8 +32,11 @@
   ],
   "exports": {
     ".": {
-      "import": "./dist/index.es.js",
-      "require": "./dist/index.cjs.js"
+      "node": {
+        "import": "./dist/index.mjs",
+        "require": "./dist/index.cjs.js"
+      },
+      "default": "./dist/index.es.js"
     }
   },
   "publishConfig": {
@@ -42,7 +45,7 @@
   "scripts": {
     "dev": "vite build --config ../../config/vite.react.dev.config.js",
     "build": "run-p build:lib build:umd",
-    "build:lib": "vite build --config ../../config/vite.react.config.js",
+    "build:lib": "vite build --config ../../config/vite.react.config.js && cp dist/index.mjs dist/index.es.js && cp dist/index.mjs.map dist/index.es.js.map",
     "build:umd": "vite build --config ../../config/vite.react.umd.config.js",
     "test": "vitest run --config ../../config/vite.react.config.js",
     "test:watch": "vitest --config ../../config/vite.react.config.js",

--- a/packages/react/package.json
+++ b/packages/react/package.json
@@ -22,7 +22,7 @@
     "url": "https://github.com/nhost/nhost.git"
   },
   "main": "dist/index.cjs.js",
-  "module": "dist/index.es.js",
+  "module": "dist/index.mjs",
   "types": "dist/index.d.ts",
   "source": "src/index.ts",
   "files": [
@@ -32,8 +32,11 @@
   ],
   "exports": {
     ".": {
-      "import": "./dist/index.es.js",
-      "require": "./dist/index.cjs.js"
+      "node": {
+        "import": "./dist/index.mjs",
+        "require": "./dist/index.cjs.js"
+      },
+      "default": "./dist/index.es.js"
     }
   },
   "publishConfig": {
@@ -42,7 +45,7 @@
   "scripts": {
     "dev": "vite build --config ../../config/vite.react.dev.config.js",
     "build": "run-p build:lib build:umd",
-    "build:lib": "vite build --config ../../config/vite.react.config.js",
+    "build:lib": "vite build --config ../../config/vite.react.config.js && cp dist/index.mjs dist/index.es.js && cp dist/index.mjs.map dist/index.es.js.map",
     "build:umd": "vite build --config ../../config/vite.react.umd.config.js",
     "test": "vitest run --config ../../config/vite.react.config.js",
     "test:watch": "vitest --config ../../config/vite.react.config.js",

--- a/packages/vue/package.json
+++ b/packages/vue/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@nhost/vue",
-  "version": "0.1.0",
+  "version": "0.1.1",
   "description": "Nhost Vue library",
   "license": "MIT",
   "keywords": [
@@ -22,7 +22,7 @@
     "url": "https://github.com/nhost/nhost.git"
   },
   "main": "dist/index.cjs.js",
-  "module": "dist/index.es.js",
+  "module": "dist/index.mjs",
   "types": "dist/index.d.ts",
   "source": "src/index.ts",
   "files": [
@@ -32,8 +32,11 @@
   ],
   "exports": {
     ".": {
-      "import": "./dist/index.es.js",
-      "require": "./dist/index.cjs.js"
+      "node": {
+        "import": "./dist/index.mjs",
+        "require": "./dist/index.cjs.js"
+      },
+      "default": "./dist/index.es.js"
     }
   },
   "publishConfig": {
@@ -42,7 +45,7 @@
   "scripts": {
     "dev": "vite build --config ../../config/vite.vue.dev.config.js",
     "build": "run-p build:lib build:umd",
-    "build:lib": "vite build --config ../../config/vite.vue.config.js",
+    "build:lib": "vite build --config ../../config/vite.vue.config.js && cp dist/index.mjs dist/index.es.js && cp dist/index.mjs.map dist/index.es.js.map",
     "build:umd": "vite build --config ../../config/vite.vue.umd.config.js",
     "test": "vitest run --config ../../config/vite.vue.config.js",
     "test:watch": "vitest --config ../../config/vite.vue.config.js",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -4221,7 +4221,7 @@ packages:
     dependencies:
       '@jest/fake-timers': 27.5.1
       '@jest/types': 27.5.1
-      '@types/node': 17.0.31
+      '@types/node': 17.0.33
       jest-mock: 27.5.1
     dev: true
 
@@ -4231,7 +4231,7 @@ packages:
     dependencies:
       '@jest/types': 27.5.1
       '@sinonjs/fake-timers': 8.1.0
-      '@types/node': 17.0.31
+      '@types/node': 17.0.33
       jest-message-util: 27.5.1
       jest-mock: 27.5.1
       jest-util: 27.5.1
@@ -5591,7 +5591,7 @@ packages:
   /@types/graceful-fs/4.1.5:
     resolution: {integrity: sha512-anKkLmZZ+xm4p8JWBf4hElkM4XR+EZeA2M9BAkkTldmcyDY4mbdIJnRghDJH3Ov5ooY7/UAoENtmdMSkaAd7Cw==}
     dependencies:
-      '@types/node': 17.0.31
+      '@types/node': 17.0.33
     dev: true
 
   /@types/hast/2.3.4:
@@ -7674,6 +7674,8 @@ packages:
       qs: 6.9.7
       raw-body: 2.4.3
       type-is: 1.6.18
+    transitivePeerDependencies:
+      - supports-color
 
   /bonjour-service/1.0.11:
     resolution: {integrity: sha512-drMprzr2rDTCtgEE3VgdA9uUFaUHF+jXduwYSThHJnKMYM+FhI9Z3ph+TX3xy0LtgYHae6CHYPJ/2UnK8nQHcA==}
@@ -8382,7 +8384,7 @@ packages:
     dev: true
 
   /commondir/1.0.1:
-    resolution: {integrity: sha1-3dgA2gxmEnOTzKWVDqloo6rxJTs=}
+    resolution: {integrity: sha512-W9pAhw0ja1Edb5GVdIF1mjZw/ASI0AlShXM83UUGe2DVr5TdAPEA1OA8m/g8zWp9x6On7gqufY+FatDbC3MDQg==}
 
   /compressible/2.0.18:
     resolution: {integrity: sha512-AF3r7P5dWxL8MxyITRMlORQNaOA2IkAFaTr4k7BUumjPtRpGDTZpl0Pb1XCO6JeDCBdp126Cgs9sMxqSjgYyRg==}
@@ -10519,6 +10521,8 @@ packages:
     dependencies:
       debug: 3.2.7
       resolve: 1.22.0
+    transitivePeerDependencies:
+      - supports-color
     dev: true
 
   /eslint-import-resolver-typescript/2.7.1_662e1b2e8ef3f6aa5d22c3f7cd670612:
@@ -11303,6 +11307,8 @@ packages:
       type-is: 1.6.18
       utils-merge: 1.0.1
       vary: 1.1.2
+    transitivePeerDependencies:
+      - supports-color
 
   /extend-shallow/2.0.1:
     resolution: {integrity: sha1-Ua99YUrZqfYQ6huvu5idaxxWiQ8=}
@@ -11503,6 +11509,8 @@ packages:
       parseurl: 1.3.3
       statuses: 1.5.0
       unpipe: 1.0.0
+    transitivePeerDependencies:
+      - supports-color
 
   /find-cache-dir/3.3.2:
     resolution: {integrity: sha512-wXZV5emFEjrridIgED11OoUKLxiYjAcqot/NJdAkOhlJ+vGzwhOAfcG5OX1jP+S0PcjEn8bdMJv+g2jwQ3Onig==}
@@ -13230,7 +13238,7 @@ packages:
       '@jest/environment': 27.5.1
       '@jest/test-result': 27.5.1
       '@jest/types': 27.5.1
-      '@types/node': 17.0.31
+      '@types/node': 17.0.33
       chalk: 4.1.2
       co: 4.6.0
       dedent: 0.7.0
@@ -13436,7 +13444,7 @@ packages:
       '@jest/environment': 27.5.1
       '@jest/fake-timers': 27.5.1
       '@jest/types': 27.5.1
-      '@types/node': 17.0.31
+      '@types/node': 17.0.33
       jest-mock: 27.5.1
       jest-util: 27.5.1
       jsdom: 16.7.0
@@ -13454,7 +13462,7 @@ packages:
       '@jest/environment': 27.5.1
       '@jest/fake-timers': 27.5.1
       '@jest/types': 27.5.1
-      '@types/node': 17.0.31
+      '@types/node': 17.0.33
       jest-mock: 27.5.1
       jest-util: 27.5.1
     dev: true
@@ -13497,7 +13505,7 @@ packages:
       '@jest/source-map': 27.5.1
       '@jest/test-result': 27.5.1
       '@jest/types': 27.5.1
-      '@types/node': 17.0.31
+      '@types/node': 17.0.33
       chalk: 4.1.2
       co: 4.6.0
       expect: 27.5.1
@@ -13552,7 +13560,7 @@ packages:
     engines: {node: ^10.13.0 || ^12.13.0 || ^14.15.0 || >=15.0.0}
     dependencies:
       '@jest/types': 27.5.1
-      '@types/node': 17.0.31
+      '@types/node': 17.0.33
     dev: true
 
   /jest-pnp-resolver/1.2.2_jest-resolve@27.5.1:
@@ -13665,7 +13673,7 @@ packages:
     resolution: {integrity: sha512-jZCyo6iIxO1aqUxpuBlwTDMkzOAJS4a3eYz3YzgxxVQFwLeSA7Jfq5cbqCY+JLvTDrWirgusI/0KwxKMgrdf7w==}
     engines: {node: ^10.13.0 || ^12.13.0 || ^14.15.0 || >=15.0.0}
     dependencies:
-      '@types/node': 17.0.31
+      '@types/node': 17.0.33
       graceful-fs: 4.2.10
     dev: true
 
@@ -17672,6 +17680,8 @@ packages:
       on-finished: 2.3.0
       range-parser: 1.2.1
       statuses: 1.5.0
+    transitivePeerDependencies:
+      - supports-color
 
   /sentence-case/3.0.4:
     resolution: {integrity: sha512-8LS0JInaQMCRoQ7YUytAo/xUu5W2XnQxV2HI/6uM6U7CITS1RqPElr30V6uIqyMKM9lJGRVFy5/4CuzcixNYSg==}


### PR DESCRIPTION
## Problem

```
SyntaxError: Named export 'NhostClient' not found. The requested module '@nhost/nhost-js' is a CommonJS module, which may not support all module.exports as named exports.

(node:56887) Warning: To load an ES module, set "type": "module" in the package.json or use the .mjs extension.
(Use `node --trace-warnings ...` to show where the warning was created)
```
## Solution

Updated `exports` field of all packages to move away from `.es.js` files to `.mjs` when using `import` statements on the consumer side. Also fixed an issue related to this where `graphql` package was incorrectly imported in `@nhost/nhost-js`.