### PR TITLE
Corrected the yarn switch for installing express

### DIFF
--- a/docs/docs/platform/serverless-functions.mdx
+++ b/docs/docs/platform/serverless-functions.mdx
@@ -55,7 +55,7 @@ You **MUST** install `express` locally in the base directory of your Nhost app.
 ```bash
 npm install -d express
 # or yarn
-yarn add -d express
+yarn add -D express
 ```
 
 :::


### PR DESCRIPTION
The switch for yarn should `D`, not `d`.