### PR TITLE
fix: correct rewriting options when `clientUrl` is not available

### DIFF
--- a/.changeset/tricky-peaches-pump.md
+++ b/.changeset/tricky-peaches-pump.md
@@ -1,0 +1,8 @@
+---
+'@nhost/core': patch
+'@nhost/react': patch
+'@nhost/nextjs': patch
+---
+
+correct rewriting options when `clientUrl` is not available
+The client URL is set to `window.location.origin`, so it can rewrite redirection urls that are passed on to authenticaion methods. However, `clientUrl` is set to `''` when running on the server side. This fix then avoid raising an error when trying to rewrite `redirectTo` on non-browser environment, and forces `useProviderLink` to be rendered on the client side.

--- a/examples/nextjs/components/OauthLinks.tsx
+++ b/examples/nextjs/components/OauthLinks.tsx
@@ -1,6 +1,6 @@
 import { FaFacebook, FaGithub, FaGoogle } from 'react-icons/fa'
 
-import { useProviderLink } from '@nhost/react'
+import { useProviderLink } from '@nhost/nextjs'
 
 import AuthLink from './AuthLink'
 

--- a/packages/core/src/utils.ts
+++ b/packages/core/src/utils.ts
@@ -17,14 +17,26 @@ export const encodeQueryParameters = (baseUrl: string, parameters?: Record<strin
   else return baseUrl
 }
 
-export const rewriteRedirectTo = <T extends RedirectOption>(clientUrl?: string, options?: T) => {
+/**
+ * Transform options that include a redirectTo property so the
+ * redirect url is absolute, given a base clientUrl.
+ * If no client url is given, any relative redirectUrl is removed while
+ * the other options are sent as-is.
+ * @param clientUrl base client url
+ * @param options
+ * @returns
+ */
+export const rewriteRedirectTo = <T extends RedirectOption>(
+  clientUrl?: string,
+  options?: T
+): (Omit<T, 'redirectTo'> & { redirectTo?: string }) | undefined => {
   if (!options?.redirectTo) {
     return options
   }
   const { redirectTo, ...otherOptions } = options
-  // If the clientUrl is not defined, we can't rewrite the redirectTo
+  // * If the clientUrl is not defined, we can't rewrite the redirectTo
   if (!clientUrl) {
-    // If redirectTo is a relative path, we therefore pull it out of the options
+    // * If redirectTo is a relative path, we therefore pull it out of the options
     if (redirectTo.startsWith('/')) {
       return otherOptions
     } else {

--- a/packages/core/tests/utils.test.ts
+++ b/packages/core/tests/utils.test.ts
@@ -6,6 +6,18 @@ test(`should not add redirectTo when none is given`, async () => {
   expect(rewriteRedirectTo('https://frontend.com')).toBeUndefined()
 })
 
+test(`should remove redirectTo when it's relative and no clientUrl is given`, async () => {
+  const options: RedirectOption = { redirectTo: '/index' }
+  expect(rewriteRedirectTo('', options)).toEqual({})
+  expect(rewriteRedirectTo(undefined, options)).toEqual({})
+})
+
+test(`should preserve options when redirectTo is not a relative url and no clientUrl is given`, async () => {
+  const options: RedirectOption = { redirectTo: 'https://frontend.com' }
+  expect(rewriteRedirectTo('', options)).toEqual(options)
+  expect(rewriteRedirectTo(undefined, options)).toEqual(options)
+})
+
 test(`should append redirectTo with the clientUrl prefix`, async () => {
   const options: RedirectOption = { redirectTo: '/index' }
 

--- a/packages/react/src/useProviderLink.ts
+++ b/packages/react/src/useProviderLink.ts
@@ -1,4 +1,4 @@
-import { useContext, useMemo } from 'react'
+import { useContext, useEffect, useState } from 'react'
 
 import { encodeQueryParameters, Provider, ProviderOptions, rewriteRedirectTo } from '@nhost/core'
 
@@ -29,13 +29,25 @@ import { NhostReactContext } from './provider'
  * ```
  */
 export const useProviderLink = (options?: ProviderOptions) => {
+  /**
+   * @internal When using Nextjs or any SSR framework, nhost.auth.client.clientUrl will be set to `undefined`
+   * as its value is set to window.location.origin.
+   * This is because the request context is not available when setting up the client `new NhostClient()` outside of
+   * the React/Nextjs context.
+   */
+  const [isSSR, setIsSSR] = useState(true)
+
+  useEffect(() => {
+    setIsSSR(false)
+  }, [])
+
   const nhost = useContext(NhostReactContext)
 
   return new Proxy({} as Record<Provider, string>, {
     get(_, provider: string) {
       return encodeQueryParameters(
         `${nhost.auth.client.backendUrl}/signin/provider/${provider}`,
-        rewriteRedirectTo(nhost.auth.client.clientUrl, options as any)
+        rewriteRedirectTo(isSSR ? undefined : nhost.auth.client.clientUrl, options as any)
       )
     }
   })

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -1,4 +1,4 @@
-lockfileVersion: 5.4
+lockfileVersion: 5.3
 
 overrides:
   graphql: 15.7.2
@@ -104,20 +104,20 @@ importers:
       swagger-ui-react: ^4.10.3
       typescript: ^4.6.3
     dependencies:
-      '@docusaurus/core': 2.0.0-beta.20_fdtqczkawcrswx4npptvkurkw4
-      '@docusaurus/plugin-sitemap': 2.0.0-beta.20_fdtqczkawcrswx4npptvkurkw4
-      '@docusaurus/preset-classic': 2.0.0-beta.20_fdtqczkawcrswx4npptvkurkw4
+      '@docusaurus/core': 2.0.0-beta.20_66c8c36abcfdbeab71528ce4b75c41f7
+      '@docusaurus/plugin-sitemap': 2.0.0-beta.20_66c8c36abcfdbeab71528ce4b75c41f7
+      '@docusaurus/preset-classic': 2.0.0-beta.20_66c8c36abcfdbeab71528ce4b75c41f7
       '@mdx-js/react': 1.6.22_react@17.0.2
       clsx: 1.1.1
       docusaurus-plugin-image-zoom: 0.1.1
-      mdx-mermaid: 1.2.2_c22t5semscxhgv3n3sjop6jcyy
+      mdx-mermaid: 1.2.2_mermaid@8.14.0+react@17.0.2
       mermaid: 8.14.0
       prism-react-renderer: 1.3.1_react@17.0.2
       react: 17.0.2
       react-dom: 17.0.2_react@17.0.2
-      swagger-ui-react: 4.10.3_sfoxds7t5ydpegc3knd667wn6m
+      swagger-ui-react: 4.10.3_react-dom@17.0.2+react@17.0.2
     devDependencies:
-      '@docusaurus/module-type-aliases': 2.0.0-beta.20_sfoxds7t5ydpegc3knd667wn6m
+      '@docusaurus/module-type-aliases': 2.0.0-beta.20_react-dom@17.0.2+react@17.0.2
       '@tsconfig/docusaurus': 1.0.5
       '@types/swagger-ui-react': 4.1.1
       typescript: 4.6.3
@@ -2654,7 +2654,7 @@ packages:
     resolution: {integrity: sha512-1kkV7tkAsiuEd0shunYRByKJe3xQDG2q7wYg24SOw1nV9/2lwEd4WrUYRJC/ukGTl2/kHeFxsaUvtiOy0y6fFA==}
     dev: false
 
-  /@docsearch/react/3.0.0_sfoxds7t5ydpegc3knd667wn6m:
+  /@docsearch/react/3.0.0_react-dom@17.0.2+react@17.0.2:
     resolution: {integrity: sha512-yhMacqS6TVQYoBh/o603zszIb5Bl8MIXuOc6Vy617I74pirisDzzcNh0NEaYQt50fVVR3khUbeEhUEWEWipESg==}
     peerDependencies:
       '@types/react': '>= 16.8.0 < 18.0.0'
@@ -2671,7 +2671,7 @@ packages:
       - '@algolia/client-search'
     dev: false
 
-  /@docusaurus/core/2.0.0-beta.20_fdtqczkawcrswx4npptvkurkw4:
+  /@docusaurus/core/2.0.0-beta.20_66c8c36abcfdbeab71528ce4b75c41f7:
     resolution: {integrity: sha512-a3UgZ4lIcIOoZd4j9INqVkWSXEDxR7EicJXt8eq2whg4N5hKGqLHoDSnWfrVSPQn4NoG5T7jhPypphSoysImfQ==}
     engines: {node: '>=14'}
     hasBin: true
@@ -2691,7 +2691,7 @@ packages:
       '@babel/traverse': 7.17.10
       '@docusaurus/cssnano-preset': 2.0.0-beta.20
       '@docusaurus/logger': 2.0.0-beta.20
-      '@docusaurus/mdx-loader': 2.0.0-beta.20_sfoxds7t5ydpegc3knd667wn6m
+      '@docusaurus/mdx-loader': 2.0.0-beta.20_react-dom@17.0.2+react@17.0.2
       '@docusaurus/react-loadable': 5.5.2_react@17.0.2
       '@docusaurus/utils': 2.0.0-beta.20
       '@docusaurus/utils-common': 2.0.0-beta.20
@@ -2699,7 +2699,7 @@ packages:
       '@slorber/static-site-generator-webpack-plugin': 4.0.4
       '@svgr/webpack': 6.2.1
       autoprefixer: 10.4.7_postcss@8.4.13
-      babel-loader: 8.2.5_rb5fcebzp6kx3hqg3ucus54t3m
+      babel-loader: 8.2.5_887a5110397f957d9e06dd05497793db
       babel-plugin-dynamic-import-node: 2.3.0
       boxen: 6.2.1
       chokidar: 3.5.3
@@ -2710,7 +2710,7 @@ packages:
       copy-webpack-plugin: 10.2.4_webpack@5.72.0
       core-js: 3.22.5
       css-loader: 6.7.1_webpack@5.72.0
-      css-minimizer-webpack-plugin: 3.4.1_tejugib4y3rw5hvgnfmxavjvsu
+      css-minimizer-webpack-plugin: 3.4.1_clean-css@5.3.0+webpack@5.72.0
       cssnano: 5.1.7_postcss@8.4.13
       del: 6.0.0
       detect-port: 1.3.0
@@ -2726,16 +2726,16 @@ packages:
       lodash: 4.17.21
       mini-css-extract-plugin: 2.6.0_webpack@5.72.0
       postcss: 8.4.13
-      postcss-loader: 6.2.1_g4najheu5gwop3kphiif6aqpde
+      postcss-loader: 6.2.1_postcss@8.4.13+webpack@5.72.0
       prompts: 2.4.2
       react: 17.0.2
-      react-dev-utils: 12.0.1_4dvvomwfbhpgf7xcm7gogbdvgu
+      react-dev-utils: 12.0.1_509a9d40d32ea50a4d33125362dc897b
       react-dom: 17.0.2_react@17.0.2
-      react-helmet-async: 1.3.0_sfoxds7t5ydpegc3knd667wn6m
+      react-helmet-async: 1.3.0_react-dom@17.0.2+react@17.0.2
       react-loadable: /@docusaurus/react-loadable/5.5.2_react@17.0.2
-      react-loadable-ssr-addon-v5-slorber: 1.0.1_5grs2dwrf6hqtfkptfcfoiy4bu
+      react-loadable-ssr-addon-v5-slorber: 1.0.1_e9a32d0ed12f8f09954f994457231c0d
       react-router: 5.3.1_react@17.0.2
-      react-router-config: 5.1.1_53jg2tb4f34fvmclurfotx7m6y
+      react-router-config: 5.1.1_react-router@5.3.1+react@17.0.2
       react-router-dom: 5.3.1_react@17.0.2
       remark-admonitions: 1.2.1
       rtl-detect: 1.0.4
@@ -2745,7 +2745,7 @@ packages:
       terser-webpack-plugin: 5.3.1_webpack@5.72.0
       tslib: 2.4.0
       update-notifier: 5.1.0
-      url-loader: 4.1.1_csgzzuwaerdr4d7s3u52mzcn7m
+      url-loader: 4.1.1_file-loader@6.2.0+webpack@5.72.0
       wait-on: 6.0.1
       webpack: 5.72.0
       webpack-bundle-analyzer: 4.5.0
@@ -2784,7 +2784,7 @@ packages:
       tslib: 2.4.0
     dev: false
 
-  /@docusaurus/mdx-loader/2.0.0-beta.20_sfoxds7t5ydpegc3knd667wn6m:
+  /@docusaurus/mdx-loader/2.0.0-beta.20_react-dom@17.0.2+react@17.0.2:
     resolution: {integrity: sha512-BBuf77sji3JxbCEW7Qsv3CXlgpm+iSLTQn6JUK7x8vJ1JYZ3KJbNgpo9TmxIIltpcvNQ/QOy6dvqrpSStaWmKQ==}
     engines: {node: '>=14'}
     peerDependencies:
@@ -2807,7 +2807,7 @@ packages:
       stringify-object: 3.3.0
       tslib: 2.4.0
       unist-util-visit: 2.0.3
-      url-loader: 4.1.1_csgzzuwaerdr4d7s3u52mzcn7m
+      url-loader: 4.1.1_file-loader@6.2.0+webpack@5.72.0
       webpack: 5.72.0
     transitivePeerDependencies:
       - '@swc/core'
@@ -2817,35 +2817,35 @@ packages:
       - webpack-cli
     dev: false
 
-  /@docusaurus/module-type-aliases/2.0.0-beta.20_sfoxds7t5ydpegc3knd667wn6m:
+  /@docusaurus/module-type-aliases/2.0.0-beta.20_react-dom@17.0.2+react@17.0.2:
     resolution: {integrity: sha512-lUIXLwQEOyYwcb3iCNibPUL6O9ijvYF5xQwehGeVraTEBts/Ch8ZwELFk+XbaGHKh52PiVxuWL2CP4Gdjy5QKw==}
     peerDependencies:
       react: '*'
       react-dom: '*'
     dependencies:
-      '@docusaurus/types': 2.0.0-beta.20_sfoxds7t5ydpegc3knd667wn6m
+      '@docusaurus/types': 2.0.0-beta.20_react-dom@17.0.2+react@17.0.2
       '@types/react': 18.0.8
       '@types/react-router-config': 5.0.6
       '@types/react-router-dom': 5.3.3
       react: 17.0.2
       react-dom: 17.0.2_react@17.0.2
-      react-helmet-async: 1.3.0_sfoxds7t5ydpegc3knd667wn6m
+      react-helmet-async: 1.3.0_react-dom@17.0.2+react@17.0.2
     transitivePeerDependencies:
       - '@swc/core'
       - esbuild
       - uglify-js
       - webpack-cli
 
-  /@docusaurus/plugin-content-blog/2.0.0-beta.20_fdtqczkawcrswx4npptvkurkw4:
+  /@docusaurus/plugin-content-blog/2.0.0-beta.20_66c8c36abcfdbeab71528ce4b75c41f7:
     resolution: {integrity: sha512-6aby36Gmny5h2oo/eEZ2iwVsIlBWbRnNNeqT0BYnJO5aj53iCU/ctFPpJVYcw0l2l8+8ITS70FyePIWEsaZ0jA==}
     engines: {node: '>=14'}
     peerDependencies:
       react: ^16.8.4 || ^17.0.0
       react-dom: ^16.8.4 || ^17.0.0
     dependencies:
-      '@docusaurus/core': 2.0.0-beta.20_fdtqczkawcrswx4npptvkurkw4
+      '@docusaurus/core': 2.0.0-beta.20_66c8c36abcfdbeab71528ce4b75c41f7
       '@docusaurus/logger': 2.0.0-beta.20
-      '@docusaurus/mdx-loader': 2.0.0-beta.20_sfoxds7t5ydpegc3knd667wn6m
+      '@docusaurus/mdx-loader': 2.0.0-beta.20_react-dom@17.0.2+react@17.0.2
       '@docusaurus/utils': 2.0.0-beta.20
       '@docusaurus/utils-common': 2.0.0-beta.20
       '@docusaurus/utils-validation': 2.0.0-beta.20
@@ -2877,16 +2877,16 @@ packages:
       - webpack-cli
     dev: false
 
-  /@docusaurus/plugin-content-docs/2.0.0-beta.20_fdtqczkawcrswx4npptvkurkw4:
+  /@docusaurus/plugin-content-docs/2.0.0-beta.20_66c8c36abcfdbeab71528ce4b75c41f7:
     resolution: {integrity: sha512-XOgwUqXtr/DStpB3azdN6wgkKtQkOXOx1XetORzhHnjihrSMn6daxg+spmcJh1ki/mpT3n7yBbKJxVNo+VB38Q==}
     engines: {node: '>=14'}
     peerDependencies:
       react: ^16.8.4 || ^17.0.0
       react-dom: ^16.8.4 || ^17.0.0
     dependencies:
-      '@docusaurus/core': 2.0.0-beta.20_fdtqczkawcrswx4npptvkurkw4
+      '@docusaurus/core': 2.0.0-beta.20_66c8c36abcfdbeab71528ce4b75c41f7
       '@docusaurus/logger': 2.0.0-beta.20
-      '@docusaurus/mdx-loader': 2.0.0-beta.20_sfoxds7t5ydpegc3knd667wn6m
+      '@docusaurus/mdx-loader': 2.0.0-beta.20_react-dom@17.0.2+react@17.0.2
       '@docusaurus/utils': 2.0.0-beta.20
       '@docusaurus/utils-validation': 2.0.0-beta.20
       combine-promises: 1.1.0
@@ -2916,15 +2916,15 @@ packages:
       - webpack-cli
     dev: false
 
-  /@docusaurus/plugin-content-pages/2.0.0-beta.20_fdtqczkawcrswx4npptvkurkw4:
+  /@docusaurus/plugin-content-pages/2.0.0-beta.20_66c8c36abcfdbeab71528ce4b75c41f7:
     resolution: {integrity: sha512-ubY6DG4F0skFKjfNGCbfO34Qf+MZy6C05OtpIYsoA2YU8ADx0nRH7qPgdEkwR3ma860DbY612rleRT13ogSlhg==}
     engines: {node: '>=14'}
     peerDependencies:
       react: ^16.8.4 || ^17.0.0
       react-dom: ^16.8.4 || ^17.0.0
     dependencies:
-      '@docusaurus/core': 2.0.0-beta.20_fdtqczkawcrswx4npptvkurkw4
-      '@docusaurus/mdx-loader': 2.0.0-beta.20_sfoxds7t5ydpegc3knd667wn6m
+      '@docusaurus/core': 2.0.0-beta.20_66c8c36abcfdbeab71528ce4b75c41f7
+      '@docusaurus/mdx-loader': 2.0.0-beta.20_react-dom@17.0.2+react@17.0.2
       '@docusaurus/utils': 2.0.0-beta.20
       '@docusaurus/utils-validation': 2.0.0-beta.20
       fs-extra: 10.1.0
@@ -2949,19 +2949,19 @@ packages:
       - webpack-cli
     dev: false
 
-  /@docusaurus/plugin-debug/2.0.0-beta.20_fdtqczkawcrswx4npptvkurkw4:
+  /@docusaurus/plugin-debug/2.0.0-beta.20_66c8c36abcfdbeab71528ce4b75c41f7:
     resolution: {integrity: sha512-acGZmpncPA1XDczpV1ji1ajBCRBY/H2lXN8alSjOB1vh0c/2Qz+KKD05p17lsUbhIyvsnZBa/BaOwtek91Lu7Q==}
     engines: {node: '>=14'}
     peerDependencies:
       react: ^16.8.4 || ^17.0.0
       react-dom: ^16.8.4 || ^17.0.0
     dependencies:
-      '@docusaurus/core': 2.0.0-beta.20_fdtqczkawcrswx4npptvkurkw4
+      '@docusaurus/core': 2.0.0-beta.20_66c8c36abcfdbeab71528ce4b75c41f7
       '@docusaurus/utils': 2.0.0-beta.20
       fs-extra: 10.1.0
       react: 17.0.2
       react-dom: 17.0.2_react@17.0.2
-      react-json-view: 1.21.3_sfoxds7t5ydpegc3knd667wn6m
+      react-json-view: 1.21.3_react-dom@17.0.2+react@17.0.2
       tslib: 2.4.0
     transitivePeerDependencies:
       - '@parcel/css'
@@ -2981,14 +2981,14 @@ packages:
       - webpack-cli
     dev: false
 
-  /@docusaurus/plugin-google-analytics/2.0.0-beta.20_fdtqczkawcrswx4npptvkurkw4:
+  /@docusaurus/plugin-google-analytics/2.0.0-beta.20_66c8c36abcfdbeab71528ce4b75c41f7:
     resolution: {integrity: sha512-4C5nY25j0R1lntFmpSEalhL7jYA7tWvk0VZObiIxGilLagT/f9gWPQtIjNBe4yzdQvkhiaXpa8xcMcJUAKRJyw==}
     engines: {node: '>=14'}
     peerDependencies:
       react: ^16.8.4 || ^17.0.0
       react-dom: ^16.8.4 || ^17.0.0
     dependencies:
-      '@docusaurus/core': 2.0.0-beta.20_fdtqczkawcrswx4npptvkurkw4
+      '@docusaurus/core': 2.0.0-beta.20_66c8c36abcfdbeab71528ce4b75c41f7
       '@docusaurus/utils-validation': 2.0.0-beta.20
       react: 17.0.2
       react-dom: 17.0.2_react@17.0.2
@@ -3009,14 +3009,14 @@ packages:
       - webpack-cli
     dev: false
 
-  /@docusaurus/plugin-google-gtag/2.0.0-beta.20_fdtqczkawcrswx4npptvkurkw4:
+  /@docusaurus/plugin-google-gtag/2.0.0-beta.20_66c8c36abcfdbeab71528ce4b75c41f7:
     resolution: {integrity: sha512-EMZdiMTNg4NwE60xwjbetcqMDqAOazMTwQAQ4OuNAclv7oh8+VPCvqRF8s8AxCoI2Uqc7vh8yzNUuM307Ne9JA==}
     engines: {node: '>=14'}
     peerDependencies:
       react: ^16.8.4 || ^17.0.0
       react-dom: ^16.8.4 || ^17.0.0
     dependencies:
-      '@docusaurus/core': 2.0.0-beta.20_fdtqczkawcrswx4npptvkurkw4
+      '@docusaurus/core': 2.0.0-beta.20_66c8c36abcfdbeab71528ce4b75c41f7
       '@docusaurus/utils-validation': 2.0.0-beta.20
       react: 17.0.2
       react-dom: 17.0.2_react@17.0.2
@@ -3037,14 +3037,14 @@ packages:
       - webpack-cli
     dev: false
 
-  /@docusaurus/plugin-sitemap/2.0.0-beta.20_fdtqczkawcrswx4npptvkurkw4:
+  /@docusaurus/plugin-sitemap/2.0.0-beta.20_66c8c36abcfdbeab71528ce4b75c41f7:
     resolution: {integrity: sha512-Rf5a2vOBWjbe7PJJEBDeLZzDA7lsDi+16bqzKN8OKSXlcZLhxjmIpL5NrjANNbpGpL5vbl9z+iqvjbQmZ3QSmA==}
     engines: {node: '>=14'}
     peerDependencies:
       react: ^16.8.4 || ^17.0.0
       react-dom: ^16.8.4 || ^17.0.0
     dependencies:
-      '@docusaurus/core': 2.0.0-beta.20_fdtqczkawcrswx4npptvkurkw4
+      '@docusaurus/core': 2.0.0-beta.20_66c8c36abcfdbeab71528ce4b75c41f7
       '@docusaurus/utils': 2.0.0-beta.20
       '@docusaurus/utils-common': 2.0.0-beta.20
       '@docusaurus/utils-validation': 2.0.0-beta.20
@@ -3069,24 +3069,24 @@ packages:
       - webpack-cli
     dev: false
 
-  /@docusaurus/preset-classic/2.0.0-beta.20_fdtqczkawcrswx4npptvkurkw4:
+  /@docusaurus/preset-classic/2.0.0-beta.20_66c8c36abcfdbeab71528ce4b75c41f7:
     resolution: {integrity: sha512-artUDjiYFIlGd2fxk0iqqcJ5xSCrgormOAoind1c0pn8TRXY1WSCQWYI6p4X24jjhSCzLv0s6Z9PMDyxZdivhg==}
     engines: {node: '>=14'}
     peerDependencies:
       react: ^16.8.4 || ^17.0.0
       react-dom: ^16.8.4 || ^17.0.0
     dependencies:
-      '@docusaurus/core': 2.0.0-beta.20_fdtqczkawcrswx4npptvkurkw4
-      '@docusaurus/plugin-content-blog': 2.0.0-beta.20_fdtqczkawcrswx4npptvkurkw4
-      '@docusaurus/plugin-content-docs': 2.0.0-beta.20_fdtqczkawcrswx4npptvkurkw4
-      '@docusaurus/plugin-content-pages': 2.0.0-beta.20_fdtqczkawcrswx4npptvkurkw4
-      '@docusaurus/plugin-debug': 2.0.0-beta.20_fdtqczkawcrswx4npptvkurkw4
-      '@docusaurus/plugin-google-analytics': 2.0.0-beta.20_fdtqczkawcrswx4npptvkurkw4
-      '@docusaurus/plugin-google-gtag': 2.0.0-beta.20_fdtqczkawcrswx4npptvkurkw4
-      '@docusaurus/plugin-sitemap': 2.0.0-beta.20_fdtqczkawcrswx4npptvkurkw4
-      '@docusaurus/theme-classic': 2.0.0-beta.20_fdtqczkawcrswx4npptvkurkw4
-      '@docusaurus/theme-common': 2.0.0-beta.20_fdtqczkawcrswx4npptvkurkw4
-      '@docusaurus/theme-search-algolia': 2.0.0-beta.20_fdtqczkawcrswx4npptvkurkw4
+      '@docusaurus/core': 2.0.0-beta.20_66c8c36abcfdbeab71528ce4b75c41f7
+      '@docusaurus/plugin-content-blog': 2.0.0-beta.20_66c8c36abcfdbeab71528ce4b75c41f7
+      '@docusaurus/plugin-content-docs': 2.0.0-beta.20_66c8c36abcfdbeab71528ce4b75c41f7
+      '@docusaurus/plugin-content-pages': 2.0.0-beta.20_66c8c36abcfdbeab71528ce4b75c41f7
+      '@docusaurus/plugin-debug': 2.0.0-beta.20_66c8c36abcfdbeab71528ce4b75c41f7
+      '@docusaurus/plugin-google-analytics': 2.0.0-beta.20_66c8c36abcfdbeab71528ce4b75c41f7
+      '@docusaurus/plugin-google-gtag': 2.0.0-beta.20_66c8c36abcfdbeab71528ce4b75c41f7
+      '@docusaurus/plugin-sitemap': 2.0.0-beta.20_66c8c36abcfdbeab71528ce4b75c41f7
+      '@docusaurus/theme-classic': 2.0.0-beta.20_66c8c36abcfdbeab71528ce4b75c41f7
+      '@docusaurus/theme-common': 2.0.0-beta.20_66c8c36abcfdbeab71528ce4b75c41f7
+      '@docusaurus/theme-search-algolia': 2.0.0-beta.20_66c8c36abcfdbeab71528ce4b75c41f7
       react: 17.0.2
       react-dom: 17.0.2_react@17.0.2
     transitivePeerDependencies:
@@ -3118,18 +3118,18 @@ packages:
       react: 17.0.2
     dev: false
 
-  /@docusaurus/theme-classic/2.0.0-beta.20_fdtqczkawcrswx4npptvkurkw4:
+  /@docusaurus/theme-classic/2.0.0-beta.20_66c8c36abcfdbeab71528ce4b75c41f7:
     resolution: {integrity: sha512-rs4U68x8Xk6rPsZC/7eaPxCKqzXX1S45FICKmq/IZuaDaQyQIijCvv2ssxYnUyVZUNayZfJK7ZtNu+A0kzYgSQ==}
     engines: {node: '>=14'}
     peerDependencies:
       react: ^16.8.4 || ^17.0.0
       react-dom: ^16.8.4 || ^17.0.0
     dependencies:
-      '@docusaurus/core': 2.0.0-beta.20_fdtqczkawcrswx4npptvkurkw4
-      '@docusaurus/plugin-content-blog': 2.0.0-beta.20_fdtqczkawcrswx4npptvkurkw4
-      '@docusaurus/plugin-content-docs': 2.0.0-beta.20_fdtqczkawcrswx4npptvkurkw4
-      '@docusaurus/plugin-content-pages': 2.0.0-beta.20_fdtqczkawcrswx4npptvkurkw4
-      '@docusaurus/theme-common': 2.0.0-beta.20_fdtqczkawcrswx4npptvkurkw4
+      '@docusaurus/core': 2.0.0-beta.20_66c8c36abcfdbeab71528ce4b75c41f7
+      '@docusaurus/plugin-content-blog': 2.0.0-beta.20_66c8c36abcfdbeab71528ce4b75c41f7
+      '@docusaurus/plugin-content-docs': 2.0.0-beta.20_66c8c36abcfdbeab71528ce4b75c41f7
+      '@docusaurus/plugin-content-pages': 2.0.0-beta.20_66c8c36abcfdbeab71528ce4b75c41f7
+      '@docusaurus/theme-common': 2.0.0-beta.20_66c8c36abcfdbeab71528ce4b75c41f7
       '@docusaurus/theme-translations': 2.0.0-beta.20
       '@docusaurus/utils': 2.0.0-beta.20
       '@docusaurus/utils-common': 2.0.0-beta.20
@@ -3163,17 +3163,17 @@ packages:
       - webpack-cli
     dev: false
 
-  /@docusaurus/theme-common/2.0.0-beta.20_fdtqczkawcrswx4npptvkurkw4:
+  /@docusaurus/theme-common/2.0.0-beta.20_66c8c36abcfdbeab71528ce4b75c41f7:
     resolution: {integrity: sha512-lmdGB3/GQM5z0GH0iHGRXUco4Wfqc6sR5eRKuW4j0sx3+UFVvtbVTTIGt0Cie4Dh6omnFxjPbNDlPDgWr/agVQ==}
     engines: {node: '>=14'}
     peerDependencies:
       react: ^16.8.4 || ^17.0.0
       react-dom: ^16.8.4 || ^17.0.0
     dependencies:
-      '@docusaurus/module-type-aliases': 2.0.0-beta.20_sfoxds7t5ydpegc3knd667wn6m
-      '@docusaurus/plugin-content-blog': 2.0.0-beta.20_fdtqczkawcrswx4npptvkurkw4
-      '@docusaurus/plugin-content-docs': 2.0.0-beta.20_fdtqczkawcrswx4npptvkurkw4
-      '@docusaurus/plugin-content-pages': 2.0.0-beta.20_fdtqczkawcrswx4npptvkurkw4
+      '@docusaurus/module-type-aliases': 2.0.0-beta.20_react-dom@17.0.2+react@17.0.2
+      '@docusaurus/plugin-content-blog': 2.0.0-beta.20_66c8c36abcfdbeab71528ce4b75c41f7
+      '@docusaurus/plugin-content-docs': 2.0.0-beta.20_66c8c36abcfdbeab71528ce4b75c41f7
+      '@docusaurus/plugin-content-pages': 2.0.0-beta.20_66c8c36abcfdbeab71528ce4b75c41f7
       clsx: 1.1.1
       parse-numeric-range: 1.3.0
       prism-react-renderer: 1.3.1_react@17.0.2
@@ -3197,18 +3197,18 @@ packages:
       - webpack-cli
     dev: false
 
-  /@docusaurus/theme-search-algolia/2.0.0-beta.20_fdtqczkawcrswx4npptvkurkw4:
+  /@docusaurus/theme-search-algolia/2.0.0-beta.20_66c8c36abcfdbeab71528ce4b75c41f7:
     resolution: {integrity: sha512-9XAyiXXHgyhDmKXg9RUtnC4WBkYAZUqKT9Ntuk0OaOb4mBwiYUGL74tyP0LLL6T+oa9uEdXiUMlIL1onU8xhvA==}
     engines: {node: '>=14'}
     peerDependencies:
       react: ^16.8.4 || ^17.0.0
       react-dom: ^16.8.4 || ^17.0.0
     dependencies:
-      '@docsearch/react': 3.0.0_sfoxds7t5ydpegc3knd667wn6m
-      '@docusaurus/core': 2.0.0-beta.20_fdtqczkawcrswx4npptvkurkw4
+      '@docsearch/react': 3.0.0_react-dom@17.0.2+react@17.0.2
+      '@docusaurus/core': 2.0.0-beta.20_66c8c36abcfdbeab71528ce4b75c41f7
       '@docusaurus/logger': 2.0.0-beta.20
-      '@docusaurus/plugin-content-docs': 2.0.0-beta.20_fdtqczkawcrswx4npptvkurkw4
-      '@docusaurus/theme-common': 2.0.0-beta.20_fdtqczkawcrswx4npptvkurkw4
+      '@docusaurus/plugin-content-docs': 2.0.0-beta.20_66c8c36abcfdbeab71528ce4b75c41f7
+      '@docusaurus/theme-common': 2.0.0-beta.20_66c8c36abcfdbeab71528ce4b75c41f7
       '@docusaurus/theme-translations': 2.0.0-beta.20
       '@docusaurus/utils': 2.0.0-beta.20
       '@docusaurus/utils-validation': 2.0.0-beta.20
@@ -3248,13 +3248,13 @@ packages:
       tslib: 2.4.0
     dev: false
 
-  /@docusaurus/types/2.0.0-beta.20_sfoxds7t5ydpegc3knd667wn6m:
+  /@docusaurus/types/2.0.0-beta.20_react-dom@17.0.2+react@17.0.2:
     resolution: {integrity: sha512-d4ZIpcrzGsUUcZJL3iz8/iSaewobPPiYfn2Lmmv7GTT5ZPtPkOAtR5mE6+LAf/KpjjgqrC7mpwDKADnOL/ic4Q==}
     dependencies:
       commander: 5.1.0
       history: 4.10.1
       joi: 17.6.0
-      react-helmet-async: 1.3.0_sfoxds7t5ydpegc3knd667wn6m
+      react-helmet-async: 1.3.0_react-dom@17.0.2+react@17.0.2
       utility-types: 3.10.0
       webpack: 5.72.0
       webpack-merge: 5.8.0
@@ -3307,7 +3307,7 @@ packages:
       resolve-pathname: 3.0.0
       shelljs: 0.8.5
       tslib: 2.4.0
-      url-loader: 4.1.1_csgzzuwaerdr4d7s3u52mzcn7m
+      url-loader: 4.1.1_file-loader@6.2.0+webpack@5.72.0
       webpack: 5.72.0
     transitivePeerDependencies:
       - '@swc/core'
@@ -7404,7 +7404,7 @@ packages:
       - supports-color
     dev: true
 
-  /babel-loader/8.2.5_rb5fcebzp6kx3hqg3ucus54t3m:
+  /babel-loader/8.2.5_887a5110397f957d9e06dd05497793db:
     resolution: {integrity: sha512-OSiFfH89LrEMiWd4pLNqGz4CwJDtbs2ZVc+iGu2HrkRfPxId9F2anQj38IxWpmRfsUY0aBZYi1EFcd3mhtRMLQ==}
     engines: {node: '>= 8.9'}
     peerDependencies:
@@ -8666,7 +8666,7 @@ packages:
       webpack: 5.72.0
     dev: false
 
-  /css-minimizer-webpack-plugin/3.4.1_tejugib4y3rw5hvgnfmxavjvsu:
+  /css-minimizer-webpack-plugin/3.4.1_clean-css@5.3.0+webpack@5.72.0:
     resolution: {integrity: sha512-1u6D71zeIfgngN2XNRJefc/hY7Ybsxd74Jm4qngIXyUEk7fss3VUzuHxLAq/R8NAba4QU9OUSaMZlbpRc7bM4Q==}
     engines: {node: '>= 12.13.0'}
     peerDependencies:
@@ -11611,7 +11611,7 @@ packages:
       signal-exit: 3.0.7
     dev: true
 
-  /fork-ts-checker-webpack-plugin/6.5.1_4dvvomwfbhpgf7xcm7gogbdvgu:
+  /fork-ts-checker-webpack-plugin/6.5.1_509a9d40d32ea50a4d33125362dc897b:
     resolution: {integrity: sha512-x1wumpHOEf4gDROmKTaB6i4/Q6H3LwmjVO7fIX47vBwlZbtPjU33hgoMuD/Q/y6SU8bnuYSoN6ZQOLshGp0T/g==}
     engines: {node: '>=10', yarn: '>=1.0.0'}
     peerDependencies:
@@ -11631,6 +11631,7 @@ packages:
       chokidar: 3.5.3
       cosmiconfig: 6.0.0
       deepmerge: 4.2.2
+      eslint: 8.14.0
       fs-extra: 9.1.0
       glob: 7.2.0
       memfs: 3.4.1
@@ -14620,7 +14621,7 @@ packages:
     resolution: {integrity: sha1-/oWy7HWlkDfyrf7BAP1sYBdhFS4=}
     dev: false
 
-  /mdx-mermaid/1.2.2_c22t5semscxhgv3n3sjop6jcyy:
+  /mdx-mermaid/1.2.2_mermaid@8.14.0+react@17.0.2:
     resolution: {integrity: sha512-izl9Vaus0fJHJb6IGgcGZ79LpfFACfn28ExPXKL815RTMT9bgDRIAubufZUCgoCAAv/2S1VTxJLWTwbck4TpLA==}
     peerDependencies:
       mermaid: '>= 8.11.0 < 8.12.0'
@@ -14779,7 +14780,7 @@ packages:
     engines: {node: '>=4'}
     dev: true
 
-  /mini-create-react-context/0.4.1_at7mkepldmzoo6silmqc5bca74:
+  /mini-create-react-context/0.4.1_prop-types@15.8.1+react@17.0.2:
     resolution: {integrity: sha512-YWCYEmd5CQeHGSAKrYvXgmzzkrvssZcuuQDDeqkT+PziKGMgE+0MCCtcKbROzocGBG1meBLl2FotlRwf4gAzbQ==}
     peerDependencies:
       prop-types: ^15.0.0
@@ -15906,7 +15907,7 @@ packages:
       yaml: 1.10.2
     dev: true
 
-  /postcss-loader/6.2.1_g4najheu5gwop3kphiif6aqpde:
+  /postcss-loader/6.2.1_postcss@8.4.13+webpack@5.72.0:
     resolution: {integrity: sha512-WbbYpmAaKcux/P66bZ40bpWsBucjx/TTgVVzRZ9yUO8yQfVBlameJ0ZGVaPfH64hNSBh63a+ICP5nqOpBA0w+Q==}
     engines: {node: '>= 12.13.0'}
     peerDependencies:
@@ -16675,7 +16676,7 @@ packages:
       react: 17.0.2
     dev: false
 
-  /react-dev-utils/12.0.1_4dvvomwfbhpgf7xcm7gogbdvgu:
+  /react-dev-utils/12.0.1_509a9d40d32ea50a4d33125362dc897b:
     resolution: {integrity: sha512-84Ivxmr17KjUupyqzFode6xKhjwuEJDROWKJy/BthkL7Wn6NJ8h4WE6k/exAv6ImS+0oZLRRW5j/aINMHyeGeQ==}
     engines: {node: '>=14'}
     dependencies:
@@ -16688,7 +16689,7 @@ packages:
       escape-string-regexp: 4.0.0
       filesize: 8.0.7
       find-up: 5.0.0
-      fork-ts-checker-webpack-plugin: 6.5.1_4dvvomwfbhpgf7xcm7gogbdvgu
+      fork-ts-checker-webpack-plugin: 6.5.1_509a9d40d32ea50a4d33125362dc897b
       global-modules: 2.0.0
       globby: 11.1.0
       gzip-size: 6.0.0
@@ -16737,7 +16738,7 @@ packages:
   /react-fast-compare/3.2.0:
     resolution: {integrity: sha512-rtGImPZ0YyLrscKI9xTpV8psd6I8VAtjKCzQDlzyDvqJA8XOW78TXYQwNRNd8g8JZnDu8q9Fu/1v4HPAVwVdHA==}
 
-  /react-helmet-async/1.3.0_sfoxds7t5ydpegc3knd667wn6m:
+  /react-helmet-async/1.3.0_react-dom@17.0.2+react@17.0.2:
     resolution: {integrity: sha512-9jZ57/dAn9t3q6hneQS0wukqC2ENOBgMNVEhb/ZG9ZSxUetzVIw4iAmEU38IaVg3QGYauQPhSeUTuIUtFglWpg==}
     peerDependencies:
       react: ^16.6.0 || ^17.0.0 || ^18.0.0
@@ -16768,7 +16769,7 @@ packages:
       invariant: 2.2.4
     dev: false
 
-  /react-immutable-pure-component/2.2.2_xuna42ff4dsik7bgiahtwx36tu:
+  /react-immutable-pure-component/2.2.2_bd1a0e68a5e0e4857c26400f3b5f7e9d:
     resolution: {integrity: sha512-vkgoMJUDqHZfXXnjVlG3keCxSO/U6WeDQ5/Sl0GK2cH8TOxEzQ5jXqDXHEL/jqk6fsNxV05oH5kD7VNMUE2k+A==}
     peerDependencies:
       immutable: '>= 2 || >= 4.0.0-rc'
@@ -16797,7 +16798,7 @@ packages:
   /react-is/17.0.2:
     resolution: {integrity: sha512-w2GsyukL62IJnlaff/nRegPQR94C/XXamvMWmSHRJ4y7Ts/4ocGRmTHvOs8PSE6pB3dWOrD/nueuU5sduBsQ4w==}
 
-  /react-json-view/1.21.3_sfoxds7t5ydpegc3knd667wn6m:
+  /react-json-view/1.21.3_react-dom@17.0.2+react@17.0.2:
     resolution: {integrity: sha512-13p8IREj9/x/Ye4WI/JpjhoIwuzEgUAtgJZNBJckfzJt1qyh24BdTm6UQNGnyTq9dapQdrqvquZTo3dz1X6Cjw==}
     peerDependencies:
       react: ^17.0.0 || ^16.3.0 || ^15.5.4
@@ -16818,7 +16819,7 @@ packages:
     resolution: {integrity: sha512-fBASbA6LnOU9dOU2eW7aQ8xmYBSXUIWr+UmF9b1efZBazGNO+rcXT/icdKnYm2pTwcRylVUYwW7H1PHfLekVzA==}
     dev: false
 
-  /react-loadable-ssr-addon-v5-slorber/1.0.1_5grs2dwrf6hqtfkptfcfoiy4bu:
+  /react-loadable-ssr-addon-v5-slorber/1.0.1_e9a32d0ed12f8f09954f994457231c0d:
     resolution: {integrity: sha512-lq3Lyw1lGku8zUEJPDxsNm1AfYHBrO9Y1+olAYwpUJ2IGFBskM0DMKok97A6LWUpHm+o7IvQBOWu9MLenp9Z+A==}
     engines: {node: '>=10.13.0'}
     peerDependencies:
@@ -16848,7 +16849,7 @@ packages:
     resolution: {integrity: sha512-kzmNjIgU32mO4mmH5+iUyrqlpFQhF8K2k7eZ4fdLSOPFrD1XgEuSBv9LDEgxRXTMBqMd8ppT0x6TIzqE5pdGdw==}
     dev: false
 
-  /react-redux/7.2.8_sfoxds7t5ydpegc3knd667wn6m:
+  /react-redux/7.2.8_react-dom@17.0.2+react@17.0.2:
     resolution: {integrity: sha512-6+uDjhs3PSIclqoCk0kd6iX74gzrGc3W5zcAjbrFgEdIjRSQObdIwfx80unTkVUYvbQ95Y8Av3OvFHq1w5EOUw==}
     peerDependencies:
       react: ^16.8.3 || ^17 || ^18
@@ -16875,7 +16876,7 @@ packages:
     engines: {node: '>=0.10.0'}
     dev: true
 
-  /react-router-config/5.1.1_53jg2tb4f34fvmclurfotx7m6y:
+  /react-router-config/5.1.1_react-router@5.3.1+react@17.0.2:
     resolution: {integrity: sha512-DuanZjaD8mQp1ppHjgnnUnyOlqYXZVjnov/JzFhjLEwd3Z4dYjMSnqrEzzGThH47vpCOqPPwJM2FtthLeJ8Pbg==}
     peerDependencies:
       react: '>=15'
@@ -16934,7 +16935,7 @@ packages:
       history: 4.10.1
       hoist-non-react-statics: 3.3.2
       loose-envify: 1.4.0
-      mini-create-react-context: 0.4.1_at7mkepldmzoo6silmqc5bca74
+      mini-create-react-context: 0.4.1_prop-types@15.8.1+react@17.0.2
       path-to-regexp: 1.8.0
       prop-types: 15.8.1
       react: 17.0.2
@@ -18448,7 +18449,7 @@ packages:
       - encoding
     dev: false
 
-  /swagger-ui-react/4.10.3_sfoxds7t5ydpegc3knd667wn6m:
+  /swagger-ui-react/4.10.3_react-dom@17.0.2+react@17.0.2:
     resolution: {integrity: sha512-rxLVM8hv6aH+8BEJuyfejt2BweV2TLB8KiifE/8CAk96PoDyQeCTnLgivTdXIuDqdSSSajlzTq0ccw0QMYQbvA==}
     peerDependencies:
       react: '>=17.0.0'
@@ -18474,9 +18475,9 @@ packages:
       react-debounce-input: 3.2.4_react@17.0.2
       react-dom: 17.0.2_react@17.0.2
       react-immutable-proptypes: 2.2.0_immutable@3.8.2
-      react-immutable-pure-component: 2.2.2_xuna42ff4dsik7bgiahtwx36tu
+      react-immutable-pure-component: 2.2.2_bd1a0e68a5e0e4857c26400f3b5f7e9d
       react-inspector: 5.1.1_react@17.0.2
-      react-redux: 7.2.8_sfoxds7t5ydpegc3knd667wn6m
+      react-redux: 7.2.8_react-dom@17.0.2+react@17.0.2
       react-syntax-highlighter: 15.5.0_react@17.0.2
       redux: 4.2.0
       redux-immutable: 4.0.0_immutable@3.8.2
@@ -19569,7 +19570,7 @@ packages:
     dependencies:
       punycode: 2.1.1
 
-  /url-loader/4.1.1_csgzzuwaerdr4d7s3u52mzcn7m:
+  /url-loader/4.1.1_file-loader@6.2.0+webpack@5.72.0:
     resolution: {integrity: sha512-3BTV812+AVHHOJQO8O5MkWgZ5aosP7GnROJwvzLS9hWDj00lZ6Z0wNak423Lp9PBZN05N+Jk/N5Si8jRAlGyWA==}
     engines: {node: '>= 10.13.0'}
     peerDependencies:


### PR DESCRIPTION
The client URL is set to `window.location.origin`, so it can rewrite redirection urls that are
passed on to authenticaion methods. However, `clientUrl` is set to `''` when running on the server
side. This fix then avoid raising an error when trying to rewrite `redirectTo` on non-browser
environment, and forces `useProviderLink` to be rendered on the client side.