### PR TITLE
included an optional ticket in changePassword function to allow for c…

### DIFF
--- a/.changeset/lucky-rabbits-arrive.md
+++ b/.changeset/lucky-rabbits-arrive.md
@@ -1,0 +1,5 @@
+---
+'@nhost/hasura-auth-js': minor
+---
+
+added option to include ticket in changePassword to allow for changing password without the user being signed in

--- a/.changeset/stale-bags-design.md
+++ b/.changeset/stale-bags-design.md
@@ -1,6 +1,0 @@
----
-"@nhost/core": patch
-"@nhost/hasura-auth-js": patch
----
-
-included an optional `ticket` in changePassword function to allow for changing password using ticket

--- a/.changeset/stale-bags-design.md
+++ b/.changeset/stale-bags-design.md
@@ -1,0 +1,6 @@
+---
+"@nhost/core": patch
+"@nhost/hasura-auth-js": patch
+---
+
+included an optional `ticket` in changePassword function to allow for changing password using ticket

--- a/packages/core/src/machines/change-password.ts
+++ b/packages/core/src/machines/change-password.ts
@@ -12,6 +12,7 @@ export type ChangePasswordEvents =
   | {
       type: 'REQUEST'
       password?: string
+      ticket?: string
     }
   | { type: 'SUCCESS' }
   | { type: 'ERROR'; error: ErrorPayload | null }
@@ -75,10 +76,10 @@ export const createChangePasswordMachine = ({ backendUrl, interpreter }: AuthCli
         invalidPassword: (_, { password }) => !isValidPassword(password)
       },
       services: {
-        requestChange: (_, { password }) =>
+        requestChange: (_, { password, ticket }) =>
           api.post<string, { data: { error?: ErrorPayload } }>(
             '/user/password',
-            { newPassword: password },
+            { newPassword: password, ticket: ticket },
             {
               headers: {
                 authorization: `Bearer ${interpreter?.state.context.accessToken.value}`

--- a/packages/core/src/promises/changePassword.ts
+++ b/packages/core/src/promises/changePassword.ts
@@ -10,11 +10,12 @@ export interface ChangePasswordHandlerResult extends ActionErrorState, ActionSuc
 
 export const changePasswordPromise = async (
   interpreter: InterpreterFrom<ChangePasswordMachine>,
-  password: string
+  password: string,
+  ticket?: string
 ): Promise<ChangePasswordHandlerResult> =>
   new Promise<ChangePasswordHandlerResult>((resolve) => {
     interpreter.send('REQUEST', {
-      password
+      password, ticket
     })
     interpreter.onTransition((state) => {
       if (state.matches({ idle: 'error' })) {

--- a/packages/hasura-auth-js/src/hasura-auth-client.ts
+++ b/packages/hasura-auth-js/src/hasura-auth-client.ts
@@ -276,7 +276,7 @@ export class HasuraAuthClient {
   }
 
   /**
-   * Use `nhost.auth.changePassword` to change the password for the user. The old password is not needed.
+   * Use `nhost.auth.changePassword` to change the password for the signed-in user. The old password is not needed. In case the user is not signed-in, a password reset ticket needs to be provided.
    *
    * @example
    * ```ts
@@ -285,9 +285,9 @@ export class HasuraAuthClient {
    *
    * @docs https://docs.nhost.io/reference/javascript/auth/change-password
    */
-  async changePassword({ newPassword }: ChangePasswordParams): Promise<ApiChangePasswordResponse> {
+  async changePassword({ newPassword, ticket }: ChangePasswordParams): Promise<ApiChangePasswordResponse> {
     const service = interpret(createChangePasswordMachine(this._client)).start()
-    const { error } = await changePasswordPromise(service, newPassword)
+    const { error } = await changePasswordPromise(service, newPassword, ticket)
     return { error }
   }
 

--- a/packages/hasura-auth-js/src/utils/types.ts
+++ b/packages/hasura-auth-js/src/utils/types.ts
@@ -89,6 +89,7 @@ export interface ResetPasswordParams {
 
 export interface ChangePasswordParams {
   newPassword: string
+  ticket?: string
 }
 
 export interface SendVerificationEmailParams {


### PR DESCRIPTION
This is the nhost-js SDK changes to enable changing password for users that are not logged in but have a valid password reset ticket. See backend `hasura-auth` PR here: [hasura-auth #186](https://github.com/nhost/hasura-auth/pull/186)

I believe this should work, I struggled a little as I haven't used the machines that you use to create the request that goes into the backend (looks very impressive, nice work by the way). Have a look and let me know if this would work !