### PR TITLE
docs: replace the `books` table by a `todos` table

### DIFF
--- a/examples/react-apollo/.vscode/settings.json
+++ b/examples/react-apollo/.vscode/settings.json
@@ -1,0 +1,5 @@
+{
+  "yaml.schemas": {
+    "https://unpkg.com/graphql-config/config-schema.json": "file:///Users/pilou/dev/nhost/nhost/examples/react-apollo/graphql.config.yaml"
+  }
+}

--- a/examples/react-apollo/.vscode/settings.json
+++ b/examples/react-apollo/.vscode/settings.json
@@ -1,5 +1,0 @@
-{
-  "yaml.schemas": {
-    "https://unpkg.com/graphql-config/config-schema.json": "file:///Users/pilou/dev/nhost/nhost/examples/react-apollo/graphql.config.yaml"
-  }
-}

--- a/examples/react-apollo/cypress/e2e/4-authenticated/apollo.cy.ts
+++ b/examples/react-apollo/cypress/e2e/4-authenticated/apollo.cy.ts
@@ -1,0 +1,16 @@
+import faker from '@faker-js/faker'
+
+context('Apollo', () => {
+  beforeEach(() => {
+    cy.signUpAndConfirmEmail()
+  })
+
+  it('should add an item to the todo list', () => {
+    const sentence = faker.lorem.sentence()
+    cy.getNavBar().contains('Apollo').click()
+    cy.contains('Todo list')
+    cy.focused().type(sentence)
+    cy.get('button').contains('Add').click()
+    cy.get('ul').contains(sentence)
+  })
+})

--- a/examples/react-apollo/cypress/e2e/4-authenticated/apollo.cy.ts
+++ b/examples/react-apollo/cypress/e2e/4-authenticated/apollo.cy.ts
@@ -7,10 +7,12 @@ context('Apollo', () => {
 
   it('should add an item to the todo list', () => {
     const sentence = faker.lorem.sentence()
-    cy.getNavBar().contains('Apollo').click()
+    cy.getNavBar()
+      .findByRole('button', { name: /Apollo/i })
+      .click()
     cy.contains('Todo list')
     cy.focused().type(sentence)
-    cy.get('button').contains('Add').click()
+    cy.findByRole('button', { name: /Add/i }).click()
     cy.get('ul').contains(sentence)
   })
 })

--- a/examples/react-apollo/graphql.config.yaml
+++ b/examples/react-apollo/graphql.config.yaml
@@ -1,0 +1,15 @@
+schema:
+  - http://localhost:1337/v1/graphql:
+      headers:
+        x-hasura-admin-secret: nhost-admin-secret
+        x-hasura-role: user
+documents: 'src/**/!(*.d).{ts,tsx}'
+generates:
+  ./src/generated.ts:
+    config:
+      namingConvention:
+        typeNames: change-case-all#pascalCase
+        transformUnderscore: true
+    plugins:
+      - typescript
+      - typescript-operations

--- a/examples/react-apollo/nhost/metadata/databases/default/tables/public_todos.yaml
+++ b/examples/react-apollo/nhost/metadata/databases/default/tables/public_todos.yaml
@@ -1,0 +1,68 @@
+table:
+  name: todos
+  schema: public
+configuration:
+  column_config:
+    created_at:
+      custom_name: createdAt
+    updated_at:
+      custom_name: updatedAt
+    user_id:
+      custom_name: userId
+  custom_column_names:
+    created_at: createdAt
+    updated_at: updatedAt
+    user_id: userId
+  custom_root_fields:
+    delete: deleteTodos
+    delete_by_pk: deleteTodo
+    insert: insertTodos
+    insert_one: insertTodo
+    select_aggregate: todosAggregate
+    select_by_pk: todo
+    update: updateTodos
+    update_by_pk: updateTodo
+object_relationships:
+- name: user
+  using:
+    foreign_key_constraint_on: user_id
+insert_permissions:
+- permission:
+    backend_only: false
+    check: {}
+    columns:
+    - contents
+    - id
+    set:
+      user_id: x-hasura-user-id
+  role: user
+select_permissions:
+- permission:
+    allow_aggregations: true
+    columns:
+    - contents
+    - created_at
+    - updated_at
+    - id
+    - user_id
+    filter:
+      user_id:
+        _eq: X-Hasura-User-Id
+  role: user
+update_permissions:
+- permission:
+    check:
+      user_id:
+        _eq: X-Hasura-User-Id
+    columns:
+    - contents
+    filter:
+      user_id:
+        _eq: X-Hasura-User-Id
+  role: user
+delete_permissions:
+- permission:
+    filter:
+      user_id:
+        _eq: X-Hasura-User-Id
+  role: user

--- a/examples/react-apollo/nhost/metadata/databases/default/tables/tables.yaml
+++ b/examples/react-apollo/nhost/metadata/databases/default/tables/tables.yaml
@@ -5,6 +5,6 @@
 - "!include auth_user_providers.yaml"
 - "!include auth_user_roles.yaml"
 - "!include auth_users.yaml"
-- "!include public_books.yaml"
+- "!include public_todos.yaml"
 - "!include storage_buckets.yaml"
 - "!include storage_files.yaml"

--- a/examples/react-apollo/nhost/migrations/default/1654842138617_create_table_public_todos/down.sql
+++ b/examples/react-apollo/nhost/migrations/default/1654842138617_create_table_public_todos/down.sql
@@ -1,0 +1,1 @@
+DROP TABLE "public"."todos";

--- a/examples/react-apollo/nhost/migrations/default/1654842138617_create_table_public_todos/down.sql
+++ b/examples/react-apollo/nhost/migrations/default/1654842138617_create_table_public_todos/down.sql
@@ -1,1 +1,2 @@
+DROP INDEX IF EXISTS "public"."user_id";
 DROP TABLE "public"."todos";

--- a/examples/react-apollo/nhost/migrations/default/1654842138617_create_table_public_todos/down.sql
+++ b/examples/react-apollo/nhost/migrations/default/1654842138617_create_table_public_todos/down.sql
@@ -1,2 +1,2 @@
 DROP INDEX IF EXISTS "public"."user_id";
-DROP TABLE "public"."todos";
+DROP TABLE "public"."todos_user_id";

--- a/examples/react-apollo/nhost/migrations/default/1654842138617_create_table_public_todos/up.sql
+++ b/examples/react-apollo/nhost/migrations/default/1654842138617_create_table_public_todos/up.sql
@@ -16,3 +16,5 @@ EXECUTE PROCEDURE "public"."set_current_timestamp_updated_at"();
 COMMENT ON TRIGGER "set_public_todos_updated_at" ON "public"."todos" 
 IS 'trigger to set value of column "updated_at" to current timestamp on row update';
 CREATE EXTENSION IF NOT EXISTS pgcrypto;
+CREATE  INDEX "user_id" on
+  "public"."todos" using btree ("user_id");

--- a/examples/react-apollo/nhost/migrations/default/1654842138617_create_table_public_todos/up.sql
+++ b/examples/react-apollo/nhost/migrations/default/1654842138617_create_table_public_todos/up.sql
@@ -16,5 +16,5 @@ EXECUTE PROCEDURE "public"."set_current_timestamp_updated_at"();
 COMMENT ON TRIGGER "set_public_todos_updated_at" ON "public"."todos" 
 IS 'trigger to set value of column "updated_at" to current timestamp on row update';
 CREATE EXTENSION IF NOT EXISTS pgcrypto;
-CREATE  INDEX "user_id" on
+CREATE INDEX "todos_user_id" on
   "public"."todos" using btree ("user_id");

--- a/examples/react-apollo/nhost/migrations/default/1654842138617_create_table_public_todos/up.sql
+++ b/examples/react-apollo/nhost/migrations/default/1654842138617_create_table_public_todos/up.sql
@@ -1,0 +1,18 @@
+CREATE TABLE "public"."todos" ("id" uuid NOT NULL DEFAULT gen_random_uuid(), "created_at" timestamptz NOT NULL DEFAULT now(), "updated_at" timestamptz NOT NULL DEFAULT now(), "user_id" uuid NOT NULL, "contents" text NOT NULL, PRIMARY KEY ("id") , FOREIGN KEY ("user_id") REFERENCES "auth"."users"("id") ON UPDATE cascade ON DELETE cascade);
+CREATE OR REPLACE FUNCTION "public"."set_current_timestamp_updated_at"()
+RETURNS TRIGGER AS $$
+DECLARE
+  _new record;
+BEGIN
+  _new := NEW;
+  _new."updated_at" = NOW();
+  RETURN _new;
+END;
+$$ LANGUAGE plpgsql;
+CREATE TRIGGER "set_public_todos_updated_at"
+BEFORE UPDATE ON "public"."todos"
+FOR EACH ROW
+EXECUTE PROCEDURE "public"."set_current_timestamp_updated_at"();
+COMMENT ON TRIGGER "set_public_todos_updated_at" ON "public"."todos" 
+IS 'trigger to set value of column "updated_at" to current timestamp on row update';
+CREATE EXTENSION IF NOT EXISTS pgcrypto;

--- a/examples/react-apollo/nhost/migrations/default/1654843938796_drop_table_public_books/down.sql
+++ b/examples/react-apollo/nhost/migrations/default/1654843938796_drop_table_public_books/down.sql
@@ -1,0 +1,3 @@
+-- Could not auto-generate a down migration.
+-- Please write an appropriate down migration for the SQL below:
+-- DROP table "public"."books";

--- a/examples/react-apollo/nhost/migrations/default/1654843938796_drop_table_public_books/down.sql
+++ b/examples/react-apollo/nhost/migrations/default/1654843938796_drop_table_public_books/down.sql
@@ -1,3 +1,2 @@
--- Could not auto-generate a down migration.
--- Please write an appropriate down migration for the SQL below:
--- DROP table "public"."books";
+CREATE TABLE "public"."books" ("id" uuid NOT NULL DEFAULT gen_random_uuid(), "title" text NOT NULL, PRIMARY KEY ("id") );
+CREATE EXTENSION IF NOT EXISTS pgcrypto;

--- a/examples/react-apollo/nhost/migrations/default/1654843938796_drop_table_public_books/up.sql
+++ b/examples/react-apollo/nhost/migrations/default/1654843938796_drop_table_public_books/up.sql
@@ -1,0 +1,1 @@
+DROP table "public"."books";

--- a/examples/react-apollo/package.json
+++ b/examples/react-apollo/package.json
@@ -19,6 +19,7 @@
   },
   "scripts": {
     "dev": "vite",
+    "generate": "graphql-codegen --config graphql.config.yaml",
     "cypress": "cypress open",
     "test": "cypress run",
     "e2e": "start-test e2e:backend :1337/v1/auth/healthz e2e:frontend 3000 test",
@@ -52,6 +53,7 @@
   },
   "devDependencies": {
     "@faker-js/faker": "^6.3.1",
+    "@graphql-codegen/cli": "^2.6.2",
     "@testing-library/cypress": "^8.0.3",
     "@types/react": "^18.0.8",
     "@types/react-dom": "^18.0.3",

--- a/examples/react-apollo/src/apollo/index.tsx
+++ b/examples/react-apollo/src/apollo/index.tsx
@@ -1,32 +1,94 @@
-import { gql } from '@apollo/client'
-import { Container, Loader, Title } from '@mantine/core'
+import { gql, useMutation } from '@apollo/client'
+import { Button, Card, Container, Grid, Loader, TextInput, Title } from '@mantine/core'
+import { useInputState } from '@mantine/hooks'
 import { useAuthQuery } from '@nhost/react-apollo'
+import { AddItemMutation, TodoListQuery } from 'src/generated'
 
-const GET_BOOKS = gql`
-  query BooksQuery {
-    books {
+const TODO_LIST = gql`
+  query TodoList {
+    todos {
       id
-      title
+      contents
+    }
+  }
+`
+
+const ADD_ITEM = gql`
+  mutation AddItem($contents: String!) {
+    insertTodo(object: { contents: $contents }) {
+      id
+      contents
     }
   }
 `
 
 export const ApolloPage: React.FC = () => {
-  const { loading, data } = useAuthQuery(GET_BOOKS, {
+  const { loading, data } = useAuthQuery<TodoListQuery>(TODO_LIST, {
     pollInterval: 5000,
     fetchPolicy: 'cache-and-network'
   })
+  const [contents, setContents] = useInputState('')
+
+  const [mutate] = useMutation<AddItemMutation>(ADD_ITEM, {
+    variables: { contents },
+    update: (cache, { data }) => {
+      cache.modify({
+        fields: {
+          todos(existingTodos = []) {
+            const newTodoRef = cache.writeFragment({
+              data: data?.insertTodo,
+              fragment: gql`
+                fragment NewTodo on todos {
+                  id
+                  contents
+                }
+              `
+            })
+            return [...existingTodos, newTodoRef]
+          }
+        }
+      })
+    }
+  })
+
+  const add = async () => {
+    if (!contents) {
+      return
+    }
+    await mutate()
+    setContents('')
+  }
   return (
     <Container>
-      <Title>Apollo GraphQL</Title>
       {loading && <Loader />}
-      {data?.books && (
+      <Card shadow="sm" p="lg" m="sm">
+        <Title>Todo list</Title>
+        <Grid>
+          <Grid.Col span={9}>
+            <TextInput
+              value={contents}
+              onChange={setContents}
+              autoFocus
+              onKeyDown={(e) => e.code === 'Enter' && add()}
+            />
+          </Grid.Col>
+          <Grid.Col span={3}>
+            <Button
+              onClick={(e: React.MouseEvent) => {
+                e.preventDefault()
+                add()
+              }}
+            >
+              Add
+            </Button>
+          </Grid.Col>
+        </Grid>
         <ul>
-          {data.books.map((book) => (
-            <li key={book.id}>{book.title}</li>
+          {data?.todos.map((item) => (
+            <li key={item.id}>{item.contents}</li>
           ))}
         </ul>
-      )}
+      </Card>
     </Container>
   )
 }

--- a/examples/react-apollo/src/generated.ts
+++ b/examples/react-apollo/src/generated.ts
@@ -1,0 +1,356 @@
+export type Maybe<T> = T | null;
+export type InputMaybe<T> = Maybe<T>;
+export type Exact<T extends { [key: string]: unknown }> = { [K in keyof T]: T[K] };
+export type MakeOptional<T, K extends keyof T> = Omit<T, K> & { [SubKey in K]?: Maybe<T[SubKey]> };
+export type MakeMaybe<T, K extends keyof T> = Omit<T, K> & { [SubKey in K]: Maybe<T[SubKey]> };
+/** All built-in and custom scalars, mapped to their actual values */
+export type Scalars = {
+  ID: string;
+  String: string;
+  Boolean: boolean;
+  Int: number;
+  Float: number;
+  timestamptz: any;
+  uuid: any;
+};
+
+/** Boolean expression to compare columns of type "String". All fields are combined with logical 'AND'. */
+export type StringComparisonExp = {
+  _eq?: InputMaybe<Scalars['String']>;
+  _gt?: InputMaybe<Scalars['String']>;
+  _gte?: InputMaybe<Scalars['String']>;
+  /** does the column match the given case-insensitive pattern */
+  _ilike?: InputMaybe<Scalars['String']>;
+  _in?: InputMaybe<Array<Scalars['String']>>;
+  /** does the column match the given POSIX regular expression, case insensitive */
+  _iregex?: InputMaybe<Scalars['String']>;
+  _is_null?: InputMaybe<Scalars['Boolean']>;
+  /** does the column match the given pattern */
+  _like?: InputMaybe<Scalars['String']>;
+  _lt?: InputMaybe<Scalars['String']>;
+  _lte?: InputMaybe<Scalars['String']>;
+  _neq?: InputMaybe<Scalars['String']>;
+  /** does the column NOT match the given case-insensitive pattern */
+  _nilike?: InputMaybe<Scalars['String']>;
+  _nin?: InputMaybe<Array<Scalars['String']>>;
+  /** does the column NOT match the given POSIX regular expression, case insensitive */
+  _niregex?: InputMaybe<Scalars['String']>;
+  /** does the column NOT match the given pattern */
+  _nlike?: InputMaybe<Scalars['String']>;
+  /** does the column NOT match the given POSIX regular expression, case sensitive */
+  _nregex?: InputMaybe<Scalars['String']>;
+  /** does the column NOT match the given SQL regular expression */
+  _nsimilar?: InputMaybe<Scalars['String']>;
+  /** does the column match the given POSIX regular expression, case sensitive */
+  _regex?: InputMaybe<Scalars['String']>;
+  /** does the column match the given SQL regular expression */
+  _similar?: InputMaybe<Scalars['String']>;
+};
+
+/** mutation root */
+export type MutationRoot = {
+  __typename?: 'mutation_root';
+  /** delete single row from the table: "todos" */
+  deleteTodo?: Maybe<Todos>;
+  /** delete data from the table: "todos" */
+  deleteTodos?: Maybe<TodosMutationResponse>;
+  /** insert a single row into the table: "todos" */
+  insertTodo?: Maybe<Todos>;
+  /** insert data into the table: "todos" */
+  insertTodos?: Maybe<TodosMutationResponse>;
+  /** update single row of the table: "todos" */
+  updateTodo?: Maybe<Todos>;
+  /** update data of the table: "todos" */
+  updateTodos?: Maybe<TodosMutationResponse>;
+};
+
+
+/** mutation root */
+export type MutationRootDeleteTodoArgs = {
+  id: Scalars['uuid'];
+};
+
+
+/** mutation root */
+export type MutationRootDeleteTodosArgs = {
+  where: TodosBoolExp;
+};
+
+
+/** mutation root */
+export type MutationRootInsertTodoArgs = {
+  object: TodosInsertInput;
+  on_conflict?: InputMaybe<TodosOnConflict>;
+};
+
+
+/** mutation root */
+export type MutationRootInsertTodosArgs = {
+  objects: Array<TodosInsertInput>;
+  on_conflict?: InputMaybe<TodosOnConflict>;
+};
+
+
+/** mutation root */
+export type MutationRootUpdateTodoArgs = {
+  _set?: InputMaybe<TodosSetInput>;
+  pk_columns: TodosPkColumnsInput;
+};
+
+
+/** mutation root */
+export type MutationRootUpdateTodosArgs = {
+  _set?: InputMaybe<TodosSetInput>;
+  where: TodosBoolExp;
+};
+
+/** column ordering options */
+export enum OrderBy {
+  /** in ascending order, nulls last */
+  Asc = 'asc',
+  /** in ascending order, nulls first */
+  AscNullsFirst = 'asc_nulls_first',
+  /** in ascending order, nulls last */
+  AscNullsLast = 'asc_nulls_last',
+  /** in descending order, nulls first */
+  Desc = 'desc',
+  /** in descending order, nulls first */
+  DescNullsFirst = 'desc_nulls_first',
+  /** in descending order, nulls last */
+  DescNullsLast = 'desc_nulls_last'
+}
+
+export type QueryRoot = {
+  __typename?: 'query_root';
+  /** fetch data from the table: "todos" using primary key columns */
+  todo?: Maybe<Todos>;
+  /** fetch data from the table: "todos" */
+  todos: Array<Todos>;
+  /** fetch aggregated fields from the table: "todos" */
+  todosAggregate: TodosAggregate;
+};
+
+
+export type QueryRootTodoArgs = {
+  id: Scalars['uuid'];
+};
+
+
+export type QueryRootTodosArgs = {
+  distinct_on?: InputMaybe<Array<TodosSelectColumn>>;
+  limit?: InputMaybe<Scalars['Int']>;
+  offset?: InputMaybe<Scalars['Int']>;
+  order_by?: InputMaybe<Array<TodosOrderBy>>;
+  where?: InputMaybe<TodosBoolExp>;
+};
+
+
+export type QueryRootTodosAggregateArgs = {
+  distinct_on?: InputMaybe<Array<TodosSelectColumn>>;
+  limit?: InputMaybe<Scalars['Int']>;
+  offset?: InputMaybe<Scalars['Int']>;
+  order_by?: InputMaybe<Array<TodosOrderBy>>;
+  where?: InputMaybe<TodosBoolExp>;
+};
+
+export type SubscriptionRoot = {
+  __typename?: 'subscription_root';
+  /** fetch data from the table: "todos" using primary key columns */
+  todo?: Maybe<Todos>;
+  /** fetch data from the table: "todos" */
+  todos: Array<Todos>;
+  /** fetch aggregated fields from the table: "todos" */
+  todosAggregate: TodosAggregate;
+};
+
+
+export type SubscriptionRootTodoArgs = {
+  id: Scalars['uuid'];
+};
+
+
+export type SubscriptionRootTodosArgs = {
+  distinct_on?: InputMaybe<Array<TodosSelectColumn>>;
+  limit?: InputMaybe<Scalars['Int']>;
+  offset?: InputMaybe<Scalars['Int']>;
+  order_by?: InputMaybe<Array<TodosOrderBy>>;
+  where?: InputMaybe<TodosBoolExp>;
+};
+
+
+export type SubscriptionRootTodosAggregateArgs = {
+  distinct_on?: InputMaybe<Array<TodosSelectColumn>>;
+  limit?: InputMaybe<Scalars['Int']>;
+  offset?: InputMaybe<Scalars['Int']>;
+  order_by?: InputMaybe<Array<TodosOrderBy>>;
+  where?: InputMaybe<TodosBoolExp>;
+};
+
+/** Boolean expression to compare columns of type "timestamptz". All fields are combined with logical 'AND'. */
+export type TimestamptzComparisonExp = {
+  _eq?: InputMaybe<Scalars['timestamptz']>;
+  _gt?: InputMaybe<Scalars['timestamptz']>;
+  _gte?: InputMaybe<Scalars['timestamptz']>;
+  _in?: InputMaybe<Array<Scalars['timestamptz']>>;
+  _is_null?: InputMaybe<Scalars['Boolean']>;
+  _lt?: InputMaybe<Scalars['timestamptz']>;
+  _lte?: InputMaybe<Scalars['timestamptz']>;
+  _neq?: InputMaybe<Scalars['timestamptz']>;
+  _nin?: InputMaybe<Array<Scalars['timestamptz']>>;
+};
+
+/** columns and relationships of "todos" */
+export type Todos = {
+  __typename?: 'todos';
+  contents: Scalars['String'];
+  createdAt: Scalars['timestamptz'];
+  id: Scalars['uuid'];
+  updatedAt: Scalars['timestamptz'];
+  userId: Scalars['uuid'];
+};
+
+/** aggregated selection of "todos" */
+export type TodosAggregate = {
+  __typename?: 'todos_aggregate';
+  aggregate?: Maybe<TodosAggregateFields>;
+  nodes: Array<Todos>;
+};
+
+/** aggregate fields of "todos" */
+export type TodosAggregateFields = {
+  __typename?: 'todos_aggregate_fields';
+  count: Scalars['Int'];
+  max?: Maybe<TodosMaxFields>;
+  min?: Maybe<TodosMinFields>;
+};
+
+
+/** aggregate fields of "todos" */
+export type TodosAggregateFieldsCountArgs = {
+  columns?: InputMaybe<Array<TodosSelectColumn>>;
+  distinct?: InputMaybe<Scalars['Boolean']>;
+};
+
+/** Boolean expression to filter rows from the table "todos". All fields are combined with a logical 'AND'. */
+export type TodosBoolExp = {
+  _and?: InputMaybe<Array<TodosBoolExp>>;
+  _not?: InputMaybe<TodosBoolExp>;
+  _or?: InputMaybe<Array<TodosBoolExp>>;
+  contents?: InputMaybe<StringComparisonExp>;
+  createdAt?: InputMaybe<TimestamptzComparisonExp>;
+  id?: InputMaybe<UuidComparisonExp>;
+  updatedAt?: InputMaybe<TimestamptzComparisonExp>;
+  userId?: InputMaybe<UuidComparisonExp>;
+};
+
+/** unique or primary key constraints on table "todos" */
+export enum TodosConstraint {
+  /** unique or primary key constraint */
+  TodosPkey = 'todos_pkey'
+}
+
+/** input type for inserting data into table "todos" */
+export type TodosInsertInput = {
+  contents?: InputMaybe<Scalars['String']>;
+  id?: InputMaybe<Scalars['uuid']>;
+};
+
+/** aggregate max on columns */
+export type TodosMaxFields = {
+  __typename?: 'todos_max_fields';
+  contents?: Maybe<Scalars['String']>;
+  createdAt?: Maybe<Scalars['timestamptz']>;
+  id?: Maybe<Scalars['uuid']>;
+  updatedAt?: Maybe<Scalars['timestamptz']>;
+  userId?: Maybe<Scalars['uuid']>;
+};
+
+/** aggregate min on columns */
+export type TodosMinFields = {
+  __typename?: 'todos_min_fields';
+  contents?: Maybe<Scalars['String']>;
+  createdAt?: Maybe<Scalars['timestamptz']>;
+  id?: Maybe<Scalars['uuid']>;
+  updatedAt?: Maybe<Scalars['timestamptz']>;
+  userId?: Maybe<Scalars['uuid']>;
+};
+
+/** response of any mutation on the table "todos" */
+export type TodosMutationResponse = {
+  __typename?: 'todos_mutation_response';
+  /** number of rows affected by the mutation */
+  affected_rows: Scalars['Int'];
+  /** data from the rows affected by the mutation */
+  returning: Array<Todos>;
+};
+
+/** on_conflict condition type for table "todos" */
+export type TodosOnConflict = {
+  constraint: TodosConstraint;
+  update_columns?: Array<TodosUpdateColumn>;
+  where?: InputMaybe<TodosBoolExp>;
+};
+
+/** Ordering options when selecting data from "todos". */
+export type TodosOrderBy = {
+  contents?: InputMaybe<OrderBy>;
+  createdAt?: InputMaybe<OrderBy>;
+  id?: InputMaybe<OrderBy>;
+  updatedAt?: InputMaybe<OrderBy>;
+  userId?: InputMaybe<OrderBy>;
+};
+
+/** primary key columns input for table: todos */
+export type TodosPkColumnsInput = {
+  id: Scalars['uuid'];
+};
+
+/** select columns of table "todos" */
+export enum TodosSelectColumn {
+  /** column name */
+  Contents = 'contents',
+  /** column name */
+  CreatedAt = 'createdAt',
+  /** column name */
+  Id = 'id',
+  /** column name */
+  UpdatedAt = 'updatedAt',
+  /** column name */
+  UserId = 'userId'
+}
+
+/** input type for updating data in table "todos" */
+export type TodosSetInput = {
+  contents?: InputMaybe<Scalars['String']>;
+};
+
+/** update columns of table "todos" */
+export enum TodosUpdateColumn {
+  /** column name */
+  Contents = 'contents'
+}
+
+/** Boolean expression to compare columns of type "uuid". All fields are combined with logical 'AND'. */
+export type UuidComparisonExp = {
+  _eq?: InputMaybe<Scalars['uuid']>;
+  _gt?: InputMaybe<Scalars['uuid']>;
+  _gte?: InputMaybe<Scalars['uuid']>;
+  _in?: InputMaybe<Array<Scalars['uuid']>>;
+  _is_null?: InputMaybe<Scalars['Boolean']>;
+  _lt?: InputMaybe<Scalars['uuid']>;
+  _lte?: InputMaybe<Scalars['uuid']>;
+  _neq?: InputMaybe<Scalars['uuid']>;
+  _nin?: InputMaybe<Array<Scalars['uuid']>>;
+};
+
+export type TodoListQueryVariables = Exact<{ [key: string]: never; }>;
+
+
+export type TodoListQuery = { __typename?: 'query_root', todos: Array<{ __typename?: 'todos', id: any, contents: string }> };
+
+export type AddItemMutationVariables = Exact<{
+  contents: Scalars['String'];
+}>;
+
+
+export type AddItemMutation = { __typename?: 'mutation_root', insertTodo?: { __typename?: 'todos', id: any } | null };

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -184,6 +184,7 @@ importers:
     specifiers:
       '@apollo/client': ^3.6.2
       '@faker-js/faker': ^6.3.1
+      '@graphql-codegen/cli': ^2.6.2
       '@mantine/core': ^4.2.2
       '@mantine/hooks': ^4.2.2
       '@mantine/notifications': ^4.2.2
@@ -215,7 +216,7 @@ importers:
       '@mantine/notifications': 4.2.2_af46c71ecf518c86fb9b76e8a89b700a
       '@mantine/prism': 4.2.2_af46c71ecf518c86fb9b76e8a89b700a
       '@nhost/react': link:../../packages/react
-      '@nhost/react-apollo': 4.2.16_58f3e90a6170f0045c5bb6e207aee083
+      '@nhost/react-apollo': link:../../packages/react-apollo
       graphql: 15.7.2
       react: 18.1.0
       react-dom: 18.1.0_react@18.1.0
@@ -224,6 +225,7 @@ importers:
       react-router-dom: 6.3.0_react-dom@18.1.0+react@18.1.0
     devDependencies:
       '@faker-js/faker': 6.3.1
+      '@graphql-codegen/cli': 2.6.2_69d0880ffe20510408ab76445f7abda8
       '@testing-library/cypress': 8.0.3_cypress@10.0.1
       '@types/react': 18.0.8
       '@types/react-dom': 18.0.3
@@ -3468,7 +3470,7 @@ packages:
       lodash.get: 4.4.2
       make-error: 1.3.6
       ts-node: 9.1.1_typescript@4.6.3
-      tslib: 2.3.1
+      tslib: 2.4.0
     transitivePeerDependencies:
       - typescript
     dev: true
@@ -3596,6 +3598,64 @@ packages:
       globby: 11.1.0
       graphql: 15.7.2
       graphql-config: 4.3.0_330a9efc941eb871384f32390ba029ff
+      inquirer: 8.2.2
+      is-glob: 4.0.3
+      json-to-pretty-yaml: 1.2.2
+      latest-version: 5.1.0
+      listr: 0.14.3
+      listr-update-renderer: 0.5.0_listr@0.14.3
+      log-symbols: 4.1.0
+      minimatch: 4.2.1
+      mkdirp: 1.0.4
+      string-env-interpolation: 1.0.1
+      ts-log: 2.2.4
+      tslib: 2.3.1
+      valid-url: 1.0.9
+      wrap-ansi: 7.0.0
+      yaml: 1.10.2
+      yargs: 17.4.1
+    transitivePeerDependencies:
+      - '@types/node'
+      - bufferutil
+      - encoding
+      - supports-color
+      - typescript
+      - utf-8-validate
+      - zen-observable
+      - zenObservable
+    dev: true
+
+  /@graphql-codegen/cli/2.6.2_69d0880ffe20510408ab76445f7abda8:
+    resolution: {integrity: sha512-UO75msoVgvLEvfjCezM09cQQqp32+mR8Ma1ACsBpr7nroFvHbgcu2ulx1cMovg4sxDBCsvd9Eq/xOOMpARUxtw==}
+    hasBin: true
+    peerDependencies:
+      graphql: ^0.8.0 || ^0.9.0 || ^0.10.0 || ^0.11.0 || ^0.12.0 || ^0.13.0 || ^14.0.0 || ^15.0.0 || ^16.0.0
+    dependencies:
+      '@graphql-codegen/core': 2.5.1_graphql@15.7.2
+      '@graphql-codegen/plugin-helpers': 2.4.2_graphql@15.7.2
+      '@graphql-tools/apollo-engine-loader': 7.2.11_graphql@15.7.2
+      '@graphql-tools/code-file-loader': 7.2.14_graphql@15.7.2
+      '@graphql-tools/git-loader': 7.1.13_graphql@15.7.2
+      '@graphql-tools/github-loader': 7.2.15_graphql@15.7.2
+      '@graphql-tools/graphql-file-loader': 7.3.11_graphql@15.7.2
+      '@graphql-tools/json-file-loader': 7.3.11_graphql@15.7.2
+      '@graphql-tools/load': 7.5.10_graphql@15.7.2
+      '@graphql-tools/prisma-loader': 7.1.13_b0e0055cf12c1aa2bc11d469d5e639ec
+      '@graphql-tools/url-loader': 7.9.14_b0e0055cf12c1aa2bc11d469d5e639ec
+      '@graphql-tools/utils': 8.6.9_graphql@15.7.2
+      ansi-escapes: 4.3.2
+      chalk: 4.1.2
+      change-case-all: 1.0.14
+      chokidar: 3.5.3
+      common-tags: 1.8.2
+      cosmiconfig: 7.0.1
+      debounce: 1.2.1
+      dependency-graph: 0.11.0
+      detect-indent: 6.1.0
+      glob: 7.2.0
+      globby: 11.1.0
+      graphql: 15.7.2
+      graphql-config: 4.3.0_69d0880ffe20510408ab76445f7abda8
       inquirer: 8.2.2
       is-glob: 4.0.3
       json-to-pretty-yaml: 1.2.2
@@ -3847,9 +3907,9 @@ packages:
     peerDependencies:
       graphql: ^14.0.0 || ^15.0.0 || ^16.0.0
     dependencies:
-      '@babel/parser': 7.17.9
-      '@babel/traverse': 7.17.9
-      '@babel/types': 7.17.0
+      '@babel/parser': 7.17.10
+      '@babel/traverse': 7.17.10
+      '@babel/types': 7.17.10
       '@graphql-tools/utils': 8.6.9_graphql@15.7.2
       graphql: 15.7.2
       tslib: 2.3.1
@@ -3945,6 +4005,40 @@ packages:
       - utf-8-validate
     dev: true
 
+  /@graphql-tools/prisma-loader/7.1.13_b0e0055cf12c1aa2bc11d469d5e639ec:
+    resolution: {integrity: sha512-rctgCI11ZjPJd4ncNTV7mmjV2WN2LRL3aTuTJWHjudO+iJPgoWyor0idl+aP0fOX2GnDK7zASmWwVShuGBJb9g==}
+    peerDependencies:
+      graphql: ^14.0.0 || ^15.0.0 || ^16.0.0
+    dependencies:
+      '@graphql-tools/url-loader': 7.9.14_b0e0055cf12c1aa2bc11d469d5e639ec
+      '@graphql-tools/utils': 8.6.9_graphql@15.7.2
+      '@types/js-yaml': 4.0.5
+      '@types/json-stable-stringify': 1.0.34
+      '@types/jsonwebtoken': 8.5.8
+      chalk: 4.1.2
+      debug: 4.3.4
+      dotenv: 16.0.0
+      graphql: 15.7.2
+      graphql-request: 4.2.0_graphql@15.7.2
+      http-proxy-agent: 5.0.0
+      https-proxy-agent: 5.0.1
+      isomorphic-fetch: 3.0.0
+      js-yaml: 4.1.0
+      json-stable-stringify: 1.0.1
+      jsonwebtoken: 8.5.1
+      lodash: 4.17.21
+      replaceall: 0.1.6
+      scuid: 1.1.0
+      tslib: 2.3.1
+      yaml-ast-parser: 0.0.43
+    transitivePeerDependencies:
+      - '@types/node'
+      - bufferutil
+      - encoding
+      - supports-color
+      - utf-8-validate
+    dev: true
+
   /@graphql-tools/relay-operation-optimizer/6.4.9_graphql@15.7.2:
     resolution: {integrity: sha512-fHMR1bNyx+ryBnmtXWnYmxvQLEx0O3yIG0MTVB1Mp6GlsyKTGI3O9njvjv0EI2JmCszs1uakT/6BW0LO37E6tQ==}
     peerDependencies:
@@ -4000,6 +4094,35 @@ packages:
       - utf-8-validate
     dev: true
 
+  /@graphql-tools/url-loader/7.9.14_b0e0055cf12c1aa2bc11d469d5e639ec:
+    resolution: {integrity: sha512-7IXiqUYp0cHeM+qvgjM4jAq8uJhl3PDdQYkyIj5wzZ7XjrkdV3JjPt0cHj2IBIeEwQJOjEKNeFYXjOlg73guCQ==}
+    peerDependencies:
+      graphql: ^14.0.0 || ^15.0.0 || ^16.0.0
+    dependencies:
+      '@graphql-tools/delegate': 8.7.7_graphql@15.7.2
+      '@graphql-tools/utils': 8.6.9_graphql@15.7.2
+      '@graphql-tools/wrap': 8.4.16_graphql@15.7.2
+      '@graphql-yoga/node': 2.3.0_graphql@15.7.2
+      '@n1ru4l/graphql-live-query': 0.9.0_graphql@15.7.2
+      '@types/ws': 8.5.3
+      cross-undici-fetch: 0.3.0
+      dset: 3.1.1
+      extract-files: 11.0.0
+      graphql: 15.7.2
+      graphql-ws: 5.7.0_graphql@15.7.2
+      isomorphic-ws: 4.0.1_ws@8.7.0
+      meros: 1.2.0_@types+node@17.0.31
+      sync-fetch: 0.3.1
+      tslib: 2.4.0
+      value-or-promise: 1.0.11
+      ws: 8.7.0
+    transitivePeerDependencies:
+      - '@types/node'
+      - bufferutil
+      - encoding
+      - utf-8-validate
+    dev: true
+
   /@graphql-tools/utils/8.6.9_graphql@15.7.2:
     resolution: {integrity: sha512-Z1X4d4GCT81+8CSt6SgU4t1w1UAUsAIRb67mI90k/zAs+ArkB95iE3bWXuJCUmd1+r8DGGtmUNOArtd6wkt+OQ==}
     peerDependencies:
@@ -4045,7 +4168,7 @@ packages:
       cross-undici-fetch: 0.2.5
       dset: 3.1.1
       graphql: 15.7.2
-      tslib: 2.3.1
+      tslib: 2.4.0
     transitivePeerDependencies:
       - encoding
     dev: true
@@ -4061,7 +4184,7 @@ packages:
       '@graphql-yoga/subscription': 2.0.0
       cross-undici-fetch: 0.2.5
       graphql: 15.7.2
-      tslib: 2.3.1
+      tslib: 2.4.0
     transitivePeerDependencies:
       - encoding
     dev: true
@@ -4070,7 +4193,7 @@ packages:
     resolution: {integrity: sha512-HlG+gIddjIP3/BDrMZymdzmzDjNdYuSGMxx6+1JA83gAEVRDR4yOoT4QeNKYqRhLK9xca/Hxp1PfBpquSa244Q==}
     dependencies:
       '@repeaterjs/repeater': 3.0.4
-      tslib: 2.3.1
+      tslib: 2.4.0
     dev: true
 
   /@hapi/hoek/9.3.0:
@@ -4990,25 +5113,6 @@ packages:
       - debug
     dev: false
 
-  /@nhost/react-apollo/4.2.16_58f3e90a6170f0045c5bb6e207aee083:
-    resolution: {integrity: sha512-FJ7zgAXXBrblene2QEAG06XajCfWnteXwCGQBcrcd4vDK5wBubJCALs1xHvrucze2Nbow7EzWcvaEqzuU+HxkQ==}
-    peerDependencies:
-      '@apollo/client': ^3.6.2
-      '@nhost/react': 0.7.13
-      graphql: ^16.0.0
-      react: ^17.0.0 || ^18.0.0
-      react-dom: ^17.0.0 || ^18.0.0
-    dependencies:
-      '@apollo/client': 3.6.2_graphql@15.7.2+react@18.1.0
-      '@nhost/apollo': 0.5.14_@apollo+client@3.6.2
-      '@nhost/react': link:packages/react
-      graphql: 15.7.2
-      react: 18.1.0
-      react-dom: 18.1.0_react@18.1.0
-    transitivePeerDependencies:
-      - debug
-    dev: false
-
   /@nodelib/fs.scandir/2.1.5:
     resolution: {integrity: sha512-vq24Bq3ym5HEQm2NKCr3yXDwjc7vTsEThRDnkp2DK9p1uqLR+DHurm/NOTo0KG7HYHU7eppKZj3MyqYuMBf62g==}
     engines: {node: '>= 8'}
@@ -5839,7 +5943,7 @@ packages:
   /@types/jsonwebtoken/8.5.8:
     resolution: {integrity: sha512-zm6xBQpFDIDM6o9r6HSgDeIcLy82TKWctCXEPbJJcXb5AKmi5BNNdLXneixK4lplX3PqIVcwLBCGE/kAGnlD4A==}
     dependencies:
-      '@types/node': 12.20.48
+      '@types/node': 17.0.33
     dev: true
 
   /@types/keygrip/1.0.2:
@@ -5849,7 +5953,7 @@ packages:
   /@types/keyv/3.1.4:
     resolution: {integrity: sha512-BQ5aZNSCpj7D6K2ksrRCTmKRLEpnPvWDiLPfoGyhZ++8YtiK9d/3DBKPJgry359X/P1PfruyYwvnvwFjuEiEIg==}
     dependencies:
-      '@types/node': 17.0.31
+      '@types/node': 17.0.33
 
   /@types/mdast/3.0.10:
     resolution: {integrity: sha512-W864tg/Osz1+9f4lrGTZpCSO5/z4608eUp19tbozkq2HJK6i3z1kT0H9tlADXuYIb1YYOBByU4Jsqkk75q48qA==}
@@ -5984,7 +6088,7 @@ packages:
   /@types/responselike/1.0.0:
     resolution: {integrity: sha512-85Y2BjiufFzaMIlvJDvTTB8Fxl2xfLo4HgmHzVBz08w4wDePCTjYw66PdrolO0kzli3yam/YCgRufyo1DdQVTA==}
     dependencies:
-      '@types/node': 17.0.31
+      '@types/node': 17.0.33
 
   /@types/retry/0.12.1:
     resolution: {integrity: sha512-xoDlM2S4ortawSWORYqsdU+2rxdh4LRW9ytc3zmT37RIKQh6IHyKwwtKhKis9ah8ol07DCkZxPt8BBvPjC6v4g==}
@@ -6055,7 +6159,7 @@ packages:
   /@types/ws/8.5.3:
     resolution: {integrity: sha512-6YOoWjruKj1uLf3INHH7D3qTXwFfEsg1kf3c0uDdSBJwfa/llkwIjrAGV7j7mVgGNbzTQ3HiHKKDXl6bJPD97w==}
     dependencies:
-      '@types/node': 17.0.31
+      '@types/node': 17.0.33
 
   /@types/yargs-parser/21.0.0:
     resolution: {integrity: sha512-iO9ZQHkZxHn4mSakYV0vFHAVDyEOIJQrV2uZ06HxEPcx+mt8swXoZHIbaaJ2crJYFfErySgktuTZ3BeLz+XmFA==}
@@ -7272,7 +7376,7 @@ packages:
     dev: false
 
   /ansi-regex/2.1.1:
-    resolution: {integrity: sha1-w7M6te42DYbg5ijwRorn7yfWVN8=}
+    resolution: {integrity: sha512-TIGnTpdo+E3+pCyAluZvtED5p5wCqLdezCyhPZzKPcxvFplEt4i+W7OONCKgeZFT3+y5NZZfOOS/Bdcanm1MYA==}
     engines: {node: '>=0.10.0'}
     dev: true
 
@@ -7291,7 +7395,7 @@ packages:
     dev: false
 
   /ansi-styles/2.2.1:
-    resolution: {integrity: sha1-tDLdM1i2NM914eRmQ2gkBTPB3b4=}
+    resolution: {integrity: sha512-kmCevFghRiWM7HB5zTPULl4r9bVFSWjz62MhqizDGUrq2NWuNMQyuv4tHHoKJHs69M/MF64lEcHdYIocrdWQYA==}
     engines: {node: '>=0.10.0'}
     dev: true
 
@@ -8190,7 +8294,7 @@ packages:
     resolution: {integrity: sha512-ds37W8CytHgwnhGGTi88pcPyR15qoNkOpYwmMMfnWqqWgESapLqvDx6huFjQ5vqWSn2Z06173XNA7LtMOeUh1A==}
     dependencies:
       no-case: 3.0.4
-      tslib: 2.3.1
+      tslib: 2.4.0
       upper-case-first: 2.0.2
     dev: true
 
@@ -8216,7 +8320,7 @@ packages:
     dev: true
 
   /chalk/1.1.3:
-    resolution: {integrity: sha1-qBFcVeSnAv5NFQq9OHKCKn4J/Jg=}
+    resolution: {integrity: sha512-U3lRVLMSlsCfjqYPbLyVv11M9CPW4I728d6TCKMAOJueEeB9/8o+eSsMnxPJD+Q+K909sdESg7C+tIkoH6on1A==}
     engines: {node: '>=0.10.0'}
     dependencies:
       ansi-styles: 2.2.1
@@ -8286,7 +8390,7 @@ packages:
       path-case: 3.0.4
       sentence-case: 3.0.4
       snake-case: 3.0.4
-      tslib: 2.3.1
+      tslib: 2.4.0
     dev: true
 
   /char-regex/1.0.2:
@@ -8444,7 +8548,7 @@ packages:
     dev: false
 
   /cli-cursor/2.1.0:
-    resolution: {integrity: sha1-s12sN2R5+sw+lHR9QdDQ9SOP/LU=}
+    resolution: {integrity: sha512-8lgKz8LmCRYZZQDpRyT2m5rKJ08TnU4tR9FFFW2rxpxR1FzWi4PQ/NfyODchAatHaUgnSPVcx/R5w6NuTBzFiw==}
     engines: {node: '>=4'}
     dependencies:
       restore-cursor: 2.0.0
@@ -8471,7 +8575,7 @@ packages:
       '@colors/colors': 1.5.0
 
   /cli-truncate/0.2.1:
-    resolution: {integrity: sha1-nxXPuwcFAFNpIWxiasfQWrkN1XQ=}
+    resolution: {integrity: sha512-f4r4yJnbT++qUPI9NR4XLDLq41gQ+uqnPItWG0F5ZkehuNiTTa3EY0S4AqTSUOeJ7/zU41oWPQSNkW5BqPL9bg==}
     engines: {node: '>=0.10.0'}
     dependencies:
       slice-ansi: 0.0.4
@@ -8516,12 +8620,12 @@ packages:
       shallow-clone: 3.0.1
 
   /clone-response/1.0.2:
-    resolution: {integrity: sha1-0dyXOSAxTfZ/vrlCI7TuNQI56Ws=}
+    resolution: {integrity: sha512-yjLXh88P599UOyPTFX0POsd7WxnbsVsGohcwzHOLspIhhpalPw1BcqED8NblyZLKcGrL8dTgMlcaZxV2jAD41Q==}
     dependencies:
       mimic-response: 1.0.1
 
   /clone/1.0.4:
-    resolution: {integrity: sha1-2jCcwmPfFZlMaIypAheco8fNfH4=}
+    resolution: {integrity: sha512-JQHZ2QMW6l3aH/j6xCqQThY/9OH4D/9ls34cgkUBiEeocRTU04tHfKPBsUK1PqZCUQM7GiA0IIXJSuXHI64Kbg==}
     engines: {node: '>=0.8'}
     dev: true
 
@@ -8542,7 +8646,7 @@ packages:
     dev: true
 
   /code-point-at/1.1.0:
-    resolution: {integrity: sha1-DQcLTQQ6W+ozovGkDi7bPZpMz3c=}
+    resolution: {integrity: sha512-RpAVKQA5T63xEj6/giIbUEtZwJ4UFIc3ZtvEkiaUERylqe8xb5IvqcgOurZLahv93CLKfxcw5YI+DZcUBRyLXA==}
     engines: {node: '>=0.10.0'}
     dev: true
 
@@ -8700,7 +8804,7 @@ packages:
     resolution: {integrity: sha512-I2hSBi7Vvs7BEuJDr5dDHfzb/Ruj3FyvFyh7KLilAjNQw3Be+xgqUBA2W6scVEcL0hL1dwPRtIqEPVUCKkSsyQ==}
     dependencies:
       no-case: 3.0.4
-      tslib: 2.3.1
+      tslib: 2.4.0
       upper-case: 2.0.2
     dev: true
 
@@ -9805,7 +9909,7 @@ packages:
     dev: false
 
   /decompress-response/3.3.0:
-    resolution: {integrity: sha1-gKTdMjdIOEv6JICDYirt7Jgq3/M=}
+    resolution: {integrity: sha512-BzRPQuY1ip+qDonAOz42gRm/pg9F768C+npV/4JOsxRC2sq+Rlk+Q4ZCAsOhnIaMrgarILY+RMUIvMmmX1qAEA==}
     engines: {node: '>=4'}
     dependencies:
       mimic-response: 1.0.1
@@ -9861,7 +9965,7 @@ packages:
     dev: false
 
   /defaults/1.0.3:
-    resolution: {integrity: sha1-xlYFHpgX2f8I7YgUd/P+QBnz730=}
+    resolution: {integrity: sha512-s82itHOnYrN0Ib8r+z7laQz3sdE+4FP3d9Q7VLO7U+KRT+CR0GsWuyHxzdAY82I7cXv0G/twrqomTJLOssO5HA==}
     dependencies:
       clone: 1.0.4
     dev: true
@@ -10192,7 +10296,7 @@ packages:
     dev: false
 
   /duplexer3/0.1.4:
-    resolution: {integrity: sha1-7gHdHKwO08vH/b6jfcCo8c4ALOI=}
+    resolution: {integrity: sha512-CEj8FwwNA4cVH2uFCoHUrmojhYh1vmCdOaneKJXwkeY1i9jnlslVo9dx+hQ5Hl9GnH/Bwy/IjxAyOePyPKYnzA==}
 
   /eastasianwidth/0.2.0:
     resolution: {integrity: sha512-I88TYZWc9XiYHRQ4/3c5rjjfgkjhLyW2luGIheGERbNQ6OY7yTybanSpDXZa8y7VUP9YmDcYa+eyq4ca7iLqWA==}
@@ -10222,7 +10326,7 @@ packages:
     resolution: {integrity: sha512-oi3YPmaP87hiHn0c4ePB67tXaF+ldGhxvZnT19tW9zX6/Ej+pLN0Afja5rQ6S+TND7I9EuwQTT8JYn1k7R7rrw==}
 
   /elegant-spinner/1.0.1:
-    resolution: {integrity: sha1-2wQ1IcldfjA/2PNFvtwzSc+wcp4=}
+    resolution: {integrity: sha512-B+ZM+RXvRqQaAmkMlO/oSe5nMUOaUnyfGYCEHoR8wrXsZR2mA0XVibsxV1bvTwxdRWah1PkQqso2EzhILGHtEQ==}
     engines: {node: '>=0.10.0'}
     dev: true
 
@@ -11871,7 +11975,7 @@ packages:
     dev: false
 
   /figures/1.7.0:
-    resolution: {integrity: sha1-y+Hjr/zxzUS4DK3+0o3Hk6lwHS4=}
+    resolution: {integrity: sha512-UxKlfCRuCBxSXU4C6t9scbDyWZ4VlaFFdojKtzJuSkuOBQ5CNFum+zZXFwHjo+CxBC1t6zlYPgHIgFjL8ggoEQ==}
     engines: {node: '>=0.10.0'}
     dependencies:
       escape-string-regexp: 1.0.5
@@ -11879,7 +11983,7 @@ packages:
     dev: true
 
   /figures/2.0.0:
-    resolution: {integrity: sha1-OrGi0qYsi/tDGgyUy3l6L84nyWI=}
+    resolution: {integrity: sha512-Oa2M9atig69ZkfwiApY8F2Yy+tzMbazyvqv21R0NsSC8floSOC09BbT1ITWAdoMGQvJ/aZnR1KMwdx9tvHnTNA==}
     engines: {node: '>=4'}
     dependencies:
       escape-string-regexp: 1.0.5
@@ -12456,6 +12560,32 @@ packages:
       - utf-8-validate
     dev: true
 
+  /graphql-config/4.3.0_69d0880ffe20510408ab76445f7abda8:
+    resolution: {integrity: sha512-Uiu3X7+s5c056WyrvdZVz2vG1fhAipMlYmtiCU/4Z2mX79OXDr1SqIon2MprC/pExIWJfAQZCcjYDY76fPBUQg==}
+    engines: {node: '>= 10.0.0'}
+    peerDependencies:
+      graphql: ^0.11.0 || ^0.12.0 || ^0.13.0 || ^14.0.0 || ^15.0.0 || ^16.0.0
+    dependencies:
+      '@endemolshinegroup/cosmiconfig-typescript-loader': 3.0.2_ec5c0ebd3030a0a5109338876648df1b
+      '@graphql-tools/graphql-file-loader': 7.3.11_graphql@15.7.2
+      '@graphql-tools/json-file-loader': 7.3.11_graphql@15.7.2
+      '@graphql-tools/load': 7.5.10_graphql@15.7.2
+      '@graphql-tools/merge': 8.2.10_graphql@15.7.2
+      '@graphql-tools/url-loader': 7.9.14_b0e0055cf12c1aa2bc11d469d5e639ec
+      '@graphql-tools/utils': 8.6.9_graphql@15.7.2
+      cosmiconfig: 7.0.1
+      cosmiconfig-toml-loader: 1.0.0
+      graphql: 15.7.2
+      minimatch: 4.2.1
+      string-env-interpolation: 1.0.1
+    transitivePeerDependencies:
+      - '@types/node'
+      - bufferutil
+      - encoding
+      - typescript
+      - utf-8-validate
+    dev: true
+
   /graphql-executor/0.0.23_graphql@15.7.2:
     resolution: {integrity: sha512-3Ivlyfjaw3BWmGtUSnMpP/a4dcXCp0mJtj0PiPG14OKUizaMKlSEX+LX2Qed0LrxwniIwvU6B4w/koVjEPyWJg==}
     engines: {node: ^12.22.0 || ^14.16.0 || >=16.0.0}
@@ -12525,7 +12655,7 @@ packages:
     dev: true
 
   /has-ansi/2.0.0:
-    resolution: {integrity: sha1-NPUEnOHs3ysGSa8+8k5F7TVBbZE=}
+    resolution: {integrity: sha512-C8vBJ8DwUCx19vhm7urhTuUsr4/IyP6l4VzNQDv+ryHQObW3TTTp9yB68WpYgRe2bbaGuZ/se74IqFeVnMnLZg==}
     engines: {node: '>=0.10.0'}
     dependencies:
       ansi-regex: 2.1.1
@@ -12671,7 +12801,7 @@ packages:
     resolution: {integrity: sha512-H/vuk5TEEVZwrR0lp2zed9OCo1uAILMlx0JEMgC26rzyJJ3N1v6XkwHHXJQdR2doSjcGPM6OKPYoJgf0plJ11Q==}
     dependencies:
       capital-case: 1.0.4
-      tslib: 2.3.1
+      tslib: 2.4.0
     dev: true
 
   /headers-polyfill/3.0.7:
@@ -13068,7 +13198,7 @@ packages:
     engines: {node: '>=0.8.19'}
 
   /indent-string/3.2.0:
-    resolution: {integrity: sha1-Sl/W0nzDMvN+VBmlBNu4NxBckok=}
+    resolution: {integrity: sha512-BYqTHXTGUIvg7t1r4sJNKcbDZkL92nkXA8YtRpbjFHRHGDL/NtUeiBJMeE60kIFN/Mg8ESaWQvftaYMGJzQZCQ==}
     engines: {node: '>=4'}
     dev: true
 
@@ -13305,14 +13435,14 @@ packages:
     engines: {node: '>=0.10.0'}
 
   /is-fullwidth-code-point/1.0.0:
-    resolution: {integrity: sha1-754xOG8DGn8NZDr4L95QxFfvAMs=}
+    resolution: {integrity: sha512-1pqUqRjkhPJ9miNq9SwMfdvi6lBJcd6eFxvfaivQhaH3SgisfiuudvFntdKOmxuee/77l+FPjKrQjWvmPjWrRw==}
     engines: {node: '>=0.10.0'}
     dependencies:
       number-is-nan: 1.0.1
     dev: true
 
   /is-fullwidth-code-point/2.0.0:
-    resolution: {integrity: sha1-o7MKXE8ZkYMWeqq5O+764937ZU8=}
+    resolution: {integrity: sha512-VHskAKYM8RfSFXwee5t5cbN5PZeq1Wrh6qd5bkyiXIf6UQcN6w/A0eXM9r6t8d+GYOh+o6ZhiEnb88LN/Y8m2w==}
     engines: {node: '>=4'}
     dev: true
 
@@ -13353,7 +13483,7 @@ packages:
   /is-lower-case/2.0.2:
     resolution: {integrity: sha512-bVcMJy4X5Og6VZfdOZstSexlEy20Sr0k/p/b2IlQJlfdKAQuMpiv5w2Ccxb8sKdRUNAG1PnHVHjFSdRDVS6NlQ==}
     dependencies:
-      tslib: 2.3.1
+      tslib: 2.4.0
     dev: true
 
   /is-map/2.0.2:
@@ -13492,7 +13622,7 @@ packages:
     dev: true
 
   /is-stream/1.1.0:
-    resolution: {integrity: sha1-EtSj3U5o4Lec6428hBc66A2RykQ=}
+    resolution: {integrity: sha512-uQPm8kcs47jx38atAcWTVxyltQYoPT68y9aWYdV6yWXSyW8mzSat0TL6CiWdZeCdF3KrAvpVtnHbTv4RN+rqdQ==}
     engines: {node: '>=0.10.0'}
     dev: true
 
@@ -13550,7 +13680,7 @@ packages:
   /is-upper-case/2.0.2:
     resolution: {integrity: sha512-44pxmxAvnnAOwBg4tHPnkfvgjPwbc5QIsSstNU+YcJ1ovxVzCWpSGosPJOZh/a1tdl81fbgnLc9LLv+x2ywbPQ==}
     dependencies:
-      tslib: 2.3.1
+      tslib: 2.4.0
     dev: true
 
   /is-uri/1.2.4:
@@ -13655,6 +13785,14 @@ packages:
       ws: '*'
     dependencies:
       ws: 8.5.0
+    dev: true
+
+  /isomorphic-ws/4.0.1_ws@8.7.0:
+    resolution: {integrity: sha512-BhBvN2MBpWTaSHdWRb/bwdZJ1WaehQ2L1KngkCkfLUGF0mAWAT1sQUQacEmQ0jXkFw/czDXPNQSL5u2/Krsz1w==}
+    peerDependencies:
+      ws: '*'
+    dependencies:
+      ws: 8.7.0
     dev: true
 
   /isostring/0.0.1:
@@ -14462,7 +14600,7 @@ packages:
     dev: true
 
   /json-stable-stringify/1.0.1:
-    resolution: {integrity: sha1-mnWdOcXy/1A/1TAGRu1EX4jE+a8=}
+    resolution: {integrity: sha512-i/J297TW6xyj7sDFa7AmBPkQvLIxWr2kKPWI26tXydnZrzVAocNqn5DMNT1Mzk0vit1V5UkRM7C1KdVNp7Lmcg==}
     dependencies:
       jsonify: 0.0.0
     dev: true
@@ -14472,7 +14610,7 @@ packages:
     dev: true
 
   /json-to-pretty-yaml/1.2.2:
-    resolution: {integrity: sha1-9M0L0KXo/h3yWq9boRiwmf2ZLVs=}
+    resolution: {integrity: sha512-rvm6hunfCcqegwYaG5T4yKJWxc9FXFgBVrcTZ4XfSVRwa5HA/Xs+vB/Eo9treYYHCeNM0nrSUr82V/M31Urc7A==}
     engines: {node: '>= 0.2.0'}
     dependencies:
       remedial: 1.0.8
@@ -14523,7 +14661,7 @@ packages:
       graceful-fs: 4.2.10
 
   /jsonify/0.0.0:
-    resolution: {integrity: sha1-LHS27kHZPKUbe1qu6PUDYx0lKnM=}
+    resolution: {integrity: sha512-trvBk1ki43VZptdBI5rIlG4YOzyeH/WefQt5rj1grasPn4iiZWKet8nkgc4GlsAylaztn0qZfUYOiTsASJFdNA==}
     dev: true
 
   /jsonwebtoken/8.5.1:
@@ -14672,7 +14810,7 @@ packages:
     resolution: {integrity: sha512-7ylylesZQ/PV29jhEDl3Ufjo6ZX7gCqJr5F7PKrqc93v7fzSymt1BpwEU8nAUXs8qzzvqhbjhK5QZg6Mt/HkBg==}
 
   /listr-silent-renderer/1.1.1:
-    resolution: {integrity: sha1-kktaN1cVN3C/Go4/v3S4u/P5JC4=}
+    resolution: {integrity: sha512-L26cIFm7/oZeSNVhWB6faeorXhMg4HNlb/dS/7jHhr708jxlXrtrBWo4YUxZQkc6dGoxEAe6J/D3juTRBUzjtA==}
     engines: {node: '>=4'}
     dev: true
 
@@ -14853,31 +14991,31 @@ packages:
     dev: false
 
   /lodash.get/4.4.2:
-    resolution: {integrity: sha1-LRd/ZS+jHpObRDjVNBSZ36OCXpk=}
+    resolution: {integrity: sha512-z+Uw/vLuy6gQe8cfaFWD7p0wVv8fJl3mbzXh33RS+0oW2wvUqiRXiQ69gLWSLpgB5/6sU+r6BlQR0MBILadqTQ==}
     dev: true
 
   /lodash.includes/4.3.0:
-    resolution: {integrity: sha1-YLuYqHy5I8aMoeUTJUgzFISfVT8=}
+    resolution: {integrity: sha512-W3Bx6mdkRTGtlJISOvVD/lbqjTlPPUDTMnlXZFnVwi9NKJ6tiAk6LVdlhZMm17VZisqhKcgzpO5Wz91PCt5b0w==}
     dev: true
 
   /lodash.isboolean/3.0.3:
-    resolution: {integrity: sha1-bC4XHbKiV82WgC/UOwGyDV9YcPY=}
+    resolution: {integrity: sha512-Bz5mupy2SVbPHURB98VAcw+aHh4vRV5IPNhILUCsOzRmsTmSQ17jIuqopAentWoehktxGd9e/hbIXq980/1QJg==}
     dev: true
 
   /lodash.isinteger/4.0.4:
-    resolution: {integrity: sha1-YZwK89A/iwTDH1iChAt3sRzWg0M=}
+    resolution: {integrity: sha512-DBwtEWN2caHQ9/imiNeEA5ys1JoRtRfY3d7V9wkqtbycnAmTvRRmbHKDV4a0EYc678/dia0jrte4tjYwVBaZUA==}
     dev: true
 
   /lodash.isnumber/3.0.3:
-    resolution: {integrity: sha1-POdoEMWSjQM1IwGsKHMX8RwLH/w=}
+    resolution: {integrity: sha512-QYqzpfwO3/CWf3XP+Z+tkQsfaLL/EnUlXWVkIk5FUPc4sBdTehEqZONuyRt2P67PXAk+NXmTBcc97zw9t1FQrw==}
     dev: true
 
   /lodash.isplainobject/4.0.6:
-    resolution: {integrity: sha1-fFJqUtibRcRcxpC4gWO+BJf1UMs=}
+    resolution: {integrity: sha512-oSXzaWypCMHkPC3NvBEaPHf0KsA5mvPrOPgQWDsbg8n7orZ290M0BmC/jgRZ4vcJ6DTAhjrsSYgdsW/F+MFOBA==}
     dev: true
 
   /lodash.isstring/4.0.1:
-    resolution: {integrity: sha1-1SfftUVuynzJu5XV2ur4i6VKVFE=}
+    resolution: {integrity: sha512-0wJxfxH1wgO3GrbuP+dTTk7op+6L41QCXbGINEmD+ny/G/eCqGzxyCsh7159S+mgDDcoarnBw6PC1PS5+wUGgw==}
     dev: true
 
   /lodash.map/4.6.0:
@@ -14922,7 +15060,7 @@ packages:
     resolution: {integrity: sha512-v2kDEe57lecTulaDIuNTPy3Ry4gLGJ6Z1O3vE1krgXZNrsQ+LFTGHVxVjcXPs17LhbZVGedAJv8XZ1tvj5FvSg==}
 
   /log-symbols/1.0.2:
-    resolution: {integrity: sha1-N2/3tY6jCGoPCfrMdGF+ylAeGhg=}
+    resolution: {integrity: sha512-mmPrW0Fh2fxOzdBbFv4g1m6pR72haFLPJ2G5SJEELf1y+iaQrDG6cWCPjy54RHYbZAt7X+ls690Kw62AdWXBzQ==}
     engines: {node: '>=0.10.0'}
     dependencies:
       chalk: 1.1.3
@@ -14937,7 +15075,7 @@ packages:
     dev: true
 
   /log-update/2.3.0:
-    resolution: {integrity: sha1-iDKP19HOeTiykoN0bwsbwSayRwg=}
+    resolution: {integrity: sha512-vlP11XfFGyeNQlmEn9tJ66rEW1coA/79m5z6BCkudjbAGE83uhAcGYrBFwfs3AdLiLzGRusRPAbSPK9xZteCmg==}
     engines: {node: '>=4'}
     dependencies:
       ansi-escapes: 3.2.0
@@ -14970,7 +15108,7 @@ packages:
   /lower-case-first/2.0.2:
     resolution: {integrity: sha512-EVm/rR94FJTZi3zefZ82fLWab+GX14LJN4HrWBcuo6Evmsl9hEfnqxgcHCKb9q+mNf6EVdsjx/qucYFIIB84pg==}
     dependencies:
-      tslib: 2.3.1
+      tslib: 2.4.0
     dev: true
 
   /lower-case/2.0.2:
@@ -15249,6 +15387,18 @@ packages:
         optional: true
     dependencies:
       '@types/node': 12.20.48
+    dev: true
+
+  /meros/1.2.0_@types+node@17.0.31:
+    resolution: {integrity: sha512-3QRZIS707pZQnijHdhbttXRWwrHhZJ/gzolneoxKVz9N/xmsvY/7Ls8lpnI9gxbgxjcHsAVEW3mgwiZCo6kkJQ==}
+    engines: {node: '>=12'}
+    peerDependencies:
+      '@types/node': '>=12'
+    peerDependenciesMeta:
+      '@types/node':
+        optional: true
+    dependencies:
+      '@types/node': 17.0.31
     dev: true
 
   /methods/1.1.2:
@@ -15734,7 +15884,7 @@ packages:
     dev: true
 
   /normalize-path/2.1.1:
-    resolution: {integrity: sha1-GrKLVW4Zg2Oowab35vogE3/mrtk=}
+    resolution: {integrity: sha512-3pKJwH184Xo/lnH6oyP1q2pMd7HcypqqmRs91/6/i2CGtWwIKGCkOOMTm/zXbgTEWHw1uNpNi/igc3ePOYHb6w==}
     engines: {node: '>=0.10.0'}
     dependencies:
       remove-trailing-separator: 1.1.0
@@ -15808,7 +15958,7 @@ packages:
     dev: true
 
   /number-is-nan/1.0.1:
-    resolution: {integrity: sha1-CXtgK1NCKlIsGvuHkDGDNpQaAR0=}
+    resolution: {integrity: sha512-4jbtZXNAsfZbAHiiqjLPBiCl16dES1zI4Hpzzxw61Tk+loF+sBDBKx1ICKKKwIqQ7M0mFn1TmkN7euSncWgHiQ==}
     engines: {node: '>=0.10.0'}
     dev: true
 
@@ -15817,7 +15967,7 @@ packages:
     dev: true
 
   /object-assign/4.1.1:
-    resolution: {integrity: sha1-IQmtx5ZYh8/AXLvUQsrIv7s2CGM=}
+    resolution: {integrity: sha512-rJgTQnkUnH1sFw8yT6VSU3zD3sWmu6sZhIseY8VX+GRu3P6F7Fu+JNDoXfklElbLJSnc3FUQHVe4cU5hj+BcUg==}
     engines: {node: '>=0.10.0'}
 
   /object-hash/3.0.0:
@@ -15917,7 +16067,7 @@ packages:
       wrappy: 1.0.2
 
   /onetime/2.0.1:
-    resolution: {integrity: sha1-BnQoIw/WdEOyeUsiu6UotoZ5YtQ=}
+    resolution: {integrity: sha512-oyyPpiMaKARvvcgip+JV+7zci5L8D1W9RZIz2l1o08AM3pfspitVWnPt3mzHcBPp12oYMTy0pqrFs/C+m3EwsQ==}
     engines: {node: '>=4'}
     dependencies:
       mimic-fn: 1.2.0
@@ -15988,7 +16138,7 @@ packages:
     dev: true
 
   /os-tmpdir/1.0.2:
-    resolution: {integrity: sha1-u+Z0BseaqFxc/sdm/lc0VV36EnQ=}
+    resolution: {integrity: sha512-D2FR03Vir7FIu45XBY20mTb+/ZSWB00sjU9jdQXt83gDrI4Ztz5Fs7/yy74g2N5SVQY4xY1qDr4rNddwYRVX0g==}
     engines: {node: '>=0.10.0'}
     dev: true
 
@@ -16184,7 +16334,7 @@ packages:
     resolution: {integrity: sha512-qO4qCFjXqVTrcbPt/hQfhTQ+VhFsqNKOPtytgNKkKxSoEp3XPUQ8ObFuePylOIok5gjn69ry8XiULxCwot3Wfg==}
     dependencies:
       dot-case: 3.0.4
-      tslib: 2.3.1
+      tslib: 2.4.0
     dev: true
 
   /path-exists/3.0.0:
@@ -16844,7 +16994,7 @@ packages:
     dev: true
 
   /prepend-http/2.0.0:
-    resolution: {integrity: sha1-6SQ0v6XqjBn0HN/UAddBo8gZ2Jc=}
+    resolution: {integrity: sha512-ravE6m9Atw9Z/jjttRUZ+clIXogdghyZAuWJ3qEzjT+jI/dL1ifAqhZeC5VHzQp1MSt1+jxKkFNemj/iO7tVUA==}
     engines: {node: '>=4'}
 
   /prettier/1.19.1:
@@ -17937,7 +18087,7 @@ packages:
     dev: true
 
   /remove-trailing-separator/1.1.0:
-    resolution: {integrity: sha1-wkvOKig62tW8P1jg1IJJuSN52O8=}
+    resolution: {integrity: sha512-/hS+Y0u3aOfIETiaiirUFwDBDzmXPvO+jAfKTitUngIPzdKc6Z0LoFjM/CK5PL4C+eKwHohlHAb6H0VFfmmUsw==}
     dev: true
 
   /remove-trailing-spaces/1.0.8:
@@ -17960,7 +18110,7 @@ packages:
     dev: false
 
   /replaceall/0.1.6:
-    resolution: {integrity: sha1-gdgax663LX9cSUKt8ml6MiBojY4=}
+    resolution: {integrity: sha512-sL26E4+8Kec7bwpRjHlQvbNZcpnGroT3PA7ywsgH6GjzxAg4IGNlNalLoRC/JmTed7cMhyDbi44pWw1kMhDxlw==}
     engines: {node: '>= 0.8.x'}
     dev: true
 
@@ -17975,7 +18125,7 @@ packages:
     dev: true
 
   /require-directory/2.1.1:
-    resolution: {integrity: sha1-jGStX9MNqxyXbiNE/+f3kqam30I=}
+    resolution: {integrity: sha512-fGxEI7+wsG9xrvdjsrlmL22OMTTiHRwAMroiEeMgq8gzoLC/PQr7RsRDSTLUg/bZAZtF+TVIkHc6/4RIKrui+Q==}
     engines: {node: '>=0.10.0'}
     dev: true
 
@@ -18040,12 +18190,12 @@ packages:
     dev: true
 
   /responselike/1.0.2:
-    resolution: {integrity: sha1-kYcg7ztjHFZCvgaPFa3lpG9Loec=}
+    resolution: {integrity: sha512-/Fpe5guzJk1gPqdJLJR5u7eG/gNY4nImjbRDaVWVMRhne55TCmj2i9Q+54PBRfatRC8v/rIiv9BN0pMd9OV5EQ==}
     dependencies:
       lowercase-keys: 1.0.1
 
   /restore-cursor/2.0.0:
-    resolution: {integrity: sha1-n37ih/gv0ybU/RYpI9YhKe7g368=}
+    resolution: {integrity: sha512-6IzJLuGi4+R14vwagDHX+JrXmPVtPpn4mffDJ1UdR7/Edm87fl6yi8mMBIVvFtJaNTUvjughmW4hwLhRG7gC1Q==}
     engines: {node: '>=4'}
     dependencies:
       onetime: 2.0.1
@@ -18307,7 +18457,7 @@ packages:
     resolution: {integrity: sha512-8LS0JInaQMCRoQ7YUytAo/xUu5W2XnQxV2HI/6uM6U7CITS1RqPElr30V6uIqyMKM9lJGRVFy5/4CuzcixNYSg==}
     dependencies:
       no-case: 3.0.4
-      tslib: 2.3.1
+      tslib: 2.4.0
       upper-case-first: 2.0.2
     dev: true
 
@@ -18543,7 +18693,7 @@ packages:
     resolution: {integrity: sha512-LAOh4z89bGQvl9pFfNF8V146i7o7/CqFPbqzYgP+yYzDIDeS9HaNFtXABamRW+AQzEVODcvE79ljJ+8a9YSdMg==}
     dependencies:
       dot-case: 3.0.4
-      tslib: 2.3.1
+      tslib: 2.4.0
     dev: true
 
   /sockjs/0.3.24:
@@ -18681,7 +18831,7 @@ packages:
   /sponge-case/1.0.1:
     resolution: {integrity: sha512-dblb9Et4DAtiZ5YSUZHLl4XhH4uK80GhAZrVXdN4O2P4gQ40Wa5UIOPUHlA/nFd2PLblBZWUioLMMAVrgpoYcA==}
     dependencies:
-      tslib: 2.3.1
+      tslib: 2.4.0
     dev: true
 
   /sprintf-js/1.0.3:
@@ -18794,7 +18944,7 @@ packages:
     dev: true
 
   /string-width/1.0.2:
-    resolution: {integrity: sha1-EYvfW4zcUaKn5w0hHgfisLmxB9M=}
+    resolution: {integrity: sha512-0XsVpQLnVCXHJfyEs8tC0zpTVIr5PKKsQtkT29IwupnPTjtPmQ3xT/4yCREF9hYkV/3M3kzcUTSAZT6a6h81tw==}
     engines: {node: '>=0.10.0'}
     dependencies:
       code-point-at: 1.1.0
@@ -18890,14 +19040,14 @@ packages:
     dev: false
 
   /strip-ansi/3.0.1:
-    resolution: {integrity: sha1-ajhfuIU9lS1f8F0Oiq+UJ43GPc8=}
+    resolution: {integrity: sha512-VhumSSbBqDTP8p2ZLKj40UjBCV4+v8bUSEpUb4KjRgWk9pbqGF4REFj6KEagidb2f/M6AzC0EmFyDNGaw9OCzg==}
     engines: {node: '>=0.10.0'}
     dependencies:
       ansi-regex: 2.1.1
     dev: true
 
   /strip-ansi/4.0.0:
-    resolution: {integrity: sha1-qEeQIusaw2iocTibY1JixQXuNo8=}
+    resolution: {integrity: sha512-4XaJ2zQdCzROZDivEVIDPkcQn8LMFSa8kj8Gxb/Lnwzv9A8VctNZ+lfivC/sV3ivW8ElJTERXZoPBRrZKkNKow==}
     engines: {node: '>=4'}
     dependencies:
       ansi-regex: 3.0.1
@@ -18943,7 +19093,7 @@ packages:
     dev: true
 
   /strip-json-comments/2.0.1:
-    resolution: {integrity: sha1-PFMZQukIwml8DsNEhYwobHygpgo=}
+    resolution: {integrity: sha512-4gB8na07fecVVkOI6Rs4e7T6NOTki5EmL7TUduTs6bu3EdnSycntVJ4re8kgZA+wx9IueI2Y11bfbgwtzuE0KQ==}
     engines: {node: '>=0.10.0'}
 
   /strip-json-comments/3.1.1:
@@ -19029,7 +19179,7 @@ packages:
     dev: true
 
   /supports-color/2.0.0:
-    resolution: {integrity: sha1-U10EXOa2Nj+kARcIRimZXp3zJMc=}
+    resolution: {integrity: sha512-KKNVtd6pCYgPIKU4cp2733HWYCpplQhddZLBUryaAHou723x+FRzQ5Df824Fj+IyyuiQTRoub4SnIFfIcrp70g==}
     engines: {node: '>=0.8.0'}
     dev: true
 
@@ -19151,7 +19301,7 @@ packages:
   /swap-case/2.0.2:
     resolution: {integrity: sha512-kc6S2YS/2yXbtkSMunBtKdah4VFETZ8Oh6ONSmSd9bRxhqTrtARUCBUiWXH3xVPpvR7tz2CSnkuXVE42EcGnMw==}
     dependencies:
-      tslib: 2.3.1
+      tslib: 2.4.0
     dev: true
 
   /symbol-observable/1.2.0:
@@ -19350,7 +19500,7 @@ packages:
   /title-case/3.0.3:
     resolution: {integrity: sha512-e1zGYRvbffpcHIrnuqT0Dh+gEJtDaxDSoG4JAIpq4oDFyooziLBIiYQv0GBT4FUAnUop5uZ1hiIAj7oAF6sOCA==}
     dependencies:
-      tslib: 2.3.1
+      tslib: 2.4.0
     dev: true
 
   /tlds/1.231.0:
@@ -20243,13 +20393,13 @@ packages:
   /upper-case-first/2.0.2:
     resolution: {integrity: sha512-514ppYHBaKwfJRK/pNC6c/OxfGa0obSnAl106u97Ed0I625Nin96KAjttZF6ZL3e1XLtphxnqrOi9iWgm+u+bg==}
     dependencies:
-      tslib: 2.3.1
+      tslib: 2.4.0
     dev: true
 
   /upper-case/2.0.2:
     resolution: {integrity: sha512-KgdgDGJt2TpuwBUIjgG6lzw2GWFRCW9Qkfkiv0DxqHHLYJHmtmdUIKcZd8rHgFSjopVTlw6ggzCm1b8MFQwikg==}
     dependencies:
-      tslib: 2.3.1
+      tslib: 2.4.0
     dev: true
 
   /uri-js/4.4.1:


### PR DESCRIPTION
- replace the `books` table by a `todos` table
- adjust the Apollo page to add a todo item to the list
- filter user permissions to only see and modify their own todo items
- use Apollo codegen to generate typings for the default user role, and to enable autocompletion with VS code
- Add a Cypress test for the todo list