### PR TITLE
Correct use of ref values in action options

### DIFF
--- a/.changeset/violet-poets-melt.md
+++ b/.changeset/violet-poets-melt.md
@@ -1,0 +1,19 @@
+---
+'@nhost/vue': patch
+---
+
+Correct use of ref values in action options
+The `nestedUnref` helper was not correctly un-refing nested values. For instance, the values the properties of the following metadata were still `refs`:
+
+```jsx
+const { signUpEmailPassword } = useSignUpEmailPassword()
+const firstName = ref('John')
+const lastName = ref('Doe')
+signUpEmailPassword(
+    email: 'john@world.com',
+    password: 'not-1234',
+    {
+      metadata: { firstName, lastName }
+    }
+  );
+```

--- a/packages/vue/src/helpers.ts
+++ b/packages/vue/src/helpers.ts
@@ -14,9 +14,9 @@ export type NestedRefOfValue<T> = RefOrValue<{
 
 export const nestedUnref = <T>(input: NestedRefOfValue<T>): T => {
   const result: NestedRefOfValue<T> = unref(input)
-  if (result) {
+  if (result && typeof result === 'object') {
     return Object.entries(result).reduce(
-      (aggr, [key, value]) => ({ ...aggr, [key]: unref(value) }),
+      (aggr, [key, value]) => ({ ...aggr, [key]: nestedUnref(value as NestedRefOfValue<unknown>) }),
       {} as T
     )
   } else {

--- a/packages/vue/tests/main.test.ts
+++ b/packages/vue/tests/main.test.ts
@@ -1,12 +1,20 @@
 import { ref } from 'vue'
 import { nestedUnref } from '../src/helpers'
 describe('nestedUnref', () => {
-  it('shoud unref ref values in a unref property', async () => {
+  it('should unref ref values in a unref property', async () => {
     const a = ref('value of a')
     const b = ref('value of b')
     const input = { metadata: { a, b } }
     const result = nestedUnref(input)
 
     expect(result).toEqual({ metadata: { a: a.value, b: b.value } })
+  })
+
+  it('should unref a property', async () => {
+    const metadataValue = { firstName: 'John', lastName: 'Doe' }
+    const input = { metadata: ref(metadataValue) }
+    const result = nestedUnref(input)
+
+    expect(result).toEqual({ metadata: metadataValue })
   })
 })

--- a/packages/vue/tests/main.test.ts
+++ b/packages/vue/tests/main.test.ts
@@ -6,15 +6,19 @@ describe('nestedUnref', () => {
     const b = ref('value of b')
     const input = { metadata: { a, b } }
     const result = nestedUnref(input)
-
     expect(result).toEqual({ metadata: { a: a.value, b: b.value } })
   })
 
-  it('should unref a property', async () => {
+  it('should unref a property', () => {
     const metadataValue = { firstName: 'John', lastName: 'Doe' }
     const input = { metadata: ref(metadataValue) }
     const result = nestedUnref(input)
-
     expect(result).toEqual({ metadata: metadataValue })
+  })
+
+  it('should return the same value when not a ref', () => {
+    const input = { metadata: { firstName: 'John', lastName: 'Doe' } }
+    const result = nestedUnref(input)
+    expect(result).toEqual(input)
   })
 })

--- a/packages/vue/tests/main.test.ts
+++ b/packages/vue/tests/main.test.ts
@@ -1,5 +1,12 @@
-describe('main', () => {
-  it('shoud work', async () => {
-    expect(true).toBeTruthy()
+import { ref } from 'vue'
+import { nestedUnref } from '../src/helpers'
+describe('nestedUnref', () => {
+  it('shoud unref ref values in a unref property', async () => {
+    const a = ref('value of a')
+    const b = ref('value of b')
+    const input = { metadata: { a, b } }
+    const result = nestedUnref(input)
+
+    expect(result).toEqual({ metadata: { a: a.value, b: b.value } })
   })
 })


### PR DESCRIPTION
The `nestedUnref` helper was not correctly un-refing nested values. For instance, the values the properties of the following metadata were still `refs`:

```jsx
const { signUpEmailPassword } = useSignUpEmailPassword()
const firstName = ref('John')
const lastName = ref('Doe')
signUpEmailPassword(
    email: 'john@world.com',
    password: 'not-1234',
    {
      metadata: { firstName, lastName }
    }
  );
```