### PR TITLE
Add "redirectTo" in Provider SignIn interface

### DIFF
--- a/packages/hasura-auth-js/src/utils/types.ts
+++ b/packages/hasura-auth-js/src/utils/types.ts
@@ -78,6 +78,7 @@ export interface SignInPasswordlessSmsOtpParams {
 export interface SignInWithProviderOptions {
   provider: Provider
   options?: ProviderOptions
+  redirectTo?: string
 }
 
 export type SignInParams =


### PR DESCRIPTION
The provider SignIn interface doesn't have "redirectTo" param.