### PR TITLE
docs: fix typo

### DIFF
--- a/packages/hasura-auth-js/src/hasura-auth-client.ts
+++ b/packages/hasura-auth-js/src/hasura-auth-client.ts
@@ -220,7 +220,7 @@ export class HasuraAuthClient {
    * ```
    *
    * @example
-   * ### Sign out the user from all decvices
+   * ### Sign out the user from all devices
    * ```ts
    * nhost.auth.signOut({all: true})
    * ```


### PR DESCRIPTION
Typo on #744 was fixed on an autogenerated file, but not the source