### PR TITLE
React-apollo example: correct links to external urls (social providers)

### DIFF
--- a/examples/react-apollo/src/components/AuthLink.tsx
+++ b/examples/react-apollo/src/components/AuthLink.tsx
@@ -1,38 +1,41 @@
 import { Link } from 'react-router-dom'
 
-import { Button, ButtonVariant } from '@mantine/core'
+import { Button, ButtonProps, SharedButtonProps } from '@mantine/core'
 
-const AuthLink: React.FC<{
-  icon?: React.ReactNode
-  link: string
-  color?: string
-  children?: React.ReactNode
-  variant?: ButtonVariant
-}> = ({ icon, color, link, variant, children }) => {
-  return (
-    <Button
-      role="button"
-      component={Link}
-      fullWidth
-      radius="sm"
-      variant={variant}
-      to={link}
-      leftIcon={icon}
-      styles={(theme) => ({
-        root: {
-          backgroundColor: color,
-          '&:hover': {
-            backgroundColor: color && theme.fn.darken(color, 0.05)
-          }
-        },
-
-        leftIcon: {
-          marginRight: 15
+const AuthButton: <C = 'button'>(props: ButtonProps<C>) => React.ReactElement = ({
+  color,
+  ...rest
+}) => (
+  <Button
+    role="button"
+    fullWidth
+    radius="sm"
+    styles={(theme) => ({
+      root: {
+        backgroundColor: color,
+        '&:hover': {
+          backgroundColor: color && theme.fn.darken(color, 0.05)
         }
-      })}
-    >
-      {children}
-    </Button>
+      },
+
+      leftIcon: {
+        marginRight: 15
+      }
+    })}
+    {...rest}
+  />
+)
+
+const AuthLink: React.FC<
+  SharedButtonProps & {
+    link: string
+  }
+> = ({ link, ...rest }) => {
+  const isExternal = link.startsWith('http://') || link.startsWith('https://')
+  return isExternal ? (
+    <AuthButton component={'a'} href={link} {...rest} />
+  ) : (
+    <AuthButton component={Link} to={link} {...rest} />
   )
 }
 

--- a/examples/react-apollo/src/components/OauthLinks.tsx
+++ b/examples/react-apollo/src/components/OauthLinks.tsx
@@ -8,13 +8,13 @@ export default function OauthLinks() {
   const { github, google, facebook } = useProviderLink()
   return (
     <>
-      <AuthLink icon={<FaGithub />} link={github} color="#333">
+      <AuthLink leftIcon={<FaGithub />} link={github} color="#333">
         Continue with GitHub
       </AuthLink>
-      <AuthLink icon={<FaGoogle />} link={google} color="#de5246">
+      <AuthLink leftIcon={<FaGoogle />} link={google} color="#de5246">
         Continue with Google
       </AuthLink>
-      <AuthLink icon={<FaFacebook />} link={facebook} color="#3b5998">
+      <AuthLink leftIcon={<FaFacebook />} link={facebook} color="#3b5998">
         Continue with Facebook
       </AuthLink>
     </>

--- a/examples/react-apollo/src/sign-in/index.tsx
+++ b/examples/react-apollo/src/sign-in/index.tsx
@@ -16,7 +16,7 @@ const Index: React.FC = () => (
   <>
     <OAuthLinks />
     <Divider my="sm" />
-    <AuthLink icon={<FaLock />} variant="outline" link="/sign-in/email-passwordless">
+    <AuthLink leftIcon={<FaLock />} variant="outline" link="/sign-in/email-passwordless">
       Continue with passwordless email
     </AuthLink>
     <AuthLink variant="subtle" link="/sign-in/email-password">

--- a/examples/react-apollo/src/sign-up/index.tsx
+++ b/examples/react-apollo/src/sign-up/index.tsx
@@ -21,7 +21,7 @@ const Index: React.FC = () => {
           <Divider my="sm" />
         </>
       )}
-      <AuthLink icon={<FaLock />} variant="outline" link="/sign-up/email-passwordless">
+      <AuthLink leftIcon={<FaLock />} variant="outline" link="/sign-up/email-passwordless">
         Continue with passwordless email
       </AuthLink>
       <AuthLink variant="subtle" link="/sign-up/email-password">


### PR DESCRIPTION
Authentication links were rendered as a react-router `Link` instead of a simple `a` tag. As the `Link` tag does not support external url, it ended up with incorrect urls such as 
```
https://frontend.com/sign-in/https://backend.nhost.run/v1/auth/signin/provider/github
```