### PR TITLE
fix: `exports` field to support server-side environments

### DIFF
--- a/.changeset/afraid-carpets-cough.md
+++ b/.changeset/afraid-carpets-cough.md
@@ -1,0 +1,14 @@
+---
+'@nhost/apollo': patch
+'@nhost/core': patch
+'@nhost/hasura-auth-js': patch
+'@nhost/hasura-storage-js': patch
+'@nhost/nextjs': patch
+'@nhost/nhost-js': patch
+'@nhost/react': patch
+'@nhost/react-apollo': patch
+'@nhost/react-auth': patch
+'@nhost/vue': patch
+---
+
+fixed `exports` field to support imports in a server-side environment

--- a/packages/apollo/package.json
+++ b/packages/apollo/package.json
@@ -32,7 +32,10 @@
   ],
   "exports": {
     ".": {
-      "import": "./dist/index.esm.js",
+      "import": {
+        "node": "./dist/index.cjs.js",
+        "default": "./dist/index.esm.js"
+      },
       "require": "./dist/index.cjs.js"
     }
   },

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -31,7 +31,10 @@
   ],
   "exports": {
     ".": {
-      "import": "./dist/index.esm.js",
+      "import": {
+        "node": "./dist/index.cjs.js",
+        "default": "./dist/index.esm.js"
+      },
       "require": "./dist/index.cjs.js"
     }
   },

--- a/packages/hasura-auth-js/package.json
+++ b/packages/hasura-auth-js/package.json
@@ -30,7 +30,10 @@
   ],
   "exports": {
     ".": {
-      "import": "./dist/index.esm.js",
+      "import": {
+        "node": "./dist/index.cjs.js",
+        "default": "./dist/index.esm.js"
+      },
       "require": "./dist/index.cjs.js"
     }
   },

--- a/packages/hasura-storage-js/package.json
+++ b/packages/hasura-storage-js/package.json
@@ -28,7 +28,10 @@
   ],
   "exports": {
     ".": {
-      "import": "./dist/index.esm.js",
+      "import": {
+        "node": "./dist/index.cjs.js",
+        "default": "./dist/index.esm.js"
+      },
       "require": "./dist/index.cjs.js"
     }
   },

--- a/packages/nextjs/package.json
+++ b/packages/nextjs/package.json
@@ -34,7 +34,10 @@
   ],
   "exports": {
     ".": {
-      "import": "./dist/index.esm.js",
+      "import": {
+        "node": "./dist/index.cjs.js",
+        "default": "./dist/index.esm.js"
+      },
       "require": "./dist/index.cjs.js"
     }
   },

--- a/packages/nhost-js/package.json
+++ b/packages/nhost-js/package.json
@@ -31,7 +31,10 @@
   ],
   "exports": {
     ".": {
-      "import": "./dist/index.esm.js",
+      "import": {
+        "node": "./dist/index.cjs.js",
+        "default": "./dist/index.esm.js"
+      },
       "require": "./dist/index.cjs.js"
     }
   },

--- a/packages/react-apollo/package.json
+++ b/packages/react-apollo/package.json
@@ -33,7 +33,10 @@
   ],
   "exports": {
     ".": {
-      "import": "./dist/index.esm.js",
+      "import": {
+        "node": "./dist/index.cjs.js",
+        "default": "./dist/index.esm.js"
+      },
       "require": "./dist/index.cjs.js"
     }
   },

--- a/packages/react-auth/package.json
+++ b/packages/react-auth/package.json
@@ -32,7 +32,10 @@
   ],
   "exports": {
     ".": {
-      "import": "./dist/index.esm.js",
+      "import": {
+        "node": "./dist/index.cjs.js",
+        "default": "./dist/index.esm.js"
+      },
       "require": "./dist/index.cjs.js"
     }
   },

--- a/packages/react/package.json
+++ b/packages/react/package.json
@@ -32,7 +32,10 @@
   ],
   "exports": {
     ".": {
-      "import": "./dist/index.esm.js",
+      "import": {
+        "node": "./dist/index.cjs.js",
+        "default": "./dist/index.esm.js"
+      },
       "require": "./dist/index.cjs.js"
     }
   },

--- a/packages/vue/package.json
+++ b/packages/vue/package.json
@@ -32,7 +32,10 @@
   ],
   "exports": {
     ".": {
-      "import": "./dist/index.esm.js",
+      "import": {
+        "node": "./dist/index.cjs.js",
+        "default": "./dist/index.esm.js"
+      },
       "require": "./dist/index.cjs.js"
     }
   },


### PR DESCRIPTION
This PR fixes #730 that is caused by a regression introduced in [`@nhost/nhost-js@1.1.10`](https://github.com/nhost/nhost/releases/tag/%40nhost%2Fnhost-js%401.1.10).