### PR TITLE
patch: Using same cookie package and made sure cookies are not becoming session cookies

### DIFF
--- a/.changeset/lovely-windows-accept.md
+++ b/.changeset/lovely-windows-accept.md
@@ -1,0 +1,7 @@
+---
+"@nhost/core": patch
+"@nhost/nextjs": patch
+---
+
+- Using same cookie package ([`js-cookie`](https://www.npmjs.com/package/js-cookie)) for both `@nhost/nextjs` and `@nhost/core` packages.
+- Adding `expires` to avoid the cookie turning into a session cookie that some browsers aggressively destroy.

--- a/packages/core/src/storage.ts
+++ b/packages/core/src/storage.ts
@@ -84,7 +84,9 @@ export const localStorageSetter = (
     return (key, value) => {
       if (isBrowser) {
         if (value) {
-          Cookies.set(key, value)
+          // TODO: Set expires based on the actual refresh cookie expire time
+          // For now, we're using 30 days so the cookie is not removed when the browser is closed because if `expiers` is omitted, the cookie becomes a session cookie.
+          Cookies.set(key, value, { expires: 30 })
         } else {
           Cookies.remove(key)
         }

--- a/packages/core/src/storage.ts
+++ b/packages/core/src/storage.ts
@@ -84,7 +84,7 @@ export const localStorageSetter = (
     return (key, value) => {
       if (isBrowser) {
         if (value) {
-          // TODO: Set expires based on the actual refresh cookie expire time
+          // TODO: Set expires based on the actual refresh token expire time
           // For now, we're using 30 days so the cookie is not removed when the browser is closed because if `expiers` is omitted, the cookie becomes a session cookie.
           Cookies.set(key, value, { expires: 30 })
         } else {

--- a/packages/nextjs/package.json
+++ b/packages/nextjs/package.json
@@ -64,8 +64,8 @@
   "dependencies": {
     "@nhost/core": "workspace:*",
     "@nhost/nhost-js": "workspace:*",
-    "cookies": "^0.8.0",
     "cross-fetch": "^3.1.5",
+    "js-cookie": "^3.0.1",
     "xstate": "^4.32.1"
   },
   "peerDependencies": {
@@ -77,7 +77,7 @@
   "devDependencies": {
     "@nhost/docgen": "workspace:*",
     "@nhost/react": "workspace:*",
-    "@types/cookies": "^0.7.7",
+    "@types/js-cookie": "^3.0.2",
     "next": "12.0.10",
     "react": "^17.0.2",
     "react-dom": "^17.0.2"

--- a/packages/nextjs/src/create-server-side-client.ts
+++ b/packages/nextjs/src/create-server-side-client.ts
@@ -34,7 +34,7 @@ export const createServerSideClient = async (
         return typeof urlValue === 'string' ? urlValue : cookieValue
       },
       setItem: (key, value) => {
-        // TODO: Set expires based on the actual refresh cookie expire time
+        // TODO: Set expires based on the actual refresh token expire time
         // For now, we're using 30 days so the cookie is not removed when the browser is closed because if `expiers` is omitted, the cookie becomes a session cookie.
         Cookies.set(key, value, { httpOnly: false, sameSite: 'strict', expires: 30 })
       },

--- a/packages/nextjs/src/create-server-side-client.ts
+++ b/packages/nextjs/src/create-server-side-client.ts
@@ -1,4 +1,4 @@
-import Cookies from 'cookies'
+import Cookies from 'js-cookie'
 import { GetServerSidePropsContext } from 'next'
 import { StateFrom } from 'xstate'
 import { waitFor } from 'xstate/lib/waitFor'
@@ -19,7 +19,6 @@ export const createServerSideClient = async (
   backendUrl: string,
   context: GetServerSidePropsContext
 ) => {
-  const cookies = Cookies(context.req, context.res)
   const nhost = new NhostClient({
     backendUrl,
     clientStorageType: 'custom',
@@ -31,14 +30,16 @@ export const createServerSideClient = async (
         // * in the url as this is the key sent by hasura-auth
         const urlKey = key === NHOST_REFRESH_TOKEN_KEY ? 'refreshToken' : key
         const urlValue = context.query[urlKey]
-        const cookieValue = cookies.get(key) ?? null
+        const cookieValue = Cookies.get(key) ?? null
         return typeof urlValue === 'string' ? urlValue : cookieValue
       },
       setItem: (key, value) => {
-        cookies.set(key, value, { httpOnly: false, sameSite: true })
+        // TODO: Set expires based on the actual refresh cookie expire time
+        // For now, we're using 30 days so the cookie is not removed when the browser is closed because if `expiers` is omitted, the cookie becomes a session cookie.
+        Cookies.set(key, value, { httpOnly: false, sameSite: 'strict', expires: 30 })
       },
       removeItem: (key) => {
-        cookies.set(key, null)
+        Cookies.remove(key)
       }
     },
     start: true,

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -562,9 +562,9 @@ importers:
       '@nhost/docgen': workspace:*
       '@nhost/nhost-js': workspace:*
       '@nhost/react': workspace:*
-      '@types/cookies': ^0.7.7
-      cookies: ^0.8.0
+      '@types/js-cookie': ^3.0.2
       cross-fetch: ^3.1.5
+      js-cookie: ^3.0.1
       next: 12.0.10
       react: ^17.0.2
       react-dom: ^17.0.2
@@ -572,13 +572,13 @@ importers:
     dependencies:
       '@nhost/core': link:../core
       '@nhost/nhost-js': link:../nhost-js
-      cookies: 0.8.0
       cross-fetch: 3.1.5
+      js-cookie: 3.0.1
       xstate: 4.32.1
     devDependencies:
       '@nhost/docgen': link:../docgen
       '@nhost/react': link:../react
-      '@types/cookies': 0.7.7
+      '@types/js-cookie': 3.0.2
       next: 12.0.10_sfoxds7t5ydpegc3knd667wn6m
       react: 17.0.2
       react-dom: 17.0.2_react@17.0.2
@@ -6305,15 +6305,6 @@ packages:
     resolution: {integrity: sha512-XW/Aa8APYr6jSVVA1y/DEIZX0/GMKLEVekNG727R8cs56ahETkRAy/3DR7+fJyh7oUgGwNQaRfXCun0+KbWY7Q==}
     dev: true
 
-  /@types/cookies/0.7.7:
-    resolution: {integrity: sha512-h7BcvPUogWbKCzBR2lY4oqaZbO3jXZksexYJVFvkrFeLgbZjQkU4x8pRq6eg2MHXQhY0McQdqmmsxRWlVAHooA==}
-    dependencies:
-      '@types/connect': 3.4.35
-      '@types/express': 4.17.13
-      '@types/keygrip': 1.0.2
-      '@types/node': 17.0.25
-    dev: true
-
   /@types/debug/4.1.7:
     resolution: {integrity: sha512-9AonUzyTjXXhEOa0DnqpzZi6VHlqKMswga9EXjpXnnqxwLtdvPPtlO8evrI5D9S6asFRCQ6v+wpiUKbw+vKqyg==}
     dependencies:
@@ -6458,10 +6449,6 @@ packages:
       '@types/node': 17.0.33
     dev: true
 
-  /@types/keygrip/1.0.2:
-    resolution: {integrity: sha512-GJhpTepz2udxGexqos8wgaBx4I/zWIDPh/KOGEwAqtuGDkOUJu5eFvwmdBX4AmB8Odsr+9pHCQqiAqDL/yKMKw==}
-    dev: true
-
   /@types/keyv/3.1.4:
     resolution: {integrity: sha512-BQ5aZNSCpj7D6K2ksrRCTmKRLEpnPvWDiLPfoGyhZ++8YtiK9d/3DBKPJgry359X/P1PfruyYwvnvwFjuEiEIg==}
     dependencies:
@@ -6505,10 +6492,6 @@ packages:
 
   /@types/node/17.0.23:
     resolution: {integrity: sha512-UxDxWn7dl97rKVeVS61vErvw086aCYhDLyvRQZ5Rk65rZKepaFdm53GeqXaKBuOhED4e9uWq34IC3TdSdJJ2Gw==}
-    dev: true
-
-  /@types/node/17.0.25:
-    resolution: {integrity: sha512-wANk6fBrUwdpY4isjWrKTufkrXdu1D2YHCot2fD/DfWxF5sMrVSA+KN7ydckvaTCh0HiqX9IVl0L5/ZoXg5M7w==}
     dev: true
 
   /@types/node/17.0.31:
@@ -9370,14 +9353,6 @@ packages:
     resolution: {integrity: sha512-aSWTXFzaKWkvHO1Ny/s+ePFpvKsPnjc551iI41v3ny/ow6tBG5Vd+FuqGNhh1LxOmVzOlGUriIlOaokOvhaStA==}
     engines: {node: '>= 0.6'}
 
-  /cookies/0.8.0:
-    resolution: {integrity: sha512-8aPsApQfebXnuI+537McwYsDtjVxGm8gTIzQI3FDW6t5t/DAhERxtnbEPN/8RX+uZthoz4eCOgloXaE5cYyNow==}
-    engines: {node: '>= 0.8'}
-    dependencies:
-      depd: 2.0.0
-      keygrip: 1.1.0
-    dev: false
-
   /copy-text-to-clipboard/3.0.1:
     resolution: {integrity: sha512-rvVsHrpFcL4F2P8ihsoLdFHmd404+CMg71S756oRSeQgqk51U3kicGdnvfkrxva0xXH92SjGS62B0XIJsbh+9Q==}
     engines: {node: '>=12'}
@@ -10544,11 +10519,6 @@ packages:
   /depd/1.1.2:
     resolution: {integrity: sha1-m81S4UwJd2PnSbJ0xDRu0uVgtak=}
     engines: {node: '>= 0.6'}
-
-  /depd/2.0.0:
-    resolution: {integrity: sha512-g7nH6P6dyDioJogAAGprGpCtVImJhpPk/roCzdb3fIh61/s/nPsfR6onyMwkCAR/OlC3yBC0lESvUoQEAssIrw==}
-    engines: {node: '>= 0.8'}
-    dev: false
 
   /dependency-graph/0.11.0:
     resolution: {integrity: sha512-JeMq7fEshyepOWDfcfHK06N3MhyPhz++vtqWhMT5O9A3K42rdsEDpfdVqjaqaAhsw6a+ZqeDvQVtD0hFHQWrzg==}
@@ -15388,13 +15358,6 @@ packages:
 
   /jwt-decode/3.1.2:
     resolution: {integrity: sha512-UfpWE/VZn0iP50d8cz9NrZLM9lSWhcJ+0Gt/nm4by88UL+J1SiKN8/5dkjMmbEzwL2CAe+67GsegCbIKtbp75A==}
-    dev: false
-
-  /keygrip/1.1.0:
-    resolution: {integrity: sha512-iYSchDJ+liQ8iwbSI2QqsQOvqv58eJCEanyJPJi+Khyu8smkcKSFUCbPwzFcL7YVtZ6eONjqRX/38caJ7QjRAQ==}
-    engines: {node: '>= 0.6'}
-    dependencies:
-      tsscmp: 1.0.6
     dev: false
 
   /keyv/3.1.0:
@@ -20280,11 +20243,6 @@ packages:
 
   /tslib/2.4.0:
     resolution: {integrity: sha512-d6xOpEDfsi2CZVlPQzGeux8XMwLT9hssAsaPYExaQMuYskwb+x1x7J371tWlbBdWHroy99KnVB6qIkUbs5X3UQ==}
-
-  /tsscmp/1.0.6:
-    resolution: {integrity: sha512-LxhtAkPDTkVCMQjt2h6eBVY28KCjikZqZfMcC15YBeNjkgUpdCfBu5HoiOTDu86v6smE8yOjyEktJ8hlbANHQA==}
-    engines: {node: '>=0.6.x'}
-    dev: false
 
   /tsup/5.12.6_r2f2fcz3zztmgx5yz2r3q5xsqi:
     resolution: {integrity: sha512-tpePOgdMRKRgazF+ujq9k1Fo44PUFUJJjRLtxq87pQrYW/Ub/fu1GpFGLzdUF9qjJ4FX1ykhf2d9mWCNy+jAtg==}


### PR DESCRIPTION
- Using same cookie package ([`js-cookie`](https://www.npmjs.com/package/js-cookie)) for both `@nhost/nextjs` and `@nhost/core` packages.
- Adding `expires` to avoid the cookie turning into a session cookie that some browsers aggressively destroy.