### PR TITLE
Fix React Native build

### DIFF
--- a/.changeset/nine-students-design.md
+++ b/.changeset/nine-students-design.md
@@ -1,0 +1,14 @@
+---
+"@nhost/apollo": patch
+"@nhost/core": patch
+"@nhost/hasura-auth-js": patch
+"@nhost/hasura-storage-js": patch
+"@nhost/nextjs": patch
+"@nhost/nhost-js": patch
+"@nhost/react-apollo": patch
+"@nhost/react-auth": patch
+"@nhost/react": patch
+"@nhost/vue": patch
+---
+
+Fix React Native build: Export `package.json` for all npm packages.

--- a/packages/apollo/package.json
+++ b/packages/apollo/package.json
@@ -31,6 +31,7 @@
     "README.md"
   ],
   "exports": {
+    "./package.json": "./package.json",
     ".": {
       "import": {
         "node": "./dist/index.cjs.js",

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -30,6 +30,7 @@
     "README.md"
   ],
   "exports": {
+    "./package.json": "./package.json",
     ".": {
       "import": {
         "node": "./dist/index.cjs.js",

--- a/packages/hasura-auth-js/package.json
+++ b/packages/hasura-auth-js/package.json
@@ -29,6 +29,7 @@
     "README.md"
   ],
   "exports": {
+    "./package.json": "./package.json",
     ".": {
       "import": {
         "node": "./dist/index.cjs.js",

--- a/packages/hasura-storage-js/package.json
+++ b/packages/hasura-storage-js/package.json
@@ -27,6 +27,7 @@
     "README.md"
   ],
   "exports": {
+    "./package.json": "./package.json",
     ".": {
       "import": {
         "node": "./dist/index.cjs.js",

--- a/packages/nextjs/package.json
+++ b/packages/nextjs/package.json
@@ -33,6 +33,7 @@
     "README.md"
   ],
   "exports": {
+    "./package.json": "./package.json",
     ".": {
       "import": {
         "node": "./dist/index.cjs.js",

--- a/packages/nhost-js/package.json
+++ b/packages/nhost-js/package.json
@@ -30,6 +30,7 @@
     "README.md"
   ],
   "exports": {
+    "./package.json": "./package.json",
     ".": {
       "import": {
         "node": "./dist/index.cjs.js",

--- a/packages/react-apollo/package.json
+++ b/packages/react-apollo/package.json
@@ -32,6 +32,7 @@
     "README.md"
   ],
   "exports": {
+    "./package.json": "./package.json",
     ".": {
       "import": {
         "node": "./dist/index.cjs.js",

--- a/packages/react-auth/package.json
+++ b/packages/react-auth/package.json
@@ -31,6 +31,7 @@
     "README.md"
   ],
   "exports": {
+    "./package.json": "./package.json",
     ".": {
       "import": {
         "node": "./dist/index.cjs.js",

--- a/packages/react/package.json
+++ b/packages/react/package.json
@@ -31,6 +31,7 @@
     "README.md"
   ],
   "exports": {
+    "./package.json": "./package.json",
     ".": {
       "import": {
         "node": "./dist/index.cjs.js",

--- a/packages/vue/package.json
+++ b/packages/vue/package.json
@@ -31,6 +31,7 @@
     "README.md"
   ],
   "exports": {
+    "./package.json": "./package.json",
     ".": {
       "import": {
         "node": "./dist/index.cjs.js",


### PR DESCRIPTION
After installing @nhost/react and @nhost/react-apollo into a React Native 0.69.1 project, attempting to start the Metro bundler fails:

```
$ npm run start                                                                                                                                                                      
                                                                                                      
> phenomenological@0.0.1 start                                                                        
> react-native start                                                                                                                                                                                        
                                                                                                      
error Failed to load configuration of your project.                                                                                                                                                         
Error [ERR_PACKAGE_PATH_NOT_EXPORTED]: Package subpath './package.json' is not defined by "exports" in /Users/dmitry/dev/phenomenological/node_modules/@nhost/react/package.json                            
    at new NodeError (node:internal/errors:372:5)                                                                                                                                                           
    at throwExportsNotFound (node:internal/modules/esm/resolve:472:9)                                                                                                                                       
    at packageExportsResolve (node:internal/modules/esm/resolve:753:3)                                
    at resolveExports (node:internal/modules/cjs/loader:482:36)                                       
    at Function.Module._findPath (node:internal/modules/cjs/loader:522:31)                            
    at Function.Module._resolveFilename (node:internal/modules/cjs/loader:919:27)                     
    at Function.resolve (node:internal/modules/cjs/helpers:108:19)                                                                                                                                          
    at resolveNodeModuleDir (/Users/dmitry/dev/phenomenological/node_modules/@react-native-community/cli-tools/build/resolveNodeModuleDir.js:24:42)                                                         
    at /Users/dmitry/dev/phenomenological/node_modules/@react-native-community/cli-config/build/loadConfig.js:93:76                                                                                         
    at Array.reduce (<anonymous>)                                                                     
info Run CLI with --verbose flag for more details.
```

This PR changes `package.json` to fix that issue. I followed this example: https://github.com/uuidjs/uuid/commit/2e93665bad99edfb39f50df3e2460751357580bd.