### PR TITLE
Add discord to provider types

### DIFF
--- a/packages/core/src/types.ts
+++ b/packages/core/src/types.ts
@@ -149,6 +149,7 @@ export type Provider =
   | 'strava'
   | 'gitlab'
   | 'bitbucket'
+  | 'discord'
 
 // TODO share with hasura-auth
 export interface JWTHasuraClaims {


### PR DESCRIPTION
Discord wasn't present in the provider type, making it throw a typescript error