### PR TITLE
Bump hasura version to 2.10.1

### DIFF
--- a/examples/codegen-react-apollo/nhost/config.yaml
+++ b/examples/codegen-react-apollo/nhost/config.yaml
@@ -3,7 +3,7 @@ services:
   mailhog:
     port: 8025
   hasura:
-    version: v2.8.0
+    version: v2.10.1
     environment:
       hasura_graphql_enable_remote_schema_permissions: false
   auth:

--- a/examples/codegen-react-query/nhost/config.yaml
+++ b/examples/codegen-react-query/nhost/config.yaml
@@ -3,7 +3,7 @@ services:
   mailhog:
     port: 8025
   hasura:
-    version: v2.8.0
+    version: v2.10.1
     environment:
       hasura_graphql_enable_remote_schema_permissions: false
   auth:

--- a/examples/multi-tenant-one-to-many/nhost/config.yaml
+++ b/examples/multi-tenant-one-to-many/nhost/config.yaml
@@ -3,7 +3,7 @@ services:
   hasura:
     environment:
       hasura_graphql_enable_remote_schema_permissions: false
-    version: v2.8.0
+    version: v2.10.1
   minio:
     environment:
       minio_root_password: minioaccesskey123123

--- a/examples/nextjs/nhost/config.yaml
+++ b/examples/nextjs/nhost/config.yaml
@@ -3,7 +3,7 @@ services:
   mailhog:
     port: 8025
   hasura:
-    version: v2.8.0
+    version: v2.10.1
     environment:
       hasura_graphql_enable_remote_schema_permissions: false
   auth:

--- a/examples/react-apollo-crm/nhost/config.yaml
+++ b/examples/react-apollo-crm/nhost/config.yaml
@@ -1,7 +1,7 @@
 metadata_directory: metadata
 services:
   hasura:
-    version: v2.8.0
+    version: v2.10.1
     environment:
       hasura_graphql_enable_remote_schema_permissions: true
   auth:

--- a/examples/react-apollo/nhost/config.yaml
+++ b/examples/react-apollo/nhost/config.yaml
@@ -3,7 +3,7 @@ services:
   mailhog:
     port: 8025
   hasura:
-    version: v2.8.0
+    version: v2.10.1
     environment:
       hasura_graphql_enable_remote_schema_permissions: false
   auth:

--- a/examples/vue-apollo/nhost/config.yaml
+++ b/examples/vue-apollo/nhost/config.yaml
@@ -3,7 +3,7 @@ services:
   mailhog:
     port: 8025
   hasura:
-    version: v2.8.0
+    version: v2.10.1
     environment:
       hasura_graphql_enable_remote_schema_permissions: false
   auth:

--- a/nhost-cloud.yaml
+++ b/nhost-cloud.yaml
@@ -1,4 +1,4 @@
 # Docker image versions used in the cloud
-hasura: v2.8.0
+hasura: v2.10.1
 auth: 0.10.0
 storage: 0.2.3

--- a/packages/hasura-auth-js/nhost/config.yaml
+++ b/packages/hasura-auth-js/nhost/config.yaml
@@ -3,7 +3,7 @@ services:
   mailhog:
     port: 8025
   hasura:
-    version: v2.8.0
+    version: v2.10.1
     environment:
       hasura_graphql_enable_remote_schema_permissions: false
   auth:

--- a/packages/nhost-js/nhost/config.yaml
+++ b/packages/nhost-js/nhost/config.yaml
@@ -3,7 +3,7 @@ services:
   mailhog:
     port: 8025
   hasura:
-    version: v2.8.0
+    version: v2.10.1
     environment:
       hasura_graphql_enable_remote_schema_permissions: false
   auth:


### PR DESCRIPTION
Changes made in modifying [nhost-cloud.yaml](https://github.com/nhost/nhost/pull/884/files#diff-8d75136358596200fe1b1f76630959618cf170fb4c8d003fd03d34cfeae09bdb). It runs tests against bumped versions of hasura, hasura-auth and hasura-storage.

Do not merge until service versions are effectively changed in the cloud, as examples from this repo are deployed into the cloud with production versions.