### PR TITLE
Fixed-up typo in custom_claim config.

### DIFF
--- a/docs/docs/platform/graphql/permissions.md
+++ b/docs/docs/platform/graphql/permissions.md
@@ -60,11 +60,10 @@ To use custom permission variables locally, add your claims to the `config.yml` 
 
 ```
 auth:
-  jwt:
-    custom_claims: '{"organisation-id":"profile.organisation.id"}'
+  custom_claims: '{"organisation-id":"profile.organisation.id"}'
 ```
 
-Your custom claim will be automatically prefixed with `x-hasura-`, therefore, the example above results in a custom permission variable named `x-hasura-organisation-id`.
+Your custom claim will be automatically prefixed with `x-hasura-`, therefore, the example above results in a custom permission variable named `x-hasura-organisation-id`. View your new Custom Permission Variable by [decoding the jwt token online](https://jwt-decoder.com/). 
 
 ## Roles
 


### PR DESCRIPTION
Spotted a typo in the docs of custom claim configuration.

I updated the documentation so others don't get confused. Also added a note about decoding the token.