### PR TITLE
fix: 🐛 Return a `network` error code

### DIFF
--- a/.changeset/strange-glasses-whisper.md
+++ b/.changeset/strange-glasses-whisper.md
@@ -1,0 +1,5 @@
+---
+'@nhost/core': patch
+---
+
+Return a `network` error code when the backend url can't be reached

--- a/packages/core/src/hasura-auth.ts
+++ b/packages/core/src/hasura-auth.ts
@@ -16,7 +16,7 @@ export const nhostApiClient = (backendUrl: string) => {
             error.request.responseText ??
             JSON.stringify(error),
           status: error.response?.status ?? error.response?.data.statusCode ?? NETWORK_ERROR_CODE,
-          error: error.response?.data.error || error.request.statusText || 'network'
+          error: error.response?.data?.error || error.request.statusText || 'network'
         }
       })
   )


### PR DESCRIPTION
The error code was not captured correctly when the requested url was incorrect, as the `response?.data` property in `AxiosError` could be null, ending in an error when getting `response?.data.error`