### PR TITLE
fix: read nextjs context cookie in clientStorage

### DIFF
--- a/.changeset/eleven-turkeys-clean.md
+++ b/.changeset/eleven-turkeys-clean.md
@@ -1,0 +1,5 @@
+---
+'@nhost/nextjs': patch
+---
+
+read nextjs context cookies in `createServerSideClient`

--- a/.changeset/unlucky-months-work.md
+++ b/.changeset/unlucky-months-work.md
@@ -1,0 +1,8 @@
+---
+'@nhost/nextjs': patch
+---
+
+Fix `createServerSideClient`
+
+The refresh token was not fetched from the cookie when using `createServerSideClient` since [this PR](https://github.com/nhost/nhost/pull/823).
+It is now fixed.

--- a/packages/nextjs/src/create-server-side-client.ts
+++ b/packages/nextjs/src/create-server-side-client.ts
@@ -31,7 +31,9 @@ export const createServerSideClient = async (
         const urlKey = key === NHOST_REFRESH_TOKEN_KEY ? 'refreshToken' : key
         const urlValue = context.query[urlKey]
         const cookieValue = Cookies.get(key) ?? null
-        return typeof urlValue === 'string' ? urlValue : cookieValue
+        const nextCtxValue = context.req.cookies[key]
+
+        return typeof urlValue === 'string' ? urlValue : cookieValue ?? nextCtxValue
       },
       setItem: (key, value) => {
         // TODO: Set expires based on the actual refresh token expire time


### PR DESCRIPTION
The nextjs package creates its own NhostClient with a custom `clientStorage` that reads cookies to check if there's an active user session. However, it doesn't read cookies from the nextjs context, meaning that it'll never find the `nhostRefreshToken` cookie when used inside `getServerSideProps`. 

Fixes #886 and #930.