### PR TITLE
feat/added payment intents type for customer and invoice objects

### DIFF
--- a/packages/stripe-graphql-js/README.md
+++ b/packages/stripe-graphql-js/README.md
@@ -197,6 +197,14 @@ Start the development server:
 pnpm dev
 ```
 
+Include the correct admin secret header for admin access
+
+```js
+{
+  "x-hasura-admin-secret":"<secret value matching your NHOST_ADMIN_SECRET environment variable>"
+}
+```
+
 The GraphQL Server will reload every time the code changes.
 
 Open GraphiQL:

--- a/packages/stripe-graphql-js/src/builder.ts
+++ b/packages/stripe-graphql-js/src/builder.ts
@@ -3,7 +3,7 @@ import Stripe from 'stripe'
 
 import SchemaBuilder from '@pothos/core'
 
-import { Context, StripeInvoice, StripePaymentMethod, StripeSubscription } from './types'
+import { Context, StripeInvoice, StripePaymentMethod, StripeSubscription, StripePaymentIntent } from './types'
 
 // TODO: Make sure we either use Type or Types (e.g. StripePaymentMethodTypes or StripePaymentMethodType ) everywhere
 
@@ -93,6 +93,10 @@ const builder = new SchemaBuilder<{
 
     // BILLING PORTAL
     StripeBillingPortalSession: Stripe.BillingPortal.Session
+
+    // PAYMENT INTENT
+    StripePaymentIntent: StripePaymentIntent
+    StripePaymentIntents: Stripe.ApiList<StripePaymentIntent>
   }
   Context: Context
 }>({})

--- a/packages/stripe-graphql-js/src/schema/customer.ts
+++ b/packages/stripe-graphql-js/src/schema/customer.ts
@@ -1,7 +1,7 @@
 import Stripe from 'stripe'
 
 import { builder } from '../builder'
-import { StripeInvoice, StripePaymentMethod, StripeSubscription } from '../types'
+import { StripeInvoice, StripePaymentMethod, StripeSubscription, StripePaymentIntent } from '../types';
 import { stripe } from '../utils'
 
 import { StripePaymentMethodTypes } from './payment-methods'
@@ -85,6 +85,16 @@ builder.objectType('StripeCustomer', {
           customer: customer.id
         })
         return invoices as Stripe.Response<Stripe.ApiList<StripeInvoice>>
+      }
+    }),
+    paymentIntents: t.field({
+      type: 'StripePaymentIntents',
+      nullable: false,
+      resolve: async (customer) => {
+        const paymentIntents = await stripe.paymentIntents.list({
+          customer: customer.id
+        })
+        return paymentIntents as Stripe.Response<Stripe.ApiList<StripePaymentIntent>>
       }
     }),
     paymentMethods: t.field({

--- a/packages/stripe-graphql-js/src/schema/index.ts
+++ b/packages/stripe-graphql-js/src/schema/index.ts
@@ -42,6 +42,8 @@ import './product'
 import './tax-rate'
 import './test-clock'
 import './billing-portal-session'
+import './payment-intent'
+import './payment-intents'
 
 import { builder } from '../builder'
 

--- a/packages/stripe-graphql-js/src/schema/invoice.ts
+++ b/packages/stripe-graphql-js/src/schema/invoice.ts
@@ -1,5 +1,6 @@
+import Stripe from 'stripe';
 import { builder } from '../builder'
-import { StripePaymentMethod, StripeSubscription } from '../types'
+import { StripePaymentMethod, StripeSubscription, StripePaymentIntent } from '../types';
 import { stripe } from '../utils'
 
 builder.objectType('StripeInvoice', {
@@ -128,7 +129,21 @@ builder.objectType('StripeInvoice', {
     // todo: on behalf of
     paid: t.exposeBoolean('paid'),
     paidOutOfBand: t.exposeBoolean('paid_out_of_band'),
-    // todo: payment intent
+    paymentIntent: t.field({
+      type: 'StripePaymentIntent',
+      nullable: true,
+      resolve: async (invoice) => {
+        const { payment_intent } = invoice
+
+        if (!payment_intent) {
+          return null
+        }
+
+        const paymentIntentData = await stripe.paymentIntents.retrieve(payment_intent as string) 
+
+        return paymentIntentData as Stripe.Response<StripePaymentIntent> 
+      }
+    }),
     // todo: payment settings
     periodEnd: t.exposeInt('period_end'),
     periodStart: t.exposeInt('period_start'),

--- a/packages/stripe-graphql-js/src/schema/payment-intent.ts
+++ b/packages/stripe-graphql-js/src/schema/payment-intent.ts
@@ -1,0 +1,74 @@
+import Stripe from 'stripe';
+import { builder } from '../builder'
+import { stripe } from '../utils'
+import { StripeInvoice } from '../types';
+
+builder.objectType('StripePaymentIntent', {
+  description: 'Payment intents',
+  fields: (t) => ({
+    id: t.exposeString('id'),
+    object: t.exposeString('object'),
+    amount: t.exposeInt('amount'),
+    currency: t.exposeString('currency'),
+    description: t.exposeString('description',{
+        nullable: true
+    }),
+    metadata: t.expose('metadata', {
+        type: 'JSON',
+        nullable: true
+    }),
+    payment_method_types: t.exposeStringList('payment_method_types'),
+    statement_descriptor: t.exposeString('statement_descriptor', {
+        nullable: true
+    }),
+    statement_descriptor_suffix: t.exposeString('statement_descriptor_suffix',{
+        nullable: true
+    }),
+    receipt_email: t.exposeString('receipt_email', {
+        nullable: true
+    }),
+    customer: t.exposeString('customer'),
+    amount_capturable: t.exposeInt('amount_capturable'),
+    amount_details: t.expose('amount_details', {
+        nullable: true,
+        type: 'JSON'
+    }),
+    amount_received: t.exposeInt('amount_received'),
+
+    application_fee_amount: t.exposeInt('application_fee_amount', {
+        nullable:true
+    }),
+    canceled_at: t.exposeInt('canceled_at', {
+        nullable: true
+    }),
+    transfer_group: t.exposeString('transfer_group',{ 
+      nullable:true
+    }),
+    cancellation_reason: t.exposeString('cancellation_reason', {
+        nullable:true
+    }),
+    created: t.exposeInt('created', {
+        nullable: true, 
+    }),
+    status: t.exposeString('status'),
+    invoice: t.field({
+      type: 'StripeInvoice',
+      nullable: true,
+      resolve: async (paymentIntent) => {
+        const {invoice} = paymentIntent
+
+        if(!invoice) {
+            return null
+        }
+
+        const invoiceData  = await stripe.invoices.retrieve(invoice as string) 
+
+        return invoiceData as Stripe.Response<StripeInvoice>
+      }
+    }),
+    // todo: missing fields
+    // capture_method
+    // add charges
+    // application
+  })
+})

--- a/packages/stripe-graphql-js/src/schema/payment-intent.ts
+++ b/packages/stripe-graphql-js/src/schema/payment-intent.ts
@@ -1,7 +1,7 @@
-import Stripe from 'stripe';
+import Stripe from 'stripe'
 import { builder } from '../builder'
 import { stripe } from '../utils'
-import { StripeInvoice } from '../types';
+import { StripeInvoice } from '../types'
 
 builder.objectType('StripePaymentIntent', {
   description: 'Payment intents',
@@ -10,62 +10,62 @@ builder.objectType('StripePaymentIntent', {
     object: t.exposeString('object'),
     amount: t.exposeInt('amount'),
     currency: t.exposeString('currency'),
-    description: t.exposeString('description',{
-        nullable: true
+    description: t.exposeString('description', {
+      nullable: true
     }),
     metadata: t.expose('metadata', {
-        type: 'JSON',
-        nullable: true
+      type: 'JSON',
+      nullable: true
     }),
-    payment_method_types: t.exposeStringList('payment_method_types'),
-    statement_descriptor: t.exposeString('statement_descriptor', {
-        nullable: true
+    paymentMethodTypes: t.exposeStringList('payment_method_types'),
+    statementDescriptor: t.exposeString('statement_descriptor', {
+      nullable: true
     }),
-    statement_descriptor_suffix: t.exposeString('statement_descriptor_suffix',{
-        nullable: true
+    statementDescriptorSuffix: t.exposeString('statement_descriptor_suffix', {
+      nullable: true
     }),
-    receipt_email: t.exposeString('receipt_email', {
-        nullable: true
+    receiptEmail: t.exposeString('receipt_email', {
+      nullable: true
     }),
     customer: t.exposeString('customer'),
-    amount_capturable: t.exposeInt('amount_capturable'),
-    amount_details: t.expose('amount_details', {
-        nullable: true,
-        type: 'JSON'
+    amountCapturable: t.exposeInt('amount_capturable'),
+    amountDetails: t.expose('amount_details', {
+      nullable: true,
+      type: 'JSON'
     }),
-    amount_received: t.exposeInt('amount_received'),
+    amountReceived: t.exposeInt('amount_received'),
 
-    application_fee_amount: t.exposeInt('application_fee_amount', {
-        nullable:true
+    applicationFeeAmount: t.exposeInt('application_fee_amount', {
+      nullable: true
     }),
-    canceled_at: t.exposeInt('canceled_at', {
-        nullable: true
+    canceledAt: t.exposeInt('canceled_at', {
+      nullable: true
     }),
-    transfer_group: t.exposeString('transfer_group',{ 
-      nullable:true
+    transferGroup: t.exposeString('transfer_group', {
+      nullable: true
     }),
-    cancellation_reason: t.exposeString('cancellation_reason', {
-        nullable:true
+    cancellationReason: t.exposeString('cancellation_reason', {
+      nullable: true
     }),
     created: t.exposeInt('created', {
-        nullable: true, 
+      nullable: true
     }),
     status: t.exposeString('status'),
     invoice: t.field({
       type: 'StripeInvoice',
       nullable: true,
       resolve: async (paymentIntent) => {
-        const {invoice} = paymentIntent
+        const { invoice } = paymentIntent
 
-        if(!invoice) {
-            return null
+        if (!invoice) {
+          return null
         }
 
-        const invoiceData  = await stripe.invoices.retrieve(invoice as string) 
+        const invoiceData = await stripe.invoices.retrieve(invoice as string)
 
         return invoiceData as Stripe.Response<StripeInvoice>
       }
-    }),
+    })
     // todo: missing fields
     // capture_method
     // add charges

--- a/packages/stripe-graphql-js/src/schema/payment-intents.ts
+++ b/packages/stripe-graphql-js/src/schema/payment-intents.ts
@@ -1,0 +1,13 @@
+import { builder } from '../builder'
+
+builder.objectType('StripePaymentIntents', {
+  fields: (t) => ({
+    object: t.exposeString('object'),
+    url: t.exposeString('url'),
+    hasMore: t.exposeBoolean('has_more'),
+    data: t.expose('data', {
+      type: ['StripePaymentIntent'],
+      nullable: false
+    })
+  })
+})

--- a/packages/stripe-graphql-js/src/types.ts
+++ b/packages/stripe-graphql-js/src/types.ts
@@ -31,6 +31,11 @@ export type StripeInvoice = Stripe.Invoice & {
   id: string
   customer: string
   default_payment_method: StripePaymentMethod | null
+  payment_intent: any
+}
+
+export type StripePaymentIntent = Stripe.PaymentIntent & {
+  customer: string
 }
 
 export type UserHasuraClaims = {


### PR DESCRIPTION
### Description

This PR adds [Stripe payment intents](https://stripe.com/docs/api/payment_intents/object) to the stripe package.
It adds the ability to query payment intent on the cutomer and invoice objects.

Example query 
```ts
query ($id: String!){
  stripe {
    customer(id: $id) {
     id
      paymentIntents {
        data
        {
          status
        }
      }
      invoices {
        data {
          paymentIntent {
            id
            invoice {
              paid
            }
          }
        }
      }
    }
  }
}
```