### PR TITLE
Recover documentation consistency

### DIFF
--- a/examples/vue-quickstart/src/main.ts
+++ b/examples/vue-quickstart/src/main.ts
@@ -11,7 +11,8 @@ import './styles/main.css'
 import 'uno.css'
 
 const nhost = new NhostClient({
-  backendUrl: import.meta.env.VITE_NHOST_URL
+  subdomain: import.meta.env.VITE_NHOST_SUBDOMAIN
+  region: import.meta.env.VITE_NHOST_REGION
 })
 
 const app = createApp(App)


### PR DESCRIPTION
This file has diverged from the respective doc [page](https://docs.nhost.io/platform/quickstarts/vue#configure-nhost-with-vue). 
Maybe the docs should be updated instead to match the current file, in any case, i think will be nice to fix this and avoid confusion & friction to new comers trying the vue integration out.