### PR TITLE
fix: refresh useAuthenticationStatus on conn attempt changes

### DIFF
--- a/examples/react-apollo/cypress/e2e/3-sign-in/token.cy.ts
+++ b/examples/react-apollo/cypress/e2e/3-sign-in/token.cy.ts
@@ -1,5 +1,5 @@
-context('Sign in with a refresh token', () => {
-  it('should sign-in with a refresh token', () => {
+context('Automatic sign-in with a refresh token', () => {
+  it('should sign in automatically with a refresh token', () => {
     cy.signUpAndConfirmEmail()
     cy.contains('Profile page')
     cy.clearLocalStorage()
@@ -9,7 +9,7 @@ context('Sign in with a refresh token', () => {
     cy.contains('Profile page')
   })
 
-  it('should fail authentication when network is not available', () => {
+  it('should fail automatic sign-in when network is not available', () => {
     cy.signUpAndConfirmEmail()
     cy.contains('Profile page')
     cy.disconnectBackend()
@@ -17,6 +17,6 @@ context('Sign in with a refresh token', () => {
     cy.reload()
     cy.contains('Sign in to the Application')
     cy.visitPathWithRefreshToken('/profile')
-    cy.location('pathname').should('equal', '/sign-in')
+    cy.contains('Could not sign in automatically. Retrying to get user information..')
   })
 })

--- a/examples/react-apollo/src/components/auth-gates.tsx
+++ b/examples/react-apollo/src/components/auth-gates.tsx
@@ -1,13 +1,26 @@
 import { Navigate, useLocation } from 'react-router-dom'
 
-import { useAuthenticationStatus } from '@nhost/react'
-import { useUserIsAnonymous } from '@nhost/react'
+import { useAuthenticationStatus, useUserIsAnonymous } from '@nhost/react'
+
+const LoadingComponent: React.FC<React.PropsWithChildren<{ connectionAttempts: number }>> = ({
+  connectionAttempts
+}) => {
+  if (connectionAttempts > 0) {
+    return (
+      <div>
+        Could not sign in automatically. Retrying to get user information
+        {Array(connectionAttempts).join('.')}
+      </div>
+    )
+  }
+  return <div>Loading...</div>
+}
 
 export const AuthGate: React.FC<React.PropsWithChildren<unknown>> = ({ children }) => {
-  const { isLoading, isAuthenticated } = useAuthenticationStatus()
+  const { isLoading, isAuthenticated, connectionAttempts } = useAuthenticationStatus()
   const location = useLocation()
   if (isLoading) {
-    return <div>Loading...</div>
+    return <LoadingComponent connectionAttempts={connectionAttempts} />
   }
 
   if (!isAuthenticated) {
@@ -23,11 +36,11 @@ export const PublicGate: React.FC<
     anonymous?: boolean
   }>
 > = ({ anonymous, children }) => {
-  const { isLoading, isAuthenticated } = useAuthenticationStatus()
+  const { isLoading, isAuthenticated, connectionAttempts } = useAuthenticationStatus()
   const isAnonymous = useUserIsAnonymous()
   const location = useLocation()
   if (isLoading) {
-    return <div>Loading...</div>
+    return <LoadingComponent connectionAttempts={connectionAttempts} />
   }
 
   if (isAuthenticated && !anonymous && isAnonymous) {

--- a/packages/react/src/useAuthenticationStatus.ts
+++ b/packages/react/src/useAuthenticationStatus.ts
@@ -21,6 +21,9 @@ export const useAuthenticationStatus = () => {
       isError: state.matches({ authentication: { signedOut: 'failed' } }),
       connectionAttempts: state.context.importTokenAttempts
     }),
-    (a, b) => a.isAuthenticated === b.isAuthenticated && a.isLoading === b.isLoading
+    (a, b) =>
+      a.isAuthenticated === b.isAuthenticated &&
+      a.isLoading === b.isLoading &&
+      a.connectionAttempts === b.connectionAttempts
   )
 }

--- a/packages/vue/src/useAuthenticationStatus.ts
+++ b/packages/vue/src/useAuthenticationStatus.ts
@@ -23,7 +23,10 @@ export const useAuthenticationStatus = () => {
         isError: state.matches({ authentication: { signedOut: 'failed' } }),
         connectionAttempts: state.context.importTokenAttempts
       }),
-      (a, b) => a.isAuthenticated === b.isAuthenticated && a.isLoading === b.isLoading
+      (a, b) =>
+        a.isAuthenticated === b.isAuthenticated &&
+        a.isLoading === b.isLoading &&
+        a.connectionAttempts === b.connectionAttempts
     )
   )
 }


### PR DESCRIPTION
- `useAuthenticationStatus` was not re-rendered when `connectionAttempts` was changing
- the e2e test on offline auto-signin needed to be adapted