### PR TITLE
chore: 🤖 warn about node 14 or 16, & adapt packageManager

### DIFF
--- a/package.json
+++ b/package.json
@@ -86,9 +86,9 @@
   "resolutions": {
     "graphql": "15.7.2"
   },
-  "packageManager": "pnpm@6.24.0",
+  "packageManager": "pnpm@7.9.1",
   "engines": {
-    "node": ">=14",
+    "node": ">=14 <17",
     "pnpm": ">=7.9.1"
   },
   "eslintConfig": {


### PR DESCRIPTION
Our monorepo is not compatible with Node 18.
This PR raises a warning when Node version is higher than 16.
Moreover the `packageManager` has been adjusted to use the right `pnpm` 