### PR TITLE
Chore/remove todos

### DIFF
--- a/packages/core/src/constants.ts
+++ b/packages/core/src/constants.ts
@@ -11,8 +11,3 @@ export const TOKEN_REFRESH_MARGIN = 300 // five minutes
 
 /** Number of seconds before retrying a token refresh after an error */
 export const REFRESH_TOKEN_RETRY_INTERVAL = 5
-
-// TODO not yet implemented
-// TODO try when offline for a long time: maybe we could keep state as 'signedIn'
-/** Maximum number of attempts to refresh a token before stopping the timer and logging out */
-export const REFRESH_TOKEN_RETRY_MAX_ATTEMPTS = 30

--- a/packages/core/tests/passwordSignIn.test.ts
+++ b/packages/core/tests/passwordSignIn.test.ts
@@ -88,8 +88,8 @@ test(`should fail if server returns an error`, async () => {
   `)
 })
 
-// TODO this test is incorrect. Fix it in https://github.com/nhost/nhost/pull/1022
-test.skip(`should retry token refresh if refresh endpoint is unreachable`, async () => {
+test(`should retry token refresh if refresh endpoint is unreachable`, async () => {
+  server.use(authTokenNetworkErrorHandler)
   authService.send({
     type: 'SIGNIN_PASSWORD',
     email: faker.internet.email(),

--- a/packages/core/tests/passwordSignIn.test.ts
+++ b/packages/core/tests/passwordSignIn.test.ts
@@ -88,26 +88,6 @@ test(`should fail if server returns an error`, async () => {
   `)
 })
 
-test(`should retry token refresh if refresh endpoint is unreachable`, async () => {
-  authService.send({
-    type: 'SIGNIN_PASSWORD',
-    email: faker.internet.email(),
-    password: faker.internet.password(15)
-  })
-
-  await waitFor(authService, (state) =>
-    state.matches({
-      authentication: { signedIn: { refreshTimer: { running: 'refreshing' } } }
-    })
-  )
-
-  server.use(authTokenNetworkErrorHandler)
-
-  const state = await waitFor(authService, (state) => state.context.refreshTimer.attempts > 0)
-
-  expect(state.context.refreshTimer.attempts).toBeGreaterThan(0)
-})
-
 test(`should fail if either email or password is incorrectly formatted`, async () => {
   // Scenario 1: Providing an invalid email address with a valid password
   authService.send({

--- a/packages/core/tests/passwordSignIn.test.ts
+++ b/packages/core/tests/passwordSignIn.test.ts
@@ -89,7 +89,6 @@ test(`should fail if server returns an error`, async () => {
 })
 
 test(`should retry token refresh if refresh endpoint is unreachable`, async () => {
-  server.use(authTokenNetworkErrorHandler)
   authService.send({
     type: 'SIGNIN_PASSWORD',
     email: faker.internet.email(),
@@ -102,11 +101,9 @@ test(`should retry token refresh if refresh endpoint is unreachable`, async () =
     })
   )
 
-  const state = await waitFor(authService, (state) =>
-    state.matches({
-      authentication: { signedIn: { refreshTimer: { running: 'pending' } } }
-    })
-  )
+  server.use(authTokenNetworkErrorHandler)
+
+  const state = await waitFor(authService, (state) => state.context.refreshTimer.attempts > 0)
 
   expect(state.context.refreshTimer.attempts).toBeGreaterThan(0)
 })


### PR DESCRIPTION
- correct and activate refresh token test on unavailable network
- remove unused constant that we decided not to use