### PR TITLE
ci: remove deprecated set-output

### DIFF
--- a/.github/workflows/tests.yaml
+++ b/.github/workflows/tests.yaml
@@ -37,7 +37,7 @@ jobs:
             | xargs -I@ jq "if (.scripts.e2e | length) != 0  then {name: .name, path: \"@\"} else null end" @/package.json \
             | awk "!/null/" \
             | jq -c --slurp)
-          echo "::set-output name=matrix::$PACKAGES"
+          echo "{matrix}={$PACKAGES}" >> $GITHUB_OUTPUT
     outputs:
       matrix: ${{ steps.set-matrix.outputs.matrix }}
   e2e:
@@ -69,7 +69,7 @@ jobs:
         name: Tranform package name into a valid file name
         run: |
           PACKAGE_FILE_NAME=$(echo "${{ matrix.package.name }}" | sed 's/@//g; s/\//-/g')
-          echo "::set-output name=fileName::$PACKAGE_FILE_NAME"
+          echo "fileName=$PACKAGE_FILE_NAME"  >> $GITHUB_OUTPUT
       # * Run this step only if the previous step failed, and some Cypress screenshots/videos exist
       - name: Upload Cypress videos and screenshots
         if: ${{ failure() && hashFiles(format('{0}/cypress/screenshots/**', matrix.package.path), format('{0}/cypress/videos/**', matrix.package.path)) != ''}}


### PR DESCRIPTION
Stop using `::set-output` in GitHub actions as [they are now deprecated](https://github.blog/changelog/2022-10-11-github-actions-deprecating-save-state-and-set-output-commands/)