### PR TITLE
fix: make "@nhost-examples/serverless-functions private

### DIFF
--- a/examples/serverless-functions/package.json
+++ b/examples/serverless-functions/package.json
@@ -1,5 +1,6 @@
 {
   "name": "@nhost-examples/serverless-functions",
+  "private": true,
   "version": "0.0.1",
   "devDependencies": {
     "@types/express": "^4.17.13"


### PR DESCRIPTION
Don't try to publish the package - see [this action](https://github.com/nhost/nhost/actions/runs/3427734944/jobs/5711100627)