### PR TITLE
ci: 🎡 Skip e2e jobs when not affected by the changes in the PR

### DIFF
--- a/.github/actions/install-dependencies/action.yaml
+++ b/.github/actions/install-dependencies/action.yaml
@@ -12,7 +12,7 @@ runs:
       shell: bash
       run: echo "dir=$(pnpm store path)" >> $GITHUB_OUTPUT
     - uses: actions/cache@v3
-      id: pnpm-cache 
+      id: pnpm-cache
       with:
         path: |
           ${{ steps.pnpm-cache-dir.outputs.dir }}

--- a/.github/workflows/tests.yaml
+++ b/.github/workflows/tests.yaml
@@ -26,14 +26,18 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v3
+        with:
+          fetch-depth: 0
       # * Install Node and dependencies. Package downloads will be cached for the next jobs.
       - name: Install Node and dependencies
         uses: ./.github/actions/install-dependencies
       # * List packagesthat has an `e2e` script, except the root, and return an array of their name and path
+      # * In a PR, only include packages that have been modified, and their dependencies
       - name: List examples with an e2e script
         id: set-matrix
         run: |
-          PACKAGES=$(pnpm recursive list --depth -1 --parseable --filter=!nhost-root \
+          FILTER_MODIFIED="${{ github.event_name == 'pull_request' && format('--filter=...[origin/{0}]', github.base_ref) || '' }}"
+          PACKAGES=$(pnpm recursive list --depth -1 --parseable --filter='!nhost-root' $FILTER_MODIFIED \
             | xargs -I@ jq "if (.scripts.e2e | length) != 0  then {name: .name, path: \"@\"} else null end" @/package.json \
             | awk "!/null/" \
             | jq -c --slurp)
@@ -43,6 +47,7 @@ jobs:
   e2e:
     name: 'e2e: ${{ matrix.package.name }}'
     needs: build
+    if: ${{ needs.build.outputs.matrix != '[]' && needs.build.outputs.matrix != '' }}
     strategy:
       # * Don't cancel other matrices when one fails
       fail-fast: false


### PR DESCRIPTION
The `tests` GH action will filter out e2e tests that are not depending on the changes of the PR