### PR TITLE
Correct handling of network error

### DIFF
--- a/.changeset/lovely-cheetahs-suffer.md
+++ b/.changeset/lovely-cheetahs-suffer.md
@@ -1,0 +1,5 @@
+---
+'@nhost/core': patch
+---
+
+Retry auto-signin when starting offline

--- a/.changeset/nice-hornets-listen.md
+++ b/.changeset/nice-hornets-listen.md
@@ -1,0 +1,5 @@
+---
+'@nhost/core': patch
+---
+
+Return the correct error code for a network error

--- a/.changeset/three-icons-speak.md
+++ b/.changeset/three-icons-speak.md
@@ -1,0 +1,8 @@
+---
+'@nhost/core': patch
+'@nhost/hasura-auth-js': patch
+'@nhost/hasura-storage-js': patch
+'@nhost/nhost-js': patch
+---
+
+Bump Axios to v1.1.3

--- a/docs/docs/reference/docgen/javascript/nhost-js/content/create-functions-client.mdx
+++ b/docs/docs/reference/docgen/javascript/nhost-js/content/create-functions-client.mdx
@@ -4,7 +4,7 @@ title: createFunctionsClient()
 sidebar_label: createFunctionsClient()
 slug: /reference/javascript/nhost-js/create-functions-client
 description: Creates a client for Functions from either a subdomain or a URL
-custom_edit_url: https://github.com/nhost/nhost/edit/main/packages/nhost-js/src/clients/functions.ts#L19
+custom_edit_url: https://github.com/nhost/nhost/edit/main/packages/nhost-js/src/clients/functions.ts#L24
 ---
 
 # `createFunctionsClient()`

--- a/docs/docs/reference/docgen/javascript/nhost-js/content/nhost-functions-client/content/01-call.mdx
+++ b/docs/docs/reference/docgen/javascript/nhost-js/content/nhost-functions-client/content/01-call.mdx
@@ -4,7 +4,7 @@ title: call()
 sidebar_label: call()
 slug: /reference/javascript/nhost-js/functions/call
 description: Use `nhost.functions.call` to call (sending a POST request to) a serverless function.
-custom_edit_url: https://github.com/nhost/nhost/edit/main/packages/nhost-js/src/clients/functions.ts#L62
+custom_edit_url: https://github.com/nhost/nhost/edit/main/packages/nhost-js/src/clients/functions.ts#L67
 ---
 
 # `call()`

--- a/docs/docs/reference/docgen/javascript/nhost-js/content/nhost-functions-client/content/02-set-access-token.mdx
+++ b/docs/docs/reference/docgen/javascript/nhost-js/content/nhost-functions-client/content/02-set-access-token.mdx
@@ -4,7 +4,7 @@ title: setAccessToken()
 sidebar_label: setAccessToken()
 slug: /reference/javascript/nhost-js/functions/set-access-token
 description: Use `nhost.functions.setAccessToken` to a set an access token to be used in subsequent functions requests. Note that if you're signin in users with `nhost.auth.signIn()` the access token will be set automatically.
-custom_edit_url: https://github.com/nhost/nhost/edit/main/packages/nhost-js/src/clients/functions.ts#L101
+custom_edit_url: https://github.com/nhost/nhost/edit/main/packages/nhost-js/src/clients/functions.ts#L106
 ---
 
 # `setAccessToken()`

--- a/docs/docs/reference/docgen/javascript/nhost-js/content/nhost-functions-client/index.mdx
+++ b/docs/docs/reference/docgen/javascript/nhost-js/content/nhost-functions-client/index.mdx
@@ -4,7 +4,7 @@ title: NhostFunctionsClient
 sidebar_label: Functions
 description: No description provided.
 slug: /reference/javascript/nhost-js/functions
-custom_edit_url: https://github.com/nhost/nhost/edit/main/packages/nhost-js/src/clients/functions.ts#L35
+custom_edit_url: https://github.com/nhost/nhost/edit/main/packages/nhost-js/src/clients/functions.ts#L40
 ---
 
 # `NhostFunctionsClient`

--- a/docs/docs/reference/docgen/javascript/nhost-js/types/nhost-functions-constructor-params.mdx
+++ b/docs/docs/reference/docgen/javascript/nhost-js/types/nhost-functions-constructor-params.mdx
@@ -4,7 +4,7 @@ title: NhostFunctionsConstructorParams
 sidebar_label: NhostFunctionsConstructorParams
 description: No description provided.
 displayed_sidebar: referenceSidebar
-custom_edit_url: https://github.com/nhost/nhost/edit/main/packages/nhost-js/src/clients/functions.ts#L5
+custom_edit_url: https://github.com/nhost/nhost/edit/main/packages/nhost-js/src/clients/functions.ts#L10
 ---
 
 # `NhostFunctionsConstructorParams`

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -59,7 +59,7 @@
   },
   "dependencies": {
     "@simplewebauthn/browser": "^6.0.0",
-    "axios": "^0.27.2",
+    "axios": "^1.1.3",
     "js-cookie": "^3.0.1",
     "xstate": "^4.33.5"
   },

--- a/packages/core/src/hasura-auth.ts
+++ b/packages/core/src/hasura-auth.ts
@@ -15,7 +15,7 @@ export const nhostApiClient = (backendUrl: string) => {
             error.message ??
             error.request.responseText ??
             JSON.stringify(error),
-          status: error.response?.status ?? error.response?.data.statusCode ?? NETWORK_ERROR_CODE,
+          status: error.response?.status ?? error.response?.data?.statusCode ?? NETWORK_ERROR_CODE,
           error: error.response?.data?.error || error.request.statusText || 'network'
         }
       })

--- a/packages/core/tests/anonymousSignIn.test.ts
+++ b/packages/core/tests/anonymousSignIn.test.ts
@@ -52,7 +52,7 @@ describe('Anonymous Sign-in', () => {
       "authentication": {
         "error": "OK",
         "message": "Network Error",
-        "status": 200,
+        "status": 0,
       },
     }
   `)
@@ -126,7 +126,7 @@ describe('Anonymous Sign-in', () => {
 
     authService.send({
       type: 'PASSWORDLESS_SMS',
-      phoneNumber: faker.phone.phoneNumber()
+      phoneNumber: faker.phone.number()
     })
 
     const state = await waitFor(authService, (state) =>

--- a/packages/core/tests/changeEmail.test.ts
+++ b/packages/core/tests/changeEmail.test.ts
@@ -57,7 +57,7 @@ test(`should fail if there is a network error`, async () => {
     {
       "error": "OK",
       "message": "Network Error",
-      "status": 200,
+      "status": 0,
     }
   `)
 })

--- a/packages/core/tests/changePassword.test.ts
+++ b/packages/core/tests/changePassword.test.ts
@@ -60,7 +60,7 @@ test(`should fail if there is a network error`, async () => {
     {
       "error": "OK",
       "message": "Network Error",
-      "status": 200,
+      "status": 0,
     }
   `)
 })

--- a/packages/core/tests/emailPasswordSignUp.test.ts
+++ b/packages/core/tests/emailPasswordSignUp.test.ts
@@ -55,7 +55,7 @@ test(`should fail if network is unavailable`, async () => {
       "registration": {
         "error": "OK",
         "message": "Network Error",
-        "status": 200,
+        "status": 0,
       },
     }
   `)

--- a/packages/core/tests/enableMfa.test.ts
+++ b/packages/core/tests/enableMfa.test.ts
@@ -64,7 +64,7 @@ describe(`Generation`, () => {
       {
         "error": "OK",
         "message": "Network Error",
-        "status": 200,
+        "status": 0,
       }
     `)
   })

--- a/packages/core/tests/helpers/handlers/securityKeySignUpHandlers.ts
+++ b/packages/core/tests/helpers/handlers/securityKeySignUpHandlers.ts
@@ -63,7 +63,7 @@ export const signUpEmailSecurityKeySuccessHandler = rest.post(
         excludeCredentials: [],
         pubKeyCredParams: [],
         rp: {
-          name: faker.company.companyName(),
+          name: faker.company.name(),
           id: faker.internet.domainName()
         }
       })

--- a/packages/core/tests/mfaTotpSignIn.test.ts
+++ b/packages/core/tests/mfaTotpSignIn.test.ts
@@ -55,7 +55,7 @@ test(`should fail if network is unavailable`, async () => {
       "authentication": {
         "error": "OK",
         "message": "Network Error",
-        "status": 200,
+        "status": 0,
       },
     }
   `)

--- a/packages/core/tests/passwordSignIn.test.ts
+++ b/packages/core/tests/passwordSignIn.test.ts
@@ -58,7 +58,7 @@ test(`should fail if network is unavailable`, async () => {
       "authentication": {
         "error": "OK",
         "message": "Network Error",
-        "status": 200,
+        "status": 0,
       },
     }
   `)
@@ -82,7 +82,7 @@ test(`should fail if server returns an error`, async () => {
       "authentication": {
         "error": "OK",
         "message": "Network Error",
-        "status": 200,
+        "status": 0,
       },
     }
   `)

--- a/packages/core/tests/passwordlessEmailSignIn.test.ts
+++ b/packages/core/tests/passwordlessEmailSignIn.test.ts
@@ -52,7 +52,7 @@ test('should fail if network is unavailable', async () => {
       "registration": {
         "error": "OK",
         "message": "Network Error",
-        "status": 200,
+        "status": 0,
       },
     }
   `)

--- a/packages/core/tests/passwordlessSmsSignIn.test.ts
+++ b/packages/core/tests/passwordlessSmsSignIn.test.ts
@@ -40,7 +40,7 @@ test(`should fail if network is unavailable`, async () => {
 
   authService.send({
     type: 'PASSWORDLESS_SMS',
-    phoneNumber: faker.phone.phoneNumber()
+    phoneNumber: faker.phone.number()
   })
 
   const state = await waitFor(authService, (state) =>
@@ -52,7 +52,7 @@ test(`should fail if network is unavailable`, async () => {
       "registration": {
         "error": "OK",
         "message": "Network Error",
-        "status": 200,
+        "status": 0,
       },
     }
   `)
@@ -63,7 +63,7 @@ test(`should fail if server returns an error`, async () => {
 
   authService.send({
     type: 'PASSWORDLESS_SMS',
-    phoneNumber: faker.phone.phoneNumber()
+    phoneNumber: faker.phone.number()
   })
 
   const state = await waitFor(authService, (state) =>
@@ -106,7 +106,7 @@ test(`should fail if the provided phone number was invalid`, async () => {
 test(`should succeed if the provided phone number was valid`, async () => {
   authService.send({
     type: 'PASSWORDLESS_SMS',
-    phoneNumber: faker.phone.phoneNumber()
+    phoneNumber: faker.phone.number()
   })
 
   const state = await waitFor(authService, (state) =>

--- a/packages/core/tests/refreshToken.test.ts
+++ b/packages/core/tests/refreshToken.test.ts
@@ -341,7 +341,7 @@ describe('General and disabled auto-sign in', () => {
         "authentication": {
           "error": "OK",
           "message": "Network Error",
-          "status": 200,
+          "status": 0,
         },
       }
     `)
@@ -457,9 +457,9 @@ describe(`Auto sign-in`, () => {
     `)
   })
 
-  test(`should fail if network is unavailable`, async () => {
+  test(`should retry token refresh if network is unavailable`, async () => {
     server.use(authTokenNetworkErrorHandler)
-
+    //
     vi.stubGlobal('location', {
       ...globalThis.location,
       href: `http://localhost:3000/?refreshToken=${faker.datatype.uuid()}`
@@ -467,19 +467,9 @@ describe(`Auto sign-in`, () => {
 
     authService.start()
 
-    const state = await waitFor(authService, (state) =>
-      state.matches({ authentication: { signedOut: 'noErrors' } })
-    )
+    const state = await waitFor(authService, (state) => state.context.importTokenAttempts === 2)
 
-    expect(state.context.errors).toMatchInlineSnapshot(`
-      {
-        "authentication": {
-          "error": "OK",
-          "message": "Network Error",
-          "status": 200,
-        },
-      }
-    `)
+    expect(state.context.importTokenAttempts).toEqual(2)
   })
 
   test(`should retry a token refresh if server returns an error`, async () => {

--- a/packages/core/tests/resetPassword.test.ts
+++ b/packages/core/tests/resetPassword.test.ts
@@ -52,7 +52,7 @@ test(`should fail if there is a network error`, async () => {
     {
       "error": "OK",
       "message": "Network Error",
-      "status": 200,
+      "status": 0,
     }
   `)
 })

--- a/packages/core/tests/securityKeyEmailSignIn.test.ts
+++ b/packages/core/tests/securityKeyEmailSignIn.test.ts
@@ -80,7 +80,7 @@ test(`should fail if network is unavailable`, async () => {
       "authentication": {
         "error": "OK",
         "message": "Network Error",
-        "status": 200,
+        "status": 0,
       },
     }
   `)
@@ -101,7 +101,7 @@ test(`should fail if server returns an error`, async () => {
       "authentication": {
         "error": "OK",
         "message": "Network Error",
-        "status": 200,
+        "status": 0,
       },
     }
   `)

--- a/packages/core/tests/securityKeySignUp.test.ts
+++ b/packages/core/tests/securityKeySignUp.test.ts
@@ -82,7 +82,7 @@ describe('Security Key', () => {
         "registration": {
           "error": "OK",
           "message": "Network Error",
-          "status": 200,
+          "status": 0,
         },
       }
     `)

--- a/packages/core/tests/sendVerificationEmail.test.ts
+++ b/packages/core/tests/sendVerificationEmail.test.ts
@@ -54,7 +54,7 @@ test(`should fail if there is a network error`, async () => {
     {
       "error": "OK",
       "message": "Network Error",
-      "status": 200,
+      "status": 0,
     }
   `)
 })

--- a/packages/core/tests/signOut.test.ts
+++ b/packages/core/tests/signOut.test.ts
@@ -72,7 +72,7 @@ test(`should fail if network is unavailable`, async () => {
       "authentication": {
         "error": "OK",
         "message": "Network Error",
-        "status": 200,
+        "status": 0,
       },
     }
   `)

--- a/packages/core/tests/smsOtpSignIn.test.ts
+++ b/packages/core/tests/smsOtpSignIn.test.ts
@@ -41,7 +41,7 @@ test(`should fail if network is unavailable`, async () => {
 
   authService.send({
     type: 'PASSWORDLESS_SMS_OTP',
-    phoneNumber: faker.phone.phoneNumber(),
+    phoneNumber: faker.phone.number(),
     otp: faker.random.numeric(6).toString()
   })
 
@@ -54,7 +54,7 @@ test(`should fail if network is unavailable`, async () => {
       "registration": {
         "error": "OK",
         "message": "Network Error",
-        "status": 200,
+        "status": 0,
       },
     }
   `)
@@ -65,7 +65,7 @@ test(`should fail if server returns an error`, async () => {
 
   authService.send({
     type: 'PASSWORDLESS_SMS_OTP',
-    phoneNumber: faker.phone.phoneNumber(),
+    phoneNumber: faker.phone.number(),
     otp: faker.random.numeric(6).toString()
   })
 
@@ -112,7 +112,7 @@ test(`should fail if the provided OTP was invalid`, async () => {
 
   authService.send({
     type: 'PASSWORDLESS_SMS_OTP',
-    phoneNumber: faker.phone.phoneNumber(),
+    phoneNumber: faker.phone.number(),
     otp: faker.random.numeric(6).toString()
   })
 
@@ -134,7 +134,7 @@ test(`should fail if the provided OTP was invalid`, async () => {
 test(`should succeed if the provided phone number and OTP were valid`, async () => {
   authService.send({
     type: 'PASSWORDLESS_SMS_OTP',
-    phoneNumber: faker.phone.phoneNumber(),
+    phoneNumber: faker.phone.number(),
     otp: faker.random.numeric(6).toString()
   })
 

--- a/packages/hasura-auth-js/package.json
+++ b/packages/hasura-auth-js/package.json
@@ -61,7 +61,7 @@
     "docgen": "pnpm typedoc && docgen --config ./auth.docgen.json"
   },
   "dependencies": {
-    "axios": "^0.27.2",
+    "axios": "^1.1.3",
     "jwt-decode": "^3.1.2",
     "xstate": "^4.33.5"
   },

--- a/packages/hasura-storage-js/package.json
+++ b/packages/hasura-storage-js/package.json
@@ -59,7 +59,7 @@
     "docgen": "pnpm typedoc && docgen --config ./storage.docgen.json"
   },
   "dependencies": {
-    "axios": "^0.27.2",
+    "axios": "^1.1.3",
     "form-data": "^4.0.0",
     "xstate": "^4.33.5"
   },

--- a/packages/hasura-storage-js/src/machines/file-upload.ts
+++ b/packages/hasura-storage-js/src/machines/file-upload.ts
@@ -1,4 +1,4 @@
-import axios, { AxiosError, AxiosRequestHeaders } from 'axios'
+import axios, { AxiosError, AxiosProgressEvent, RawAxiosRequestHeaders } from 'axios'
 import { assign, createMachine } from 'xstate'
 
 import { ErrorPayload } from '@nhost/core'
@@ -98,7 +98,7 @@ export const createFileUploadMachine = () =>
       },
       services: {
         uploadFile: (context, event) => (callback) => {
-          const headers: AxiosRequestHeaders = {
+          const headers: RawAxiosRequestHeaders = {
             'Content-Type': 'multipart/form-data'
           }
           const fileId = event.id || context.id
@@ -136,13 +136,15 @@ export const createFileUploadMachine = () =>
             }>(event.url + '/files', data, {
               headers,
               signal: controller.signal,
-              onUploadProgress: (event: ProgressEvent) => {
-                const loaded = Math.round((event.loaded * file.size!) / event.total)
+              onUploadProgress: (event: AxiosProgressEvent) => {
+                const loaded = event.total
+                  ? Math.round((event.loaded * file.size!) / event.total)
+                  : 0
                 const additions = loaded - currentLoaded
                 currentLoaded = loaded
                 callback({
                   type: 'UPLOAD_PROGRESS',
-                  progress: Math.round((loaded * 100) / event.total),
+                  progress: event.total ? Math.round((loaded * 100) / event.total) : 0,
                   loaded,
                   additions
                 })

--- a/packages/nhost-js/package.json
+++ b/packages/nhost-js/package.json
@@ -65,7 +65,7 @@
   "dependencies": {
     "@nhost/hasura-auth-js": "workspace:*",
     "@nhost/hasura-storage-js": "workspace:*",
-    "axios": "^0.27.2",
+    "axios": "^1.1.3",
     "jwt-decode": "^3.1.2",
     "query-string": "^7.0.1"
   },

--- a/packages/nhost-js/src/clients/functions.ts
+++ b/packages/nhost-js/src/clients/functions.ts
@@ -1,4 +1,9 @@
-import axios, { AxiosInstance, AxiosRequestConfig, AxiosRequestHeaders, AxiosResponse } from 'axios'
+import axios, {
+  AxiosInstance,
+  AxiosRequestConfig,
+  AxiosResponse,
+  RawAxiosRequestHeaders
+} from 'axios'
 
 import { urlFromSubdomain } from '../utils/helpers'
 import { FunctionCallResponse, NhostClientConstructorParams } from '../utils/types'
@@ -107,7 +112,7 @@ export class NhostFunctionsClient {
     this.accessToken = accessToken
   }
 
-  private generateAccessTokenHeaders(): AxiosRequestHeaders {
+  private generateAccessTokenHeaders(): RawAxiosRequestHeaders {
     if (this.adminSecret) {
       return {
         'x-hasura-admin-secret': this.adminSecret

--- a/packages/nhost-js/src/clients/graphql.ts
+++ b/packages/nhost-js/src/clients/graphql.ts
@@ -1,4 +1,4 @@
-import axios, { AxiosInstance, AxiosRequestConfig, AxiosRequestHeaders } from 'axios'
+import axios, { AxiosInstance, AxiosRequestConfig, RawAxiosRequestHeaders } from 'axios'
 import { DocumentNode, print } from 'graphql'
 
 import { urlFromSubdomain } from '../utils/helpers'
@@ -159,7 +159,7 @@ export class NhostGraphqlClient {
     this.accessToken = accessToken
   }
 
-  private generateAccessTokenHeaders(): AxiosRequestHeaders {
+  private generateAccessTokenHeaders(): RawAxiosRequestHeaders {
     if (this.adminSecret) {
       return {
         'x-hasura-admin-secret': this.adminSecret

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -630,6 +630,9 @@ importers:
       typescript: 4.8.3
       vite: 3.2.2
 
+  examples/seed-data-storage:
+    specifiers: {}
+
   examples/serverless-functions:
     specifiers:
       '@graphql-yoga/node': ^2.13.13
@@ -796,13 +799,13 @@ importers:
       '@simplewebauthn/browser': ^6.0.0
       '@simplewebauthn/typescript-types': ^6.0.0
       '@types/js-cookie': ^3.0.2
-      axios: ^0.27.2
+      axios: ^1.1.3
       js-cookie: ^3.0.1
       msw: ^0.47.4
       xstate: ^4.33.5
     dependencies:
       '@simplewebauthn/browser': 6.0.0
-      axios: 0.27.2
+      axios: 1.1.3
       js-cookie: 3.0.1
       xstate: 4.33.6
     devDependencies:
@@ -844,14 +847,14 @@ importers:
       '@nhost/core': workspace:*
       '@nhost/docgen': workspace:*
       '@types/faker': '5'
-      axios: ^0.27.2
+      axios: ^1.1.3
       html-urls: ^2.4.38
       jwt-decode: ^3.1.2
       mailhog: ^4.16.0
       start-server-and-test: ^1.14.0
       xstate: ^4.33.5
     dependencies:
-      axios: 0.27.2
+      axios: 1.1.3
       jwt-decode: 3.1.2
       xstate: 4.33.6
     devDependencies:
@@ -869,14 +872,14 @@ importers:
     specifiers:
       '@nhost/core': workspace:*
       '@nhost/docgen': workspace:*
-      axios: ^0.27.2
+      axios: ^1.1.3
       cross-fetch: ^3.1.5
       form-data: ^4.0.0
       start-server-and-test: ^1.14.0
       uuid: ^8.3.2
       xstate: ^4.33.5
     dependencies:
-      axios: 0.27.2
+      axios: 1.1.3
       form-data: 4.0.0
       xstate: 4.33.6
     devDependencies:
@@ -921,7 +924,7 @@ importers:
       '@nhost/docgen': workspace:*
       '@nhost/hasura-auth-js': workspace:*
       '@nhost/hasura-storage-js': workspace:*
-      axios: ^0.27.2
+      axios: ^1.1.3
       graphql: 15.7.2
       jwt-decode: ^3.1.2
       query-string: ^7.0.1
@@ -929,7 +932,7 @@ importers:
     dependencies:
       '@nhost/hasura-auth-js': link:../hasura-auth-js
       '@nhost/hasura-storage-js': link:../hasura-storage-js
-      axios: 0.27.2
+      axios: 1.1.3
       jwt-decode: 3.1.2
       query-string: 7.1.1
     devDependencies:
@@ -12341,7 +12344,7 @@ packages:
   /axios/0.21.4_debug@4.3.2:
     resolution: {integrity: sha512-ut5vewkiu8jjGBdqpM44XxjuCjq9LAKeHVmoVfHVzy8eHgxxq8SbAVQNovDA8mVi05kP0Ea/n/UzcSHcTJQfNg==}
     dependencies:
-      follow-redirects: 1.14.9
+      follow-redirects: 1.15.2
     transitivePeerDependencies:
       - debug
     dev: true
@@ -12349,15 +12352,25 @@ packages:
   /axios/0.25.0:
     resolution: {integrity: sha512-cD8FOb0tRH3uuEe6+evtAbgJtfxr7ly3fQjYcMcuPlgkwVS9xboaVIpcDV+cYQe+yGykgwZCs1pzjntcGa6l5g==}
     dependencies:
-      follow-redirects: 1.14.9
+      follow-redirects: 1.15.2
     transitivePeerDependencies:
       - debug
 
   /axios/0.27.2:
     resolution: {integrity: sha512-t+yRIyySRTp/wua5xEr+z1q60QmLq8ABsS5O9Me1AsE5dfKqgnCFzwiCZZ/cGNd1lq4/7akDWMxdhVlucjmnOQ==}
     dependencies:
-      follow-redirects: 1.14.9
+      follow-redirects: 1.15.2
       form-data: 4.0.0
+    transitivePeerDependencies:
+      - debug
+    dev: false
+
+  /axios/1.1.3:
+    resolution: {integrity: sha512-00tXVRwKx/FZr/IDVFt4C+f9FYairX517WoGCL6dpOntqLkZofjhu43F/Xl44UOpqa+9sLFDrG/XAnFsUYgkDA==}
+    dependencies:
+      follow-redirects: 1.15.2
+      form-data: 4.0.0
+      proxy-from-env: 1.1.0
     transitivePeerDependencies:
       - debug
     dev: false
@@ -18367,8 +18380,8 @@ packages:
       tslib: 1.14.1
     dev: true
 
-  /follow-redirects/1.14.9:
-    resolution: {integrity: sha512-MQDfihBQYMcyy5dhRDJUHcw7lb2Pv/TuE6xP1vyraLukNDHKbDxDNaOE3NbCAdKQApno+GPRyo1YAp89yCjK4w==}
+  /follow-redirects/1.15.2:
+    resolution: {integrity: sha512-VQLG33o04KaQ8uYi2tVNbdrWp1QWxNNea+nmIB4EVM28v0hmP17z7aG1+wAkNzVq4KeXTq3221ye5qTJP91JwA==}
     engines: {node: '>=4.0'}
     peerDependencies:
       debug: '*'
@@ -19685,7 +19698,7 @@ packages:
     engines: {node: '>=8.0.0'}
     dependencies:
       eventemitter3: 4.0.7
-      follow-redirects: 1.14.9
+      follow-redirects: 1.15.2
       requires-port: 1.0.0
     transitivePeerDependencies:
       - debug
@@ -24618,6 +24631,10 @@ packages:
   /proxy-from-env/1.0.0:
     resolution: {integrity: sha512-F2JHgJQ1iqwnHDcQjVBsq3n/uoaFL+iPW/eAeL7kVxy/2RrWaN4WroKjjvbsoRtv0ftelNyC01bjRhn/bhcf4A==}
     dev: true
+
+  /proxy-from-env/1.1.0:
+    resolution: {integrity: sha512-D+zkORCbA9f1tdWRK0RaCR3GPv50cMxcrz4X8k5LTSUD1Dkw47mKJEZQNunItRTkWwgtaUSo1RVFRIG9ZXiFYg==}
+    dev: false
 
   /prr/1.0.1:
     resolution: {integrity: sha512-yPw4Sng1gWghHQWj0B3ZggWUm4qVbPwPFcRG8KyxiU7J2OHFSoEHKS+EZ3fv5l1t9CyCiop6l/ZYeWbrgoQejw==}


### PR DESCRIPTION
rationale: a contributor is preparing a Nuxt 3 module. They need either Axios or cross-fetch. We talked about replacing Axios with cross-fetch, but using Axios v1 is already an improvement.
- bump to Axios v1 (except in the dashboard). Adapt types
- it uncovered an issue with the network code that was not processed correctly: it was supposed to be `0` whereas it was `200`
- it then uncovered a bug: the auto-signin was not retrying the existing token in the url when there was no network
- remove deprecated `faker` methods