### PR TITLE
ci: use turborepo cache when building images

### DIFF
--- a/.github/workflows/changesets.yaml
+++ b/.github/workflows/changesets.yaml
@@ -11,6 +11,9 @@ on:
       - '!.changeset/**'
       - 'LICENSE'
 
+env:
+  TURBO_TOKEN: ${{ secrets.TURBO_TOKEN }}
+  TURBO_TEAM: nhost
 jobs:
   version:
     runs-on: ubuntu-latest
@@ -81,6 +84,9 @@ jobs:
           context: .
           file: ./dashboard/Dockerfile
           platforms: linux/amd64,linux/arm64
+          build-args: |
+            TURBO_TOKEN=${{ env.TURBO_TOKEN }}
+            TURBO_TEAM=#{{ env.TURBO_TEAM }}
           tags: ${{ steps.meta.outputs.tags }}
           labels: ${{ steps.meta.outputs.labels }}
           push: true

--- a/dashboard/Dockerfile
+++ b/dashboard/Dockerfile
@@ -9,6 +9,9 @@ COPY . .
 RUN turbo prune --scope="@nhost/dashboard" --docker
 
 FROM node:16-alpine AS builder
+ARG TURBO_TOKEN
+ARG TURBO_TEAM
+RUN env
 RUN apk add --no-cache libc6-compat
 RUN apk update
 WORKDIR /app


### PR DESCRIPTION
Before merging this PR, we should remove the existing dashboard tag:
```sh
git tag -d @nhost/dashboard@0.2.0
git push --delete origin @nhost/dashboard@0.2.0
```