### PR TITLE
ci: fix version

### DIFF
--- a/.github/workflows/changesets.yaml
+++ b/.github/workflows/changesets.yaml
@@ -45,7 +45,7 @@ jobs:
           package="@nhost/dashboard"
           version=$(jq -r .version dashboard/package.json)
           tag="$package@$version"
-          git tag $tag 2>/dev/null && (git push origin --tags ; echo "dashboardVersion=$tag" >> $GITHUB_OUTPUT) || true
+          git tag $tag 2>/dev/null && (git push origin --tags ; echo "dashboardVersion=$version" >> $GITHUB_OUTPUT) || true
 
   publish:
     runs-on: ubuntu-latest

--- a/dashboard/Dockerfile
+++ b/dashboard/Dockerfile
@@ -11,7 +11,7 @@ RUN turbo prune --scope="@nhost/dashboard" --docker
 FROM node:16-alpine AS builder
 ARG TURBO_TOKEN
 ARG TURBO_TEAM
-RUN env
+
 RUN apk add --no-cache libc6-compat
 RUN apk update
 WORKDIR /app

--- a/turbo.json
+++ b/turbo.json
@@ -4,7 +4,7 @@
   "pipeline": {
     "build": {
       "dependsOn": ["^build"],
-      "outputs": ["dist/**", "umd/**", "build/**", ".next"]
+      "outputs": ["dist/**", "umd/**", "build/**", ".next/**"]
     },
     "@nhost-examples/react-apollo#build": {
       "dependsOn": ["^build"],
@@ -15,6 +15,17 @@
       "dependsOn": ["^build"],
       "outputs": ["dist/**"],
       "env": ["VITE_NHOST_SUBDOMAIN", "VITE_NHOST_REGION"]
+    },
+    "@nhost/dashboard#build": {
+      "dependsOn": ["^build"],
+      "outputs": ["dist/**", ".next/**"],
+      "env": [
+        "NEXT_TELEMETRY_DISABLED",
+        "NEXT_PUBLIC_NHOST_PLATFORM",
+        "NEXT_PUBLIC_NHOST_MIGRATIONS_URL",
+        "NEXT_PUBLIC_NHOST_HASURA_URL",
+        "NEXT_PUBLIC_NHOST_HASURA_URL"
+      ]
     },
     "@nhost/sync-versions#start": {
       "cache": false

--- a/turbo.json
+++ b/turbo.json
@@ -24,7 +24,7 @@
         "NEXT_PUBLIC_NHOST_PLATFORM",
         "NEXT_PUBLIC_NHOST_MIGRATIONS_URL",
         "NEXT_PUBLIC_NHOST_HASURA_URL",
-        "NEXT_PUBLIC_NHOST_HASURA_URL"
+        "NEXT_PUBLIC_ENV"
       ]
     },
     "@nhost/sync-versions#start": {


### PR DESCRIPTION
problems:

1. we were sending the entire tag `@nhost/dashboard@0.2.0` instead of `0.2.0`
As a result, the semver version used by docker meta was `v@nhost/dashboard@0.2.0` instead of `v0.2.0`

2. turborepo did not restore the cache correctly

We'll need to remove the tag again
