### PR TITLE
fix: 🐛 Set same-site cookie to `lax`

### DIFF
--- a/.changeset/mean-cats-explain.md
+++ b/.changeset/mean-cats-explain.md
@@ -1,0 +1,5 @@
+---
+'@nhost/core': major
+---
+
+Set same-site cookie to `lax`

--- a/packages/core/src/storage.ts
+++ b/packages/core/src/storage.ts
@@ -86,7 +86,7 @@ export const localStorageSetter = (
         if (value) {
           // TODO: Set expires based on the actual refresh token expire time
           // For now, we're using 30 days so the cookie is not removed when the browser is closed because if `expiers` is omitted, the cookie becomes a session cookie.
-          Cookies.set(key, value, { expires: 30 })
+          Cookies.set(key, value, { expires: 30, sameSite: 'lax', httpOnly: false })
         } else {
           Cookies.remove(key)
         }


### PR DESCRIPTION
[Firefox raises a warning when no same-site value is set](https://discord.com/channels/552499021260914688/1044122100228706334/1044242141888651265)