### PR TITLE
chore: bump pnpm version to v7.17.0

### DIFF
--- a/.github/actions/install-dependencies/action.yaml
+++ b/.github/actions/install-dependencies/action.yaml
@@ -10,7 +10,7 @@ runs:
   steps:
     - uses: pnpm/action-setup@v2.2.4
       with:
-        version: 7.9.1
+        version: 7.17.0
         run_install: false
     - name: Get pnpm cache directory
       id: pnpm-cache-dir

--- a/package.json
+++ b/package.json
@@ -86,10 +86,10 @@
   "resolutions": {
     "graphql": "15.7.2"
   },
-  "packageManager": "pnpm@7.9.1",
+  "packageManager": "pnpm@7.17.0",
   "engines": {
     "node": ">=14 <17",
-    "pnpm": ">=7.9.1"
+    "pnpm": ">=7.17.0"
   },
   "eslintConfig": {
     "extends": "./config/.eslintrc.js"


### PR DESCRIPTION
In particular `strict-peer-dependencies` should default to `false` - see [v7.13.5 release notes](https://github.com/pnpm/pnpm/releases/tag/v7.13.5)