### PR TITLE
fix(dashboard): remove functions folder reference from codegen config

### DIFF
--- a/dashboard/graphql.config.yaml
+++ b/dashboard/graphql.config.yaml
@@ -13,11 +13,3 @@ generates:
       - 'typescript-react-apollo'
     config:
       withRefetchFn: true
-  functions/utils/__generated__/graphql-request.ts:
-    documents:
-      - 'functions/**/*.graphql'
-      - 'functions/**/*.gql'
-    plugins:
-      - 'typescript'
-      - 'typescript-operations'
-      - 'typescript-graphql-request'


### PR DESCRIPTION
We don't have access to the functions folder in this repository, and it breaks the GraphQL codegen process.