### PR TITLE
Update minimum version of node

### DIFF
--- a/package.json
+++ b/package.json
@@ -88,7 +88,7 @@
   },
   "packageManager": "pnpm@7.17.0",
   "engines": {
-    "node": ">=14 <17",
+    "node": ">=16 <17",
     "pnpm": ">=7.17.0"
   },
   "eslintConfig": {


### PR DESCRIPTION
The pre-commit hook will fail with Node versions less than 16 which prevents contributions.