### PR TITLE
docs: update developer's guide

### DIFF
--- a/DEVELOPERS.md
+++ b/DEVELOPERS.md
@@ -2,6 +2,8 @@
 
 ## Requirements
 
+- This repository works with **Node 16**
+
 - We use [pnpm](https://pnpm.io/) as a package manager to speed up development and builds, and as a basis for our monorepo. You need to make sure it's installed on your machine. There are [several ways to install it](https://pnpm.io/installation), but the easiest way is with `npm`:
 
 ```sh
@@ -96,6 +98,12 @@ You can take a look at the changeset documentation: [How to add a changeset](htt
 ## Committing changes
 
 You'll notice that `git commit` takes a few seconds to run. We set a commit hook that scans the changes in the code, automatically generates documentation from the inline [TSDoc](https://tsdoc.org/) annotations, and adds these generated documentation files to the commit. They automatically update the [reference documentation](https://docs.nhost.io/reference).
+
+The document generation script that is run in the pre-commit hook requires to be built first. You may need to run the following command before the commit:
+
+```sh
+pnpm run build
+```
 
 <!-- ## Good practices
 - lint


### PR DESCRIPTION
Lessons learned from our discussion with Sheena and Chris:
- Don't use Node 14
- Run `pnpm run build` at least once before any commit, as `docgen` needs to be built 