### PR TITLE
feat(dashboard): add Vercel deployment

### DIFF
--- a/.github/workflows/changesets.yaml
+++ b/.github/workflows/changesets.yaml
@@ -18,6 +18,7 @@ env:
 
 jobs:
   version:
+    name: Version
     runs-on: ubuntu-latest
     outputs:
       hasChangesets: ${{ steps.changesets.outputs.hasChangesets }}
@@ -60,7 +61,8 @@ jobs:
     uses: ./.github/workflows/dashboard.yaml
     secrets: inherit
 
-  publish:
+  tag:
+    name: Tag
     runs-on: ubuntu-latest
     needs:
       - test
@@ -74,6 +76,13 @@ jobs:
         run: |
           git tag "${{ env.DASHBOARD_PACKAGE }}@${{ needs.version.outputs.dashboardVersion }}"
           git push origin --tags
+
+  publish:
+    name: Publish
+    runs-on: ubuntu-latest
+    needs:
+      - tag
+    steps:
       - name: Docker meta
         id: meta
         uses: docker/metadata-action@v4
@@ -117,6 +126,11 @@ jobs:
           token: ${{ secrets.GITHUB_TOKEN }}
           prefix: ${{ env.DASHBOARD_PACKAGE }}@
           ref: refs/tags/${{ env.DASHBOARD_PACKAGE }}@${{ needs.version.outputs.dashboardVersion }}
-      - name: Remove tag on failure
-        if: failure()
-        run: git push --delete origin ${{ env.DASHBOARD_PACKAGE }}@${{ needs.version.outputs.dashboardVersion }}
+
+  publish-vercel:
+    name: Publish to Vercel
+    runs-on: ubuntu-latest
+    needs:
+      - tag
+    steps:
+      - run: curl -X POST -d {} https://api.vercel.com/v1/integrations/deploy/${{ secrets.DASHBOARD_VERCEL_PROJECT_ID }}/${{ secrets.DASHBOARD_VERCEL_WEBHOOK_ID }}

--- a/.github/workflows/changesets.yaml
+++ b/.github/workflows/changesets.yaml
@@ -78,7 +78,7 @@ jobs:
           git push origin --tags
 
   publish:
-    name: Publish
+    name: Publish to Docker Hub
     runs-on: ubuntu-latest
     needs:
       - tag

--- a/.github/workflows/changesets.yaml
+++ b/.github/workflows/changesets.yaml
@@ -61,8 +61,8 @@ jobs:
     uses: ./.github/workflows/dashboard.yaml
     secrets: inherit
 
-  tag:
-    name: Tag
+  publish:
+    name: Publish
     runs-on: ubuntu-latest
     needs:
       - test
@@ -76,13 +76,6 @@ jobs:
         run: |
           git tag "${{ env.DASHBOARD_PACKAGE }}@${{ needs.version.outputs.dashboardVersion }}"
           git push origin --tags
-
-  publish:
-    name: Publish to Docker Hub
-    runs-on: ubuntu-latest
-    needs:
-      - tag
-    steps:
       - name: Docker meta
         id: meta
         uses: docker/metadata-action@v4
@@ -119,6 +112,8 @@ jobs:
           tags: ${{ steps.meta.outputs.tags }}
           labels: ${{ steps.meta.outputs.labels }}
           push: true
+      - name: Trigger a Vercel deployment
+        run: curl -X POST -d {} https://api.vercel.com/v1/integrations/deploy/${{ secrets.DASHBOARD_VERCEL_PROJECT_ID }}/${{ secrets.DASHBOARD_VERCEL_WEBHOOK_ID }}
       - name: Create GitHub Release
         uses: taiki-e/create-gh-release-action@v1
         with:
@@ -126,11 +121,6 @@ jobs:
           token: ${{ secrets.GITHUB_TOKEN }}
           prefix: ${{ env.DASHBOARD_PACKAGE }}@
           ref: refs/tags/${{ env.DASHBOARD_PACKAGE }}@${{ needs.version.outputs.dashboardVersion }}
-
-  publish-vercel:
-    name: Publish to Vercel
-    runs-on: ubuntu-latest
-    needs:
-      - tag
-    steps:
-      - run: curl -X POST -d {} https://api.vercel.com/v1/integrations/deploy/${{ secrets.DASHBOARD_VERCEL_PROJECT_ID }}/${{ secrets.DASHBOARD_VERCEL_WEBHOOK_ID }}
+      - name: Remove tag on failure
+        if: failure()
+        run: git push --delete origin ${{ env.DASHBOARD_PACKAGE }}@${{ needs.version.outputs.dashboardVersion }}


### PR DESCRIPTION
This PR adds the ability to trigger production deployments when a new tag is created for the Dashboard.