### PR TITLE
ci: adjust workflows

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -1,4 +1,4 @@
-name: Packages
+name: Continuous Integration
 
 on:
   push:

--- a/.github/workflows/dashboard.yaml
+++ b/.github/workflows/dashboard.yaml
@@ -2,12 +2,6 @@ name: 'Dashboard'
 
 on:
   workflow_call:
-  pull_request:
-    branches: [main]
-    types: [opened, synchronize]
-    paths:
-      - 'packages/**'
-      - 'dashboard/**'
 
 env:
   TURBO_TOKEN: ${{ secrets.TURBO_TOKEN }}


### PR DESCRIPTION
- rename the `Packages` workflow to `Continuous Integration`
- deactivate the `Dashboard` workflow on pull request as the dashboard build/test/lint jobs now run in the CI workflow