### PR TITLE
chore: add missing version field to the vue-starter example

### DIFF
--- a/examples/vue-quickstart/.eslintrc.js
+++ b/examples/vue-quickstart/.eslintrc.js
@@ -6,6 +6,7 @@ module.exports = {
     curly: 'off',
     'quote-props': 'off',
     'vue/html-self-closing': 'off',
-    'vue/singleline-html-element-content-newline': 'off'
+    'vue/singleline-html-element-content-newline': 'off',
+    'eol-last': 'off'
   }
 }

--- a/examples/vue-quickstart/package.json
+++ b/examples/vue-quickstart/package.json
@@ -1,5 +1,6 @@
 {
   "name": "@nhost-examples/vue-quickstart",
+  "version": "0.0.1",
   "private": true,
   "scripts": {
     "build": "vite build",


### PR DESCRIPTION
Changesets is not able to bump the example's version as the version field is missing in its `package.json` field.
See https://github.com/nhost/nhost/pull/1274