### PR TITLE
chore: improve docker-compose example

### DIFF
--- a/.changeset/fair-students-enjoy.md
+++ b/.changeset/fair-students-enjoy.md
@@ -1,0 +1,9 @@
+---
+"@nhost-examples/docker-compose": patch
+---
+
+Improve QA
+
+- Add end-to-end tests
+- Use the default health checks from the services
+- Do not use `latest` tags so we are sure the docker-compose example works for the given versions of the services

--- a/.github/renovate.json
+++ b/.github/renovate.json
@@ -3,6 +3,9 @@
   "extends": [
     "config:base"
   ],
+  "docker-compose": {
+    "enabled": true
+  },
   "ignoreDeps": [
     "pnpm",
     "node"

--- a/examples/docker-compose/docker-compose.yaml
+++ b/examples/docker-compose/docker-compose.yaml
@@ -42,7 +42,7 @@ services:
       - "traefik.http.routers.hasura.rule=Host(`localhost`) && PathPrefix(`/`)"
       - "traefik.http.routers.hasura.entrypoints=web"
   auth:
-    image: nhost/hasura-auth:latest
+    image: nhost/hasura-auth:0.16.2
     depends_on:
       - postgres
       - graphql-engine
@@ -63,8 +63,6 @@ services:
       AUTH_SMTP_SENDER: mail@example.com
     expose: 
       - 4000
-    healthcheck:
-      disable: true
     labels:
       - "traefik.enable=true"
       - "traefik.http.middlewares.strip-auth.stripprefix.prefixes=/v1/auth"
@@ -80,8 +78,6 @@ services:
     restart: always
     expose:
       - 8000
-    healthcheck:
-      disable: true
     environment:
       PUBLIC_URL: http://localhost:${PROXY_PORT:-1337}
       HASURA_METADATA: 1
@@ -103,7 +99,7 @@ services:
       - "traefik.http.routers.storage.middlewares=strip-suffix@docker"
     command: serve
   functions:
-    image: nhost/functions:latest
+    image: nhost/functions:0.1.8
     labels:
       - "traefik.enable=true"
       - "traefik.http.middlewares.strip-functions.stripprefix.prefixes=/v1/functions"
@@ -113,8 +109,6 @@ services:
     restart: always
     expose: 
       - 3000
-    healthcheck:
-      disable: true
     volumes:
       - .:/opt/project
       - functions_node_modules:/opt/project/node_modules
@@ -146,7 +140,7 @@ services:
     volumes:
       - ./data/mailhog:/maildir
   dashboard:
-    image: nhost/dashboard:latest
+    image: nhost/dashboard:0.7.4
     ports:
       - "3030:3000"
 volumes:

--- a/examples/docker-compose/package.json
+++ b/examples/docker-compose/package.json
@@ -1,0 +1,11 @@
+{
+  "name": "@nhost-examples/docker-compose",
+  "version": "0.0.1",
+  "private": true,
+  "scripts": {
+    "e2e": "vitest run"
+  },
+  "devDependencies": {
+    "cross-fetch": "^3.1.5"
+  }
+}

--- a/examples/docker-compose/test/docker-compose.test.ts
+++ b/examples/docker-compose/test/docker-compose.test.ts
@@ -7,7 +7,7 @@ it(
   async () => {
     // * Start the docker-compose
     expect(() => {
-      execSync('docker-compose -f docker-compose.yaml --env-file .env.example up --wait')
+      execSync('docker compose -f docker-compose.yaml --env-file .env.example up --wait')
     }).not.toThrowError()
 
     // * Hasura
@@ -35,7 +35,7 @@ it(
 
     // * Stop the docker-compose
     expect(() => {
-      execSync('docker-compose -f docker-compose.yaml --env-file .env.example down')
+      execSync('docker compose -f docker-compose.yaml --env-file .env.example down')
     }).not.toThrowError()
   },
   { timeout: 5 * 60 * 1000 }

--- a/examples/docker-compose/test/docker-compose.test.ts
+++ b/examples/docker-compose/test/docker-compose.test.ts
@@ -7,7 +7,9 @@ it(
   async () => {
     // * Start the docker-compose
     expect(() => {
-      execSync('docker compose -f docker-compose.yaml --env-file .env.example up --wait')
+      execSync(
+        'docker compose -f docker-compose.yaml --env-file .env.example up --wait --quiet-pull'
+      )
     }).not.toThrowError()
 
     // * Hasura

--- a/examples/docker-compose/test/docker-compose.test.ts
+++ b/examples/docker-compose/test/docker-compose.test.ts
@@ -1,0 +1,42 @@
+import { execSync } from 'child_process'
+import fetch from 'cross-fetch'
+import { expect, it } from 'vitest'
+
+it(
+  'docker-compose',
+  async () => {
+    // * Start the docker-compose
+    expect(() => {
+      execSync('docker-compose -f docker-compose.yaml --env-file .env.example up --wait')
+    }).not.toThrowError()
+
+    // * Hasura
+    await expect(fetch('http://localhost:1337/healthz').then((res) => res.status)).resolves.toEqual(
+      200
+    )
+
+    // * Hasura-auth
+    await expect(
+      fetch('http://localhost:1337/v1/auth/healthz').then((res) => res.status)
+    ).resolves.toEqual(200)
+
+    // * Hasura-storage
+    await expect(
+      fetch('http://localhost:1337/v1/storage/version').then((res) => res.status)
+    ).resolves.toEqual(200)
+
+    // * Serverless functions
+    await expect(
+      fetch('http://localhost:1337/v1/functions/hello').then((res) => res.status)
+    ).resolves.toEqual(200)
+
+    // * Dashboard
+    await expect(fetch('http://localhost:3030').then((res) => res.status)).resolves.toEqual(200)
+
+    // * Stop the docker-compose
+    expect(() => {
+      execSync('docker-compose -f docker-compose.yaml --env-file .env.example down')
+    }).not.toThrowError()
+  },
+  { timeout: 5 * 60 * 1000 }
+)

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -441,6 +441,12 @@ importers:
       typescript: 4.8.3
       vite: 3.2.2
 
+  examples/docker-compose:
+    specifiers:
+      cross-fetch: ^3.1.5
+    devDependencies:
+      cross-fetch: 3.1.5
+
   examples/docker-compose/functions:
     specifiers: {}
 


### PR DESCRIPTION
- enable renovate for `docker-compose`
- create e2e tests for the docker-compose example. Among other things it will ensure renovate bumps are tested against CI
- use the default health checks from the services
- do not use `latest` tags so we are sure the docker-compose example works for the given versions of the services