### PR TITLE
fix: use workspace to resolve internal dependencies

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -41,6 +41,8 @@ jobs:
         uses: tj-actions/changed-files@v34
         with:
           files: pnpm-lock.yaml
+      # * Determine a pnpm filter argument for packages that have been modified.
+      # * If the lockfile has changed, we don't filter anything in order to run all the e2e tests.
       - name: filter packages
         id: filter-packages
         if: steps.changed-lockfile.outputs.any_changed != 'true' && github.event_name == 'pull_request'

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -43,7 +43,7 @@ jobs:
           files: pnpm-lock.yaml
       - name: filter packages
         id: filter-packages
-        if: steps.changed-lockfile.outputs.any_changed == 'true' && github.event_name == 'pull_request'
+        if: steps.changed-lockfile.outputs.any_changed != 'true' && github.event_name == 'pull_request'
         run: echo "filter=${{ format('--filter=...[origin/{0}]', github.base_ref) }}" >> $GITHUB_OUTPUT
       # * List packagesthat has an `e2e` script, except the root, and return an array of their name and path
       # * In a PR, only include packages that have been modified, and their dependencies

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -36,13 +36,21 @@ jobs:
           TURBO_TOKEN: ${{ env.TURBO_TOKEN }}
           TURBO_TEAM: ${{ env.TURBO_TEAM }}
           BUILD: 'all'
+      - name: Check if the pnpm lockfile changed
+        id: changed-lockfile
+        uses: tj-actions/changed-files@v34
+        with:
+          files: pnpm-lock.yaml
+      - name: filter packages
+        id: filter-packages
+        if: steps.changed-lockfile.outputs.any_changed == 'true' && github.event_name == 'pull_request'
+        run: echo "filter=${{ format('--filter=...[origin/{0}]', github.base_ref) }}" >> $GITHUB_OUTPUT
       # * List packagesthat has an `e2e` script, except the root, and return an array of their name and path
       # * In a PR, only include packages that have been modified, and their dependencies
       - name: List examples with an e2e script
         id: set-matrix
         run: |
-          FILTER_MODIFIED="${{ github.event_name == 'pull_request' && format('--filter=...[origin/{0}]', github.base_ref) || '' }}"
-          PACKAGES=$(pnpm recursive list --depth -1 --parseable --filter='!nhost-root' $FILTER_MODIFIED \
+          PACKAGES=$(pnpm recursive list --depth -1 --parseable --filter='!nhost-root' ${{ steps.filter-packages.outputs.filter }} \
             | xargs -I@ realpath --relative-to=$PWD @ \
             | xargs -I@ jq "if (.scripts.e2e | length) != 0  then {name: .name, path: \"@\"} else null end" @/package.json \
             | awk "!/null/" \

--- a/.npmrc
+++ b/.npmrc
@@ -1,0 +1,1 @@
+prefer-workspace-packages = true

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -389,8 +389,8 @@ importers:
       vite: ^3.2.2
     dependencies:
       '@apollo/client': 3.6.9_qqqj7xqn73klpidhtp57t4zzwm
-      '@nhost/react': 0.15.2_gp4likmy5canqa5vezccvrluf4
-      '@nhost/react-apollo': 4.9.2_kcwooay62h34ta66pwakq6hh5m
+      '@nhost/react': link:../../packages/react
+      '@nhost/react-apollo': link:../../packages/react-apollo
       graphql: 15.7.2
       react: 18.2.0
       react-dom: 18.2.0_react@18.2.0
@@ -424,7 +424,7 @@ importers:
       typescript: ^4.8.2
       vite: ^3.2.2
     dependencies:
-      '@nhost/react': 0.15.2_gp4likmy5canqa5vezccvrluf4
+      '@nhost/react': link:../../packages/react
       '@tanstack/react-query': 4.10.3_biqbaboplfbrettd7655fr4n2y
       '@tanstack/react-query-devtools': 4.11.0_vhepussragssjkevgznguhxexq
       graphql: 15.7.2
@@ -457,7 +457,7 @@ importers:
       express: ^4.18.1
       typescript: ^4.8.2
     dependencies:
-      '@nhost/nhost-js': 1.6.2
+      '@nhost/nhost-js': link:../../packages/nhost-js
     devDependencies:
       '@types/express': 4.17.13
       express: 4.18.2
@@ -492,9 +492,9 @@ importers:
       '@mantine/hooks': 4.2.12_react@18.2.0
       '@mantine/next': 4.2.12_oihdxrcjzie72t7wq3ezd4naxa
       '@mantine/notifications': 4.2.12_n5fi23fjjzlwcbqhnnpdtjftw4
-      '@nhost/nextjs': 1.9.3_4umcnubejb2mvyxfkpzvq3wsvy
-      '@nhost/react': 0.15.2_gp4likmy5canqa5vezccvrluf4
-      '@nhost/react-apollo': 4.9.2_kcwooay62h34ta66pwakq6hh5m
+      '@nhost/nextjs': link:../../packages/nextjs
+      '@nhost/react': link:../../packages/react
+      '@nhost/react-apollo': link:../../packages/react-apollo
       graphql: 15.7.2
       next: 12.1.6_biqbaboplfbrettd7655fr4n2y
       react: 18.2.0
@@ -551,8 +551,8 @@ importers:
       '@mantine/hooks': 4.2.12_react@18.2.0
       '@mantine/notifications': 4.2.12_n5fi23fjjzlwcbqhnnpdtjftw4
       '@mantine/prism': 4.2.12_n5fi23fjjzlwcbqhnnpdtjftw4
-      '@nhost/react': 0.15.2_gp4likmy5canqa5vezccvrluf4
-      '@nhost/react-apollo': 4.9.2_kcwooay62h34ta66pwakq6hh5m
+      '@nhost/react': link:../../packages/react
+      '@nhost/react-apollo': link:../../packages/react-apollo
       graphql: 15.7.2
       react: 18.2.0
       react-dom: 18.2.0_react@18.2.0
@@ -599,7 +599,7 @@ importers:
       vite: ^3.2.2
     dependencies:
       '@gqty/react': 2.1.0_facumlwdezyowqzbzb2sy4uxwu
-      '@nhost/react': 0.15.2_gp4likmy5canqa5vezccvrluf4
+      '@nhost/react': link:../../packages/react
       gqty: 2.3.0_graphql@15.7.2
       graphql: 15.7.2
       react: 18.2.0
@@ -632,7 +632,7 @@ importers:
       stripe: ^11.1.0
     dependencies:
       '@graphql-yoga/node': 2.13.13_graphql@15.7.2
-      '@nhost/stripe-graphql-js': 0.0.6
+      '@nhost/stripe-graphql-js': link:../../integrations/stripe-graphql-js
       '@pothos/core': 3.21.0_graphql@15.7.2
       cross-fetch: 3.1.5
       graphql: 15.7.2
@@ -668,8 +668,8 @@ importers:
     dependencies:
       '@apollo/client': 3.7.1_graphql@15.7.2
       '@mdi/font': 5.9.55
-      '@nhost/apollo': 0.5.35_46b2fnp7cma3gul4fmexgosbs4
-      '@nhost/vue': 0.6.2_graphql@15.7.2+vue@3.2.41
+      '@nhost/apollo': link:../../packages/apollo
+      '@nhost/vue': link:../../packages/vue
       '@vue/apollo-composable': 4.0.0-alpha.18_bfqjzh474jiy2vndpovanot4va
       graphql: 15.7.2
       graphql-tag: 2.12.6_graphql@15.7.2
@@ -680,7 +680,7 @@ importers:
       vuetify: 3.0.0-beta.10_5xmtcui7n2fsr6aaqzp3akxd4q
       webfontloader: 1.6.28
     devDependencies:
-      '@nhost/core': 0.9.4
+      '@nhost/core': link:../../packages/core
       '@types/webfontloader': 1.6.35
       '@vitejs/plugin-vue': 2.3.4_vite@3.2.2+vue@3.2.41
       '@xstate/inspect': 0.6.5
@@ -719,8 +719,8 @@ importers:
       vue-tsc: ^0.38.9
     dependencies:
       '@apollo/client': 3.6.9_graphql@15.7.2
-      '@nhost/apollo': 0.5.35_@apollo+client@3.6.9
-      '@nhost/vue': 0.6.2_graphql@15.7.2+vue@3.2.40
+      '@nhost/apollo': link:../../packages/apollo
+      '@nhost/vue': link:../../packages/vue
       '@vue/apollo-composable': 4.0.0-alpha.18_u5o5osmz2el7lvswqxi2nfxzl4
       '@vueuse/core': 8.9.4_vue@3.2.40
       graphql: 15.7.2
@@ -7022,261 +7022,6 @@ packages:
     dev: true
     optional: true
 
-  /@nhost/apollo/0.5.35_46b2fnp7cma3gul4fmexgosbs4:
-    resolution: {integrity: sha512-S4xDn/s76ALjterZQevhQ8YE/3VMis7RQaPe2laZ5T86zdn9wF7I74fYueRnnllvuYQXnRSDG7i1ue6xsmahxA==}
-    peerDependencies:
-      '@apollo/client': ^3.6.2
-    dependencies:
-      '@apollo/client': 3.7.1_graphql@15.7.2
-      '@nhost/nhost-js': 1.6.2_v7bsqeisvp5asclpmdnitonepy
-      graphql: 15.7.2
-      graphql-ws: 5.11.2_graphql@15.7.2
-    transitivePeerDependencies:
-      - '@nhost/core'
-      - debug
-    dev: false
-
-  /@nhost/apollo/0.5.35_@apollo+client@3.6.9:
-    resolution: {integrity: sha512-S4xDn/s76ALjterZQevhQ8YE/3VMis7RQaPe2laZ5T86zdn9wF7I74fYueRnnllvuYQXnRSDG7i1ue6xsmahxA==}
-    peerDependencies:
-      '@apollo/client': ^3.6.2
-    dependencies:
-      '@apollo/client': 3.6.9_graphql@15.7.2
-      '@nhost/nhost-js': 1.6.2_graphql@15.7.2
-      graphql: 15.7.2
-      graphql-ws: 5.11.2_graphql@15.7.2
-    transitivePeerDependencies:
-      - '@nhost/core'
-      - debug
-    dev: false
-
-  /@nhost/core/0.9.4:
-    resolution: {integrity: sha512-XqHc5RVh8AWyLSh+pTlEmCXZ3VQaV37xQYUrPzIdNCUNAHiBdvK4KboxGJiSkUz7hEvA4yqgp3ph7N9w8jZR3Q==}
-    dependencies:
-      '@simplewebauthn/browser': 6.0.0
-      axios: 1.2.0
-      js-cookie: 3.0.1
-      xstate: 4.33.6
-    transitivePeerDependencies:
-      - debug
-
-  /@nhost/hasura-auth-js/1.6.4:
-    resolution: {integrity: sha512-LfWj1PQhASSZMVOK+LPHahHpjdgsbN1x3TJDE+SvS9DCj0MHQITQvsDNOeA9lPSX3N3h3Pw3tf0TY34w7aBrpA==}
-    peerDependencies:
-      '@nhost/core': 0.9.4
-    dependencies:
-      axios: 1.2.0
-      jwt-decode: 3.1.2
-      xstate: 4.33.6
-    transitivePeerDependencies:
-      - debug
-    dev: false
-
-  /@nhost/hasura-auth-js/1.6.4_@nhost+core@0.9.4:
-    resolution: {integrity: sha512-LfWj1PQhASSZMVOK+LPHahHpjdgsbN1x3TJDE+SvS9DCj0MHQITQvsDNOeA9lPSX3N3h3Pw3tf0TY34w7aBrpA==}
-    peerDependencies:
-      '@nhost/core': 0.9.4
-    dependencies:
-      '@nhost/core': 0.9.4
-      axios: 1.2.0
-      jwt-decode: 3.1.2
-      xstate: 4.33.6
-    transitivePeerDependencies:
-      - debug
-    dev: false
-
-  /@nhost/hasura-storage-js/0.7.4:
-    resolution: {integrity: sha512-/JOchl92cWSN+TKIUESdv4hmip4RTfdkvq3D/4ijberJVP0zL11Sjyq/A7mEwDMjp923qWYR7ygpjvRVwP2Ojw==}
-    peerDependencies:
-      '@nhost/core': 0.9.4
-    dependencies:
-      axios: 1.2.0
-      form-data: 4.0.0
-      xstate: 4.33.6
-    transitivePeerDependencies:
-      - debug
-    dev: false
-
-  /@nhost/hasura-storage-js/0.7.4_@nhost+core@0.9.4:
-    resolution: {integrity: sha512-/JOchl92cWSN+TKIUESdv4hmip4RTfdkvq3D/4ijberJVP0zL11Sjyq/A7mEwDMjp923qWYR7ygpjvRVwP2Ojw==}
-    peerDependencies:
-      '@nhost/core': 0.9.4
-    dependencies:
-      '@nhost/core': 0.9.4
-      axios: 1.2.0
-      form-data: 4.0.0
-      xstate: 4.33.6
-    transitivePeerDependencies:
-      - debug
-    dev: false
-
-  /@nhost/nextjs/1.9.3_4umcnubejb2mvyxfkpzvq3wsvy:
-    resolution: {integrity: sha512-oWoz69YODazVfSBtzv6m1cN20Rhud34Gqc7wROezqnWqs99kYx2jd2asQ+tZw1AwovRL1Dx23kxVnCOtPyj9QA==}
-    peerDependencies:
-      '@nhost/react': 0.15.2
-      next: ^12.0.10 || ^13.0.0
-      react: ^17.0.0 || ^18.0.0
-      react-dom: ^17.0.0 || ^18.0.0
-    dependencies:
-      '@nhost/core': 0.9.4
-      '@nhost/nhost-js': 1.6.2_v7bsqeisvp5asclpmdnitonepy
-      '@nhost/react': 0.15.2_gp4likmy5canqa5vezccvrluf4
-      cross-fetch: 3.1.5
-      js-cookie: 3.0.1
-      next: 12.1.6_biqbaboplfbrettd7655fr4n2y
-      react: 18.2.0
-      react-dom: 18.2.0_react@18.2.0
-      xstate: 4.33.6
-    transitivePeerDependencies:
-      - debug
-      - encoding
-      - graphql
-    dev: false
-
-  /@nhost/nhost-js/1.6.2:
-    resolution: {integrity: sha512-kpgUJZmXD42+rV8IHa0bs1fjhFF8eFTalEglkluxlXiYMULI90dXLM5ueaT91vbciWwUZXUGdQWkxQO2G9bkhw==}
-    peerDependencies:
-      graphql: ^14.0.0 || ^15.0.0 || ^16.0.0
-    dependencies:
-      '@nhost/hasura-auth-js': 1.6.4
-      '@nhost/hasura-storage-js': 0.7.4
-      axios: 1.2.0
-      jwt-decode: 3.1.2
-      query-string: 7.1.1
-    transitivePeerDependencies:
-      - '@nhost/core'
-      - debug
-    dev: false
-
-  /@nhost/nhost-js/1.6.2_graphql@15.7.2:
-    resolution: {integrity: sha512-kpgUJZmXD42+rV8IHa0bs1fjhFF8eFTalEglkluxlXiYMULI90dXLM5ueaT91vbciWwUZXUGdQWkxQO2G9bkhw==}
-    peerDependencies:
-      graphql: ^14.0.0 || ^15.0.0 || ^16.0.0
-    dependencies:
-      '@nhost/hasura-auth-js': 1.6.4
-      '@nhost/hasura-storage-js': 0.7.4
-      axios: 1.2.0
-      graphql: 15.7.2
-      jwt-decode: 3.1.2
-      query-string: 7.1.1
-    transitivePeerDependencies:
-      - '@nhost/core'
-      - debug
-    dev: false
-
-  /@nhost/nhost-js/1.6.2_v7bsqeisvp5asclpmdnitonepy:
-    resolution: {integrity: sha512-kpgUJZmXD42+rV8IHa0bs1fjhFF8eFTalEglkluxlXiYMULI90dXLM5ueaT91vbciWwUZXUGdQWkxQO2G9bkhw==}
-    peerDependencies:
-      graphql: ^14.0.0 || ^15.0.0 || ^16.0.0
-    dependencies:
-      '@nhost/hasura-auth-js': 1.6.4_@nhost+core@0.9.4
-      '@nhost/hasura-storage-js': 0.7.4_@nhost+core@0.9.4
-      axios: 1.2.0
-      graphql: 15.7.2
-      jwt-decode: 3.1.2
-      query-string: 7.1.1
-    transitivePeerDependencies:
-      - '@nhost/core'
-      - debug
-    dev: false
-
-  /@nhost/react-apollo/4.9.2_kcwooay62h34ta66pwakq6hh5m:
-    resolution: {integrity: sha512-1MAQMRuKhBJnMbZyh/js7mRlNQ1+fDKgBldMwpgf6aivfQmiBVTYnrvxkNrp2M65C8qdePSZPG2vHr3Qs9TadQ==}
-    peerDependencies:
-      '@apollo/client': ^3.6.2
-      '@nhost/react': 0.15.2
-      graphql: ^16.0.0
-      react: ^17.0.0 || ^18.0.0
-      react-dom: ^17.0.0 || ^18.0.0
-    dependencies:
-      '@apollo/client': 3.6.9_qqqj7xqn73klpidhtp57t4zzwm
-      '@nhost/apollo': 0.5.35_@apollo+client@3.6.9
-      '@nhost/react': 0.15.2_gp4likmy5canqa5vezccvrluf4
-      graphql: 15.7.2
-      react: 18.2.0
-      react-dom: 18.2.0_react@18.2.0
-    transitivePeerDependencies:
-      - '@nhost/core'
-      - debug
-    dev: false
-
-  /@nhost/react/0.15.2_gp4likmy5canqa5vezccvrluf4:
-    resolution: {integrity: sha512-LQuBIzyVHWrBRiRjrLgxGlatKIF8lW5nEatX6XGxLymLXoEyBTPYnYO4nRhAjjELy1CXVj52qIQB7VOD/VIgcw==}
-    peerDependencies:
-      react: ^17.0.0 || ^18.1.0
-      react-dom: ^17.0.0 || ^18.1.0
-    dependencies:
-      '@nhost/core': 0.9.4
-      '@nhost/hasura-storage-js': 0.7.4_@nhost+core@0.9.4
-      '@nhost/nhost-js': 1.6.2_v7bsqeisvp5asclpmdnitonepy
-      '@xstate/react': 3.0.1_ixnoqypvvlzhpss4ao4hyykvcy
-      immer: 9.0.15
-      jwt-decode: 3.1.2
-      react: 18.2.0
-      react-dom: 18.2.0_react@18.2.0
-      xstate: 4.33.6
-    transitivePeerDependencies:
-      - '@types/react'
-      - '@xstate/fsm'
-      - debug
-      - graphql
-    dev: false
-
-  /@nhost/stripe-graphql-js/0.0.6:
-    resolution: {integrity: sha512-FQ0q1bB5e7P2TUeVSIyobhX3RVtYL8C1khsvFtUvBSzF7FcW1WJZdC6pKZRLCamNWxYzl7ClLXBbQOcHQ8dsFg==}
-    dependencies:
-      '@graphql-yoga/node': 2.13.13_graphql@15.7.2
-      '@pothos/core': 3.22.9_graphql@15.7.2
-      graphql: 15.7.2
-      graphql-scalars: 1.18.0_graphql@15.7.2
-      jsonwebtoken: 8.5.1
-      stripe: 10.17.0
-    transitivePeerDependencies:
-      - encoding
-    dev: false
-
-  /@nhost/vue/0.6.2_graphql@15.7.2+vue@3.2.40:
-    resolution: {integrity: sha512-yqSFytmh01NOwdj+IYgjlmvzCNQ4Nx6jB7ycjZ9/NLiCKJPA3heO3v077Hjl2/JSIdst09nfyo6hYLf53K3tqg==}
-    peerDependencies:
-      vue: ^3.2.31
-    dependencies:
-      '@nhost/core': 0.9.4
-      '@nhost/hasura-storage-js': 0.7.4_@nhost+core@0.9.4
-      '@nhost/nhost-js': 1.6.2_v7bsqeisvp5asclpmdnitonepy
-      '@vueuse/core': 8.9.4_vue@3.2.40
-      '@xstate/vue': 1.0.0_vue@3.2.40
-      immer: 9.0.15
-      jwt-decode: 3.1.2
-      vue: 3.2.40
-    transitivePeerDependencies:
-      - '@vue/composition-api'
-      - '@xstate/fsm'
-      - debug
-      - graphql
-      - xstate
-    dev: false
-
-  /@nhost/vue/0.6.2_graphql@15.7.2+vue@3.2.41:
-    resolution: {integrity: sha512-yqSFytmh01NOwdj+IYgjlmvzCNQ4Nx6jB7ycjZ9/NLiCKJPA3heO3v077Hjl2/JSIdst09nfyo6hYLf53K3tqg==}
-    peerDependencies:
-      vue: ^3.2.31
-    dependencies:
-      '@nhost/core': 0.9.4
-      '@nhost/hasura-storage-js': 0.7.4_@nhost+core@0.9.4
-      '@nhost/nhost-js': 1.6.2_v7bsqeisvp5asclpmdnitonepy
-      '@vueuse/core': 8.9.4_vue@3.2.41
-      '@xstate/vue': 1.0.0_vue@3.2.41
-      immer: 9.0.15
-      jwt-decode: 3.1.2
-      vue: 3.2.41
-    transitivePeerDependencies:
-      - '@vue/composition-api'
-      - '@xstate/fsm'
-      - debug
-      - graphql
-      - xstate
-    dev: false
-
   /@nicolo-ribaudo/eslint-scope-5-internals/5.1.1-v1:
     resolution: {integrity: sha512-54/JRvkLIzzDWshCWfuhadfrfZVPiElY8Fcgmg1HroEly/EDSszzhBAsarCux+D/kOslTRquNzuyGSmUSTTHGg==}
     dependencies:
@@ -7876,6 +7621,7 @@ packages:
 
   /@simplewebauthn/browser/6.0.0:
     resolution: {integrity: sha512-gaXZmNfBPFawVZLhDPHkArCt0ttUbNSQSq24muyFmUi/QfJIhvQfQH7kfqIwlAXKqs79qpJ4RCYsRUjVj0Yl6w==}
+    dev: false
 
   /@simplewebauthn/typescript-types/6.0.0:
     resolution: {integrity: sha512-zBs5duUHwQ2CCnHckalMJycv8p2mfWGv+m9sI3WxnK3QR7Lw0/014zKkhC+Uygz5XSHuvPAxeMft6FbrP/OmtQ==}
@@ -11506,24 +11252,6 @@ packages:
       vue: 3.2.40
       vue-demi: 0.13.4_vue@3.2.40
 
-  /@vueuse/core/8.9.4_vue@3.2.41:
-    resolution: {integrity: sha512-B/Mdj9TK1peFyWaPof+Zf/mP9XuGAngaJZBwPaXBvU3aCTZlx3ltlrFFFyMV4iGBwsjSCeUCgZrtkEj9dS2Y3Q==}
-    peerDependencies:
-      '@vue/composition-api': ^1.1.0
-      vue: ^2.6.0 || ^3.2.0
-    peerDependenciesMeta:
-      '@vue/composition-api':
-        optional: true
-      vue:
-        optional: true
-    dependencies:
-      '@types/web-bluetooth': 0.0.14
-      '@vueuse/metadata': 8.9.4
-      '@vueuse/shared': 8.9.4_vue@3.2.41
-      vue: 3.2.41
-      vue-demi: 0.13.4_vue@3.2.41
-    dev: false
-
   /@vueuse/core/9.6.0_vue@3.2.41:
     resolution: {integrity: sha512-qGUcjKQXHgN+jqXEgpeZGoxdCbIDCdVPz3QiF1uyecVGbMuM63o96I1GjYx5zskKgRI0FKSNsVWM7rwrRMTf6A==}
     dependencies:
@@ -11556,21 +11284,6 @@ packages:
     dependencies:
       vue: 3.2.40
       vue-demi: 0.13.4_vue@3.2.40
-
-  /@vueuse/shared/8.9.4_vue@3.2.41:
-    resolution: {integrity: sha512-wt+T30c4K6dGRMVqPddexEVLa28YwxW5OFIPmzUHICjphfAuBFTTdDoyqREZNDOFJZ44ARH1WWQNCUK8koJ+Ag==}
-    peerDependencies:
-      '@vue/composition-api': ^1.1.0
-      vue: ^2.6.0 || ^3.2.0
-    peerDependenciesMeta:
-      '@vue/composition-api':
-        optional: true
-      vue:
-        optional: true
-    dependencies:
-      vue: 3.2.41
-      vue-demi: 0.13.4_vue@3.2.41
-    dev: false
 
   /@vueuse/shared/9.6.0_vue@3.2.41:
     resolution: {integrity: sha512-/eDchxYYhkHnFyrb00t90UfjCx94kRHxc7J1GtBCqCG4HyPMX+krV9XJgVtWIsAMaxKVU4fC8NSUviG1JkwhUQ==}
@@ -11924,36 +11637,6 @@ packages:
       xstate: 4.33.6
     transitivePeerDependencies:
       - '@types/react'
-    dev: false
-
-  /@xstate/vue/1.0.0_vue@3.2.40:
-    resolution: {integrity: sha512-GnJ2WKmef3UvpOj7tMOGkFLF2fSjVFgX/2Ik/0ZttHJCQNXRBWDaaiqNnVVB0XynTUfRPrkOPNeGD4XLqrqeVg==}
-    peerDependencies:
-      '@xstate/fsm': ^1.6.5
-      vue: ^3.0.0
-      xstate: ^4.30.3
-    peerDependenciesMeta:
-      '@xstate/fsm':
-        optional: true
-      xstate:
-        optional: true
-    dependencies:
-      vue: 3.2.40
-    dev: false
-
-  /@xstate/vue/1.0.0_vue@3.2.41:
-    resolution: {integrity: sha512-GnJ2WKmef3UvpOj7tMOGkFLF2fSjVFgX/2Ik/0ZttHJCQNXRBWDaaiqNnVVB0XynTUfRPrkOPNeGD4XLqrqeVg==}
-    peerDependencies:
-      '@xstate/fsm': ^1.6.5
-      vue: ^3.0.0
-      xstate: ^4.30.3
-    peerDependenciesMeta:
-      '@xstate/fsm':
-        optional: true
-      xstate:
-        optional: true
-    dependencies:
-      vue: 3.2.41
     dev: false
 
   /@xstate/vue/2.0.0_vue@3.2.41+xstate@4.33.6:
@@ -12688,6 +12371,7 @@ packages:
       proxy-from-env: 1.1.0
     transitivePeerDependencies:
       - debug
+    dev: false
 
   /axobject-query/2.2.0:
     resolution: {integrity: sha512-Td525n+iPOOyUQIeBfcASuG6uJsDOITl7Mds5gFyerkWiX7qhUTdYUBlSgNMyVqtSJqwpt1kXGLdUt6SykLMRA==}
@@ -21039,6 +20723,7 @@ packages:
   /js-cookie/3.0.1:
     resolution: {integrity: sha512-+0rgsUXZu4ncpPxRL+lNEptWMOWl9etvPHc/koSRp6MPwpRYAhmk0dUG00J4bxVV3r9uUzfo24wW0knS07SKSw==}
     engines: {node: '>=12'}
+    dev: false
 
   /js-levenshtein/1.1.6:
     resolution: {integrity: sha512-X2BB11YZtrRqY4EnQcLX5Rh373zbK4alC1FW7D7MBhL2gtcC17cTnr6DmfHZeS0s2rTHjUTMMHfG7gO8SSdw+g==}
@@ -24645,6 +24330,7 @@ packages:
 
   /proxy-from-env/1.1.0:
     resolution: {integrity: sha512-D+zkORCbA9f1tdWRK0RaCR3GPv50cMxcrz4X8k5LTSUD1Dkw47mKJEZQNunItRTkWwgtaUSo1RVFRIG9ZXiFYg==}
+    dev: false
 
   /prr/1.0.1:
     resolution: {integrity: sha512-yPw4Sng1gWghHQWj0B3ZggWUm4qVbPwPFcRG8KyxiU7J2OHFSoEHKS+EZ3fv5l1t9CyCiop6l/ZYeWbrgoQejw==}


### PR DESCRIPTION
- correct the lock file in order to use the packages present in the workspace instead of the npm registry
- add the `prefer-workspace-packages` option to `.npmrc` so Renovate will (hopefully) generate the lockfile accordingly
- force all e2e to run in CI when the lock file changed