### PR TITLE
Windows Live Provider displayed link updated to match backend url

### DIFF
--- a/.changeset/rude-singers-carry.md
+++ b/.changeset/rude-singers-carry.md
@@ -1,0 +1,5 @@
+---
+"@nhost/dashboard": patch
+---
+
+Windows Live Provider displayed link updated to match backend url

--- a/dashboard/src/components/settings/signInMethods/WindowsLiveProviderSettings/WindowsLiveProviderSettings.tsx
+++ b/dashboard/src/components/settings/signInMethods/WindowsLiveProviderSettings/WindowsLiveProviderSettings.tsx
@@ -130,7 +130,7 @@ export default function WindowsLiveProviderSettings() {
                         currentApplication.subdomain,
                         currentApplication.region.awsName,
                         'auth',
-                      )}/v1/signin/provider/microsoft/callback`,
+                      )}/v1/signin/provider/windowslive/callback`,
                       'Redirect URL',
                     );
                   }}

--- a/dashboard/src/components/settings/signInMethods/WindowsLiveProviderSettings/WindowsLiveProviderSettings.tsx
+++ b/dashboard/src/components/settings/signInMethods/WindowsLiveProviderSettings/WindowsLiveProviderSettings.tsx
@@ -115,7 +115,7 @@ export default function WindowsLiveProviderSettings() {
               currentApplication.subdomain,
               currentApplication.region.awsName,
               'auth',
-            )}/v1/signin/provider/microsoft/callback`}
+            )}/v1/signin/provider/windowslive/callback`}
             disabled
             endAdornment={
               <InputAdornment position="end" className="absolute right-2">


### PR DESCRIPTION
In the Nhost dashboard for signed in client, the callback url for windows live/microsoft option is shown incorrectly. Should show "/windowslive/callback" versus "/microsoft/callback"