### PR TITLE
fix(dashboard): don't break the UI when project is not loaded yet

### DIFF
--- a/dashboard/CHANGELOG.md
+++ b/dashboard/CHANGELOG.md
@@ -1,5 +1,11 @@
 # @nhost/dashboard
 
+## 0.7.9
+
+### Patch Changes
+
+- edd6c922: fix(dashboard): don't break the UI when project is not loaded yet
+
 ## 0.7.8
 
 ### Patch Changes

--- a/dashboard/CHANGELOG.md
+++ b/dashboard/CHANGELOG.md
@@ -4,7 +4,7 @@
 
 ### Patch Changes
 
-- edd6c922: fix(dashboard): don't break the UI when project is not loaded yet
+- a6d31dc2: fix(dashboard): don't break the UI when project is not loaded yet
 
 ## 0.7.8
 

--- a/dashboard/package.json
+++ b/dashboard/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@nhost/dashboard",
-  "version": "0.7.8",
+  "version": "0.7.9",
   "private": true,
   "scripts": {
     "preinstall": "npx only-allow pnpm",

--- a/dashboard/src/components/overview/OverviewProjectInfo/OverviewProjectInfo.tsx
+++ b/dashboard/src/components/overview/OverviewProjectInfo/OverviewProjectInfo.tsx
@@ -5,7 +5,7 @@ import Image from 'next/image';
 
 export default function OverviewProjectInfo() {
   const { currentApplication } = useCurrentWorkspaceAndApplication();
-  const { region, subdomain } = currentApplication;
+  const { region, subdomain } = currentApplication || {};
   const isRegionAvailable =
     region?.awsName && region?.countryCode && region?.city;
 


### PR DESCRIPTION
This is a follow-up PR for https://github.com/nhost/nhost/issues/1370.