### PR TITLE
fix: React 18 strict mode and other improvements

### DIFF
--- a/.changeset/config.json
+++ b/.changeset/config.json
@@ -2,7 +2,20 @@
   "$schema": "https://unpkg.com/@changesets/config@1.6.0/schema.json",
   "changelog": "@changesets/cli/changelog",
   "commit": false,
-  "linked": [],
+  "linked": [
+    [
+      "@nhost/nextjs",
+      "@nhost/react",
+      "@nhost/vue",
+      "@nhost/nhost-js",
+      "@nhost/hasura-auth-js",
+      "@nhost/hasura-storage-js"
+    ],
+    [
+      "@nhost/react-apollo",
+      "@nhost/apollo"
+    ]
+  ],
   "access": "restricted",
   "baseBranch": "main",
   "updateInternalDependencies": "patch",

--- a/.changeset/empty-wolves-exercise.md
+++ b/.changeset/empty-wolves-exercise.md
@@ -1,0 +1,6 @@
+---
+'@nhost/react': patch
+'@nhost/vue': patch
+---
+
+Remove unused immer dependency

--- a/.changeset/rotten-flowers-hope.md
+++ b/.changeset/rotten-flowers-hope.md
@@ -1,0 +1,7 @@
+---
+'@nhost/hasura-auth-js': patch
+'@nhost/nhost-js': patch
+'@nhost/react': patch
+---
+
+Improve the initialisation of the internal authentication state to support React 18 strict mode

--- a/.changeset/twenty-toes-jump.md
+++ b/.changeset/twenty-toes-jump.md
@@ -1,0 +1,10 @@
+---
+'@nhost/nextjs': patch
+'@nhost/nhost-js': patch
+---
+
+Use initial session sent from the server
+
+When running a SSR page, the session was correctly created from the refresh token on the server side and was sent to the client side, but was not used correctly on the client side.
+As a result, the client was refreshing the access token when loading the page, rather than using the access token sent by the server.
+The client now uses the session sent from the server.

--- a/dashboard/src/components/settings/environmentVariables/SystemEnvironmentVariableSettings/SystemEnvironmentVariableSettings.tsx
+++ b/dashboard/src/components/settings/environmentVariables/SystemEnvironmentVariableSettings/SystemEnvironmentVariableSettings.tsx
@@ -34,7 +34,7 @@ export default function SystemEnvironmentVariableSettings() {
   });
   const isPlatform = useIsPlatform();
 
-  const appClient = useAppClient({ start: false });
+  const appClient = useAppClient();
 
   if (loading) {
     return (

--- a/dashboard/src/hooks/useAppClient.ts
+++ b/dashboard/src/hooks/useAppClient.ts
@@ -1,10 +1,10 @@
 import { LOCAL_SUBDOMAIN } from '@/utils/env';
 import { isDevOrStaging } from '@/utils/helpers';
-import type { NhostClientConstructorParams } from '@nhost/nextjs';
+import type { NhostNextClientConstructorParams } from '@nhost/nextjs';
 import { NhostClient } from '@nhost/nextjs';
 import { useCurrentWorkspaceAndApplication } from './useCurrentWorkspaceAndApplication';
 
-export type UseAppClientOptions = NhostClientConstructorParams;
+export type UseAppClientOptions = NhostNextClientConstructorParams;
 export type UseAppClientReturn = NhostClient;
 
 /**
@@ -22,7 +22,6 @@ export function useAppClient(
   if (process.env.NEXT_PUBLIC_ENV === 'dev' || !currentApplication) {
     return new NhostClient({
       subdomain: LOCAL_SUBDOMAIN,
-      start: false,
       ...options,
     });
   }
@@ -32,7 +31,6 @@ export function useAppClient(
     region: isDevOrStaging()
       ? `${currentApplication.region.awsName}.staging`
       : currentApplication.region.awsName,
-    start: false,
     ...options,
   });
 }

--- a/docs/docs/quickstarts/nextjs.mdx
+++ b/docs/docs/quickstarts/nextjs.mdx
@@ -103,14 +103,14 @@ You can install the Nhost Next.js SDK with:
   <TabItem value="npm" label="npm" default>
 
 ```bash
-npm install @nhost/react @nhost/nextjs graphql
+npm install@nhost/nextjs graphql
 ```
 
   </TabItem>
   <TabItem value="yarn" label="Yarn">
 
 ```bash
-yarn add @nhost/react @nhost/nextjs graphql
+yarn add @nhost/nextjs graphql
 ```
 
   </TabItem>

--- a/docs/docs/reference/nextjs/index.mdx
+++ b/docs/docs/reference/nextjs/index.mdx
@@ -16,14 +16,14 @@ Install the Nhost Next.js client, React client together with GraphQL:
   <TabItem value="npm" label="npm" default>
 
 ```bash
-npm install @nhost/react @nhost/nextjs graphql
+npm install @nhost/nextjs graphql
 ```
 
   </TabItem>
   <TabItem value="yarn" label="Yarn">
 
 ```bash
-yarn add @nhost/react @nhost/nextjs graphql
+yarn add @nhost/nextjs graphql
 ```
 
   </TabItem>

--- a/examples/nextjs/components/protected-route.tsx
+++ b/examples/nextjs/components/protected-route.tsx
@@ -1,21 +1,23 @@
-import { useRouter } from 'next/router'
-
 import { useAuthenticationStatus } from '@nhost/nextjs'
+import { useRouter } from 'next/router'
+import { useEffect } from 'react'
 
 export function authProtected(Comp) {
   return function AuthProtected(props) {
     const router = useRouter()
     const { isLoading, isAuthenticated } = useAuthenticationStatus()
     console.log('Authentication guard: check auth status', { isLoading, isAuthenticated })
+
+    useEffect(() => {
+      if (isLoading || isAuthenticated) {
+        return
+      }
+      router.push('/sign-in')
+    }, [isAuthenticated, isLoading, router])
+
     if (isLoading) {
       return <div>Loading...</div>
     }
-
-    if (!isAuthenticated) {
-      router.push('/sign-in')
-      return null
-    }
-
     return <Comp {...props} />
   }
 }

--- a/examples/nextjs/pages/_app.tsx
+++ b/examples/nextjs/pages/_app.tsx
@@ -16,7 +16,7 @@ if (devTools) {
     iframe: false
   })
 }
-const nhost = new NhostClient({ backendUrl: BACKEND_URL })
+const nhost = new NhostClient({ backendUrl: BACKEND_URL, devTools })
 const title = 'Nhost with NextJs'
 function MyApp({ Component, pageProps }: AppProps) {
   // * Monorepo-related. See: https://stackoverflow.com/questions/71843247/react-nextjs-type-error-component-cannot-be-used-as-a-jsx-component

--- a/packages/hasura-auth-js/src/internal-client.ts
+++ b/packages/hasura-auth-js/src/internal-client.ts
@@ -1,8 +1,12 @@
 import { interpret } from 'xstate'
-
-import { AuthInterpreter, AuthMachine, createAuthMachine } from './machines'
-import { NhostClientOptions } from './types'
+import { AuthInterpreter, AuthMachine, AuthMachineOptions, createAuthMachine } from './machines'
+import { NhostSession } from './types'
 import { isBrowser } from './utils'
+
+export type NhostClientOptions = AuthMachineOptions & {
+  /** @internal create and start xstate interpreter on creation. With React, it is started inside the Nhost provider */
+  start?: boolean
+}
 
 /**
  * @internal
@@ -11,10 +15,12 @@ import { isBrowser } from './utils'
 export class AuthClient {
   readonly backendUrl: string
   readonly clientUrl: string
-  readonly machine: AuthMachine
+  private _machine: AuthMachine
   private _interpreter?: AuthInterpreter
+  private _started = false
   private _channel?: BroadcastChannel
-  private _subscriptions: Set<(client: AuthClient) => void> = new Set()
+  private _subscriptionsQueue: Set<(client: AuthClient) => void> = new Set()
+  private _subscriptions: Set<() => void> = new Set()
 
   constructor({
     clientStorageType = 'web',
@@ -29,7 +35,7 @@ export class AuthClient {
     this.backendUrl = backendUrl
     this.clientUrl = clientUrl
 
-    this.machine = createAuthMachine({
+    this._machine = createAuthMachine({
       ...defaultOptions,
       backendUrl,
       clientUrl,
@@ -39,8 +45,7 @@ export class AuthClient {
     })
 
     if (start) {
-      this.interpreter = interpret(this.machine, { devTools })
-      this.interpreter.start()
+      this.start({ devTools })
     }
 
     if (typeof window !== 'undefined' && autoSignIn) {
@@ -61,24 +66,66 @@ export class AuthClient {
     }
   }
 
+  start({
+    devTools = false,
+    initialSession,
+    interpreter
+  }: { interpreter?: AuthInterpreter; initialSession?: NhostSession; devTools?: boolean } = {}) {
+    const context = { ...this.machine.context }
+    if (initialSession) {
+      context.user = initialSession.user
+      context.refreshToken.value = initialSession.refreshToken ?? null
+      context.accessToken.value = initialSession.accessToken ?? null
+      context.accessToken.expiresAt = new Date(
+        Date.now() + initialSession.accessTokenExpiresIn * 1_000
+      )
+    }
+    const machineWithInitialContext = this.machine.withContext(context)
+
+    if (!this._interpreter) {
+      this._interpreter = interpreter || interpret(machineWithInitialContext, { devTools })
+    }
+
+    // * Start the interpreter if not started already. Always restart the interpreter when on the server side
+    if (!this._started || typeof window === 'undefined') {
+      if (this._interpreter.initialized) {
+        this._interpreter.stop()
+        this._subscriptions.forEach((fn) => fn())
+      }
+      this._interpreter.start(machineWithInitialContext.initialState)
+      this._subscriptionsQueue.forEach((fn) => fn(this))
+    }
+
+    this._started = true
+  }
+
+  public get machine() {
+    return this._machine
+  }
+
   get interpreter(): AuthInterpreter | undefined {
     return this._interpreter
   }
-  set interpreter(interpreter: AuthInterpreter | undefined) {
-    this._interpreter = interpreter
-    if (interpreter) {
-      this._subscriptions.forEach((fn) => fn(this))
-    }
+
+  get started(): boolean {
+    return this._started
   }
 
-  onStart(fn: (client: AuthClient) => void) {
-    if (this.interpreter) {
+  subscribe(fn: (client: AuthClient) => () => void): () => void {
+    if (this.started) {
       // * The interpreter is already available: we can add the listener straight ahead
-      fn(this)
+      const subscription = fn(this)
+      this._subscriptions.add(subscription)
+      return subscription
     } else {
       // * The interpreter is not yet available: we add the listener to a queue that will be started when setting the interpreter
       // * Note: in React, the Xstate interpreter does not start from the global state, but from the root component
-      this._subscriptions.add(fn)
+      this._subscriptionsQueue.add(fn)
+      return () => {
+        console.log(
+          'onTokenChanged was added before the interpreter started. Cannot unsubscribe listener.'
+        )
+      }
     }
   }
 }

--- a/packages/hasura-auth-js/src/machines/authentication/machine.typegen.ts
+++ b/packages/hasura-auth-js/src/machines/authentication/machine.typegen.ts
@@ -117,7 +117,7 @@ export interface Typegen0 {
     passwordlessEmail: 'done.invoke.passwordlessEmail'
     passwordlessSms: 'done.invoke.passwordlessSms'
     passwordlessSmsOtp: 'done.invoke.passwordlessSmsOtp'
-    refreshToken: 'done.invoke.refreshToken' | 'done.invoke.authenticateWithToken'
+    refreshToken: 'done.invoke.authenticateWithToken' | 'done.invoke.refreshToken'
     signInAnonymous: 'done.invoke.authenticateAnonymously'
     signInMfaTotp: 'done.invoke.signInMfaTotp'
     signInPassword: 'done.invoke.authenticateUserWithPassword'
@@ -128,9 +128,9 @@ export interface Typegen0 {
   }
   missingImplementations: {
     actions: never
-    services: never
-    guards: never
     delays: never
+    guards: never
+    services: never
   }
   eventsCausingActions: {
     broadcastToken:
@@ -269,6 +269,29 @@ export interface Typegen0 {
       | 'done.invoke.signUpEmailPassword'
       | 'done.invoke.signUpSecurityKey'
   }
+  eventsCausingDelays: {
+    RETRY_IMPORT_TOKEN_DELAY: 'error.platform.importRefreshToken'
+  }
+  eventsCausingGuards: {
+    hasMfaTicket: 'done.invoke.authenticateUserWithPassword'
+    hasRefreshToken: ''
+    hasSession:
+      | 'SESSION_UPDATE'
+      | 'done.invoke.importRefreshToken'
+      | 'done.invoke.signUpEmailPassword'
+      | 'done.invoke.signUpSecurityKey'
+    isAnonymous: 'SIGNED_IN'
+    isAutoRefreshDisabled: ''
+    isSignedIn: '' | 'error.platform.authenticateWithToken'
+    noToken: ''
+    refreshTimerShouldRefresh: ''
+    shouldRetryImportToken: 'error.platform.importRefreshToken'
+    unverified:
+      | 'error.platform.authenticateUserWithPassword'
+      | 'error.platform.authenticateUserWithSecurityKey'
+      | 'error.platform.signUpEmailPassword'
+      | 'error.platform.signUpSecurityKey'
+  }
   eventsCausingServices: {
     importRefreshToken:
       | 'done.invoke.authenticateWithToken'
@@ -291,29 +314,6 @@ export interface Typegen0 {
     signUpEmailPassword: 'SIGNUP_EMAIL_PASSWORD'
     signUpSecurityKey: 'SIGNUP_SECURITY_KEY'
     signout: 'SIGNOUT'
-  }
-  eventsCausingGuards: {
-    hasMfaTicket: 'done.invoke.authenticateUserWithPassword'
-    hasRefreshToken: ''
-    hasSession:
-      | 'SESSION_UPDATE'
-      | 'done.invoke.importRefreshToken'
-      | 'done.invoke.signUpEmailPassword'
-      | 'done.invoke.signUpSecurityKey'
-    isAnonymous: 'SIGNED_IN'
-    isAutoRefreshDisabled: ''
-    isSignedIn: '' | 'error.platform.authenticateWithToken'
-    noToken: ''
-    refreshTimerShouldRefresh: ''
-    shouldRetryImportToken: 'error.platform.importRefreshToken'
-    unverified:
-      | 'error.platform.authenticateUserWithPassword'
-      | 'error.platform.authenticateUserWithSecurityKey'
-      | 'error.platform.signUpEmailPassword'
-      | 'error.platform.signUpSecurityKey'
-  }
-  eventsCausingDelays: {
-    RETRY_IMPORT_TOKEN_DELAY: 'error.platform.importRefreshToken'
   }
   matchesStates:
     | 'authentication'

--- a/packages/hasura-auth-js/src/types/client.ts
+++ b/packages/hasura-auth-js/src/types/client.ts
@@ -1,5 +1,3 @@
-import { AuthMachineOptions } from '../machines'
-
 import { NhostSession, Provider } from './hasura-auth'
 import { ClientStorage, ClientStorageType, StorageGetter, StorageSetter } from './local-storage'
 import {
@@ -152,9 +150,4 @@ export interface AuthOptions {
   autoSignIn?: boolean
   /** Activate devTools e.g. the ability to connect to the xstate inspector */
   devTools?: boolean
-}
-
-export type NhostClientOptions = AuthMachineOptions & {
-  /** @internal create and start xstate interpreter on creation. With React, it is started inside the Nhost provider */
-  start?: boolean
 }

--- a/packages/hasura-auth-js/tests/changeEmail.test.ts
+++ b/packages/hasura-auth-js/tests/changeEmail.test.ts
@@ -22,14 +22,16 @@ const authClient = new AuthClient({
   start: false
 })
 
-authClient.interpreter = interpret(
-  createAuthMachine({
-    backendUrl: BASE_URL,
-    clientUrl: 'http://localhost:3000',
-    clientStorage: customStorage,
-    clientStorageType: 'custom'
-  }).withContext(contextWithUser)
-).start()
+authClient.start({
+  interpreter: interpret(
+    createAuthMachine({
+      backendUrl: BASE_URL,
+      clientUrl: 'http://localhost:3000',
+      clientStorage: customStorage,
+      clientStorageType: 'custom'
+    }).withContext(contextWithUser)
+  )
+})
 
 const changeEmailMachine = createChangeEmailMachine(authClient)
 const changeEmailService = interpret(changeEmailMachine)

--- a/packages/hasura-auth-js/tests/changePassword.test.ts
+++ b/packages/hasura-auth-js/tests/changePassword.test.ts
@@ -25,14 +25,16 @@ const authClient = new AuthClient({
   start: false
 })
 
-authClient.interpreter = interpret(
-  createAuthMachine({
-    backendUrl: BASE_URL,
-    clientUrl: 'http://localhost:3000',
-    clientStorage: customStorage,
-    clientStorageType: 'custom'
-  }).withContext(contextWithUser)
-).start()
+authClient.start({
+  interpreter: interpret(
+    createAuthMachine({
+      backendUrl: BASE_URL,
+      clientUrl: 'http://localhost:3000',
+      clientStorage: customStorage,
+      clientStorageType: 'custom'
+    }).withContext(contextWithUser)
+  )
+})
 
 const changePasswordMachine = createChangePasswordMachine(authClient)
 const changePasswordService = interpret(changePasswordMachine)

--- a/packages/hasura-auth-js/tests/enableMfa.test.ts
+++ b/packages/hasura-auth-js/tests/enableMfa.test.ts
@@ -31,14 +31,16 @@ const authClient = new AuthClient({
 })
 
 // Adding state machine with pre-existing user to the client
-authClient.interpreter = interpret(
-  createAuthMachine({
-    backendUrl: BASE_URL,
-    clientUrl: 'http://localhost:3000',
-    clientStorageType: 'custom',
-    clientStorage: customStorage
-  }).withContext(contextWithUser)
-).start()
+authClient.start({
+  interpreter: interpret(
+    createAuthMachine({
+      backendUrl: BASE_URL,
+      clientUrl: 'http://localhost:3000',
+      clientStorageType: 'custom',
+      clientStorage: customStorage
+    }).withContext(contextWithUser)
+  )
+})
 
 beforeAll(() => server.listen({ onUnhandledRequest: 'error' }))
 afterAll(() => server.close())

--- a/packages/nextjs/src/get-session.ts
+++ b/packages/nextjs/src/get-session.ts
@@ -1,4 +1,4 @@
-import { NhostSession } from '@nhost/nhost-js'
+import { NhostSession } from '@nhost/react'
 import { GetServerSidePropsContext } from 'next'
 import { createServerSideClient } from './create-server-side-client'
 

--- a/packages/nextjs/src/index.ts
+++ b/packages/nextjs/src/index.ts
@@ -12,7 +12,7 @@ export * from './get-session'
 /**
  * @deprecated use `NhostProvider` instead
  */
-const NhostNextProvider: typeof NhostProvider = NhostProvider
+export const NhostNextProvider: typeof NhostProvider = NhostProvider
 
 const isBrowser = typeof window !== 'undefined'
 

--- a/packages/nhost-js/src/clients/nhost.ts
+++ b/packages/nhost-js/src/clients/nhost.ts
@@ -1,8 +1,6 @@
 import { HasuraAuthClient } from '@nhost/hasura-auth-js'
 import { HasuraStorageClient } from '@nhost/hasura-storage-js'
-
 import { NhostClientConstructorParams } from '../utils/types'
-
 import { createAuthClient } from './auth'
 import { createFunctionsClient, NhostFunctionsClient } from './functions'
 import { createGraphqlClient, NhostGraphqlClient } from './graphql'
@@ -56,29 +54,22 @@ export class NhostClient {
     this.functions = createFunctionsClient({ adminSecret, ...urlParams })
     this.graphql = createGraphqlClient({ adminSecret, ...urlParams })
 
-    this.auth.client.onStart(() => {
-      // * Set current token if token is already accessable
-      const accessToken = this.auth.getAccessToken()
+    this.auth.onAuthStateChanged((_event, session) => {
+      if (_event === 'SIGNED_OUT') {
+        this.storage.setAccessToken(undefined)
+        this.functions.setAccessToken(undefined)
+        this.graphql.setAccessToken(undefined)
+      }
+    })
+
+    // * Update access token for clients, including when signin in
+    this.auth.onTokenChanged((session) => {
+      const accessToken = session?.accessToken
       this.storage.setAccessToken(accessToken)
       this.functions.setAccessToken(accessToken)
       this.graphql.setAccessToken(accessToken)
-      // * Set access token when signing out
-      this.auth.onAuthStateChanged((_event, session) => {
-        if (_event === 'SIGNED_OUT') {
-          this.storage.setAccessToken(undefined)
-          this.functions.setAccessToken(undefined)
-          this.graphql.setAccessToken(undefined)
-        }
-      })
-
-      // * Update access token for clients, including when signin in
-      this.auth.onTokenChanged((session) => {
-        const accessToken = session?.accessToken
-        this.storage.setAccessToken(accessToken)
-        this.functions.setAccessToken(accessToken)
-        this.graphql.setAccessToken(accessToken)
-      })
     })
+
     this._adminSecret = adminSecret
     this.devTools = devTools
   }

--- a/packages/react/package.json
+++ b/packages/react/package.json
@@ -63,7 +63,6 @@
   "dependencies": {
     "@nhost/nhost-js": "workspace:*",
     "@xstate/react": "^3.0.1",
-    "immer": "^9.0.15",
     "jwt-decode": "^3.1.2",
     "xstate": "^4.33.5"
   },

--- a/packages/react/src/provider.tsx
+++ b/packages/react/src/provider.tsx
@@ -1,6 +1,5 @@
-import { AuthContext, NhostSession } from '@nhost/nhost-js'
+import { NhostSession } from '@nhost/nhost-js'
 import { useInterpret } from '@xstate/react'
-import produce from 'immer'
 import React, { createContext, PropsWithChildren, useEffect, useRef } from 'react'
 import { NhostClient } from './client'
 
@@ -15,18 +14,9 @@ export const NhostProvider: React.FC<PropsWithChildren<NhostProviderProps>> = ({
   initial,
   ...props
 }) => {
-  const machine = nhost.auth.client.machine
-  const interpreter = useInterpret(machine, {
-    devTools: nhost.devTools,
-    context: produce<AuthContext>(machine.context, (ctx: AuthContext) => {
-      if (initial) {
-        ctx.user = initial.user
-        ctx.refreshToken.value = initial.refreshToken ?? null
-        ctx.accessToken.value = initial.accessToken ?? null
-        ctx.accessToken.expiresAt = new Date(Date.now() + initial.accessTokenExpiresIn * 1_000)
-      }
-    })
-  }).start()
+  const interpreter = useInterpret(nhost.auth.client.machine, { devTools: nhost.devTools })
+
+  nhost.auth.client.start({ interpreter, initialSession: initial, devTools: nhost.devTools })
 
   // * Hook to send session update everytime the 'initial' props changed
   const isInitialMount = useRef(true)
@@ -40,7 +30,6 @@ export const NhostProvider: React.FC<PropsWithChildren<NhostProviderProps>> = ({
     }
   }, [initial, interpreter])
 
-  nhost.auth.client.interpreter = interpreter
   return <NhostReactContext.Provider value={nhost}>{props.children}</NhostReactContext.Provider>
 }
 

--- a/packages/vue/package.json
+++ b/packages/vue/package.json
@@ -67,7 +67,6 @@
     "@nhost/nhost-js": "workspace:*",
     "@vueuse/core": "^9.0.0",
     "@xstate/vue": "^2.0.0",
-    "immer": "^9.0.15",
     "jwt-decode": "^3.1.2"
   },
   "devDependencies": {

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -941,14 +941,12 @@ importers:
       '@nhost/nhost-js': workspace:*
       '@types/react': ^18.0.25
       '@xstate/react': ^3.0.1
-      immer: ^9.0.15
       jwt-decode: ^3.1.2
       react: ^18.2.0
       xstate: ^4.33.5
     dependencies:
       '@nhost/nhost-js': link:../nhost-js
       '@xstate/react': 3.0.1_ixnoqypvvlzhpss4ao4hyykvcy
-      immer: 9.0.15
       jwt-decode: 3.1.2
       xstate: 4.33.6
     devDependencies:
@@ -1008,7 +1006,6 @@ importers:
       '@vueuse/core': ^9.0.0
       '@xstate/inspect': ^0.7.0
       '@xstate/vue': ^2.0.0
-      immer: ^9.0.15
       jwt-decode: ^3.1.2
       vue: ^3.2.41
       vue-router: ^4.1.6
@@ -1018,7 +1015,6 @@ importers:
       '@nhost/nhost-js': link:../nhost-js
       '@vueuse/core': 9.6.0_vue@3.2.41
       '@xstate/vue': 2.0.0_vue@3.2.41+xstate@4.33.6
-      immer: 9.0.15
       jwt-decode: 3.1.2
     devDependencies:
       '@nhost/docgen': link:../docgen


### PR DESCRIPTION
Extracted from the `sdk-next-major` branch. Initial PR: #1298

- iron up the start of the auth client
- simplify `onAuthStateChanged` and `onTokenChanged`
- avoid creating inconsistent states when using React 18 strict mode (components are rendered twice) 
- fix: when rendering a SSR page, do not call a token refresh on the client side as the session has been hydrated by the server 
- get rid of the `immer` dependency
- [link packages in changesets](https://github.com/changesets/changesets/blob/main/docs/linked-packages.md)
