### PR TITLE
Removed accept headers * in axios requests

### DIFF
--- a/packages/nhost-js/src/clients/graphql.ts
+++ b/packages/nhost-js/src/clients/graphql.ts
@@ -81,8 +81,7 @@ export class NhostGraphqlClient {
     // add auth headers if any
     const headers = {
       ...this.generateAccessTokenHeaders(),
-      ...config?.headers,
-      'Accept-Encoding': '*'
+      ...config?.headers
     }
 
     try {


### PR DESCRIPTION
Based on the issue: ['Accept-Encoding': '\*' causes: Refused to set unsafe header "Accept-Encoding" · Issue #1378 · nhost/nhost](https://github.com/nhost/nhost/issues/1378)

Removed `Accept-Encoding` as last part of object destructure for Axios request header configs which causes the in-browser error :`Refused to set unsafe header "Accept-Encoding"` on Chrome.