### PR TITLE
ci: retry the Nhost CLI installation

### DIFF
--- a/.github/actions/nhost-cli/action.yaml
+++ b/.github/actions/nhost-cli/action.yaml
@@ -35,8 +35,11 @@ runs:
         fi
     - name: Install Nhost CLI
       if: ${{ steps.check-nhost-cli.outputs.installed == 'false' }}
-      shell: bash
-      run: bash <(curl --silent -L https://raw.githubusercontent.com/nhost/cli/main/get.sh) ${{ inputs.version }}
+      uses: nick-fields/retry@v2
+      with:
+        timeout_minutes: 3
+        max_attempts: 3
+        command: bash <(curl --silent -L https://raw.githubusercontent.com/nhost/cli/main/get.sh) ${{ inputs.version }}
     - name: Set custom configuration
       if: ${{ inputs.config }}
       shell: bash


### PR DESCRIPTION
Since a week or two, the installation of the CLI often fails on CI.
Unless there is a clearer explanation on why it occurs, this "retry" logic will (hopefully) overcome the problem