### PR TITLE
ci: improve renovate configuration

### DIFF
--- a/.github/renovate.json
+++ b/.github/renovate.json
@@ -8,9 +8,16 @@
   },
   "ignoreDeps": [
     "pnpm",
-    "node"
+    "node",
+    "@types/node"
   ],
   "labels": [
     "dependencies"
+  ],
+  "enabledManagers": [
+    "npm",
+    "dockerfile",
+    "docker-compose",
+    "github-actions"
   ]
 }


### PR DESCRIPTION
- ignore `@types/node` as we force the repository to work with Node 16
- explicit list of enabled managers in order to enable `docker-compose`