### PR TITLE
chore: create changesest from Renovate bumps

### DIFF
--- a/.changeset/unrepeatable-expenditure-blackshirt.md
+++ b/.changeset/unrepeatable-expenditure-blackshirt.md
@@ -1,0 +1,5 @@
+---
+"@nhost/docgen": patch
+---
+
+chore(deps): update dependency tsup to v6


### PR DESCRIPTION
This PR creates the changesets from the Renovate dependencies that have been merged to main.