### PR TITLE
chore: create changesest from Renovate bumps

### DIFF
--- a/.changeset/connotations-mickey-correlated.md
+++ b/.changeset/connotations-mickey-correlated.md
@@ -1,0 +1,26 @@
+---
+"@nhost-examples/codegen-react-apollo": patch
+"@nhost-examples/codegen-react-query": patch
+"@nhost-examples/docker-compose": patch
+"@nhost-examples/nextjs": patch
+"@nhost-examples/react-apollo": patch
+"@nhost-examples/react-gqty": patch
+"@nhost-examples/react-urql": patch
+"@nhost-examples/vue-apollo": patch
+"@nhost-examples/vue-quickstart": patch
+"@nhost/apollo": patch
+"@nhost/dashboard": patch
+"@nhost/docgen": patch
+"@nhost/docs": patch
+"@nhost/hasura-auth-js": patch
+"@nhost/hasura-storage-js": patch
+"@nhost/nextjs": patch
+"@nhost/nhost-js": patch
+"@nhost/react": patch
+"@nhost/react-apollo": patch
+"@nhost/react-urql": patch
+"@nhost/stripe-graphql-js": patch
+"@nhost/vue": patch
+---
+
+chore(deps): update dependency @types/node to v16


### PR DESCRIPTION
This PR creates the changesets from the Renovate dependencies that have been merged to main.