### PR TITLE
fix(dashboard): Resetting the cache when signing out.

### DIFF
--- a/.changeset/wise-buses-pay.md
+++ b/.changeset/wise-buses-pay.md
@@ -2,4 +2,4 @@
 '@nhost/dashboard': patch
 ---
 
-fix(dashboard): sign out user cache bug
+fix(dashboard): don't show error when signing out the user

--- a/.changeset/wise-buses-pay.md
+++ b/.changeset/wise-buses-pay.md
@@ -1,0 +1,5 @@
+---
+'@nhost/dashboard': patch
+---
+
+fix(dashboard): sign out user cache bug

--- a/dashboard/src/components/dashboard/AccountMenu.tsx
+++ b/dashboard/src/components/dashboard/AccountMenu.tsx
@@ -1,13 +1,11 @@
 import { ChangePasswordModal } from '@/components/applications/ChangePasswordModal';
-import { useWorkspaceContext } from '@/context/workspace-context';
-import { useUserDataContext } from '@/context/workspace1-context';
 import { Avatar } from '@/ui/Avatar';
 import { Modal } from '@/ui/Modal';
 import Button from '@/ui/v2/Button';
 import { Dropdown, useDropdown } from '@/ui/v2/Dropdown';
 import Text from '@/ui/v2/Text';
-import { emptyWorkspace } from '@/utils/helpers';
 import { nhost } from '@/utils/nhost';
+import { useApolloClient } from '@apollo/client';
 import { useUserData } from '@nhost/nextjs';
 import Image from 'next/image';
 import { useRouter } from 'next/router';
@@ -22,9 +20,8 @@ function AccountMenuContent({
 }: AccountMenuContentProps) {
   const user = useUserData();
   const router = useRouter();
+  const client = useApolloClient();
   const [clicked, setClicked] = useState(false);
-  const { setWorkspaceContext } = useWorkspaceContext();
-  const { setUserContext } = useUserDataContext();
   const { handleClose } = useDropdown();
 
   return (
@@ -34,10 +31,9 @@ function AccountMenuContent({
         color="secondary"
         className="absolute top-6 right-4 grid grid-flow-col items-center gap-1 self-start font-medium"
         onClick={async () => {
-          setWorkspaceContext(emptyWorkspace());
-          setUserContext({ workspaces: [] });
-          nhost.auth.signOut();
           router.push('/signin');
+          await nhost.auth.signOut();
+          await client.resetStore();
         }}
         aria-label="Sign Out"
       >


### PR DESCRIPTION
# fix(dashboard): Resetting the cache when signing out.

Right now, when signing out you get an error regarding a missing field in our cache `workspace_members` this is because we sign out the user with `nhost.auth.signOut();` prior to redirecting and when we query again for the workspace the user has, it comes out as null (as there is no user) and then redirect. 

