### PR TITLE
chore: store the session in a cookie to avoid refetching the jwt on every ssr call

### DIFF
--- a/.changeset/wet-berries-smell.md
+++ b/.changeset/wet-berries-smell.md
@@ -1,0 +1,5 @@
+---
+'@nhost/nextjs': patch
+---
+
+Store the session in a cookie so there is no need for an SSR page to ask for a new access token

--- a/packages/nextjs/src/index.ts
+++ b/packages/nextjs/src/index.ts
@@ -5,6 +5,7 @@ import {
   NhostProvider,
   Subdomain
 } from '@nhost/react'
+import { setNhostSessionInCookie } from './utils'
 
 export * from '@nhost/react'
 export * from './create-server-side-client'
@@ -38,5 +39,10 @@ export class NhostClient extends ReactNhostClient {
       autoRefreshToken: isBrowser && params.autoRefreshToken,
       clientStorageType: 'cookie'
     })
+
+    this.auth.onAuthStateChanged(() => {
+      setNhostSessionInCookie(this)
+    })
+    this.auth.onTokenChanged(setNhostSessionInCookie)
   }
 }

--- a/packages/nextjs/src/utils.ts
+++ b/packages/nextjs/src/utils.ts
@@ -10,24 +10,26 @@ export const refresh = async (nhostUrl: string, refreshToken: string): Promise<N
     },
     body: JSON.stringify({ refreshToken })
   })
-  if (result.ok) return result.json()
-  else return Promise.reject(result.statusText)
+  if (result.ok) {
+    return result.json()
+  }
+  return Promise.reject(result.statusText)
 }
 
 export const NHOST_SESSION_KEY = 'nhostSession'
 
 export const setNhostSessionInCookie = (param: NhostClient | NhostSession | null) => {
   const session = param && 'auth' in param ? param.auth.getSession() : param
-  if (session) {
-    const { refreshToken, ...rest } = session
-    const expires = new Date()
-    // * Expire the cookie 60 seconds before the token expires
-    expires.setSeconds(expires.getSeconds() + session.accessTokenExpiresIn - 60)
-    Cookies.set(NHOST_SESSION_KEY, JSON.stringify(rest), {
-      sameSite: 'strict',
-      expires
-    })
-  } else {
+  if (!session) {
     Cookies.remove(NHOST_SESSION_KEY)
+    return
   }
+  const { refreshToken, ...rest } = session
+  const expires = new Date()
+  // * Expire the cookie 60 seconds before the token expires
+  expires.setSeconds(expires.getSeconds() + session.accessTokenExpiresIn - 60)
+  Cookies.set(NHOST_SESSION_KEY, JSON.stringify(rest), {
+    sameSite: 'strict',
+    expires
+  })
 }


### PR DESCRIPTION
Store the session in a cookie so there is no need for an SSR page to ask for a new access token

Closes https://github.com/nhost/nhost/issues/1336