### PR TITLE
Export commonly used types

### DIFF
--- a/.changeset/odd-roses-hug.md
+++ b/.changeset/odd-roses-hug.md
@@ -1,0 +1,10 @@
+---
+'@nhost-examples/react-apollo': patch
+'@nhost-examples/vue-apollo': patch
+'@nhost/react': patch
+'@nhost/vue': patch
+---
+
+Export commonly used types
+
+`BackendUrl`, `ErrorPayload`, `NhostSession`, `Subdomain`, and `User` are now exported in all our SDKs

--- a/examples/react-apollo/cypress/support/e2e.ts
+++ b/examples/react-apollo/cypress/support/e2e.ts
@@ -1,5 +1,5 @@
 import { faker } from '@faker-js/faker'
-import { User } from '@nhost/hasura-auth-js'
+import { User } from '@nhost/react'
 
 import '@testing-library/cypress/add-commands'
 import 'cypress-mailhog'

--- a/examples/vue-apollo/src/components/ErrorSnackBar.vue
+++ b/examples/vue-apollo/src/components/ErrorSnackBar.vue
@@ -10,7 +10,7 @@
 <script lang="ts" setup>
 import { PropType, ref, watchEffect } from 'vue'
 
-import { ErrorPayload } from '@nhost/hasura-auth-js'
+import { ErrorPayload } from '@nhost/vue'
 
 const props = defineProps({
   error: Object as PropType<ErrorPayload | null>

--- a/packages/react/src/client.ts
+++ b/packages/react/src/client.ts
@@ -3,12 +3,12 @@ import {
   BackendUrl,
   NhostAuthConstructorParams,
   NhostClient as _VanillaNhostClient,
-  NhostSession,
   NHOST_REFRESH_TOKEN_KEY,
   Subdomain
 } from '@nhost/nhost-js'
 
-export type { NhostSession, NhostAuthConstructorParams, AuthMachine, Subdomain, BackendUrl }
+// * Required for @nhost/nextjs
+export type { NhostAuthConstructorParams, AuthMachine }
 export { NHOST_REFRESH_TOKEN_KEY }
 
 /** @internal */

--- a/packages/react/src/index.ts
+++ b/packages/react/src/index.ts
@@ -1,3 +1,4 @@
+export type { BackendUrl, ErrorPayload, NhostSession, Subdomain, User } from '@nhost/nhost-js'
 export * from './client'
 export * from './components'
 export * from './provider'

--- a/packages/vue/src/client.ts
+++ b/packages/vue/src/client.ts
@@ -8,6 +8,8 @@ import {
 import { App, warn } from 'vue'
 import { DefaultNhostClient } from './useNhostClient'
 
+export type { BackendUrl, ErrorPayload, NhostSession, Subdomain, User } from '@nhost/nhost-js'
+
 export interface NhostVueClientConstructorParams
   extends Partial<BackendUrl>,
     Partial<Subdomain>,


### PR DESCRIPTION
`BackendUrl`, `ErrorPayload`, `NhostSession`, `Subdomain`, and `User` are now exported in all our SDKs