### PR TITLE
fix(dashboard): don't break the table creation process

### DIFF
--- a/.changeset/lovely-ants-provide.md
+++ b/.changeset/lovely-ants-provide.md
@@ -1,0 +1,5 @@
+---
+'@nhost/dashboard': patch
+---
+
+fix(dashboard): don't break the table creation process

--- a/dashboard/src/components/common/ControlledAutocomplete/ControlledAutocomplete.tsx
+++ b/dashboard/src/components/common/ControlledAutocomplete/ControlledAutocomplete.tsx
@@ -52,9 +52,9 @@ function ControlledAutocomplete(
 
   return (
     <Autocomplete
+      inputValue={typeof field.value === 'string' ? field.value : undefined}
       {...props}
       {...field}
-      inputValue={typeof field.value === 'string' ? field.value : undefined}
       ref={mergeRefs([field.ref, ref])}
       onChange={(event, options, reason, details) => {
         setValue?.(controllerProps?.name || name, options, {

--- a/dashboard/src/components/dataBrowser/BaseColumnForm/BaseColumnForm.tsx
+++ b/dashboard/src/components/dataBrowser/BaseColumnForm/BaseColumnForm.tsx
@@ -118,6 +118,7 @@ export default function BaseColumnForm({
             variant="inline"
             className="col-span-8 py-3"
             autoFocus
+            autoComplete="off"
           />
 
           <ControlledAutocomplete
@@ -272,6 +273,7 @@ export default function BaseColumnForm({
             error={Boolean(errors.comment)}
             variant="inline"
             className="col-span-8 py-3"
+            autoComplete="off"
           />
         </section>
       </div>

--- a/dashboard/src/components/dataBrowser/BaseTableForm/BaseTableForm.tsx
+++ b/dashboard/src/components/dataBrowser/BaseTableForm/BaseTableForm.tsx
@@ -88,6 +88,7 @@ function NameInput() {
       error={Boolean(errors.name)}
       variant="inline"
       className="col-span-8 py-3"
+      autoComplete="off"
       autoFocus
     />
   );

--- a/dashboard/src/components/dataBrowser/BaseTableForm/ColumnEditorRow.tsx
+++ b/dashboard/src/components/dataBrowser/BaseTableForm/ColumnEditorRow.tsx
@@ -70,6 +70,7 @@ function NameInput({ index }: FieldArrayInputProps) {
           }
         },
       })}
+      autoComplete="off"
       aria-label="Name"
       placeholder="Enter name"
       hideEmptyHelperText

--- a/dashboard/src/components/dataBrowser/EditPermissionsForm/sections/ColumnPresetsSection.tsx
+++ b/dashboard/src/components/dataBrowser/EditPermissionsForm/sections/ColumnPresetsSection.tsx
@@ -13,6 +13,7 @@ import Option from '@/ui/v2/Option';
 import Text from '@/ui/v2/Text';
 import getPermissionVariablesArray from '@/utils/settings/getPermissionVariablesArray';
 import { useGetAppCustomClaimsQuery } from '@/utils/__generated__/graphql';
+import { useTheme } from '@mui/material';
 import { useFieldArray, useFormContext, useWatch } from 'react-hook-form';
 import PermissionSettingsSection from './PermissionSettingsSection';
 
@@ -41,6 +42,7 @@ export default function ColumnPresetsSection({
   table,
   disabled,
 }: ColumnPresetSectionProps) {
+  const theme = useTheme();
   const {
     data: tableData,
     status: tableStatus,
@@ -131,7 +133,12 @@ export default function ColumnPresetsSection({
                   freeSolo
                   fullWidth
                   disableClearable={false}
-                  clearIcon={<XIcon />}
+                  clearIcon={
+                    <XIcon
+                      className="w-4 h-4 mt-px"
+                      sx={{ color: theme.palette.text.primary }}
+                    />
+                  }
                   autoSelect
                   autoHighlight={false}
                   error={Boolean(

--- a/dashboard/src/hooks/dataBrowser/useTrackForeignKeyRelationsMutation/prepareTrackForeignKeyRelationsMetadata.test.ts
+++ b/dashboard/src/hooks/dataBrowser/useTrackForeignKeyRelationsMutation/prepareTrackForeignKeyRelationsMetadata.test.ts
@@ -237,7 +237,10 @@ test('should drop existing relationships and prepare a new one-to-many relations
         "cascade": false,
         "relationship": "books",
         "source": "default",
-        "table": "authors",
+        "table": {
+          "name": "authors",
+          "schema": "public",
+        },
       },
       "type": "pg_drop_relationship",
     }

--- a/dashboard/src/hooks/dataBrowser/useTrackForeignKeyRelationsMutation/prepareTrackForeignKeyRelationsMetadata.ts
+++ b/dashboard/src/hooks/dataBrowser/useTrackForeignKeyRelationsMutation/prepareTrackForeignKeyRelationsMetadata.ts
@@ -152,7 +152,12 @@ export default async function prepareTrackForeignKeyRelationsMetadata({
         type: 'pg_drop_relationship',
         args: {
           source: dataSource,
-          table: foreignKeyRelation.referencedTable,
+          table: foreignKeyRelation.referencedSchema
+            ? {
+                name: foreignKeyRelation.referencedTable,
+                schema: foreignKeyRelation.referencedSchema,
+              }
+            : foreignKeyRelation.referencedTable,
           relationship: oneToManyRelationshipName,
           cascade: false,
         },

--- a/dashboard/src/hooks/dataBrowser/useUpdateTableMutation/prepareUpdateTableQuery.ts
+++ b/dashboard/src/hooks/dataBrowser/useUpdateTableMutation/prepareUpdateTableQuery.ts
@@ -184,7 +184,7 @@ export default function prepareUpdateTableQuery({
           );
 
           return [
-            ...args,
+            ...updatedArgs,
             ...prepareUpdateForeignKeyConstraintQuery({
               ...baseVariables,
               originalForeignKeyRelation,


### PR DESCRIPTION
Don't break table creation when referencing a table which is not in the `public` schema.

This PR also fixes a few other Database UI-related issues such as disabling the unnecessary `autoComplete` property on input fields, therefore, making the editing process much easier.

Thanks @timpratim for your report 🙌🏼 