### PR TITLE
chore(dashboard): `Text` API improvements

### DIFF
--- a/dashboard/src/components/applications/AppLoader.tsx
+++ b/dashboard/src/components/applications/AppLoader.tsx
@@ -71,20 +71,18 @@ export function AppLoader({
       </div>
 
       {timeElapsed <= 5 && (
-        <Text sx={{ color: 'text.disabled' }}>Setting up authentication</Text>
+        <Text color="disabled">Setting up authentication</Text>
       )}
       {timeElapsed > 5 && timeElapsed <= 10 && (
-        <Text sx={{ color: 'text.disabled' }}>Setting up file storage</Text>
+        <Text color="disabled">Setting up file storage</Text>
       )}
       {timeElapsed > 10 && timeElapsed <= 15 && (
-        <Text sx={{ color: 'text.disabled' }}>Setting up database</Text>
+        <Text color="disabled">Setting up database</Text>
       )}
       {timeElapsed > 15 && timeElapsed <= 20 && (
-        <Text sx={{ color: 'text.disabled' }}>Setting up Hasura</Text>
+        <Text color="disabled">Setting up Hasura</Text>
       )}
-      {timeElapsed > 20 && (
-        <Text sx={{ color: 'text.disabled' }}>Doing final cleanup</Text>
-      )}
+      {timeElapsed > 20 && <Text color="disabled">Doing final cleanup</Text>}
       <ActivityIndicator className="mx-auto" />
 
       {timeElapsed > 180 && (

--- a/dashboard/src/components/applications/ChangePasswordModal.tsx
+++ b/dashboard/src/components/applications/ChangePasswordModal.tsx
@@ -51,7 +51,7 @@ export function ChangePasswordModal({ close }: any) {
   };
 
   return (
-    <Box className="w-full max-w-md px-6 py-6 text-left rounded-md">
+    <Box className="w-full max-w-md rounded-md px-6 py-6 text-left">
       <form onSubmit={handleSubmit}>
         <div className="grid grid-flow-row gap-4">
           <div className="grid grid-flow-row gap-2">
@@ -93,10 +93,7 @@ export function ChangePasswordModal({ close }: any) {
 
           <div className="grid grid-flow-row gap-2">
             {formState.error && (
-              <Text
-                className="w-full px-4 text-center"
-                sx={{ color: 'error.main' }}
-              >
+              <Text className="w-full px-4 text-center" color="error">
                 Error: {formState.error}
               </Text>
             )}

--- a/dashboard/src/components/applications/ConnectGithubModal.tsx
+++ b/dashboard/src/components/applications/ConnectGithubModal.tsx
@@ -127,13 +127,13 @@ export default function ConnectGithubModal({ close }: ConnectGithubModalProps) {
                 Connect repository
               </Text>
               <Text
-                className="text-center font-normal text-xs"
-                sx={{ color: 'text.secondary' }}
+                className="text-center text-xs font-normal"
+                color="secondary"
               >
                 Showing repositories from {data.githubAppInstallations.length}{' '}
                 GitHub account(s)
               </Text>
-              <div className="mt-6 flex w-full mb-2">
+              <div className="mt-6 mb-2 flex w-full">
                 <Input
                   placeholder="Search..."
                   onChange={handleFilterChange}
@@ -152,7 +152,7 @@ export default function ConnectGithubModal({ close }: ConnectGithubModalProps) {
                   {githubRepositoriesToDisplay.map((repo, index) => (
                     <Fragment key={repo.id}>
                       <ListItem.Root
-                        className="grid grid-flow-col gap-2 py-2.5 justify-start"
+                        className="grid grid-flow-col justify-start gap-2 py-2.5"
                         secondaryAction={
                           <Button
                             variant="borderless"

--- a/dashboard/src/components/applications/RenderWorkspacesWithApps.tsx
+++ b/dashboard/src/components/applications/RenderWorkspacesWithApps.tsx
@@ -28,7 +28,7 @@ function ApplicationCreatedAt({ createdAt }: any) {
   );
 }
 
-function LastSuccesfulDeployment({ deployment }: any) {
+function LastSuccessfulDeployment({ deployment }: any) {
   return (
     <div className="flex flex-row">
       <Avatar
@@ -36,7 +36,7 @@ function LastSuccesfulDeployment({ deployment }: any) {
         avatarUrl={deployment.commitUserAvatarUrl}
         className="mr-1 h-4 w-4 self-center"
       />
-      <Text color="dark" className="cursor-pointer self-center text-sm">
+      <Text className="self-center text-sm">
         {deployment.commitUserName} deployed{' '}
         {formatDistance(new Date(deployment.deploymentEndedAt), new Date(), {
           addSuffix: true,
@@ -54,7 +54,7 @@ function CurrentDeployment({ deployment }: any) {
         avatarUrl={deployment.commitUserAvatarUrl}
         className="mr-1 h-4 w-4 self-center"
       />
-      <Text color="dark" className="cursor-pointer self-center text-sm">
+      <Text className="self-center text-sm">
         {deployment.commitUserName} updated just now
       </Text>
     </div>
@@ -197,7 +197,7 @@ export function RenderWorkspacesWithApps({
 
                                   {!isDeployingToProduction &&
                                     app.deployments[0] && (
-                                      <LastSuccesfulDeployment
+                                      <LastSuccessfulDeployment
                                         deployment={app.deployments[0]}
                                       />
                                     )}

--- a/dashboard/src/components/applications/functions/FunctionLogsTerminalFromPage.tsx
+++ b/dashboard/src/components/applications/functions/FunctionLogsTerminalFromPage.tsx
@@ -51,7 +51,7 @@ export function FunctionsLogsTerminalPage({ functionName }: any) {
           className="h-terminal overflow-auto rounded-lg px-4 py-4 font-mono shadow-sm"
           sx={{ backgroundColor: 'grey.200' }}
         >
-          <Text className="font-mono text-xs" sx={{ color: 'text.disabled' }}>
+          <Text className="font-mono text-xs" color="disabled">
             There are no stored logs yet. Try calling your function for logs to
             appear.
           </Text>
@@ -74,11 +74,7 @@ export function FunctionsLogsTerminalPage({ functionName }: any) {
           >
             <div id={`#-${log.date}`}>
               <pre className="inline">
-                <Text
-                  component="span"
-                  className="mr-4"
-                  sx={{ color: 'text.disabled' }}
-                >
+                <Text component="span" className="mr-4" color="disabled">
                   {log.date}
                 </Text>{' '}
                 <span>

--- a/dashboard/src/components/common/Breadcrumbs/Breadcrumbs.tsx
+++ b/dashboard/src/components/common/Breadcrumbs/Breadcrumbs.tsx
@@ -22,11 +22,11 @@ export default function Breadcrumbs({ className, ...props }: BreadcrumbsProps) {
         )}
         {...props}
       >
-        <Text sx={{ color: 'text.disabled' }}>/</Text>
+        <Text color="disabled">/</Text>
 
         <Text className="truncate text-[13px] sm:text-sm">local</Text>
 
-        <Text sx={{ color: 'text.disabled' }}>/</Text>
+        <Text color="disabled">/</Text>
 
         <NavLink
           href="/local/local"
@@ -48,7 +48,7 @@ export default function Breadcrumbs({ className, ...props }: BreadcrumbsProps) {
     >
       {currentWorkspace && (
         <>
-          <Text sx={{ color: 'text.disabled' }}>/</Text>
+          <Text color="disabled">/</Text>
 
           <NavLink
             href={`/${currentWorkspace.slug}`}
@@ -61,7 +61,7 @@ export default function Breadcrumbs({ className, ...props }: BreadcrumbsProps) {
 
       {currentApplication && (
         <>
-          <Text sx={{ color: 'text.disabled' }}>/</Text>
+          <Text color="disabled">/</Text>
 
           <NavLink
             href={`/${currentWorkspace.slug}/${currentApplication.slug}`}

--- a/dashboard/src/components/common/DataGridBody/DataGridBody.tsx
+++ b/dashboard/src/components/common/DataGridBody/DataGridBody.tsx
@@ -40,9 +40,9 @@ function InsertPlaceholderTableRow({
         onClick={onInsertRow}
         variant="borderless"
         color="secondary"
-        className="justify-start w-full h-full px-2 py-3 text-xs font-normal rounded-none hover:shadow-none focus:shadow-none focus:outline-none"
+        className="h-full w-full justify-start rounded-none px-2 py-3 text-xs font-normal hover:shadow-none focus:shadow-none focus:outline-none"
         startIcon={
-          <PlusIcon className="w-4 h-4" sx={{ color: 'text.secondary' }} />
+          <PlusIcon className="h-4 w-4" sx={{ color: 'text.secondary' }} />
         }
       >
         Insert New Row
@@ -181,7 +181,7 @@ export default function DataGridBody<T extends object>({
   return (
     <div {...getTableBodyProps()} ref={bodyRef} {...props}>
       {rows.length === 0 && !loading && (
-        <div className="flex pr-5 flex-nowrap">
+        <div className="flex flex-nowrap pr-5">
           {onInsertRow ? (
             <InsertPlaceholderTableRow
               style={{
@@ -263,7 +263,7 @@ export default function DataGridBody<T extends object>({
                       backgroundColor: column.isDisabled
                         ? 'grey.100'
                         : 'background.paper',
-                      text: isCellDisabled ? 'text.secondary' : 'text.primary',
+                      color: isCellDisabled ? 'text.secondary' : 'text.primary',
                     }}
                     className={twMerge(
                       'h-12 font-display text-xs motion-safe:transition-colors',

--- a/dashboard/src/components/common/DataGridDateCell/DataGridDateCell.tsx
+++ b/dashboard/src/components/common/DataGridDateCell/DataGridDateCell.tsx
@@ -98,7 +98,7 @@ export default function DataGridDateCell<TData extends object>({
         onKeyDown={handleKeyDown}
         onChange={handleChange}
         fullWidth
-        className="absolute top-0 z-10 h-full -mx-0.5 place-content-stretch"
+        className="absolute top-0 z-10 -mx-0.5 h-full place-content-stretch"
         sx={{
           [`&.${inputClasses.focused}`]: {
             boxShadow: `inset 0 0 0 1.5px rgba(0, 82, 205, 1)`,
@@ -127,7 +127,7 @@ export default function DataGridDateCell<TData extends object>({
 
   if (!optimisticValue) {
     return (
-      <Text className="truncate text-xs" sx={{ color: 'text.secondary' }}>
+      <Text className="truncate text-xs" color="secondary">
         null
       </Text>
     );
@@ -151,12 +151,11 @@ export default function DataGridDateCell<TData extends object>({
       {specificType !== 'date' && (
         <Text
           className={twMerge('truncate text-xs', timeClassName)}
-          sx={{
-            color:
-              specificType === 'time' || specificType === 'timetz'
-                ? 'text.primary'
-                : 'text.secondary',
-          }}
+          color={
+            specificType === 'time' || specificType === 'timetz'
+              ? 'primary'
+              : 'secondary'
+          }
           {...restTimeProps}
         >
           {[hour, minute, second].filter(Boolean).join(':')}

--- a/dashboard/src/components/common/DataGridNumericCell/DataGridNumericCell.tsx
+++ b/dashboard/src/components/common/DataGridNumericCell/DataGridNumericCell.tsx
@@ -71,7 +71,7 @@ export default function DataGridNumericCell<TData extends object>({
         onKeyDown={handleKeyDown}
         onChange={handleChange}
         fullWidth
-        className="absolute top-0 z-10 h-full -mx-0.5 place-content-stretch"
+        className="absolute top-0 z-10 -mx-0.5 h-full place-content-stretch"
         sx={{
           [`&.${inputClasses.focused}`]: {
             boxShadow: `inset 0 0 0 1.5px rgba(0, 82, 205, 1)`,
@@ -100,15 +100,11 @@ export default function DataGridNumericCell<TData extends object>({
 
   if (optimisticValue === null || typeof optimisticValue === 'undefined') {
     return (
-      <Text className="truncate !text-xs" sx={{ color: 'text.disabled' }}>
+      <Text className="truncate !text-xs" color="disabled">
         null
       </Text>
     );
   }
 
-  return (
-    <Text className="truncate !text-xs" sx={{ color: 'text.primary' }}>
-      {optimisticValue}
-    </Text>
-  );
+  return <Text className="truncate !text-xs">{optimisticValue}</Text>;
 }

--- a/dashboard/src/components/common/DataGridPagination/DataGridPagination.tsx
+++ b/dashboard/src/components/common/DataGridPagination/DataGridPagination.tsx
@@ -70,11 +70,7 @@ export default function DataGridPagination({
         )}
       >
         {currentPage}
-        <Text
-          component="span"
-          className="mx-1 inline-block"
-          sx={{ color: 'text.disabled' }}
-        >
+        <Text component="span" className="mx-1 inline-block" color="disabled">
           /
         </Text>
         {totalPages}

--- a/dashboard/src/components/common/DataGridTextCell/DataGridTextCell.tsx
+++ b/dashboard/src/components/common/DataGridTextCell/DataGridTextCell.tsx
@@ -127,7 +127,7 @@ export default function DataGridTextCell<TData extends object>({
         onChange={handleChange}
         onKeyDown={handleTextAreaKeyDown}
         fullWidth
-        className="absolute top-0 z-10 min-h-38 h-full -mx-0.5"
+        className="absolute top-0 z-10 -mx-0.5 h-full min-h-38"
         rows={5}
         sx={{
           [`&.${inputClasses.focused}`]: {
@@ -161,7 +161,7 @@ export default function DataGridTextCell<TData extends object>({
         onChange={handleChange}
         onKeyDown={handleInputKeyDown}
         fullWidth
-        className="absolute top-0 z-10 h-full -mx-0.5 place-content-stretch"
+        className="absolute top-0 z-10 -mx-0.5 h-full place-content-stretch"
         sx={{
           [`&.${inputClasses.focused}`]: {
             boxShadow: `inset 0 0 0 1.5px rgba(0, 82, 205, 1)`,
@@ -187,7 +187,7 @@ export default function DataGridTextCell<TData extends object>({
 
   if (!optimisticValue) {
     return (
-      <Text className="truncate !text-xs" sx={{ color: 'text.secondary' }}>
+      <Text className="truncate !text-xs" color="secondary">
         {optimisticValue === '' ? 'empty' : 'null'}
       </Text>
     );

--- a/dashboard/src/components/common/Pagination/Pagination.tsx
+++ b/dashboard/src/components/common/Pagination/Pagination.tsx
@@ -71,7 +71,7 @@ export default function Pagination({
       className={twMerge('grid grid-flow-col items-center gap-2', className)}
       {...props}
     >
-      <div className="grid justify-start grid-flow-col gap-2">
+      <div className="grid grid-flow-col justify-start gap-2">
         <Button
           variant="outlined"
           color="secondary"
@@ -79,16 +79,13 @@ export default function Pagination({
           disabled={currentPageNumber === 1}
           aria-label="Previous page"
           onClick={onPrevPageClick}
-          startIcon={<ChevronLeftIcon className="w-4 h-4" />}
+          startIcon={<ChevronLeftIcon className="h-4 w-4" />}
         >
           Back
         </Button>
 
-        <div className="grid items-center grid-cols-3 gap-1 text-center grid-col">
-          <Text
-            className="text-xs align-middle"
-            sx={{ color: 'text.secondary' }}
-          >
+        <div className="grid-col grid grid-cols-3 items-center gap-1 text-center">
+          <Text className="align-middle text-xs" color="secondary">
             Page
           </Text>
           <Input
@@ -107,10 +104,7 @@ export default function Pagination({
               },
             }}
           />
-          <Text
-            className="self-center text-xs align-middle"
-            sx={{ color: 'text.secondary' }}
-          >
+          <Text className="self-center align-middle text-xs" color="secondary">
             of {totalNrOfPages}
           </Text>
         </div>
@@ -122,14 +116,14 @@ export default function Pagination({
           aria-label="Next page"
           disabled={currentPageNumber === totalNrOfPages}
           onClick={onNextPageClick}
-          endIcon={<ChevronRightIcon className="w-4 h-4" />}
+          endIcon={<ChevronRightIcon className="h-4 w-4" />}
           {...slotProps?.nextButton}
         >
           Next
         </Button>
       </div>
-      <div className="flex flex-row items-center justify-end text-center gap-x-1">
-        <Text className="text-xs" sx={{ color: 'text.secondary' }}>
+      <div className="flex flex-row items-center justify-end gap-x-1 text-center">
+        <Text className="text-xs" color="secondary">
           {currentPageNumber === 1 && currentPageNumber}
           {currentPageNumber === 2 && elementsPerPage + currentPageNumber - 1}
           {currentPageNumber > 2 &&

--- a/dashboard/src/components/dataBrowser/BaseColumnForm/BaseColumnForm.tsx
+++ b/dashboard/src/components/dataBrowser/BaseColumnForm/BaseColumnForm.tsx
@@ -171,8 +171,8 @@ export default function BaseColumnForm({
                   <span>Identity</span>
                   <Text
                     component="span"
-                    className="font-normal text-xs"
-                    sx={{ color: 'text.secondary' }}
+                    className="text-xs font-normal"
+                    color="secondary"
                   >
                     Attach an implicit sequence to the column and make it
                     non-nullable
@@ -251,8 +251,8 @@ export default function BaseColumnForm({
                 <span>Nullable</span>
                 <Text
                   component="span"
-                  className="font-normal text-xs"
-                  sx={{ color: 'text.secondary' }}
+                  className="text-xs font-normal"
+                  color="secondary"
                 >
                   Allow the column to assume a NULL value if no value is
                   provided
@@ -271,8 +271,8 @@ export default function BaseColumnForm({
                 <span>Unique</span>
                 <Text
                   component="span"
-                  className="font-normal text-xs"
-                  sx={{ color: 'text.secondary' }}
+                  className="text-xs font-normal"
+                  color="secondary"
                 >
                   Enforce values in the column to be unique across rows
                 </Text>

--- a/dashboard/src/components/dataBrowser/BaseTableForm/ColumnEditorTable.tsx
+++ b/dashboard/src/components/dataBrowser/BaseTableForm/ColumnEditorTable.tsx
@@ -30,7 +30,7 @@ export default function ColumnEditorTable() {
           <div role="columnheader" className="col-span-3">
             <InputLabel as="span">
               Name
-              <Text component="span" sx={{ color: 'error.main' }}>
+              <Text component="span" color="error">
                 *
               </Text>
             </InputLabel>
@@ -39,7 +39,7 @@ export default function ColumnEditorTable() {
           <div role="columnheader" className="col-span-3">
             <InputLabel as="span">
               Type
-              <Text component="span" sx={{ color: 'error.main' }}>
+              <Text component="span" color="error">
                 *
               </Text>
             </InputLabel>

--- a/dashboard/src/components/dataBrowser/ColumnAutocomplete/ColumnAutocomplete.tsx
+++ b/dashboard/src/components/dataBrowser/ColumnAutocomplete/ColumnAutocomplete.tsx
@@ -302,9 +302,9 @@ function ColumnAutocomplete(
                 sx={{
                   color: props.disabled ? 'text.disabled' : 'text.primary',
                 }}
-                className="!ml-2 lg:max-w-[200px] flex-shrink-0 truncate"
+                className="!ml-2 flex-shrink-0 truncate lg:max-w-[200px]"
               >
-                <Text component="span" sx={{ color: 'text.disabled' }}>
+                <Text component="span" color="disabled">
                   {defaultTable}
                 </Text>
                 .
@@ -349,7 +349,7 @@ function ColumnAutocomplete(
           }}
         >
           <Box
-            className="px-3 py-2.5 border-b-1 grid grid-flow-col gap-2 justify-start items-center"
+            className="grid grid-flow-col items-center justify-start gap-2 border-b-1 px-3 py-2.5"
             sx={{ backgroundColor: 'transparent' }}
           >
             {selectedRelationships.length > 0 && (
@@ -366,12 +366,12 @@ function ColumnAutocomplete(
                   );
                 }}
               >
-                <ArrowLeftIcon className="w-4 h-4" />
+                <ArrowLeftIcon className="h-4 w-4" />
               </IconButton>
             )}
 
-            <Text className="truncate direction-rtl text-left">
-              <Text component="span" sx={{ color: 'text.disabled' }}>
+            <Text className="direction-rtl truncate text-left">
+              <Text component="span" color="disabled">
                 {defaultTable}
               </Text>
 

--- a/dashboard/src/components/dataBrowser/DataBrowserSidebar/DataBrowserSidebar.tsx
+++ b/dashboard/src/components/dataBrowser/DataBrowserSidebar/DataBrowserSidebar.tsx
@@ -202,7 +202,7 @@ function DataBrowserSidebarContent({
   ) {
     openDrawer('EDIT_PERMISSIONS', {
       title: (
-        <span className="inline-grid grid-flow-col gap-2 items-center">
+        <span className="inline-grid grid-flow-col items-center gap-2">
           Permissions
           <InlineCode className="!text-sm+ font-normal">{table}</InlineCode>
           <Chip label="Preview" size="small" color="info" component="span" />
@@ -232,7 +232,7 @@ function DataBrowserSidebarContent({
       {schemas && schemas.length > 0 && (
         <Select
           renderValue={(option) => (
-            <span className="grid grid-flow-col gap-1 items-center">
+            <span className="grid grid-flow-col items-center gap-1">
               {option?.label}
             </span>
           )}
@@ -245,12 +245,12 @@ function DataBrowserSidebarContent({
         >
           {schemas.map((schema) => (
             <Option
-              className="grid grid-flow-col gap-1 items-center"
+              className="grid grid-flow-col items-center gap-1"
               value={schema.schema_name}
               key={schema.schema_name}
             >
               <Text className="text-sm">
-                <Text component="span" sx={{ color: 'text.disabled' }}>
+                <Text component="span" color="disabled">
                   schema.
                 </Text>
                 <Text component="span" className="font-medium">
@@ -310,7 +310,7 @@ function DataBrowserSidebarContent({
       )}
 
       {schemas && schemas.length > 0 && tablesInSelectedSchema.length === 0 && (
-        <Text className="py-1.5 px-2 text-xs" sx={{ color: 'text.disabled' }}>
+        <Text className="py-1.5 px-2 text-xs" color="disabled">
           No tables found.
         </Text>
       )}

--- a/dashboard/src/components/dataBrowser/DatabaseRecordInputGroup/DatabaseRecordInputGroup.tsx
+++ b/dashboard/src/components/dataBrowser/DatabaseRecordInputGroup/DatabaseRecordInputGroup.tsx
@@ -88,7 +88,7 @@ export default function DatabaseRecordInputGroup({
       )}
 
       {description && (
-        <Text className="mb-3 text-xs" sx={{ color: 'text.secondary' }}>
+        <Text className="mb-3 text-xs" color="secondary">
           {description}
         </Text>
       )}

--- a/dashboard/src/components/dataBrowser/RuleGroupEditor/RuleEditorRow.tsx
+++ b/dashboard/src/components/dataBrowser/RuleGroupEditor/RuleEditorRow.tsx
@@ -82,7 +82,7 @@ function renderOption({
       </Text>
 
       {helperText && (
-        <Text component="span" sx={{ color: 'text.disabled' }}>
+        <Text component="span" color="disabled">
           {helperText}
         </Text>
       )}
@@ -130,7 +130,7 @@ export default function RuleEditorRow({
   return (
     <div
       className={twMerge(
-        'grid lg:grid-cols-[320px_140px_minmax(100px,_1fr)_40px] grid-flow-row lg:max-h-10 space-y-1 lg:space-y-0',
+        'grid grid-flow-row space-y-1 lg:max-h-10 lg:grid-cols-[320px_140px_minmax(100px,_1fr)_40px] lg:space-y-0',
         className,
       )}
       {...props}

--- a/dashboard/src/components/home/FindOldApps.tsx
+++ b/dashboard/src/components/home/FindOldApps.tsx
@@ -4,7 +4,7 @@ import Text from '@/ui/v2/Text';
 export function FindOldApps() {
   return (
     <div className="mt-4">
-      <Text className="font-medium" sx={{ color: 'text.secondary' }}>
+      <Text className="font-medium" color="secondary">
         Looking for your old apps? They&apos;re still on{' '}
         <span className="pb-0.25">
           <Link

--- a/dashboard/src/components/home/IndexHeaderApps.tsx
+++ b/dashboard/src/components/home/IndexHeaderApps.tsx
@@ -21,7 +21,7 @@ export function IndexHeaderApps({ query, setQuery }: IndexHeaderAppsProps) {
         placeholder="Find Project"
         startAdornment={
           <SearchIcon
-            className="w-4 h-4 ml-2 -mr-1 shrink-0"
+            className="ml-2 -mr-1 h-4 w-4 shrink-0"
             sx={{ color: 'text.disabled' }}
           />
         }

--- a/dashboard/src/components/home/Resources.tsx
+++ b/dashboard/src/components/home/Resources.tsx
@@ -4,7 +4,7 @@ import Text from '@/ui/v2/Text';
 export default function Resources() {
   return (
     <div>
-      <Text sx={{ color: 'text.disabled' }}>Resources</Text>
+      <Text color="disabled">Resources</Text>
       <div className="mt-4 flex flex-col space-y-1">
         <Resource
           text="Documentation"

--- a/dashboard/src/components/logs/LogsBody/LogsBody.tsx
+++ b/dashboard/src/components/logs/LogsBody/LogsBody.tsx
@@ -149,7 +149,7 @@ export default function LogsBody({ logsData, loading, error }: LogsBodyProps) {
   if (error) {
     return (
       <LogsBodyCustomMessage>
-        <Text color="red" className="truncate font-mono text-xs- font-normal">
+        <Text color="error" className="truncate font-mono text-xs- font-normal">
           {error?.message.includes('the query time range exceeds the limit')
             ? 'The query time range exceeds the limit, please select a shorter range.'
             : error?.message}

--- a/dashboard/src/components/logs/LogsDatePicker/LogsDatePicker.tsx
+++ b/dashboard/src/components/logs/LogsDatePicker/LogsDatePicker.tsx
@@ -55,7 +55,7 @@ function LogsDatePicker({
             htmlFor={label}
             component="label"
             className="self-center text-sm+ font-normal"
-            sx={{ color: 'text.secondary' }}
+            color="secondary"
           >
             {label}
           </Text>

--- a/dashboard/src/components/overview/OverviewCard/OverviewCard.tsx
+++ b/dashboard/src/components/overview/OverviewCard/OverviewCard.tsx
@@ -61,7 +61,7 @@ export default function OverviewCard({
           <Text variant="h3" className="!font-bold">
             {title}
           </Text>
-          <Text className="!font-medium" sx={{ color: 'text.secondary' }}>
+          <Text className="!font-medium" color="secondary">
             {description}
           </Text>
         </div>
@@ -72,7 +72,7 @@ export default function OverviewCard({
         href={link}
         target="_blank"
         rel="dofollow"
-        className="font-medium grid grid-flow-col gap-1 justify-start items-center"
+        className="grid grid-flow-col items-center justify-start gap-1 font-medium"
       >
         Learn more
         <ArrowRightIcon className="h-4 w-4" />

--- a/dashboard/src/components/overview/OverviewDocumentation/OverviewDocumentation.tsx
+++ b/dashboard/src/components/overview/OverviewDocumentation/OverviewDocumentation.tsx
@@ -31,10 +31,8 @@ export default function OverviewDocumentation({
   return (
     <div {...props}>
       <div className="grid grid-flow-row gap-1">
-        <Text variant="h3" sx={{ color: 'text.primary' }}>
-          {title}
-        </Text>
-        <Text sx={{ color: 'text.secondary' }}>{description}</Text>
+        <Text variant="h3">{title}</Text>
+        <Text color="secondary">{description}</Text>
       </div>
 
       <div className="mt-6 grid grid-flow-row items-center gap-6 xs:grid-cols-2 lg:grid-cols-4 lg:gap-4">

--- a/dashboard/src/components/overview/OverviewMigration/OverviewMigration.tsx
+++ b/dashboard/src/components/overview/OverviewMigration/OverviewMigration.tsx
@@ -73,7 +73,7 @@ export default function OverviewMigration() {
                                 <Text
                                   component="span"
                                   className="font-semibold"
-                                  sx={{ color: 'text.secondary' }}
+                                  color="secondary"
                                 >
                                   {index + 1}
                                 </Text>

--- a/dashboard/src/components/settings/SettingsContainer/SettingsContainer.tsx
+++ b/dashboard/src/components/settings/SettingsContainer/SettingsContainer.tsx
@@ -137,9 +137,7 @@ export default function SettingsContainer({
           <div className="grid grid-flow-row gap-1">
             <Text className="text-lg font-semibold">{title}</Text>
 
-            {description && (
-              <Text sx={{ color: 'text.secondary' }}>{description}</Text>
-            )}
+            {description && <Text color="secondary">{description}</Text>}
           </div>
         </div>
         {!switchId && showSwitch && (

--- a/dashboard/src/components/settings/environmentVariables/EnvironmentVariableSettings/EnvironmentVariableSettings.tsx
+++ b/dashboard/src/components/settings/environmentVariables/EnvironmentVariableSettings/EnvironmentVariableSettings.tsx
@@ -127,12 +127,12 @@ export default function EnvironmentVariableSettings() {
       docsTitle="Environment Variables"
       rootClassName="gap-0"
       className={twMerge(
-        'px-0 my-2',
+        'my-2 px-0',
         availableEnvironmentVariables.length === 0 && 'gap-2',
       )}
       slotProps={{ submitButton: { className: 'hidden' } }}
     >
-      <Box className="grid grid-cols-2 lg:grid-cols-3 gap-2 border-b-1 px-4 py-3">
+      <Box className="grid grid-cols-2 gap-2 border-b-1 px-4 py-3 lg:grid-cols-3">
         <Text className="font-medium">Variable Name</Text>
         <Text className="font-medium lg:col-span-2">Updated</Text>
       </Box>
@@ -149,7 +149,7 @@ export default function EnvironmentVariableSettings() {
               return (
                 <Fragment key={environmentVariable.id}>
                   <ListItem.Root
-                    className="px-4 grid grid-cols-2 lg:grid-cols-3 gap-2"
+                    className="grid grid-cols-2 gap-2 px-4 lg:grid-cols-3"
                     secondaryAction={
                       <Dropdown.Root>
                         <Dropdown.Trigger
@@ -189,10 +189,7 @@ export default function EnvironmentVariableSettings() {
                               handleConfirmDelete(environmentVariable)
                             }
                           >
-                            <Text
-                              className="font-medium"
-                              sx={{ color: 'error.main' }}
-                            >
+                            <Text className="font-medium" color="error">
                               Delete
                             </Text>
                           </Dropdown.Item>
@@ -206,7 +203,7 @@ export default function EnvironmentVariableSettings() {
 
                     <Text
                       variant="subtitle1"
-                      className="lg:col-span-2 truncate"
+                      className="truncate lg:col-span-2"
                     >
                       {timestamp === '0 seconds ago' ||
                       timestamp === 'in 0 seconds'
@@ -230,7 +227,7 @@ export default function EnvironmentVariableSettings() {
         )}
 
         <Button
-          className="justify-self-start mx-4"
+          className="mx-4 justify-self-start"
           variant="borderless"
           startIcon={<PlusIcon />}
           onClick={handleOpenCreator}

--- a/dashboard/src/components/settings/environmentVariables/SystemEnvironmentVariableSettings/SystemEnvironmentVariableSettings.tsx
+++ b/dashboard/src/components/settings/environmentVariables/SystemEnvironmentVariableSettings/SystemEnvironmentVariableSettings.tsx
@@ -131,7 +131,7 @@ export default function SystemEnvironmentVariableSettings() {
           <ListItem.Text>NHOST_ADMIN_SECRET</ListItem.Text>
 
           <div className="grid grid-flow-col items-center justify-start gap-2 lg:col-span-2">
-            <Text className="truncate" sx={{ color: 'text.secondary' }}>
+            <Text className="truncate" color="secondary">
               {showAdminSecret ? (
                 <InlineCode className="!text-sm font-medium">
                   {currentApplication?.hasuraGraphqlAdminSecret}
@@ -164,7 +164,7 @@ export default function SystemEnvironmentVariableSettings() {
           <ListItem.Text>NHOST_WEBHOOK_SECRET</ListItem.Text>
 
           <div className="grid grid-flow-col items-center justify-start gap-2 lg:col-span-2">
-            <Text className="truncate" sx={{ color: 'text.secondary' }}>
+            <Text className="truncate" color="secondary">
               {showWebhookSecret ? (
                 <InlineCode className="!text-sm font-medium">
                   {data?.app?.webhookSecret}
@@ -216,7 +216,7 @@ export default function SystemEnvironmentVariableSettings() {
         <ListItem.Root className="grid grid-cols-2 justify-start px-4 lg:grid-cols-3">
           <ListItem.Text>NHOST_JWT_SECRET</ListItem.Text>
 
-          <div className="grid grid-flow-row md:grid-flow-col gap-1.5 justify-center text-center lg:text-left lg:justify-start items-center lg:col-span-2">
+          <div className="grid grid-flow-row items-center justify-center gap-1.5 text-center md:grid-flow-col lg:col-span-2 lg:justify-start lg:text-left">
             <Button
               variant="borderless"
               onClick={showViewJwtSecretModal}

--- a/dashboard/src/components/settings/permissions/BasePermissionVariableForm/BasePermissionVariableForm.tsx
+++ b/dashboard/src/components/settings/permissions/BasePermissionVariableForm/BasePermissionVariableForm.tsx
@@ -93,7 +93,7 @@ export default function BasePermissionVariableForm({
           autoFocus
           slotProps={{ inputRoot: { className: '!pl-px' } }}
           startAdornment={
-            <Text className="shrink-0 pl-2" sx={{ color: 'text.disabled' }}>
+            <Text className="shrink-0 pl-2" color="disabled">
               X-Hasura-
             </Text>
           }
@@ -124,7 +124,7 @@ export default function BasePermissionVariableForm({
           autoComplete="off"
           slotProps={{ inputRoot: { className: '!pl-px' } }}
           startAdornment={
-            <Text className="shrink-0 pl-2" sx={{ color: 'text.disabled' }}>
+            <Text className="shrink-0 pl-2" color="disabled">
               user.
             </Text>
           }

--- a/dashboard/src/components/settings/roles/RoleSettings/RoleSettings.tsx
+++ b/dashboard/src/components/settings/roles/RoleSettings/RoleSettings.tsx
@@ -154,10 +154,10 @@ export default function RoleSettings() {
       description="Roles are used to control access to your application."
       docsLink="https://docs.nhost.io/authentication/users#roles"
       rootClassName="gap-0"
-      className="px-0 my-2"
+      className="my-2 px-0"
       slotProps={{ submitButton: { className: 'invisible' } }}
     >
-      <Box className="px-4 py-3 border-b-1">
+      <Box className="border-b-1 px-4 py-3">
         <Text className="font-medium">Name</Text>
       </Box>
 
@@ -172,7 +172,7 @@ export default function RoleSettings() {
                     <Dropdown.Trigger
                       asChild
                       hideChevron
-                      className="absolute -translate-y-1/2 right-4 top-1/2"
+                      className="absolute right-4 top-1/2 -translate-y-1/2"
                     >
                       <IconButton variant="borderless" color="secondary">
                         <DotsVerticalIcon />
@@ -210,10 +210,7 @@ export default function RoleSettings() {
                         disabled={role.isSystemRole}
                         onClick={() => handleConfirmDelete(role)}
                       >
-                        <Text
-                          className="font-medium"
-                          sx={{ color: 'error.main' }}
-                        >
+                        <Text className="font-medium" color="error">
                           Delete
                         </Text>
                       </Dropdown.Item>
@@ -230,7 +227,7 @@ export default function RoleSettings() {
                     <>
                       {role.name}
 
-                      {role.isSystemRole && <LockIcon className="w-4 h-4" />}
+                      {role.isSystemRole && <LockIcon className="h-4 w-4" />}
 
                       {data?.app?.authUserDefaultRole === role.name && (
                         <Chip

--- a/dashboard/src/components/settings/signInMethods/EmailAndPasswordSettings/EmailAndPasswordSettings.tsx
+++ b/dashboard/src/components/settings/signInMethods/EmailAndPasswordSettings/EmailAndPasswordSettings.tsx
@@ -113,7 +113,7 @@ export default function EmailAndPasswordSettings() {
             label={
               <span className="inline-grid grid-flow-row gap-y-0.5 text-sm+">
                 <Text component="span">Require Verified Emails</Text>
-                <Text component="span" sx={{ color: 'text.secondary' }}>
+                <Text component="span" color="secondary">
                   Users must verify their email to be able to sign in.
                 </Text>
               </span>
@@ -126,7 +126,7 @@ export default function EmailAndPasswordSettings() {
             label={
               <span className="inline-grid grid-flow-row gap-y-0.5 text-sm+">
                 <Text component="span">Password Protection</Text>
-                <Text component="span" sx={{ color: 'text.secondary' }}>
+                <Text component="span" color="secondary">
                   Passwords must pass haveibeenpwned.com during sign-up.
                 </Text>
               </span>

--- a/dashboard/src/components/ui/v2/Box/Box.tsx
+++ b/dashboard/src/components/ui/v2/Box/Box.tsx
@@ -14,7 +14,7 @@ export type BoxProps<
 
 const StyledBox = styled(MaterialBox)(({ theme }) => ({
   backgroundColor: theme.palette.background.paper,
-  borderColor: theme.palette.grey[300],
+  borderColor: theme.palette.divider,
   color: theme.palette.text.primary,
 }));
 

--- a/dashboard/src/components/ui/v2/Text/Text.tsx
+++ b/dashboard/src/components/ui/v2/Text/Text.tsx
@@ -4,31 +4,70 @@ import type {
   TypographyTypeMap,
 } from '@mui/material/Typography';
 import MaterialTypography, {
+  getTypographyUtilityClass,
   typographyClasses as materialTypographyClasses,
 } from '@mui/material/Typography';
+import clsx from 'clsx';
 
 export type TextProps<
   D extends React.ElementType = TypographyTypeMap['defaultComponent'],
   P = {},
-> = MaterialTypographyProps<D, P>;
+> = MaterialTypographyProps<D, P> & {
+  /**
+   * The color of the text.
+   *
+   * @default 'primary'
+   */
+  color?: 'primary' | 'secondary' | 'disabled' | 'error';
+};
+
+const textClasses = {
+  ...materialTypographyClasses,
+  colorPrimary: getTypographyUtilityClass('colorPrimary'),
+  colorSecondary: getTypographyUtilityClass('colorSecondary'),
+  colorDisabled: getTypographyUtilityClass('colorDisabled'),
+  colorError: getTypographyUtilityClass('colorError'),
+};
 
 const StyledTypography = styled(MaterialTypography)<TextProps>(({ theme }) => ({
   color: theme.palette.text.primary,
-  [`&.${materialTypographyClasses.subtitle1}`]: {
+  [`&.${textClasses.subtitle1}`]: {
     color: theme.palette.text.secondary,
   },
-  [`&.${materialTypographyClasses.subtitle2}`]: {
+  [`&.${textClasses.subtitle2}`]: {
     color: theme.palette.text.secondary,
+  },
+  [`&.${textClasses.colorSecondary}`]: {
+    color: theme.palette.text.secondary,
+  },
+  [`&.${textClasses.colorDisabled}`]: {
+    color: theme.palette.text.disabled,
+  },
+  [`&.${textClasses.colorError}`]: {
+    color: theme.palette.error.main,
   },
 }));
 
 function Text<
   D extends React.ElementType = TypographyTypeMap['defaultComponent'],
   P = {},
->({ children, variantMapping, ...props }: TextProps<D, P>) {
+>({
+  children,
+  variantMapping,
+  color = 'primary',
+  className,
+  ...props
+}: TextProps<D, P>) {
   return (
     <StyledTypography
       variantMapping={{ subtitle1: 'p', subtitle2: 'p', ...variantMapping }}
+      className={clsx(
+        color === 'primary' && textClasses.colorPrimary,
+        color === 'secondary' && textClasses.colorSecondary,
+        color === 'disabled' && textClasses.colorDisabled,
+        color === 'error' && textClasses.colorError,
+        className,
+      )}
       {...props}
     >
       {children}
@@ -37,5 +76,7 @@ function Text<
 }
 
 Text.displayName = 'NhostText';
+
+export { textClasses };
 
 export default Text;

--- a/dashboard/src/components/users/EditUserForm/EditUserForm.tsx
+++ b/dashboard/src/components/users/EditUserForm/EditUserForm.tsx
@@ -184,7 +184,7 @@ export default function EditUserForm({
   return (
     <FormProvider {...form}>
       <Form
-        className="flex flex-col lg:content-between lg:flex-auto border-t-1 overflow-hidden"
+        className="flex flex-col overflow-hidden border-t-1 lg:flex-auto lg:content-between"
         onSubmit={handleSubmit(async (values) => {
           await onEditUser(values, user);
         })}
@@ -194,14 +194,11 @@ export default function EditUserForm({
             component="section"
             className="grid grid-flow-col p-6 lg:grid-cols-7"
           >
-            <div className="grid items-center grid-flow-col col-span-6 gap-4 place-content-start">
-              <Avatar className="w-12 h-12" src={user.avatarUrl} />
-              <div className="grid items-center grid-flow-row">
+            <div className="col-span-6 grid grid-flow-col place-content-start items-center gap-4">
+              <Avatar className="h-12 w-12" src={user.avatarUrl} />
+              <div className="grid grid-flow-row items-center">
                 <Text className="text-lg font-medium">{user.displayName}</Text>
-                <Text
-                  className="font-normal text-sm+"
-                  sx={{ color: 'text.secondary' }}
-                >
+                <Text className="text-sm+ font-normal" color="secondary">
                   {user.email}
                 </Text>
               </div>
@@ -221,7 +218,7 @@ export default function EditUserForm({
                     Actions
                   </Button>
                 </Dropdown.Trigger>
-                <Dropdown.Content menu disablePortal className="w-full h-full">
+                <Dropdown.Content menu disablePortal className="h-full w-full">
                   <Dropdown.Item
                     className="font-medium"
                     sx={{ color: 'error.main' }}
@@ -249,11 +246,11 @@ export default function EditUserForm({
             component="section"
             className="grid grid-flow-row grid-cols-4 gap-8 p-6"
           >
-            <InputLabel as="h3" className="self-center col-span-1">
+            <InputLabel as="h3" className="col-span-1 self-center">
               User ID
             </InputLabel>
-            <div className="grid items-center justify-start grid-flow-col col-span-3 gap-2">
-              <Text className="font-medium truncate">{user.id}</Text>
+            <div className="col-span-3 grid grid-flow-col items-center justify-start gap-2">
+              <Text className="truncate font-medium">{user.id}</Text>
               <IconButton
                 variant="borderless"
                 color="secondary"
@@ -263,18 +260,18 @@ export default function EditUserForm({
                   copy(user.id, 'User ID');
                 }}
               >
-                <CopyIcon className="w-4 h-4" />
+                <CopyIcon className="h-4 w-4" />
               </IconButton>
             </div>
 
-            <InputLabel as="h3" className="self-center col-span-1 ">
+            <InputLabel as="h3" className="col-span-1 self-center ">
               Created At
             </InputLabel>
             <Text className="col-span-3 font-medium">
               {format(new Date(user.createdAt), 'yyyy-MM-dd hh:mm:ss')}
             </Text>
 
-            <InputLabel as="h3" className="self-center col-span-1 ">
+            <InputLabel as="h3" className="col-span-1 self-center ">
               Last Seen
             </InputLabel>
             <Text className="col-span-3 font-medium">
@@ -331,14 +328,14 @@ export default function EditUserForm({
               autoComplete="off"
             />
 
-            <div className="grid items-center grid-flow-col grid-cols-8 col-span-1 my-1">
+            <div className="col-span-1 my-1 grid grid-flow-col grid-cols-8 items-center">
               <div className="col-span-2 ">
                 <InputLabel as="h3">Password</InputLabel>
               </div>
               <Button
                 color="primary"
                 variant="borderless"
-                className="col-span-6 px-2 place-self-start"
+                className="col-span-6 place-self-start px-2"
                 onClick={handleChangeUserPassword}
               >
                 Change
@@ -387,15 +384,15 @@ export default function EditUserForm({
           </Box>
           <Box
             component="section"
-            className="grid gap-4 p-6 lg:grid-cols-4 place-content-start"
+            className="grid place-content-start gap-4 p-6 lg:grid-cols-4"
           >
-            <div className="items-center self-center col-span-1 align-middle">
+            <div className="col-span-1 items-center self-center align-middle">
               <InputLabel as="h3">OAuth Providers</InputLabel>
             </div>
-            <div className="grid w-full grid-flow-row col-span-3 gap-y-6">
+            <div className="col-span-3 grid w-full grid-flow-row gap-y-6">
               {user.userProviders.length === 0 && (
-                <div className="grid grid-flow-col gap-x-1 place-content-between">
-                  <Text className="font-normal" sx={{ color: 'text.disabled' }}>
+                <div className="grid grid-flow-col place-content-between gap-x-1">
+                  <Text className="font-normal" color="disabled">
                     This user has no OAuth providers connected.
                   </Text>
                 </div>
@@ -403,10 +400,10 @@ export default function EditUserForm({
 
               {user.userProviders.map((provider) => (
                 <div
-                  className="grid grid-flow-col gap-3 place-content-between"
+                  className="grid grid-flow-col place-content-between gap-3"
                   key={provider.id}
                 >
-                  <div className="grid grid-flow-col gap-2 span-cols-1">
+                  <div className="span-cols-1 grid grid-flow-col gap-2">
                     <Image
                       src={
                         theme.palette.mode === 'dark'
@@ -431,7 +428,7 @@ export default function EditUserForm({
           {!isAnonymous && (
             <Box
               component="section"
-              className="grid grid-flow-row p-6 gap-y-10"
+              className="grid grid-flow-row gap-y-10 p-6"
             >
               <ControlledSelect
                 {...register('defaultRole')}
@@ -451,11 +448,11 @@ export default function EditUserForm({
                   </Option>
                 ))}
               </ControlledSelect>
-              <div className="grid grid-flow-row gap-6 lg:grid-cols-8 lg:grid-flow-col place-content-start">
+              <div className="grid grid-flow-row place-content-start gap-6 lg:grid-flow-col lg:grid-cols-8">
                 <InputLabel as="h3" className="col-span-2">
                   Allowed Roles
                 </InputLabel>
-                <div className="grid grid-flow-row col-span-3 gap-6">
+                <div className="col-span-3 grid grid-flow-row gap-6">
                   {roles.map((role, i) => (
                     <ControlledCheckbox
                       id={`roles.${i}`}
@@ -471,7 +468,7 @@ export default function EditUserForm({
           )}
         </Box>
 
-        <Box className="grid justify-between flex-shrink-0 w-full grid-flow-col gap-3 p-2 place-self-end border-t-1 snap-end">
+        <Box className="grid w-full flex-shrink-0 snap-end grid-flow-col justify-between gap-3 place-self-end border-t-1 p-2">
           <Button
             variant="outlined"
             color="secondary"

--- a/dashboard/src/components/users/UsersBody/UsersBody.tsx
+++ b/dashboard/src/components/users/UsersBody/UsersBody.tsx
@@ -210,12 +210,12 @@ export default function UsersBody({
 
   if (!users) {
     return (
-      <div className="w-screen h-screen overflow-hidden">
-        <div className="absolute top-0 left-0 z-50 block w-full h-full">
-          <span className="relative block mx-auto my-0 top50percent top-1/2">
+      <div className="h-screen w-screen overflow-hidden">
+        <div className="absolute top-0 left-0 z-50 block h-full w-full">
+          <span className="top50percent relative top-1/2 mx-auto my-0 block">
             <ActivityIndicator
               label="Loading users..."
-              className="flex items-center justify-center my-auto"
+              className="my-auto flex items-center justify-center"
             />
           </span>
         </div>
@@ -228,7 +228,7 @@ export default function UsersBody({
       {users.map((user) => (
         <Fragment key={user.id}>
           <ListItem.Root
-            className="w-full h-[64px]"
+            className="h-[64px] w-full"
             secondaryAction={
               <Dropdown.Root>
                 <Dropdown.Trigger asChild hideChevron>
@@ -249,7 +249,7 @@ export default function UsersBody({
                     }}
                     className="grid grid-flow-col items-center gap-2 p-2 text-sm+ font-medium"
                   >
-                    <UserIcon className="w-4 h-4" />
+                    <UserIcon className="h-4 w-4" />
                     <Text className="font-medium">View User</Text>
                   </Dropdown.Item>
 
@@ -260,8 +260,8 @@ export default function UsersBody({
                     sx={{ color: 'error.main' }}
                     onClick={() => handleDeleteUser(user)}
                   >
-                    <TrashIcon className="w-4 h-4" />
-                    <Text className="font-medium" sx={{ color: 'error.main' }}>
+                    <TrashIcon className="h-4 w-4" />
+                    <Text className="font-medium" color="error">
                       Delete User
                     </Text>
                   </Dropdown.Item>
@@ -270,17 +270,17 @@ export default function UsersBody({
             }
           >
             <ListItem.Button
-              className="grid lg:grid-cols-6 grid-cols-1 py-2.5 h-full w-full"
+              className="grid h-full w-full grid-cols-1 py-2.5 lg:grid-cols-6"
               onClick={() => handleViewUser(user)}
             >
-              <div className="grid grid-flow-col col-span-2 gap-4 place-content-start">
+              <div className="col-span-2 grid grid-flow-col place-content-start gap-4">
                 <Avatar
                   src={user.avatarUrl}
                   alt={`Avatar of ${user.displayName}`}
                 />
-                <div className="grid items-center grid-flow-row">
-                  <div className="grid items-center grid-flow-col gap-2">
-                    <Text className="font-medium leading-5 truncate">
+                <div className="grid grid-flow-row items-center">
+                  <div className="grid grid-flow-col items-center gap-2">
+                    <Text className="truncate font-medium leading-5">
                       {user.displayName}
                     </Text>
                     {user.disabled && (
@@ -293,10 +293,7 @@ export default function UsersBody({
                     )}
                   </div>
 
-                  <Text
-                    className="font-normal truncate"
-                    sx={{ color: 'text.secondary' }}
-                  >
+                  <Text className="truncate font-normal" color="secondary">
                     {user.email}
                   </Text>
                 </div>
@@ -316,7 +313,7 @@ export default function UsersBody({
                   : '-'}
               </Text>
 
-              <div className="hidden grid-flow-col col-span-2 gap-3 px-4 lg:grid place-content-start">
+              <div className="col-span-2 hidden grid-flow-col place-content-start gap-3 px-4 lg:grid">
                 {user.userProviders.length === 0 && (
                   <Text className="col-span-3 font-medium">-</Text>
                 )}

--- a/dashboard/src/components/workspace/WorkspaceApps.tsx
+++ b/dashboard/src/components/workspace/WorkspaceApps.tsx
@@ -17,8 +17,8 @@ function AllWorkspaceApps() {
 
   if (noApplications) {
     return (
-      <Box className="flex flex-row py-4 border-y">
-        <Text className="text-xs" sx={{ color: 'text.secondary' }}>
+      <Box className="flex flex-row border-y py-4">
+        <Text className="text-xs" color="secondary">
           No projects on this workspace.
         </Text>
       </Box>
@@ -34,7 +34,7 @@ function AllWorkspaceApps() {
           <ListItem.Root>
             <NavLink href={`${currentWorkspace?.slug}/${app.slug}`} passHref>
               <ListItem.Button className="grid grid-flow-col justify-between gap-2">
-                <div className="grid grid-flow-col gap-2 items-center">
+                <div className="grid grid-flow-col items-center gap-2">
                   <div className="h-8 w-8 overflow-hidden rounded-lg">
                     <Image
                       src="/logos/new.svg"
@@ -65,7 +65,7 @@ export default function WorkspaceApps() {
     <div className="mt-9">
       <div className="mx-auto max-w-3xl font-display">
         <div className="mb-4 flex flex-row place-content-between">
-          <Text className="font-medium text-lg">Projects</Text>
+          <Text className="text-lg font-medium">Projects</Text>
           <NavLink
             href={{
               pathname: '/new',

--- a/dashboard/src/components/workspace/WorkspaceHeader.tsx
+++ b/dashboard/src/components/workspace/WorkspaceHeader.tsx
@@ -86,8 +86,8 @@ export default function WorkspaceHeader() {
             >
               <Text
                 component="span"
-                sx={{ color: 'text.secondary' }}
                 className="text-xs font-medium"
+                color="secondary"
               >
                 app.nhost.io/
               </Text>
@@ -147,7 +147,7 @@ export default function WorkspaceHeader() {
                     <Text
                       variant="caption"
                       className="font-medium"
-                      sx={{ color: 'text.disabled' }}
+                      color="disabled"
                     >
                       You can&apos;t remove this workspace because you have apps
                       running. Remove all apps first.

--- a/dashboard/src/components/workspace/WorkspaceMember.tsx
+++ b/dashboard/src/components/workspace/WorkspaceMember.tsx
@@ -27,13 +27,13 @@ export default function WorkspaceMember({
           avatarUrl={workspaceMember.user.avatarUrl}
         />
         <div className="ml-3 self-center">
-          <div className="grid items-center grid-flow-col gap-2 justify-start">
+          <div className="grid grid-flow-col items-center justify-start gap-2">
             <Text className="font-medium">
               {workspaceMember.user.displayName}
             </Text>
             {isSelf && <Chip size="small" color="info" label="Me" />}
           </div>
-          <Text className="font-medium" sx={{ color: 'text.disabled' }}>
+          <Text className="font-medium" color="disabled">
             {workspaceMember.user.email}
           </Text>
         </div>

--- a/dashboard/src/components/workspace/WorkspaceMemberInvite.tsx
+++ b/dashboard/src/components/workspace/WorkspaceMemberInvite.tsx
@@ -16,11 +16,11 @@ export default function WorkspaceMemberInvite({
       <div className=" flex flex-row">
         <Avatar className="h-12 w-12" name={workspaceMemberInvite.email} />
         <div className="ml-3 self-center">
-          <div className="grid grid-flow-col gap-2 justify-start">
+          <div className="grid grid-flow-col justify-start gap-2">
             <Text className="font-medium">{workspaceMemberInvite.email}</Text>
             <Chip size="small" color="info" label="Pending Invitation" />
           </div>
-          <Text className="font-medium" sx={{ color: 'text.disabled' }}>
+          <Text className="font-medium" color="disabled">
             {workspaceMemberInvite.email}
           </Text>
         </div>

--- a/dashboard/src/components/workspace/WorkspacePaymentMethods.tsx
+++ b/dashboard/src/components/workspace/WorkspacePaymentMethods.tsx
@@ -238,7 +238,7 @@ export default function WorkspacePaymentMethods() {
             </Button>
           )}
           {maxPaymentMethodsReached && (
-            <Text className="my-2 text-sm" sx={{ color: 'error.main' }}>
+            <Text className="my-2 text-sm" color="error">
               You can have at most three payment methods per workspace. To add a
               new payment method, please first delete one of your existing
               payment methods.

--- a/dashboard/src/components/workspace/WorkspaceSection.tsx
+++ b/dashboard/src/components/workspace/WorkspaceSection.tsx
@@ -9,7 +9,7 @@ export function WorkspaceSection() {
 
   return (
     <div>
-      <Text sx={{ color: 'text.disabled' }}>My Workspaces</Text>
+      <Text color="disabled">My Workspaces</Text>
       <SidebarWorkspaces />
 
       <Button

--- a/dashboard/src/pages/[workspaceSlug]/[appSlug]/deployments/[deploymentId].tsx
+++ b/dashboard/src/pages/[workspaceSlug]/[appSlug]/deployments/[deploymentId].tsx
@@ -44,10 +44,10 @@ export default function DeploymentDetailsPage() {
   if (!deployment) {
     return (
       <Container>
-        <Text variant="h1" className="text-4xl font-semibold text">
+        <Text variant="h1" className="text text-4xl font-semibold">
           Not found
         </Text>
-        <Text className="text-sm" sx={{ color: 'text.disabled' }}>
+        <Text className="text-sm" color="disabled">
           This deployment does not exist.
         </Text>
       </Container>
@@ -93,7 +93,7 @@ export default function DeploymentDetailsPage() {
         </div>
       </div>
       <div className="my-8 flex justify-between">
-        <div className="grid grid-flow-col gap-4 items-center">
+        <div className="grid grid-flow-col items-center gap-4">
           <Avatar
             name={deployment.commitUserName}
             avatarUrl={deployment.commitUserAvatarUrl}
@@ -102,9 +102,7 @@ export default function DeploymentDetailsPage() {
 
           <div>
             <Text>{deployment.commitMessage}</Text>
-            <Text sx={{ color: 'text.secondary' }}>
-              {relativeDateOfDeployment}
-            </Text>
+            <Text color="secondary">{relativeDateOfDeployment}</Text>
           </div>
         </div>
         <div className=" flex items-center">

--- a/dashboard/src/pages/[workspaceSlug]/[appSlug]/functions.tsx
+++ b/dashboard/src/pages/[workspaceSlug]/[appSlug]/functions.tsx
@@ -37,7 +37,7 @@ function FunctionsNoRepo() {
           alt="GitHub Logo"
         />
       </div>
-      <Text className="mt-4 font-medium text-lg">Function Logs</Text>
+      <Text className="mt-4 text-lg font-medium">Function Logs</Text>
       <div className="flex">
         <div className="mx-auto flex flex-row self-center text-center">
           <Text className="mt-1">
@@ -92,7 +92,7 @@ export default function FunctionsPage() {
 
   if (loading) {
     return (
-      <Container className="pt-12 text-center grid items-center">
+      <Container className="grid items-center pt-12 text-center">
         <ActivityIndicator delay={500} />
       </Container>
     );
@@ -109,7 +109,7 @@ export default function FunctionsPage() {
   if (error) {
     return (
       <Container>
-        <Text sx={{ color: 'error.main' }}>{error.message}</Text>
+        <Text color="error">{error.message}</Text>
       </Container>
     );
   }
@@ -129,13 +129,13 @@ export default function FunctionsPage() {
               <div className="flex w-full">
                 {folder.nestedLevel > 0 && (
                   <FolderIcon
-                    className="self-center align-middle w-4 h-4"
+                    className="h-4 w-4 self-center align-middle"
                     sx={{ color: 'text.disabled' }}
                   />
                 )}
                 <Text
                   className={twMerge(
-                    'font-medium text-xs',
+                    'text-xs font-medium',
                     folder.nestedLevel > 0 && 'ml-2',
                   )}
                 >
@@ -145,10 +145,10 @@ export default function FunctionsPage() {
               {folder.nestedLevel === 0 ? (
                 <div className="flex w-full flex-row">
                   <div className="flex w-52">
-                    <Text className="font-medium text-xs">Created At</Text>
+                    <Text className="text-xs font-medium">Created At</Text>
                   </div>
                   <div className="flex w-16 self-end">
-                    <Text className="font-medium text-xs">Status</Text>
+                    <Text className="text-xs font-medium">Status</Text>
                   </div>
                 </div>
               ) : null}
@@ -214,7 +214,7 @@ export default function FunctionsPage() {
       </div>
 
       <div className="mx-auto mt-10 max-w-6xl text-center">
-        <Text className="font-medium text-xs">
+        <Text className="text-xs font-medium">
           Base URL for function endpoints is{' '}
           {generateAppServiceUrl(
             currentApplication.subdomain,

--- a/dashboard/src/pages/[workspaceSlug]/[appSlug]/functions/[functionId].tsx
+++ b/dashboard/src/pages/[workspaceSlug]/[appSlug]/functions/[functionId].tsx
@@ -56,7 +56,7 @@ export default function FunctionDetailsPage() {
         <Text variant="h1" className="text-4xl font-semibold">
           Not found
         </Text>
-        <Text className="text-sm" sx={{ color: 'text.disabled' }}>
+        <Text className="text-sm" color="disabled">
           This function does not exist.
         </Text>
       </Container>
@@ -67,7 +67,7 @@ export default function FunctionDetailsPage() {
     <>
       <Container>
         <div className="flex place-content-between">
-          <div className="grid grid-flow-col gap-2 items-center py-1">
+          <div className="grid grid-flow-col items-center gap-2 py-1">
             <Image
               src={`/assets/functions/${
                 currentFunction.name.split('.')[1]
@@ -78,7 +78,7 @@ export default function FunctionDetailsPage() {
             />
 
             <div className="grid grid-flow-row justify-start">
-              <Text className="font-medium text-2xl">
+              <Text className="text-2xl font-medium">
                 {currentFunction.name}
               </Text>
 
@@ -91,10 +91,7 @@ export default function FunctionDetailsPage() {
                 target="_blank"
                 rel="noreferrer"
               >
-                <Text
-                  className="text-xs font-medium"
-                  sx={{ color: 'text.disabled' }}
-                >
+                <Text className="text-xs font-medium" color="disabled">
                   {`${generateAppServiceUrl(
                     currentApplication.subdomain,
                     currentApplication.region.awsName,
@@ -110,10 +107,10 @@ export default function FunctionDetailsPage() {
       <Container>
         <div className="flex flex-row place-content-between">
           <div className="flex">
-            <Text className="font-medium text-xl">Log</Text>
+            <Text className="text-xl font-medium">Log</Text>
           </div>
           <div className="flex items-center">
-            <Text className="font-medium text-xs">Awaiting new requests…</Text>
+            <Text className="text-xs font-medium">Awaiting new requests…</Text>
 
             <IconButton
               variant="borderless"

--- a/dashboard/src/pages/reset-password.tsx
+++ b/dashboard/src/pages/reset-password.tsx
@@ -72,7 +72,7 @@ function ResetPasswordForm() {
 
       {isError && (
         <div className="my-3">
-          <Text className="font-medium" sx={{ color: 'error.main' }}>
+          <Text className="font-medium" color="error">
             Error: {error.message}
           </Text>
         </div>
@@ -116,7 +116,7 @@ export default function ResetPasswordPage() {
             </Box>
 
             <div className="mt-3 flex justify-center">
-              <div className="grid grid-flow-col gap-1 justify-center items-center">
+              <div className="grid grid-flow-col items-center justify-center gap-1">
                 <Text className="text-sm">Is your password okay?</Text>
 
                 <NavLink href="/signin" passHref>

--- a/dashboard/src/pages/signin.tsx
+++ b/dashboard/src/pages/signin.tsx
@@ -33,14 +33,14 @@ function SignInWithGithub({ setSignInMethod }: any) {
         <GithubIcon className="h-6 w-6" />
         <div>Continue with GitHub</div>
       </button>
-      <div className="mt-2 grid grid-flow-col gap-px items-center justify-center">
+      <div className="mt-2 grid grid-flow-col items-center justify-center gap-px">
         <span>or</span>
         <Button
           variant="borderless"
           type="button"
           size="small"
           onClick={() => setSignInMethod('email')}
-          className="hover:underline hover:bg-transparent"
+          className="hover:bg-transparent hover:underline"
         >
           sign in with email
         </Button>
@@ -137,19 +137,19 @@ function SignInWithEmail({ setSignInMethod }: any) {
       </FormProvider>
 
       {isError && (
-        <Text className="my-3 font-medium" sx={{ color: 'error.main' }}>
+        <Text className="my-3 font-medium" color="error">
           Error: {error.message}
         </Text>
       )}
 
-      <div className="mt-2 grid gap-px grid-flow-col items-center justify-center">
+      <div className="mt-2 grid grid-flow-col items-center justify-center gap-px">
         <span>or</span>
         <Button
           variant="borderless"
           type="button"
           size="small"
           onClick={() => setSignInMethod('github')}
-          className="hover:underline hover:bg-transparent"
+          className="hover:bg-transparent hover:underline"
         >
           sign in with GitHub
         </Button>
@@ -206,7 +206,7 @@ export default function SignInPage() {
             </Box>
 
             <div className="mt-3 flex justify-center">
-              <div className="grid grid-flow-col gap-1 justify-center items-center">
+              <div className="grid grid-flow-col items-center justify-center gap-1">
                 <Text className="text-sm">Don&apos;t have an account?</Text>
 
                 <NavLink href="/signup" passHref>

--- a/dashboard/src/pages/signup.tsx
+++ b/dashboard/src/pages/signup.tsx
@@ -53,14 +53,14 @@ function SignUpWithGithub({ setSignUpMethod }: any) {
         <GithubIcon className="h-6 w-6 text-white" />
         <div>Sign Up with GitHub</div>
       </button>
-      <div className="mt-2 grid grid-flow-col gap-px items-center justify-center">
+      <div className="mt-2 grid grid-flow-col items-center justify-center gap-px">
         <span>or</span>
         <Button
           variant="borderless"
           type="button"
           size="small"
           onClick={() => setSignUpMethod('email')}
-          className="hover:underline hover:bg-transparent"
+          className="hover:bg-transparent hover:underline"
         >
           sign up with email
         </Button>
@@ -172,19 +172,19 @@ function SignUpWithEmail({ setSignUpMethod }: any) {
       </FormProvider>
 
       {isError && (
-        <Text className="font-medium" sx={{ color: 'error.main' }}>
+        <Text className="font-medium" color="error">
           Error: {error.message}
         </Text>
       )}
 
-      <div className="mt-2 grid grid-flow-col gap-px items-center justify-center">
+      <div className="mt-2 grid grid-flow-col items-center justify-center gap-px">
         <span>or</span>
         <Button
           variant="borderless"
           type="button"
           size="small"
           onClick={() => setSignUpMethod('github')}
-          className="hover:underline hover:bg-transparent"
+          className="hover:bg-transparent hover:underline"
         >
           sign up with GitHub
         </Button>
@@ -235,10 +235,7 @@ export default function SignUpPage() {
               <div className="my-4">
                 <SignUpController />
               </div>
-              <Text
-                className="mt-4 text-center text-xs"
-                sx={{ color: 'text.secondary' }}
-              >
+              <Text className="mt-4 text-center text-xs" color="secondary">
                 By signing up, you agree to our{' '}
                 <Link
                   href="https://nhost.io/legal/terms-of-service"
@@ -261,7 +258,7 @@ export default function SignUpPage() {
               </Text>
             </Box>
             <div className="mt-3 flex justify-center">
-              <div className="grid grid-flow-col gap-1 justify-center items-center">
+              <div className="grid grid-flow-col items-center justify-center gap-1">
                 <Text className="text-sm">Already have an account?</Text>
 
                 <NavLink href="/signin" passHref>
@@ -310,7 +307,7 @@ export default function SignUpPage() {
                   height={24}
                 />
 
-                <Text className="!text-xl" sx={{ color: 'text.secondary' }}>
+                <Text className="!text-xl" color="secondary">
                   {sellingPoint}
                 </Text>
               </div>


### PR DESCRIPTION
Created a `color` property for the `Text` component to make it significantly easier to style the text color. As a positive side-effect of a recent change in the Prettier configuration, all the Tailwind classes got organized in all the affected files.

Please note that the target branch of this PR is `feat/dark-mode`, as my current changes depend on that PR.