### PR TITLE
exponential backoff

### DIFF
--- a/.changeset/old-wasps-yell.md
+++ b/.changeset/old-wasps-yell.md
@@ -1,0 +1,11 @@
+---
+'@nhost/hasura-auth-js': patch
+---
+
+Set limits to refreshing the token on error
+
+When starting, the client was trying to refresh the token five times every second, then indefinitely every five seconds.
+It is now limited to 5 attempts at the following intervals: 1, 2, 4, 8, and 16 seconds. If all these attempts fail, the user state is signed out.
+
+Similarly, when refreshing the token failed, the client was attempting to refresh the token every second.
+It is now limited to 5 attempts at the following intervals: 1, 2, 4, 8, and 16 seconds.

--- a/.changeset/old-wasps-yell.md
+++ b/.changeset/old-wasps-yell.md
@@ -5,7 +5,7 @@
 Set limits to refreshing the token on error
 
 When starting, the client was trying to refresh the token five times every second, then indefinitely every five seconds.
-It is now limited to 5 attempts at the following intervals: 1, 2, 4, 8, and 16 seconds. If all these attempts fail, the user state is signed out.
+It is now limited to 5 attempts at the following intervals: 5, 10, 20, 40, and 80 seconds. If all these attempts fail, the user state is signed out.
 
 Similarly, when refreshing the token failed, the client was attempting to refresh the token every second.
-It is now limited to 5 attempts at the following intervals: 1, 2, 4, 8, and 16 seconds.
+It is now limited to 5 attempts at the following intervals: 5, 10, 20, 40, and 80 seconds.

--- a/examples/react-apollo/cypress.config.ts
+++ b/examples/react-apollo/cypress.config.ts
@@ -10,7 +10,7 @@ export default defineConfig({
     env: {
       backendUrl: 'http://localhost:1337'
     },
-    defaultCommandTimeout: 10000,
-    requestTimeout: 10000
+    defaultCommandTimeout: 20000,
+    requestTimeout: 20000
   }
 } as Cypress.ConfigOptions)

--- a/examples/react-apollo/cypress.config.ts
+++ b/examples/react-apollo/cypress.config.ts
@@ -9,6 +9,8 @@ export default defineConfig({
     mailHogUrl: 'http://127.0.0.1:8025',
     env: {
       backendUrl: 'http://localhost:1337'
-    }
+    },
+    defaultCommandTimeout: 10000,
+    requestTimeout: 10000
   }
 } as Cypress.ConfigOptions)

--- a/packages/hasura-auth-js/src/constants.ts
+++ b/packages/hasura-auth-js/src/constants.ts
@@ -9,5 +9,4 @@ export const MIN_PASSWORD_LENGTH = 3
  */
 export const TOKEN_REFRESH_MARGIN = 300 // five minutes
 
-/** Number of seconds before retrying a token refresh after an error */
-export const REFRESH_TOKEN_RETRY_INTERVAL = 5
+export const REFRESH_TOKEN_MAX_ATTEMPTS = 5

--- a/packages/hasura-auth-js/src/machines/authentication/machine.ts
+++ b/packages/hasura-auth-js/src/machines/authentication/machine.ts
@@ -637,8 +637,8 @@ export const createAuthMachine = ({
               return false
             }
             const elapsed = Date.now() - ctx.refreshTimer.lastAttempt.getTime()
-            // * Exoponential backoff
-            return elapsed > ctx.refreshTimer.attempts * (ctx.refreshTimer.attempts - 1) * 1_000
+            // * Exponential backoff
+            return elapsed > Math.pow(2, ctx.refreshTimer.attempts - 1) * 1_000
           }
           if (refreshIntervalTime) {
             // * If a refreshIntervalTime has been passed on as an option, it will notify
@@ -920,7 +920,7 @@ export const createAuthMachine = ({
       delays: {
         RETRY_IMPORT_TOKEN_DELAY: ({ importTokenAttempts }) => {
           // * Exponential backoff
-          return importTokenAttempts * (importTokenAttempts - 1) * 1000
+          return Math.pow(2, importTokenAttempts - 1) * 1000
         }
       }
     }

--- a/packages/hasura-auth-js/src/machines/authentication/machine.ts
+++ b/packages/hasura-auth-js/src/machines/authentication/machine.ts
@@ -638,7 +638,7 @@ export const createAuthMachine = ({
             }
             const elapsed = Date.now() - ctx.refreshTimer.lastAttempt.getTime()
             // * Exponential backoff
-            return elapsed > Math.pow(2, ctx.refreshTimer.attempts - 1) * 1_000
+            return elapsed > Math.pow(2, ctx.refreshTimer.attempts - 1) * 5_000
           }
           if (refreshIntervalTime) {
             // * If a refreshIntervalTime has been passed on as an option, it will notify
@@ -920,7 +920,7 @@ export const createAuthMachine = ({
       delays: {
         RETRY_IMPORT_TOKEN_DELAY: ({ importTokenAttempts }) => {
           // * Exponential backoff
-          return Math.pow(2, importTokenAttempts - 1) * 1000
+          return Math.pow(2, importTokenAttempts - 1) * 5_000
         }
       }
     }

--- a/packages/hasura-auth-js/src/machines/authentication/machine.ts
+++ b/packages/hasura-auth-js/src/machines/authentication/machine.ts
@@ -10,7 +10,7 @@ import { assign, createMachine, InterpreterFrom, send } from 'xstate'
 import {
   NHOST_JWT_EXPIRES_AT_KEY,
   NHOST_REFRESH_TOKEN_KEY,
-  REFRESH_TOKEN_RETRY_INTERVAL,
+  REFRESH_TOKEN_MAX_ATTEMPTS,
   TOKEN_REFRESH_MARGIN
 } from '../../constants'
 import {
@@ -331,19 +331,7 @@ export const createAuthMachine = ({
                               actions: ['saveSession', 'resetTimer', 'reportTokenChanged'],
                               target: 'pending'
                             },
-                            onError: [
-                              { actions: 'saveRefreshAttempt', target: 'pending' }
-                              // ? stop trying after x attempts?
-                              // {
-                              //   actions: 'retry',
-                              //   cond: 'canRetry',
-                              //   target: 'pending'
-                              // },
-                              // {
-                              //   actions: ['sendError', 'resetToken'],
-                              //   target: '#timer.stopped'
-                              // }
-                            ]
+                            onError: [{ actions: 'saveRefreshAttempt', target: 'pending' }]
                           }
                         }
                       }
@@ -644,9 +632,13 @@ export const createAuthMachine = ({
             return false
           }
           if (ctx.refreshTimer.lastAttempt) {
-            // * If a refesh previously failed, only try to refresh every `REFRESH_TOKEN_RETRY_INTERVAL` seconds
+            // * If the refresh timer reached the maximum number of attempts, we should not try again
+            if (ctx.refreshTimer.attempts > REFRESH_TOKEN_MAX_ATTEMPTS) {
+              return false
+            }
             const elapsed = Date.now() - ctx.refreshTimer.lastAttempt.getTime()
-            return elapsed > REFRESH_TOKEN_RETRY_INTERVAL * 1_000
+            // * Exoponential backoff
+            return elapsed > ctx.refreshTimer.attempts * (ctx.refreshTimer.attempts - 1) * 1_000
           }
           if (refreshIntervalTime) {
             // * If a refreshIntervalTime has been passed on as an option, it will notify
@@ -663,9 +655,12 @@ export const createAuthMachine = ({
           return remaining <= 0
         },
         // * Untyped action payload. See https://github.com/statelyai/xstate/issues/3037
-        /** Shoud retry to import the token on network error or any internal server error */
-        shouldRetryImportToken: (_, e: any) =>
-          e.data.error.status === NETWORK_ERROR_CODE || e.data.error.status >= 500,
+        /** Shoud retry to import the token on network error or any internal server error.
+         * Don't retry more than REFRESH_TOKEN_MAX_ATTEMPTS times.
+         */
+        shouldRetryImportToken: (ctx, e: any) =>
+          ctx.importTokenAttempts < REFRESH_TOKEN_MAX_ATTEMPTS &&
+          (e.data.error.status === NETWORK_ERROR_CODE || e.data.error.status >= 500),
         // * Authentication errors
         // * Untyped action payload. See https://github.com/statelyai/xstate/issues/3037
         unverified: (_, { data: { error } }: any) =>
@@ -924,10 +919,8 @@ export const createAuthMachine = ({
       },
       delays: {
         RETRY_IMPORT_TOKEN_DELAY: ({ importTokenAttempts }) => {
-          if (importTokenAttempts < 5) {
-            return 1000
-          }
-          return 5000
+          // * Exponential backoff
+          return importTokenAttempts * (importTokenAttempts - 1) * 1000
         }
       }
     }

--- a/packages/hasura-auth-js/tests/refreshToken.test.ts
+++ b/packages/hasura-auth-js/tests/refreshToken.test.ts
@@ -488,7 +488,7 @@ describe(`Auto sign-in`, () => {
     expect(state.context.importTokenAttempts).toEqual(2)
   })
 
-  test.only(`should wait for the server to be online when starting offline`, async () => {
+  test(`should wait for the server to be online when starting offline`, async () => {
     server.use(authTokenInternalErrorHandler)
 
     vi.stubGlobal('location', {

--- a/packages/hasura-auth-js/tests/refreshToken.test.ts
+++ b/packages/hasura-auth-js/tests/refreshToken.test.ts
@@ -488,7 +488,7 @@ describe(`Auto sign-in`, () => {
     expect(state.context.importTokenAttempts).toEqual(2)
   })
 
-  test(`should wait for the server to be online when starting offline`, async () => {
+  test.only(`should wait for the server to be online when starting offline`, async () => {
     server.use(authTokenInternalErrorHandler)
 
     vi.stubGlobal('location', {

--- a/packages/hasura-auth-js/tests/refreshToken.test.ts
+++ b/packages/hasura-auth-js/tests/refreshToken.test.ts
@@ -511,7 +511,7 @@ describe(`Auto sign-in`, () => {
       state.matches('authentication.signedIn')
     )
     expect(signedInState.context.user).not.toBeNull()
-  })
+  }, 5000)
 
   test(`should automatically sign in if "refreshToken" was in the URL`, async () => {
     vi.stubGlobal('location', {

--- a/packages/hasura-auth-js/tests/refreshToken.test.ts
+++ b/packages/hasura-auth-js/tests/refreshToken.test.ts
@@ -471,7 +471,7 @@ describe(`Auto sign-in`, () => {
     const state = await waitFor(authService, (state) => state.context.importTokenAttempts === 2)
 
     expect(state.context.importTokenAttempts).toEqual(2)
-  })
+  }, 20000)
 
   test(`should retry a token refresh if server returns an error`, async () => {
     server.use(authTokenInternalErrorHandler)
@@ -486,7 +486,7 @@ describe(`Auto sign-in`, () => {
     const state = await waitFor(authService, (state) => state.context.importTokenAttempts === 2)
 
     expect(state.context.importTokenAttempts).toEqual(2)
-  })
+  }, 20000)
 
   test(`should wait for the server to be online when starting offline`, async () => {
     server.use(authTokenInternalErrorHandler)
@@ -511,7 +511,7 @@ describe(`Auto sign-in`, () => {
       state.matches('authentication.signedIn')
     )
     expect(signedInState.context.user).not.toBeNull()
-  }, 5000)
+  }, 20000)
 
   test(`should automatically sign in if "refreshToken" was in the URL`, async () => {
     vi.stubGlobal('location', {


### PR DESCRIPTION
Set limits to refreshing the token on error

 When starting, the client was trying to refresh the token five times every second, then indefinitely every five seconds.
 It is now limited to 5 attempts at the following intervals: 5, 10, 20, 40, and 80 seconds. If all these attempts fail, the user state is signed out.

 Similarly, when refreshing the token failed, the client attempted to refresh the token every second.
 It is now limited to 5 attempts at the following intervals: 5, 10, 20, 40, and 80 seconds.
