### PR TITLE
Build types error different versions of NHost

### DIFF
--- a/integrations/apollo/src/index.ts
+++ b/integrations/apollo/src/index.ts
@@ -11,7 +11,7 @@ import {
 import { setContext } from '@apollo/client/link/context'
 import { GraphQLWsLink } from '@apollo/client/link/subscriptions'
 import { getMainDefinition } from '@apollo/client/utilities'
-import { NhostClient } from '@nhost/nhost-js'
+import { NhostClient } from '@nhost/react'
 
 import { createRestartableClient } from './ws'
 const isBrowser = typeof window !== 'undefined'


### PR DESCRIPTION
By making this change I have no issues with types using documentation here:

https://docs.nhost.io/reference/react/apollo

Otherwise following that same example and running yarn build to check types will throw an error.

```
Type error: Type 'import("/node_modules/@nhost/react/dist/client").NhostClient' is not assignable to type 'import("/node_modules/@nhost/nhost-js/dist/core/nhost-client").NhostClient'.
  Types of property 'auth' are incompatible.
    Type 'HasuraAuthClient' is missing the following properties from type 'HasuraAuthClient': api, onTokenChangedFunctions, onAuthChangedFunctions, refreshInterval, and 19 more.

  34 |     <NhostProvider nhost={nhost}>
  35 |       <NhostApolloProvider
> 36 |         nhost={nhost}
     |         ^
```