### PR TITLE
chore: create changesest from Renovate bumps

### DIFF
--- a/.changeset/overselling-january-smoggy.md
+++ b/.changeset/overselling-january-smoggy.md
@@ -1,0 +1,6 @@
+---
+"@nhost/docgen": patch
+"@nhost/docs": patch
+---
+
+fix(deps): update docusaurus monorepo to v2.3.1

--- a/.changeset/overselling-january-smoggy.md
+++ b/.changeset/overselling-january-smoggy.md
@@ -1,6 +1,5 @@
 ---
-"@nhost/docgen": patch
-"@nhost/docs": patch
+'@nhost/docs': patch
 ---
 
 fix(deps): update docusaurus monorepo to v2.3.1

--- a/.changeset/pink-monkeys-scream.md
+++ b/.changeset/pink-monkeys-scream.md
@@ -1,0 +1,10 @@
+---
+'@nhost/hasura-auth-js': patch
+'@nhost/hasura-storage-js': patch
+'@nhost/nextjs': patch
+'@nhost/nhost-js': patch
+'@nhost/react': patch
+'@nhost/vue': patch
+---
+
+chore(deps): update dependency @nhost/docgen to 0.1.6

--- a/.changeset/seven-eyes-develop.md
+++ b/.changeset/seven-eyes-develop.md
@@ -1,0 +1,5 @@
+---
+'@nhost/docgen': patch
+---
+
+fix(deps): update dependency commander to v10


### PR DESCRIPTION
This PR creates the changesets from the Renovate dependencies that have been merged to main.