### PR TITLE
Use es2019 build target

### DIFF
--- a/config/vite.lib.config.js
+++ b/config/vite.lib.config.js
@@ -35,6 +35,7 @@ export default defineConfig({
     }
   },
   build: {
+    target: "es2019", // https://esbuild.docschina.org/content-types/#javascript
     sourcemap: true,
     lib: {
       entry,


### PR DESCRIPTION
This is a fix for https://github.com/nhost/nhost/issues/1623 and https://github.com/nhost/nhost/issues/1607

It seems that if the target to esbuild is es2019 it transforms the nullish coalescing (??) operator, which causes problem in React Native and Expo. Starting from es2020 it does not transforms those.

From the documentation I thought we should use es2020, but actually we need es2019 to make it work.

https://esbuild.docschina.org/content-types/#javascript

I am not sure of all the implications of the build targets, but I guess targeting older JS versions is overall safe.