### PR TITLE
chore: create changesest from Renovate bumps

### DIFF
--- a/.changeset/fixity-yachting-bigot.md
+++ b/.changeset/fixity-yachting-bigot.md
@@ -1,0 +1,16 @@
+---
+"@nhost/apollo": patch
+"@nhost/dashboard": patch
+"@nhost/docgen": patch
+"@nhost/docs": patch
+"@nhost/hasura-auth-js": patch
+"@nhost/hasura-storage-js": patch
+"@nhost/nextjs": patch
+"@nhost/nhost-js": patch
+"@nhost/react": patch
+"@nhost/react-apollo": patch
+"@nhost/react-urql": patch
+"@nhost/vue": patch
+---
+
+chore(deps): update dependency @types/react to v18.0.28


### PR DESCRIPTION
This PR creates the changesets from the Renovate dependencies that have been merged to main.