### PR TITLE
Remove double forward slash "/" from function call

### DIFF
--- a/packages/nhost-js/src/clients/functions/index.ts
+++ b/packages/nhost-js/src/clients/functions/index.ts
@@ -69,7 +69,7 @@ export class NhostFunctionsClient {
     const functionUrl = url.startsWith('/') ? url : `/${url}`
 
     try {
-      const result = await fetch(`${backendUrl}/${functionUrl}`, {
+      const result = await fetch(`${backendUrl}${functionUrl}`, {
         body: JSON.stringify(body),
         headers,
         method: 'POST'


### PR DESCRIPTION
Remove double forward slash "/" from function call. Noticed today that after upgrading to the latest 2.0.4 @nhost/react package that function calls made with the Nhost client were being requested using double // forward slashes in the url.
http://localhost:1337/v1/functions//path/subpath

this happens regardless of which way I call it
nhost.functions.call("/path/subpath",.....
or
nhost.functions.call("path/subpath",.....

Small change but this should fix the issue.