### PR TITLE
chore: create changesest from Renovate bumps

### DIFF
--- a/.changeset/budgeted-original-controversies.md
+++ b/.changeset/budgeted-original-controversies.md
@@ -1,0 +1,5 @@
+---
+"@nhost/dashboard": patch
+---
+
+chore(deps): update graphqlcodegenerator monorepo to v3 (major)


### PR DESCRIPTION
This PR creates the changesets from the Renovate dependencies that have been merged to main.