### PR TITLE
chore: create changesest from Renovate bumps

### DIFF
--- a/.changeset/nanak-mundane-jitterbugs.md
+++ b/.changeset/nanak-mundane-jitterbugs.md
@@ -1,0 +1,6 @@
+---
+"@nhost/dashboard": patch
+"@nhost/vue": patch
+---
+
+chore(deps): update dependency @xstate/inspect to ^0.8.0


### PR DESCRIPTION
This PR creates the changesets from the Renovate dependencies that have been merged to main.