### PR TITLE
chore: create changesest from Renovate bumps

### DIFF
--- a/.changeset/bola-insensitivity-underpaying.md
+++ b/.changeset/bola-insensitivity-underpaying.md
@@ -1,0 +1,5 @@
+---
+"@nhost/dashboard": patch
+---
+
+fix(deps): update dependency @graphiql/react to ^0.17.0


### PR DESCRIPTION
This PR creates the changesets from the Renovate dependencies that have been merged to main.