### PR TITLE
Added Javascript origins step to docs

### DIFF
--- a/docs/docs/authentication/sign-in-methods/4-google.mdx
+++ b/docs/docs/authentication/sign-in-methods/4-google.mdx
@@ -56,7 +56,7 @@ Follow this guide to sign in users with Google.
 - Click on **Credentials** under **APIs & Services** in the left menu.
 - Click **+ CREATE CREDENTIALS** and then **OAuth client ID** in the top menu.
 - On the **Create OAuth client ID** page for **Application Type** select **Web application**.
-- Under **Authorized Javascript origins** add the start of your **OAuth Callback URL** from Nhost.
+- Under **Authorized JavaScript origins**, add your project's redirect URL for the Google sign-in method in the following format: `https://<subdomain>.auth.<region>.nhost.run`
 - Under **Authorized redirect URIs** add your **OAuth Callback URL** from Nhost.
 - Click **CREATE**.
 

--- a/docs/docs/authentication/sign-in-methods/4-google.mdx
+++ b/docs/docs/authentication/sign-in-methods/4-google.mdx
@@ -56,6 +56,7 @@ Follow this guide to sign in users with Google.
 - Click on **Credentials** under **APIs & Services** in the left menu.
 - Click **+ CREATE CREDENTIALS** and then **OAuth client ID** in the top menu.
 - On the **Create OAuth client ID** page for **Application Type** select **Web application**.
+- Under **Authorized Javascript origins** add the start of your **OAuth Callback URL** from Nhost.
 - Under **Authorized redirect URIs** add your **OAuth Callback URL** from Nhost.
 - Click **CREATE**.
 


### PR DESCRIPTION
The guide was missing a step - you also have to fill out the JavaScript origins with your Nhost URI otherwise you get a 404 error when authenticating.