### PR TITLE
Update serverless-functions to link to event trigger docs

### DIFF
--- a/.changeset/odd-dots-end.md
+++ b/.changeset/odd-dots-end.md
@@ -1,0 +1,5 @@
+---
+'@nhost/docs': patch
+---
+
+chore: add link to event triggers on the serverless functions page

--- a/docs/docs/serverless-functions.mdx
+++ b/docs/docs/serverless-functions.mdx
@@ -25,8 +25,6 @@ export default (req: Request, res: Response) => {
   res.status(200).send(`Hello ${req.query.name}!`)
 }
 ```
-    
-The same [environment variables that are used to configure event triggers](https://docs.nhost.io/database/event-triggers#format) can be used to authenticate regular serverless functions.
 
 :::info
 
@@ -85,6 +83,8 @@ older (`functions/_utils/<utils-files>.js`).
 ## Environment Variables
 
 [Environment variables](/platform/environment-variables) are available inside your Serverless Functions. Both in production and when running Nhost locally using the [Nhost CLI](/cli).
+
+The same [environment variables that are used to configure event triggers](https://docs.nhost.io/database/event-triggers#format) can be used to authenticate regular serverless functions.
 
 ## Examples
 

--- a/docs/docs/serverless-functions.mdx
+++ b/docs/docs/serverless-functions.mdx
@@ -25,6 +25,8 @@ export default (req: Request, res: Response) => {
   res.status(200).send(`Hello ${req.query.name}!`)
 }
 ```
+    
+The same [environment variables that are used to configure event triggers](https://docs.nhost.io/database/event-triggers#format) can be used to authenticate regular serverless functions.
 
 :::info
 


### PR DESCRIPTION
Based on https://github.com/nhost/nhost/discussions/1752#discussioncomment-5380702 adding a link so users know to look at the other section for more information on configuring functions.