### PR TITLE
fix(nhost-js): don't suppress error messages

### DIFF
--- a/.changeset/healthy-seals-argue.md
+++ b/.changeset/healthy-seals-argue.md
@@ -1,0 +1,5 @@
+---
+'@nhost/nhost-js': patch
+---
+
+fix(functions): show more detailed error messages

--- a/.changeset/odd-rocks-sort.md
+++ b/.changeset/odd-rocks-sort.md
@@ -1,0 +1,5 @@
+---
+'@nhost/vue': patch
+---
+
+fix(hooks): use correct return type for `useError`

--- a/packages/nhost-js/src/clients/functions/index.ts
+++ b/packages/nhost-js/src/clients/functions/index.ts
@@ -79,11 +79,11 @@ export class NhostFunctionsClient {
    *
    * @docs https://docs.nhost.io/reference/javascript/nhost-js/functions/call
    */
-  async call<TData = unknown, TBody = any, TErrorMessage = unknown>(
+  async call<TData = unknown, TBody = any, TErrorMessage = any>(
     url: string,
     body?: TBody | null,
     config?: NhostFunctionCallConfig
-  ): Promise<NhostFunctionCallResponse<TData>> {
+  ): Promise<NhostFunctionCallResponse<TData, TErrorMessage>> {
     const headers: HeadersInit = {
       'Content-Type': 'application/json',
       ...this.generateAccessTokenHeaders(),
@@ -111,7 +111,7 @@ export class NhostFunctionsClient {
         return {
           res: null,
           error: {
-            message: message || 'Unknown error',
+            message,
             error: result.statusText,
             status: result.status
           }
@@ -135,7 +135,7 @@ export class NhostFunctionsClient {
       return {
         res: null,
         error: {
-          message: error.message,
+          message: error.message as unknown as TErrorMessage,
           status: error.name === 'AbortError' ? 0 : 500,
           error: error.name === 'AbortError' ? 'abort-error' : 'unknown'
         }

--- a/packages/nhost-js/src/clients/functions/types.ts
+++ b/packages/nhost-js/src/clients/functions/types.ts
@@ -11,10 +11,10 @@ export interface NhostFunctionsConstructorParams {
   adminSecret?: string
 }
 
-export type NhostFunctionCallResponse<T = unknown> =
+export type NhostFunctionCallResponse<TData = unknown, TErrorMessage = unknown> =
   | {
       res: {
-        data: T
+        data: TData
         status: number
         statusText: string
       }
@@ -22,7 +22,7 @@ export type NhostFunctionCallResponse<T = unknown> =
     }
   | {
       res: null
-      error: ErrorPayload
+      error: ErrorPayload<TErrorMessage>
     }
 
 /** Subset of RequestInit parameters that are supported by the functions client */

--- a/packages/nhost-js/src/clients/functions/types.ts
+++ b/packages/nhost-js/src/clients/functions/types.ts
@@ -11,7 +11,7 @@ export interface NhostFunctionsConstructorParams {
   adminSecret?: string
 }
 
-export type NhostFunctionCallResponse<TData = unknown, TErrorMessage = unknown> =
+export type NhostFunctionCallResponse<TData = unknown, TErrorMessage = any> =
   | {
       res: {
         data: TData

--- a/packages/nhost-js/src/utils/types.ts
+++ b/packages/nhost-js/src/utils/types.ts
@@ -1,10 +1,10 @@
 import { NhostAuthConstructorParams } from '@nhost/hasura-auth-js'
 
 // TODO shared with other packages
-export interface ErrorPayload {
+export interface ErrorPayload<TMessage = unknown> {
   error: string
   status: number
-  message: string
+  message: TMessage
 }
 
 // TODO shared with other packages

--- a/packages/nhost-js/src/utils/types.ts
+++ b/packages/nhost-js/src/utils/types.ts
@@ -1,7 +1,7 @@
 import { NhostAuthConstructorParams } from '@nhost/hasura-auth-js'
 
 // TODO shared with other packages
-export interface ErrorPayload<TMessage = unknown> {
+export interface ErrorPayload<TMessage = any> {
   error: string
   status: number
   message: TMessage

--- a/packages/vue/src/useError.ts
+++ b/packages/vue/src/useError.ts
@@ -1,10 +1,10 @@
-import { ErrorPayload, StateErrorTypes } from '@nhost/nhost-js'
+import { AuthErrorPayload, StateErrorTypes } from '@nhost/nhost-js'
 import { useSelector } from '@xstate/vue'
 import { Ref } from 'vue'
 import { useAuthInterpreter } from './useAuthInterpreter'
 
 /** @internal */
-export const useError = (type: StateErrorTypes): Ref<ErrorPayload | null> => {
+export const useError = (type: StateErrorTypes): Ref<AuthErrorPayload | null> => {
   const service = useAuthInterpreter()
   return useSelector(
     service.value,


### PR DESCRIPTION
Error messages coming from serverless functions were suppressed by the SDK.

See this discussion for more information: https://discord.com/channels/552499021260914688/1095126695197016117

Fixes #1832 