### PR TITLE
Wait for valid token or sign out before establishing connection.

### DIFF
--- a/.changeset/green-kangaroos-wait.md
+++ b/.changeset/green-kangaroos-wait.md
@@ -1,0 +1,5 @@
+---
+'@nhost/apollo': patch
+---
+
+Adds async headers that waits for valid token before establishing connection to backend.

--- a/integrations/apollo/src/index.ts
+++ b/integrations/apollo/src/index.ts
@@ -59,7 +59,7 @@ export const createApolloClient = ({
   let accessToken: AuthContext['accessToken'] | null = null
 
   const isTokenValid = () =>
-    accessToken?.value && accessToken?.expiresAt && accessToken.expiresAt > new Date()
+    !!accessToken?.value && !!accessToken?.expiresAt && accessToken?.expiresAt > new Date()
 
   const awaitValidTokenOrNull = () =>
     new Promise((resolve) => {

--- a/integrations/apollo/src/index.ts
+++ b/integrations/apollo/src/index.ts
@@ -65,7 +65,6 @@ export const createApolloClient = ({
     new Promise((resolve) => {
       // doing this as an interval to avoid race conditions that I imagine can happen if listening to token changes. Maybe there's a better way.
       const interval = setInterval(() => {
-        console.log('checking for token change')
         if (!accessToken || isTokenValid()) {
           clearInterval(interval)
           resolve(true)


### PR DESCRIPTION
Some background: We are using nhost to develop a react-native app.

The issue we are having is that when we go back to the app after the token has been expired and a query is fired before nhost auth handles a token refresh, that query obviously fail.

This is the way I solved the issue. Maybe there's a nicer way to do it, maybe subscribing to token changes is better? Feedback is welcome if you have any ideas. But this should ensure that the connection waits to be established until we have a valid token (or are signed out).

Just threw this together now. Will test how it works for our issue tomorrow.

Update: works great for us and we don't have the issue anymore