### PR TITLE
Fixed linking to wrong destination in docs

### DIFF
--- a/docs/docs/authentication/index.mdx
+++ b/docs/docs/authentication/index.mdx
@@ -12,7 +12,7 @@ Nhost Authentication lets you authenticate users using different sign-in methods
 - [Email and Password](/authentication/sign-in-with-email-and-password)
 - [Magic Link](/authentication/sign-in-with-magic-link)
 - [Phone Number (SMS)](/authentication/sign-in-with-phone-number-sms)
-- [Security Keys (WebAuthn)](/authentication/sign-in-with-phone-number-sms)
+- [Security Keys (WebAuthn)](/authentication/sign-in-with-security-keys)
 - [Apple](/authentication/sign-in-with-apple)
 - [Discord](/authentication/sign-in-with-discord)
 - [Facebook](/authentication/sign-in-with-facebook)


### PR DESCRIPTION
On the docs page describing login methods [`Security Keys (WebAuthn)`](https://docs.nhost.io/authentication/sign-in-methods) is linking to `/authentication/sign-in-with-phone-number-sms`, however it should be linking to `/authentication/sign-in-methods`.

This PR fixes that.