### PR TITLE
fix(dashboard): don't break builds

### DIFF
--- a/dashboard/src/pages/[workspaceSlug]/[appSlug]/metrics/index.tsx
+++ b/dashboard/src/pages/[workspaceSlug]/[appSlug]/metrics/index.tsx
@@ -1,7 +1,7 @@
 import { UnlockFeatureByUpgrading } from '@/components/applications/UnlockFeatureByUpgrading';
 import Container from '@/components/layout/Container';
 import ProjectLayout from '@/components/layout/ProjectLayout';
-import { useCurrentWorkspaceAndProject } from '@/hooks/v2/useCurrentWorkspaceAndProject';
+import { useCurrentWorkspaceAndProject } from '@/features/projects/common/hooks/useCurrentWorkspaceAndProject';
 import ActivityIndicator from '@/ui/v2/ActivityIndicator';
 import Box from '@/ui/v2/Box';
 import Button from '@/ui/v2/Button/Button';


### PR DESCRIPTION
The PR that updated import paths has not been rebased onto main and there was newly added import path that was not updated.