### PR TITLE
chore: increase timeout for Publish to Docker Hub

### DIFF
--- a/.github/workflows/changesets.yaml
+++ b/.github/workflows/changesets.yaml
@@ -100,7 +100,7 @@ jobs:
           password: ${{ secrets.DOCKER_PASSWORD }}
       - name: Build and push to Docker Hub
         uses: docker/build-push-action@v4
-        timeout-minutes: 60
+        timeout-minutes: 90
         with:
           context: .
           file: ./dashboard/Dockerfile


### PR DESCRIPTION
I've deleted almost all the cache, and now we just need this to run successfully without a timeout to be able to write a new cache