### PR TITLE
fix: integrations: apollo: set accessToken to null after TOKEN_CHANGED event on sign-out

### DIFF
--- a/.changeset/violet-onions-swim.md
+++ b/.changeset/violet-onions-swim.md
@@ -1,0 +1,5 @@
+---
+'@nhost/apollo': patch
+---
+
+fix: apollo-integration: reset accessToken to null after sign-out

--- a/integrations/apollo/src/index.ts
+++ b/integrations/apollo/src/index.ts
@@ -187,7 +187,10 @@ export const createApolloClient = ({
 
   interpreter?.onTransition(async (state, event) => {
     if (['SIGNOUT', 'SIGNED_IN', 'TOKEN_CHANGED'].includes(event.type)) {
-      if (event.type === 'SIGNOUT') {
+      if (
+        event.type === 'SIGNOUT' ||
+        (event.type === 'TOKEN_CHANGED' && state.context.accessToken === null)
+      ) {
         accessToken = null
 
         try {


### PR DESCRIPTION
resolve #2297