### PR TITLE
Update Docs for useChangeEmail.ts Example

### DIFF
--- a/.changeset/fuzzy-wasps-breathe.md
+++ b/.changeset/fuzzy-wasps-breathe.md
@@ -3,4 +3,4 @@
 '@nhost/vue': patch
 ---
 
-fix(docs): update changeEmail usage referance
+fix(docs): update changeEmail usage reference

--- a/.changeset/fuzzy-wasps-breathe.md
+++ b/.changeset/fuzzy-wasps-breathe.md
@@ -1,0 +1,6 @@
+---
+'@nhost/react': patch
+'@nhost/vue': patch
+---
+
+fix(docs): update changeEmail usage referance

--- a/packages/react/src/useChangeEmail.ts
+++ b/packages/react/src/useChangeEmail.ts
@@ -30,9 +30,7 @@ export interface ChangeEmailHookResult extends ChangeEmailState {
  * const handleFormSubmit = async (e) => {
  *   e.preventDefault();
  *
- *   await changeEmail({
- *     email: 'new@example.com',
- *   })
+ *   await changeEmail('new@example.com')
  * }
  * ```
  *

--- a/packages/vue/src/useChangeEmail.ts
+++ b/packages/vue/src/useChangeEmail.ts
@@ -29,9 +29,7 @@ export interface ChangeEmailComposableResult extends ToRefs<ChangeEmailState> {
  * const handleFormSubmit = async (e) => {
  *   e.preventDefault();
  *
- *   await changeEmail({
- *     email: 'new@example.com',
- *   })
+ *   await changeEmail('new@example.com')
  * }
  * ```
  *


### PR DESCRIPTION
The example provided in docs has been modified from;
 
```
 await changeEmail({
    email: 'new@example.com'
  })
```

to;

 `await changeEmail('new@example.com')`