### PR TITLE
feat: export urlFromSubdomain helper

### DIFF
--- a/.changeset/breezy-pugs-wash.md
+++ b/.changeset/breezy-pugs-wash.md
@@ -1,0 +1,5 @@
+---
+'@nhost/nhost-js': patch
+---
+
+feat: export `urlFromSubdomain` helper

--- a/packages/nhost-js/src/index.ts
+++ b/packages/nhost-js/src/index.ts
@@ -1,4 +1,5 @@
 export * from '@nhost/hasura-auth-js'
 export * from '@nhost/hasura-storage-js'
 export * from './clients'
+export { urlFromSubdomain } from './utils/helpers'
 export * from './utils/types'

--- a/packages/nhost-js/src/utils/helpers.ts
+++ b/packages/nhost-js/src/utils/helpers.ts
@@ -5,9 +5,9 @@ export const LOCALHOST_REGEX =
   /^((?<protocol>http[s]?):\/\/)?(?<host>(localhost|local))(:(?<port>(\d+|__\w+__)))?$/
 
 /**
- * `backendUrl` should now be used only when self-hosting
- * `subdomain` and `region` should be used instead when using the Nhost platform
- * `
+ * \`backendUrl\` should now be used only when self-hosting
+ * \`subdomain\` and `region` should be used instead when using the Nhost platform
+ *
  * @param backendOrSubdomain
  * @param service
  * @returns


### PR DESCRIPTION
There are many cases when it would be useful to construct the default nhost URLs and it would be helpful to be able to use the existing urlFromSubdomain helper instead of cobbling together the URLs from scratch. One example would be when using a custom auth domain and needing to switch to init the client with serviceUrls but needing to keep the other URLs as default.

