### PR TITLE
feat(examples): add sign-in with Linked to react-apollo

### DIFF
--- a/.changeset/six-spies-tie.md
+++ b/.changeset/six-spies-tie.md
@@ -1,0 +1,5 @@
+---
+'@nhost-examples/react-apollo': patch
+---
+
+feat: add sign-in with Linked-In

--- a/examples/react-apollo/nhost/nhost.toml
+++ b/examples/react-apollo/nhost/nhost.toml
@@ -28,7 +28,7 @@ httpPoolSize = 100
 version = 18
 
 [auth]
-version = '0.21.4'
+version = 'local'
 
 [auth.redirections]
 clientUrl = 'https://react-apollo.example.nhost.io/'
@@ -112,7 +112,9 @@ clientId = '{{ secrets.GOOGLE_CLIENT_ID }}'
 clientSecret = '{{ secrets.GOOGLE_CLIENT_SECRET }}'
 
 [auth.method.oauth.linkedin]
-enabled = false
+enabled = true
+clientId='{{ secrets.LINKEDIN_CLIENT_ID }}'
+clientSecret='{{ secrets.LINKEDIN_CLIENT_SECRET }}'
 
 [auth.method.oauth.spotify]
 enabled = false

--- a/examples/react-apollo/nhost/nhost.toml
+++ b/examples/react-apollo/nhost/nhost.toml
@@ -28,7 +28,7 @@ httpPoolSize = 100
 version = 18
 
 [auth]
-version = 'local'
+version = '0.22.1'
 
 [auth.redirections]
 clientUrl = 'https://react-apollo.example.nhost.io/'

--- a/examples/react-apollo/src/components/OauthLinks.tsx
+++ b/examples/react-apollo/src/components/OauthLinks.tsx
@@ -1,11 +1,13 @@
-import { FaApple, FaGithub, FaGoogle } from 'react-icons/fa/index.js'
+import { FaApple, FaGithub, FaGoogle, FaLinkedin } from 'react-icons/fa/index.js'
 
 import { useProviderLink } from '@nhost/react'
 
 import AuthLink from './AuthLink'
 
 export default function OauthLinks() {
-  const { github, google, apple } = useProviderLink({ redirectTo: window.location.origin })
+  const { github, google, apple, linkedin } = useProviderLink({
+    redirectTo: window.location.origin
+  })
 
   return (
     <>
@@ -17,6 +19,10 @@ export default function OauthLinks() {
       </AuthLink>
       <AuthLink leftIcon={<FaApple />} link={apple} color="#333333">
         Sign In With Apple
+      </AuthLink>
+
+      <AuthLink leftIcon={<FaLinkedin />} link={linkedin} color="#0073B1">
+        Sign In With LinkedIn
       </AuthLink>
     </>
   )


### PR DESCRIPTION
- needs this [PR](https://github.com/nhost/hasura-auth/pull/438) merged and the latest version of `hasura-auth`
- related to this https://github.com/nhost/nhost/issues/2364
- fixes this https://github.com/nhost/projects/issues/43