### PR TITLE
fix(docs): add instructions for enabling Sign In with LinkedIn using OpenID Connect

### DIFF
--- a/.changeset/rare-fans-marry.md
+++ b/.changeset/rare-fans-marry.md
@@ -1,0 +1,5 @@
+---
+'@nhost/docs': patch
+---
+
+fix: add instructions for enabling Sign In with LinkedIn using OpenID Connect

--- a/docs/docs/authentication/sign-in-methods/4-linkedin.mdx
+++ b/docs/docs/authentication/sign-in-methods/4-linkedin.mdx
@@ -36,6 +36,14 @@ Follow this guide to sign in users with LinkedIn.
 - Copy and paste the **OAuth Callback URL** from Nhost.
 - Click **Update**.
 
+## Enable Sign In with LinkedIn using OpenID Connect
+
+- Click on **Products** in the top menu.
+- Scroll down and look for **Sign In with LinkedIn using OpenID Connect**.
+- Click **Request Access**.
+- Click the checkbox **I have read and agree to these terms**.
+- Click **Request Access**.
+
 ## Configure Nhost
 
 - Copy and paste the **Client ID** and **Client Secret** from LinkedIn to your Nhost OAuth settings for LinkedIn.


### PR DESCRIPTION
related to #2364 