### PR TITLE
chore (examples/docker-compose): update README.md to explain why hasura-console is needed

### DIFF
--- a/.changeset/clever-pigs-end.md
+++ b/.changeset/clever-pigs-end.md
@@ -1,0 +1,5 @@
+---
+'@nhost-examples/docker-compose': patch
+---
+
+Clarify instructions for running the Nhost dashboard with Docker Compose

--- a/examples/docker-compose/README.md
+++ b/examples/docker-compose/README.md
@@ -25,10 +25,12 @@ The following endpoints are now exposed:
 
 ## Running the Nhost dashboard locally
 
-In order to use the Nhost dashboard, you need to run the [Hasura console locally from the Hasura CLI](https://hasura.io/docs/latest/hasura-cli/commands/hasura_console/):
+In order for you to be able to make edits to the database from the Nhost dashboard, you need to run the [Hasura console locally from the Hasura CLI](https://hasura.io/docs/latest/hasura-cli/commands/hasura_console/):
 
 ```sh
 hasura console
 ```
 
-The Nhost Dashboard also requires the Hasura admin secret to `nhost-admin-secret`. This will change in the future. If you can't wait, don't hesitate to contribute.
+The Nhost Dashboard uses the [Hasura migrations API](https://hasura.io/docs/latest/hasura-cli/commands/hasura_console/#options) in order to make edits to the database. It runs over port 9693 and is only accessible through running the Hasura console from the CLI. It is not accessible from the Hasura Docker image yet. That is why you need to run it locally. See https://github.com/nhost/nhost/issues/1220.
+
+The Nhost Dashboard also requires the Hasura admin secret to `nhost-admin-secret` specified in the `.env` file.

--- a/examples/docker-compose/README.md
+++ b/examples/docker-compose/README.md
@@ -31,6 +31,6 @@ In order for you to be able to make edits to the database from the Nhost dashboa
 hasura console
 ```
 
-The Nhost Dashboard [uses](https://github.com/nhost/nhost/discussions/2398) the [Hasura migrations API](https://hasura.io/docs/latest/hasura-cli/commands/hasura_console/#options) in order to make edits to the database. It runs over port 9693 and is only accessible through running the Hasura console from the CLI. Because Nhost still uses the basic Hasura Docker image that does not include the CLI, that is why you need to run it locally. See https://github.com/nhost/nhost/issues/1220. Users are welcome to contibute a Docker configuration that includes the CLI to resolve this.
+The Nhost Dashboard [uses](https://github.com/nhost/nhost/discussions/2398) the [Hasura migrations API](https://hasura.io/docs/latest/hasura-cli/commands/hasura_console/#options) in order to make edits to the database. It runs over port 9693 and is only accessible through running the Hasura console from the CLI. Because the Docker compose still only uses the graphql-engine Hasura Docker image and does not include the CLI image, that is why you need to run it locally. See https://github.com/nhost/nhost/issues/1220. Users are welcome to contibute a Docker compose that includes the CLI image to resolve this.
 
 The Nhost Dashboard also requires the Hasura admin secret to `nhost-admin-secret` specified in the `.env` file.

--- a/examples/docker-compose/README.md
+++ b/examples/docker-compose/README.md
@@ -31,6 +31,6 @@ In order for you to be able to make edits to the database from the Nhost dashboa
 hasura console
 ```
 
-The Nhost Dashboard uses the [Hasura migrations API](https://hasura.io/docs/latest/hasura-cli/commands/hasura_console/#options) in order to make edits to the database. It runs over port 9693 and is only accessible through running the Hasura console from the CLI. It is not accessible from the Hasura Docker image yet. That is why you need to run it locally. See https://github.com/nhost/nhost/issues/1220.
+The Nhost Dashboard [uses](https://github.com/nhost/nhost/discussions/2398) the [Hasura migrations API](https://hasura.io/docs/latest/hasura-cli/commands/hasura_console/#options) in order to make edits to the database. It runs over port 9693 and is only accessible through running the Hasura console from the CLI. Because Nhost still uses the basic Hasura Docker image that does not include the CLI, that is why you need to run it locally. See https://github.com/nhost/nhost/issues/1220. Users are welcome to contibute a Docker configuration that includes the CLI to resolve this.
 
 The Nhost Dashboard also requires the Hasura admin secret to `nhost-admin-secret` specified in the `.env` file.


### PR DESCRIPTION
Add extended explanation as to why `hasura-console` needs to be run locally. Right now it's confusing to the user why editing is not possible just with the Hasura Docker container.