### PR TITLE
fix(ci): pin `@nhost/nhost-js` dep version in sveltekit quickstart

### DIFF
--- a/examples/quickstarts/sveltekit/package.json
+++ b/examples/quickstarts/sveltekit/package.json
@@ -9,7 +9,7 @@
     "check": "svelte-kit sync && svelte-check --tsconfig ./jsconfig.json",
     "check:watch": "svelte-kit sync && svelte-check --tsconfig ./jsconfig.json --watch",
     "install-browsers": "pnpm dlx playwright@1.31.0 install --with-deps",
-    "add-nhost-js": "pnpm add @nhost/nhost-js --ignore-workspace",
+    "add-nhost-js": "pnpm add @nhost/nhost-js@2.2.18 --ignore-workspace",
     "test": "pnpm install-browsers && pnpm add-nhost-js && pnpm dlx playwright@1.31.0 test",
     "lint": "eslint .",
     "postinstall": "pnpm add-nhost-js"


### PR DESCRIPTION
This will ensure CI doesn't complain about trying to install an unpublished version of the @nhost/nhost-js package in the SvelteKit quickstart.
<img width="960" alt="image" src="https://github.com/nhost/nhost/assets/2606024/ca1f3e37-94c7-453f-83a3-e0a615525b75">
