### PR TITLE
fix(vue-sdk): include `ServiceUrls` in `NhostVueClientConstructorParams`

### DIFF
--- a/.changeset/ninety-deers-whisper.md
+++ b/.changeset/ninety-deers-whisper.md
@@ -1,0 +1,5 @@
+---
+'@nhost/vue': patch
+---
+
+fix: include `ServiceUrls` in `NhostVueClientConstructorParams` interface

--- a/packages/vue/src/client.ts
+++ b/packages/vue/src/client.ts
@@ -2,6 +2,7 @@ import {
   NhostAuthConstructorParams,
   NhostClient as VanillaClient,
   removeParameterFromWindow,
+  ServiceUrls,
   Subdomain
 } from '@nhost/nhost-js'
 import { App, warn } from 'vue'
@@ -11,6 +12,7 @@ export type { ErrorPayload, NhostSession, Subdomain, User } from '@nhost/nhost-j
 
 export interface NhostVueClientConstructorParams
   extends Partial<Subdomain>,
+    Partial<ServiceUrls>,
     Omit<NhostAuthConstructorParams, 'url' | 'start' | 'client'> {}
 
 export class NhostClient extends VanillaClient {


### PR DESCRIPTION
fixes https://github.com/nhost/nhost/issues/2134