### PR TITLE
fix(hasura-auth-js): use `jose` instead of `jwt-decode` to decode the accessToken and get the Hasura claims

### DIFF
--- a/.changeset/poor-panthers-shout.md
+++ b/.changeset/poor-panthers-shout.md
@@ -1,0 +1,5 @@
+---
+'@nhost/hasura-auth-js': patch
+---
+
+fix(hasura-auth-js): replace `jwt-decode` with `jose` for decoding access tokens that works on both the browser and Node.js

--- a/packages/hasura-auth-js/package.json
+++ b/packages/hasura-auth-js/package.json
@@ -66,8 +66,8 @@
   "dependencies": {
     "@simplewebauthn/browser": "^6.2.2",
     "fetch-ponyfill": "^7.1.0",
+    "jose": "^5.2.2",
     "js-cookie": "^3.0.5",
-    "jwt-decode": "^3.1.2",
     "xstate": "^4.38.3"
   },
   "devDependencies": {

--- a/packages/hasura-auth-js/src/hasura-auth-client.ts
+++ b/packages/hasura-auth-js/src/hasura-auth-client.ts
@@ -1,4 +1,4 @@
-import jwt_decode from 'jwt-decode'
+import * as jose from 'jose'
 import { interpret } from 'xstate'
 import {
   EMAIL_NEEDS_VERIFICATION,
@@ -625,7 +625,7 @@ export class HasuraAuthClient {
   public getDecodedAccessToken(): JWTClaims | null {
     const jwt = this.getAccessToken()
     if (!jwt) return null
-    return jwt_decode<JWTClaims>(jwt)
+    return jose.decodeJwt<JWTClaims>(jwt)
   }
 
   /**

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -1591,12 +1591,12 @@ importers:
       fetch-ponyfill:
         specifier: ^7.1.0
         version: 7.1.0
+      jose:
+        specifier: ^5.2.2
+        version: 5.2.2
       js-cookie:
         specifier: ^3.0.5
         version: 3.0.5
-      jwt-decode:
-        specifier: ^3.1.2
-        version: 3.1.2
       xstate:
         specifier: ^4.38.3
         version: 4.38.3
@@ -19440,6 +19440,10 @@ packages:
   /jose@4.15.4:
     resolution: {integrity: sha512-W+oqK4H+r5sITxfxpSU+MMdr/YSWGvgZMQDIsNoBDGGy4i7GBPTtvFKibQzW06n3U3TqHjhvBJsirShsEJ6eeQ==}
     dev: true
+
+  /jose@5.2.2:
+    resolution: {integrity: sha512-/WByRr4jDcsKlvMd1dRJnPfS1GVO3WuKyaurJ/vvXcOaUQO8rnNObCQMlv/5uCceVQIq5Q4WLF44ohsdiTohdg==}
+    dev: false
 
   /jpeg-js@0.4.4:
     resolution: {integrity: sha512-WZzeDOEtTOBK4Mdsar0IqEU5sMr3vSV2RqkAIzUEV2BHnUfKGyswWFPFwK5EeDo93K3FohSHbLAjj0s1Wzd+dg==}


### PR DESCRIPTION
fixes https://github.com/nhost/nhost/issues/2513