### PR TITLE
chore (examples/docker-compose): clarification on greyed-out options in the dashboard when self-hosting

### DIFF
--- a/.changeset/afraid-ducks-hang.md
+++ b/.changeset/afraid-ducks-hang.md
@@ -2,4 +2,4 @@
 '@nhost-examples/docker-compose': minor
 ---
 
-chore: clarification on greyed-out options in the dashboard when self-hosting```
+chore: clarification on greyed-out options in the dashboard when self-hosting

--- a/.changeset/afraid-ducks-hang.md
+++ b/.changeset/afraid-ducks-hang.md
@@ -2,4 +2,4 @@
 '@nhost-examples/docker-compose': minor
 ---
 
-Note some features not available with docker-compose self hosted
+chore: clarification on greyed-out options in the dashboard when self-hosting```

--- a/.changeset/afraid-ducks-hang.md
+++ b/.changeset/afraid-ducks-hang.md
@@ -1,0 +1,5 @@
+---
+'@nhost-examples/docker-compose': minor
+---
+
+Note some features not available with docker-compose self hosted

--- a/examples/docker-compose/README.md
+++ b/examples/docker-compose/README.md
@@ -2,6 +2,8 @@
 
 Here is an example on how to reproduce the Nhost stack from a docker-compose file.
 
+Note that the Nhost instance produced will not allow you to do all the things available on Nhost Cloud. Some tabs like Settings may be greyed-out and you will need to configure them using envinoment variables or your own system. Additionally, the [Nhost CLI](https://github.com/nhost/cli) is [unable to be used](https://github.com/nhost/cli/issues/837#issuecomment-1963499492) with self-hosted instances.
+
 ## Configuration
 
 ```sh

--- a/examples/docker-compose/README.md
+++ b/examples/docker-compose/README.md
@@ -2,7 +2,7 @@
 
 Here is an example on how to reproduce the Nhost stack from a docker-compose file.
 
-Note that the Nhost instance produced will not allow you to do all the things available on Nhost Cloud. Some tabs like Settings may be greyed-out and you will need to configure them using envinoment variables or your own system. Additionally, the [Nhost CLI](https://github.com/nhost/cli) is [unable to be used](https://github.com/nhost/cli/issues/837#issuecomment-1963499492) with self-hosted instances.
+NOTE: You may notice that some options in the dashboard are greyed-out. These include additional services like CI integration, configuration management, etc., offered by the Nhost Cloud and therefore are not accessible when self-hosting.
 
 ## Configuration
 


### PR DESCRIPTION
Should answer questions like these: https://discord.com/channels/552499021260914688/1212064280170463243