### PR TITLE
fix: quickstarts: next-js-server-components: disable `autoRefreshToken` when running nhost-js server side

### DIFF
--- a/.changeset/real-pens-fly.md
+++ b/.changeset/real-pens-fly.md
@@ -1,0 +1,5 @@
+---
+'@nhost-examples/nextjs-server-components': patch
+---
+
+fix: disable autoRefreshToken when running nhost server side

--- a/examples/quickstarts/nextjs-server-components/src/utils/nhost.ts
+++ b/examples/quickstarts/nextjs-server-components/src/utils/nhost.ts
@@ -13,7 +13,8 @@ export const getNhost = async (request?: NextRequest) => {
   const nhost = new NhostClient({
     subdomain: process.env.NEXT_PUBLIC_NHOST_SUBDOMAIN || 'local',
     region: process.env.NEXT_PUBLIC_NHOST_REGION,
-    start: false
+    start: false,
+    autoRefreshToken: false
   })
 
   const sessionCookieValue = $cookies.get(NHOST_SESSION_KEY)?.value || ''


### PR DESCRIPTION
### **User description**
fixes https://github.com/nhost/nhost/issues/2742


___

### **PR Type**
Bug fix, Documentation


___

### **Description**
- Disabled `autoRefreshToken` in the server-side configuration of `NhostClient` to fix an issue.
- Added a changeset to document the fix.



___



### **Changes walkthrough** 📝
<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Bug fix
</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>nhost.ts</strong><dd><code>Disable autoRefreshToken in server-side NhostClient configuration</code></dd></summary>
<hr>
      
examples/quickstarts/nextjs-server-components/src/utils/nhost.ts

<li>Disabled <code>autoRefreshToken</code> when running server side.<br> <li> Added <code>autoRefreshToken: false</code> to <code>NhostClient</code> configuration.<br>


</details>
    

  </td>
  <td><a href="https://github.com/nhost/nhost/pull/2760/files#diff-e13ecdf248c9041902e5e8a79555ccefc225eb7df3d717cc1b61ce0d5da092db">+2/-1</a>&nbsp; &nbsp; &nbsp; </td>

</tr>                    
</table></td></tr><tr><td><strong>Documentation
</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>real-pens-fly.md</strong><dd><code>Document changeset for disabling autoRefreshToken</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>
      
.changeset/real-pens-fly.md

- Added changeset documentation for disabling `autoRefreshToken`.



</details>
    

  </td>
  <td><a href="https://github.com/nhost/nhost/pull/2760/files#diff-b16089ed98b473944ccee4a223d8b741963cf8d380d3a725646288e3bbf79263">+5/-0</a>&nbsp; &nbsp; &nbsp; </td>

</tr>                    
</table></td></tr></tr></tbody></table>

___

> 💡 **PR-Agent usage**:
>Comment `/help` on the PR to get a list of all available PR-Agent tools and their descriptions

