### PR TITLE
chore (docs): add pnpm to list of supported packagers for functions

### DIFF
--- a/.changeset/twenty-starfishes-kiss.md
+++ b/.changeset/twenty-starfishes-kiss.md
@@ -1,0 +1,5 @@
+---
+'@nhost/docs': patch
+---
+
+chore: add pnpm to list of supported packagers for functions

--- a/docs/guides/functions/runtimes.mdx
+++ b/docs/guides/functions/runtimes.mdx
@@ -40,4 +40,4 @@ For Node.js, the following package managers are supported:
 2. [yarn](https://yarnpkg.com)
 3. [pnpm](https://pnpm.io)
 
-To use one package manager or another, add the relevant lockfile (either `package-lock.json` for npm, `yarn.lock` for yarn or `pnpm-lock.yaml` for `pnpm`) to the functions folder or a parent folder. If both lockfiles are present, `npm` will take precendence.
+To use one package manager or another, add the relevant lockfile (either `package-lock.json` for npm, `yarn.lock` for yarn or `pnpm-lock.yaml` for `pnpm`) to the functions folder or a parent folder. If multiple lockfiles are present, preference order is `npm` > `pnpm` > `yarn`.

--- a/docs/guides/functions/runtimes.mdx
+++ b/docs/guides/functions/runtimes.mdx
@@ -38,5 +38,6 @@ For Node.js, the following package managers are supported:
 
 1. [npm](https://www.npmjs.com)
 2. [yarn](https://yarnpkg.com)
+3. [pnpm](https://pnpm.io)
 
-To use one package manager or another, add the relevant lockfile (either `package-lock.json` for npm or `yarn.lock` for yarn) to the functions folder or a parent folder. If both lockfiles are present, `npm` will take precendence.
+To use one package manager or another, add the relevant lockfile (either `package-lock.json` for npm, `yarn.lock` for yarn or `pnpm-lock.yaml` for `pnpm`) to the functions folder or a parent folder. If both lockfiles are present, `npm` will take precendence.


### PR DESCRIPTION
### **PR Type**
Documentation


___

### **Description**
- Added `pnpm` to the list of supported package managers for Node.js functions in the documentation.
- Updated the guide to include `pnpm-lock.yaml` and clarified the precedence order of lockfiles.
- Added a changeset entry for the documentation update.



___



### **Changes walkthrough** 📝
<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Documentation</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>twenty-starfishes-kiss.md</strong><dd><code>Add changeset entry for pnpm support in docs</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>
      
.changeset/twenty-starfishes-kiss.md

- Added a changeset entry for the documentation update.



</details>
    

  </td>
  <td><a href="https://github.com/nhost/nhost/pull/2766/files#diff-ad42cc7bec10944cf822955c9b6941dd27f453d474e4218f70e0debaacf6d3cb">+5/-0</a>&nbsp; &nbsp; &nbsp; </td>

</tr>                    

<tr>
  <td>
    <details>
      <summary><strong>runtimes.mdx</strong><dd><code>Document pnpm support for Node.js functions</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>
      
docs/guides/functions/runtimes.mdx

<li>Added <code>pnpm</code> to the list of supported package managers for Node.js <br>functions.<br> <li> Updated instructions to include <code>pnpm-lock.yaml</code> and the precedence <br>order of lockfiles.<br>


</details>
    

  </td>
  <td><a href="https://github.com/nhost/nhost/pull/2766/files#diff-b028de07c3232c8aed96f6e73b38ec996daa13e250beab1009cdda95df5091c7">+2/-1</a>&nbsp; &nbsp; &nbsp; </td>

</tr>                    
</table></td></tr></tr></tbody></table>

___

> 💡 **PR-Agent usage**:
>Comment `/help` on the PR to get a list of all available PR-Agent tools and their descriptions

