### PR TITLE
chore (dashboard): locked project contact support redirect

### DIFF
--- a/.changeset/honest-humans-explode.md
+++ b/.changeset/honest-humans-explode.md
@@ -1,0 +1,5 @@
+---
+'@nhost/dashboard': minor
+---
+
+chore: add redirect to support page when project is locked

--- a/dashboard/src/features/projects/common/components/ApplicationLockedReason/ApplicationLockedReason.tsx
+++ b/dashboard/src/features/projects/common/components/ApplicationLockedReason/ApplicationLockedReason.tsx
@@ -27,7 +27,7 @@ export default function ApplicationLockedReason({
         Please{' '}
         <Link
           className="font-semibold underline underline-offset-2"
-          href="mailto:support@nhost.io"
+          href="/support"
           target="_blank"
           rel="noopener noreferrer"
         >


### PR DESCRIPTION
Adds redirect to `/support` page when clicking on contact support on locked project screen