### PR TITLE
fix: use current project subdomain in ServiceDetailsDialog component

### DIFF
--- a/.changeset/long-plums-shave.md
+++ b/.changeset/long-plums-shave.md
@@ -1,0 +1,5 @@
+---
+'@nhost/dashboard': patch
+---
+
+fix: use current project subdomain in ServiceDetailsDialog component

--- a/dashboard/src/features/services/components/ServiceForm/ServiceForm.tsx
+++ b/dashboard/src/features/services/components/ServiceForm/ServiceForm.tsx
@@ -253,7 +253,6 @@ export default function ServiceForm({
         component: (
           <ServiceDetailsDialog
             serviceID={detailsServiceId}
-            subdomain={detailsServiceSubdomain}
             ports={formValues.ports}
           />
         ),

--- a/dashboard/src/features/services/components/ServiceForm/components/ServiceDetailsDialog/ServiceDetailsDialog.tsx
+++ b/dashboard/src/features/services/components/ServiceForm/components/ServiceDetailsDialog/ServiceDetailsDialog.tsx
@@ -47,7 +47,7 @@ export default function ServiceDetailsDialog({
               key={String(port.port)}
               title={`${port.type} <--> ${port.port}`}
               value={getRunServicePortURL(
-                currentProject.subdomain,
+                currentProject?.subdomain,
                 currentProject?.region.name,
                 currentProject?.region.domain,
                 port,

--- a/dashboard/src/features/services/components/ServiceForm/components/ServiceDetailsDialog/ServiceDetailsDialog.tsx
+++ b/dashboard/src/features/services/components/ServiceForm/components/ServiceDetailsDialog/ServiceDetailsDialog.tsx
@@ -13,11 +13,6 @@ export interface ServiceDetailsDialogProps {
   serviceID: string;
 
   /**
-   * The subdomain of the service
-   */
-  subdomain: string;
-
-  /**
    * The service ports
    * We use partial here because `port` is set as required in ConfigRunServicePort
    */
@@ -26,7 +21,6 @@ export interface ServiceDetailsDialogProps {
 
 export default function ServiceDetailsDialog({
   serviceID,
-  subdomain,
   ports,
 }: ServiceDetailsDialogProps) {
   const { currentProject } = useCurrentWorkspaceAndProject();
@@ -53,7 +47,7 @@ export default function ServiceDetailsDialog({
               key={String(port.port)}
               title={`${port.type} <--> ${port.port}`}
               value={getRunServicePortURL(
-                subdomain,
+                currentProject.subdomain,
                 currentProject?.region.name,
                 currentProject?.region.domain,
                 port,


### PR DESCRIPTION
### **PR Type**
Bug fix, Enhancement


___

### **Description**
- Removed the `subdomain` prop from the `ServiceDetailsDialog` component and its usage in `ServiceForm`.
- Updated `ServiceDetailsDialog` to use `currentProject?.subdomain` directly.
- Added a changeset file documenting the fix.



___



### **Changes walkthrough** 📝
<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Enhancement</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>ServiceForm.tsx</strong><dd><code>Remove `subdomain` prop from `ServiceDetailsDialog` usage</code></dd></summary>
<hr>

dashboard/src/features/services/components/ServiceForm/ServiceForm.tsx

<li>Removed the <code>subdomain</code> prop from <code>ServiceDetailsDialog</code> component.<br> <li> Updated the <code>ServiceDetailsDialog</code> component usage.<br>


</details>


  </td>
  <td><a href="https://github.com/nhost/nhost/pull/2800/files#diff-d62640c5c152c7b50a3a53deefcb29c6ed1fa685e15511863c09784497139c49">+0/-1</a>&nbsp; &nbsp; &nbsp; </td>

</tr>                    
</table></td></tr><tr><td><strong>Bug fix</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>ServiceDetailsDialog.tsx</strong><dd><code>Use `currentProject?.subdomain` in `ServiceDetailsDialog`</code></dd></summary>
<hr>

dashboard/src/features/services/components/ServiceForm/components/ServiceDetailsDialog/ServiceDetailsDialog.tsx

<li>Removed <code>subdomain</code> prop from <code>ServiceDetailsDialogProps</code> interface.<br> <li> Updated <code>ServiceDetailsDialog</code> to use <code>currentProject?.subdomain</code> instead <br>of <code>subdomain</code>.<br>


</details>


  </td>
  <td><a href="https://github.com/nhost/nhost/pull/2800/files#diff-2e157263deeb076634b004143232a0f97d3ab94e709c0dcf7e93fb09a62f267d">+1/-7</a>&nbsp; &nbsp; &nbsp; </td>

</tr>                    
</table></td></tr><tr><td><strong>Documentation</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>long-plums-shave.md</strong><dd><code>Add changeset for `ServiceDetailsDialog` fix</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

.changeset/long-plums-shave.md

- Added changeset for the fix in `ServiceDetailsDialog` component.



</details>


  </td>
  <td><a href="https://github.com/nhost/nhost/pull/2800/files#diff-8175ae1130dd45c62e1488253a620d11257d8fd83ec40740cf312171b976e226">+5/-0</a>&nbsp; &nbsp; &nbsp; </td>

</tr>                    
</table></td></tr></tr></tbody></table>

___

> 💡 **PR-Agent usage**:
>Comment `/help` on the PR to get a list of all available PR-Agent tools and their descriptions

