### PR TITLE
fix(dashboard): use service subdomain in service form and service details dialog

### DIFF
--- a/.changeset/clever-hats-roll.md
+++ b/.changeset/clever-hats-roll.md
@@ -1,0 +1,5 @@
+---
+'@nhost/dashboard': patch
+---
+
+fix: use service subdomain in service form and service details dialog

--- a/dashboard/src/features/services/components/ServiceForm/ServiceForm.tsx
+++ b/dashboard/src/features/services/components/ServiceForm/ServiceForm.tsx
@@ -253,6 +253,7 @@ export default function ServiceForm({
         component: (
           <ServiceDetailsDialog
             serviceID={detailsServiceId}
+            subdomain={detailsServiceSubdomain}
             ports={formValues.ports}
           />
         ),

--- a/dashboard/src/features/services/components/ServiceForm/components/PortsFormSection/PortsFormSection.tsx
+++ b/dashboard/src/features/services/components/ServiceForm/components/PortsFormSection/PortsFormSection.tsx
@@ -136,7 +136,7 @@ export default function PortsFormSection() {
               <InfoCard
                 title="URL"
                 value={getRunServicePortURL(
-                  currentProject?.subdomain,
+                  formValues?.subdomain,
                   currentProject?.region.name,
                   currentProject?.region.domain,
                   formValues.ports[index],

--- a/dashboard/src/features/services/components/ServiceForm/components/ServiceDetailsDialog/ServiceDetailsDialog.tsx
+++ b/dashboard/src/features/services/components/ServiceForm/components/ServiceDetailsDialog/ServiceDetailsDialog.tsx
@@ -13,6 +13,11 @@ export interface ServiceDetailsDialogProps {
   serviceID: string;
 
   /**
+   * The subdomain of the service
+   */
+  subdomain: string;
+
+  /**
    * The service ports
    * We use partial here because `port` is set as required in ConfigRunServicePort
    */
@@ -21,6 +26,7 @@ export interface ServiceDetailsDialogProps {
 
 export default function ServiceDetailsDialog({
   serviceID,
+  subdomain,
   ports,
 }: ServiceDetailsDialogProps) {
   const { currentProject } = useCurrentWorkspaceAndProject();
@@ -47,7 +53,7 @@ export default function ServiceDetailsDialog({
               key={String(port.port)}
               title={`${port.type} <--> ${port.port}`}
               value={getRunServicePortURL(
-                currentProject?.subdomain,
+                subdomain,
                 currentProject?.region.name,
                 currentProject?.region.domain,
                 port,


### PR DESCRIPTION
### **PR Type**
Bug fix, Enhancement


___

### **Description**
- Added `subdomain` prop to `ServiceDetailsDialog` component and its interface.
- Updated `ServiceForm` to pass `subdomain` to `ServiceDetailsDialog`.
- Changed subdomain source from `currentProject` to `formValues` in `PortsFormSection` URL generation.
- Added a changeset for the fix.



___



### **Changes walkthrough** 📝
<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Enhancement</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>ServiceForm.tsx</strong><dd><code>Pass subdomain to ServiceDetailsDialog in ServiceForm</code>&nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

dashboard/src/features/services/components/ServiceForm/ServiceForm.tsx

- Added `subdomain` prop to `ServiceDetailsDialog` component.



</details>


  </td>
  <td><a href="https://github.com/nhost/nhost/pull/2802/files#diff-d62640c5c152c7b50a3a53deefcb29c6ed1fa685e15511863c09784497139c49">+1/-0</a>&nbsp; &nbsp; &nbsp; </td>

</tr>                    

<tr>
  <td>
    <details>
      <summary><strong>ServiceDetailsDialog.tsx</strong><dd><code>Add and use subdomain prop in ServiceDetailsDialog</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

dashboard/src/features/services/components/ServiceForm/components/ServiceDetailsDialog/ServiceDetailsDialog.tsx

<li>Added <code>subdomain</code> prop to <code>ServiceDetailsDialogProps</code> interface.<br> <li> Updated <code>getRunServicePortURL</code> call to use <code>subdomain</code> prop.<br>


</details>


  </td>
  <td><a href="https://github.com/nhost/nhost/pull/2802/files#diff-2e157263deeb076634b004143232a0f97d3ab94e709c0dcf7e93fb09a62f267d">+7/-1</a>&nbsp; &nbsp; &nbsp; </td>

</tr>                    
</table></td></tr><tr><td><strong>Bug fix</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>PortsFormSection.tsx</strong><dd><code>Use formValues subdomain in PortsFormSection URL generation</code></dd></summary>
<hr>

dashboard/src/features/services/components/ServiceForm/components/PortsFormSection/PortsFormSection.tsx

<li>Changed subdomain source from <code>currentProject</code> to <code>formValues</code> in <br><code>getRunServicePortURL</code> call.<br>


</details>


  </td>
  <td><a href="https://github.com/nhost/nhost/pull/2802/files#diff-64ce17ad73e4122e8c66a1968b6737ec98bd1623ac7e3cd3f4a34b549a78717b">+1/-1</a>&nbsp; &nbsp; &nbsp; </td>

</tr>                    
</table></td></tr><tr><td><strong>Documentation</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>clever-hats-roll.md</strong><dd><code>Add changeset for service subdomain fix</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

.changeset/clever-hats-roll.md

- Added changeset for the fix.



</details>


  </td>
  <td><a href="https://github.com/nhost/nhost/pull/2802/files#diff-ddf8c642ce16a0008ac12ebd0ab78740b6b0f35a356da5b0618bff2617ff3777">+5/-0</a>&nbsp; &nbsp; &nbsp; </td>

</tr>                    
</table></td></tr></tr></tbody></table>

___

> 💡 **PR-Agent usage**:
>Comment `/help` on the PR to get a list of all available PR-Agent tools and their descriptions

