### PR TITLE
fix(hasura-auth-js): update signout to use accessToken when clearing all sessions

### DIFF
--- a/.changeset/popular-rabbits-bake.md
+++ b/.changeset/popular-rabbits-bake.md
@@ -1,0 +1,5 @@
+---
+'@nhost/hasura-auth-js': patch
+---
+
+fix: correct signout to send accessToken when clearing all session

--- a/packages/hasura-auth-js/src/machines/authentication/machine.typegen.ts
+++ b/packages/hasura-auth-js/src/machines/authentication/machine.typegen.ts
@@ -174,7 +174,17 @@ export interface Typegen0 {
       | 'done.invoke.passwordlessSms'
       | 'done.invoke.signUpEmailPassword'
       | 'done.invoke.signUpSecurityKey'
-    clearContextExceptRefreshToken: 'SIGNOUT'
+    clearContextExceptTokens: 'SIGNOUT'
+    destroyAccessToken:
+      | 'SESSION_UPDATE'
+      | 'SIGNIN_ANONYMOUS'
+      | 'SIGNIN_MFA_TOTP'
+      | 'SIGNIN_PASSWORD'
+      | 'SIGNIN_PAT'
+      | 'SIGNIN_SECURITY_KEY_EMAIL'
+      | 'done.invoke.signingOut'
+      | 'error.platform.signingOut'
+      | 'xstate.stop'
     destroyRefreshToken:
       | 'SESSION_UPDATE'
       | 'SIGNIN_ANONYMOUS'


### PR DESCRIPTION
### **User description**
fixes https://github.com/nhost/nhost/issues/2836


___

### **PR Type**
Bug fix, Enhancement


___

### **Description**
- Enhanced the signout process to utilize the access token when clearing all sessions.
- Updated the `signingOut` state to manage both access and refresh tokens.
- Introduced a new function `destroyAccessToken` to clear the access token.
- Adjusted type definitions to reflect changes in the signout process.
- Added a changeset document to outline the patch changes.



___



### **Changes walkthrough** 📝
<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Enhancement</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>machine.ts</strong><dd><code>Enhance signout process to handle access token</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

packages/hasura-auth-js/src/machines/authentication/machine.ts

<li>Updated <code>signingOut</code> state to handle access token.<br> <li> Modified <code>clearContextExceptTokens</code> to retain access token.<br> <li> Added <code>destroyAccessToken</code> function to clear access token.<br> <li> Updated <code>signout</code> function to optionally use access token.<br>


</details>


  </td>
  <td><a href="https://github.com/nhost/nhost/pull/2857/files#diff-a8fdfee087ad5a72ea0a64667e2a0c7f25baa84eaaf73ebfee3f5a5a1b7584d1">+24/-9</a>&nbsp; &nbsp; </td>

</tr>                    

<tr>
  <td>
    <details>
      <summary><strong>machine.typegen.ts</strong><dd><code>Update type definitions for signout enhancements</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

packages/hasura-auth-js/src/machines/authentication/machine.typegen.ts

<li>Updated type definitions for <code>clearContextExceptTokens</code>.<br> <li> Added type definitions for <code>destroyAccessToken</code>.<br>


</details>


  </td>
  <td><a href="https://github.com/nhost/nhost/pull/2857/files#diff-b0050ab06a8f00d3ae5decd65565adb1bdae3b4b6d19d4f67b9013ffb14e18ee">+11/-1</a>&nbsp; &nbsp; </td>

</tr>                    
</table></td></tr><tr><td><strong>Documentation</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>popular-rabbits-bake.md</strong><dd><code>Add changeset for signout fix</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

.changeset/popular-rabbits-bake.md

- Added changeset for signout fix using access token.



</details>


  </td>
  <td><a href="https://github.com/nhost/nhost/pull/2857/files#diff-cfd522f2d71d4a7da79f890c87603a0d8e85f066701af747b08712f1fd8890cd">+5/-0</a>&nbsp; &nbsp; &nbsp; </td>

</tr>                    
</table></td></tr></tr></tbody></table>

___

> 💡 **PR-Agent usage**:
>Comment `/help` on the PR to get a list of all available PR-Agent tools and their descriptions

