### PR TITLE
fix (dashboard): update url to docs in run services tooltip

### DIFF
--- a/.changeset/grumpy-toys-love.md
+++ b/.changeset/grumpy-toys-love.md
@@ -1,0 +1,5 @@
+---
+'@nhost/dashboard': minor
+---
+
+fix: update docs url in run services form tooltip

--- a/dashboard/src/features/services/components/ServiceForm/components/ComputeFormSection/ComputeFormSection.tsx
+++ b/dashboard/src/features/services/components/ServiceForm/components/ComputeFormSection/ComputeFormSection.tsx
@@ -55,7 +55,7 @@ export default function ComputeFormSection({
   };
 
   return (
-    <Box className="p-4 space-y-4 rounded border-1">
+    <Box className="space-y-4 rounded border-1 p-4">
       <Box className="flex flex-row items-center space-x-2">
         <Text variant="h4" className="font-semibold">
           vCPUs: {formValues.compute.cpu / 1000} / Memory:{' '}
@@ -107,7 +107,7 @@ export default function ComputeFormSection({
           variant="outlined"
           onClick={incrementCompute}
         >
-          <ArrowRightIcon className="w-4 h-4" />
+          <ArrowRightIcon className="h-4 w-4" />
         </Button>
       </Box>
     </Box>

--- a/dashboard/src/features/services/components/ServiceForm/components/ComputeFormSection/ComputeFormSection.tsx
+++ b/dashboard/src/features/services/components/ServiceForm/components/ComputeFormSection/ComputeFormSection.tsx
@@ -55,7 +55,7 @@ export default function ComputeFormSection({
   };
 
   return (
-    <Box className="space-y-4 rounded border-1 p-4">
+    <Box className="p-4 space-y-4 rounded border-1">
       <Box className="flex flex-row items-center space-x-2">
         <Text variant="h4" className="font-semibold">
           vCPUs: {formValues.compute.cpu / 1000} / Memory:{' '}
@@ -70,7 +70,7 @@ export default function ComputeFormSection({
                 <a
                   target="_blank"
                   rel="noopener noreferrer"
-                  href="https://docs.nhost.io/run/resources"
+                  href="https://docs.nhost.io/guides/run/resources"
                   className="underline"
                 >
                   resources
@@ -107,7 +107,7 @@ export default function ComputeFormSection({
           variant="outlined"
           onClick={incrementCompute}
         >
-          <ArrowRightIcon className="h-4 w-4" />
+          <ArrowRightIcon className="w-4 h-4" />
         </Button>
       </Box>
     </Box>

--- a/dashboard/src/features/services/components/ServiceForm/components/ReplicasFormSection/ReplicasFormSection.tsx
+++ b/dashboard/src/features/services/components/ServiceForm/components/ReplicasFormSection/ReplicasFormSection.tsx
@@ -36,6 +36,7 @@ export default function ReplicasFormSection() {
                 target="_blank"
                 rel="noopener noreferrer"
                 href="https://docs.nhost.io/guides/run/resources"
+                className="underline"
               >
                 resources
               </a>{' '}

--- a/dashboard/src/features/services/components/ServiceForm/components/ReplicasFormSection/ReplicasFormSection.tsx
+++ b/dashboard/src/features/services/components/ServiceForm/components/ReplicasFormSection/ReplicasFormSection.tsx
@@ -35,8 +35,7 @@ export default function ReplicasFormSection() {
               <a
                 target="_blank"
                 rel="noopener noreferrer"
-                href="https://docs.nhost.io/run/resources"
-                className="underline"
+                href="https://docs.nhost.io/guides/run/resources"
               >
                 resources
               </a>{' '}


### PR DESCRIPTION
### **User description**
Fixes #2885


___

### **PR Type**
Bug fix, Enhancement


___

### **Description**
- Updated documentation URLs in both ComputeFormSection and ReplicasFormSection components from 'https://docs.nhost.io/run/resources' to 'https://docs.nhost.io/guides/run/resources'


___



### **Changes walkthrough** 📝
<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Enhancement</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>ComputeFormSection.tsx</strong><dd><code>Update docs URL and minor styling adjustments</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

dashboard/src/features/services/components/ServiceForm/components/ComputeFormSection/ComputeFormSection.tsx

<li>Updated URL for documentation link from <br>'https://docs.nhost.io/run/resources' to <br>'https://docs.nhost.io/guides/run/resources'<br> <li> Minor CSS class order changes for better readability<br> <li> Adjusted icon class order for consistency<br>


</details>


  </td>
  <td><a href="https://github.com/nhost/nhost/pull/2886/files#diff-872380911b465d834a087f05d0edf98a39f9d99209f77e8127ba378263088d0c">+3/-3</a>&nbsp; &nbsp; &nbsp; </td>

</tr>                    

<tr>
  <td>
    <details>
      <summary><strong>ReplicasFormSection.tsx</strong><dd><code>Update docs URL and remove underline style</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

dashboard/src/features/services/components/ServiceForm/components/ReplicasFormSection/ReplicasFormSection.tsx

<li>Updated URL for documentation link from <br>'https://docs.nhost.io/run/resources' to <br>'https://docs.nhost.io/guides/run/resources'<br> <li> Removed 'underline' class from the documentation link<br>


</details>


  </td>
  <td><a href="https://github.com/nhost/nhost/pull/2886/files#diff-a4f36ae71ca338a439ff44995a74b98d4866dde014136656564c5b23d4f7471b">+1/-2</a>&nbsp; &nbsp; &nbsp; </td>

</tr>                    
</table></td></tr><tr><td><strong>Documentation</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>grumpy-toys-love.md</strong><dd><code>Add changeset for docs URL update</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

.changeset/grumpy-toys-love.md

<li>Added a new changeset file to document the update of docs URL in the <br>run services form tooltip<br>


</details>


  </td>
  <td><a href="https://github.com/nhost/nhost/pull/2886/files#diff-11130c65f1bf1481cd52fcc05c16f2bf166101176fbaf396d0d302704ca404ed">+5/-0</a>&nbsp; &nbsp; &nbsp; </td>

</tr>                    
</table></td></tr></tr></tbody></table>

___

> 💡 **PR-Agent usage**:
>Comment `/help` on the PR to get a list of all available PR-Agent tools and their descriptions

