### PR TITLE
fix (dashboard): long error message in error toast overflow

### DIFF
--- a/.changeset/purple-vans-protect.md
+++ b/.changeset/purple-vans-protect.md
@@ -1,0 +1,5 @@
+---
+'@nhost/dashboard': minor
+---
+
+fix: display long error messages in error toast without overflow

--- a/dashboard/src/components/ui/v2/ErrorToast/ErrorToast.tsx
+++ b/dashboard/src/components/ui/v2/ErrorToast/ErrorToast.tsx
@@ -93,7 +93,7 @@ export default function ErrorToast({
           style={{
             backgroundColor: getToastBackgroundColor(),
           }}
-          className="flex max-w-xl flex-col space-y-4 rounded-lg p-4 text-white"
+          className="flex w-full max-w-xl flex-col space-y-4 rounded-lg p-4 text-white"
           initial={{
             opacity: 0,
             y: 100,
@@ -121,14 +121,15 @@ export default function ErrorToast({
             >
               <XIcon className="h-4 w-4 text-white" />
             </button>
-            <p className="flex-grow overflow-hidden text-ellipsis">
+            <span className="flex-grow overflow-hidden break-words">
               {msg ?? 'An unkown error has occured, please try again later!'}
-            </p>
+            </span>
 
             <button
               type="button"
               onClick={() => setShowInfo(!showInfo)}
               className="flex flex-shrink-0 flex-row items-center justify-center space-x-2 text-white"
+              aria-label="Show error details"
             >
               <span>Info</span>
               {showInfo ? (

--- a/dashboard/src/components/ui/v2/ErrorToast/ErrorToast.tsx
+++ b/dashboard/src/components/ui/v2/ErrorToast/ErrorToast.tsx
@@ -93,7 +93,7 @@ export default function ErrorToast({
           style={{
             backgroundColor: getToastBackgroundColor(),
           }}
-          className="flex w-full max-w-xl flex-col space-y-4 rounded-lg p-4 text-white"
+          className="flex max-w-xl flex-col space-y-4 rounded-lg p-4 text-white"
           initial={{
             opacity: 0,
             y: 100,
@@ -112,18 +112,23 @@ export default function ErrorToast({
             bounce: 0.1,
           }}
         >
-          <div className="flex w-full flex-row items-center justify-between space-x-4">
-            <button onClick={close} type="button" aria-label="Close">
+          <div className="flex w-full flex-row items-center justify-between gap-4">
+            <button
+              className="flex-shrink-0"
+              onClick={close}
+              type="button"
+              aria-label="Close"
+            >
               <XIcon className="h-4 w-4 text-white" />
             </button>
-            <span>
+            <p className="flex-grow overflow-hidden text-ellipsis">
               {msg ?? 'An unkown error has occured, please try again later!'}
-            </span>
+            </p>
 
             <button
               type="button"
               onClick={() => setShowInfo(!showInfo)}
-              className="flex flex-row items-center justify-center space-x-2 text-white"
+              className="flex flex-shrink-0 flex-row items-center justify-center space-x-2 text-white"
             >
               <span>Info</span>
               {showInfo ? (


### PR DESCRIPTION
### **User description**
Fixes #2887


___

### **PR Type**
Bug fix, Enhancement


___

### **Description**
- Fixed issue with long error messages overflowing in the error toast component
- Improved layout and responsiveness of the error toast:
  - Added text ellipsis for long messages
  - Ensured buttons maintain their size with flex-shrink-0
  - Adjusted spacing and flex properties for better alignment
- Changed error message container from <span> to <p> for better semantics
- Added a changeset to document the fix and specify a minor version bump


___



### **Changes walkthrough** 📝
<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Enhancement</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>ErrorToast.tsx</strong><dd><code>Improve error toast layout and text overflow handling</code>&nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

dashboard/src/components/ui/v2/ErrorToast/ErrorToast.tsx

<li>Modified CSS classes to improve layout and prevent text overflow<br> <li> Added flex-shrink-0 to buttons to maintain their size<br> <li> Changed <span> to <p> for error message with overflow handling<br> <li> Adjusted spacing and flex properties for better responsiveness<br>


</details>


  </td>
  <td><a href="https://github.com/nhost/nhost/pull/2892/files#diff-189ba99303a20e964b5e3f3d6f1cf95c6376780a59604d1dee98aa84d9a2a9dc">+11/-6</a>&nbsp; &nbsp; </td>

</tr>                    
</table></td></tr><tr><td><strong>Documentation</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>purple-vans-protect.md</strong><dd><code>Add changeset for error toast overflow fix</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

.changeset/purple-vans-protect.md

<li>Added a new changeset file to document the bug fix<br> <li> Specified a minor version bump for @nhost/dashboard package<br>


</details>


  </td>
  <td><a href="https://github.com/nhost/nhost/pull/2892/files#diff-be6e4edf8538dc0d0756c992250c8a24f02d4699180f7cbf9b752db49c3cf3fc">+5/-0</a>&nbsp; &nbsp; &nbsp; </td>

</tr>                    
</table></td></tr></tr></tbody></table>

___

> 💡 **PR-Agent usage**: Comment `/help "your question"` on any pull request to receive relevant information