### PR TITLE
fix workspace migrate button

### DIFF
--- a/dashboard/src/features/projects/overview/components/OverviewTopBar/OverviewTopBar.tsx
+++ b/dashboard/src/features/projects/overview/components/OverviewTopBar/OverviewTopBar.tsx
@@ -16,7 +16,6 @@ export default function OverviewTopBar() {
   const { currentWorkspace, currentProject } = useCurrentWorkspaceAndProject();
   const isOwner = useIsCurrentUserOwner();
   const isStarter = currentProject?.legacyPlan?.name === 'Starter';
-  const isPro = currentProject?.legacyPlan?.name === 'Pro';
   const { maintenanceActive } = useUI();
 
   if (!isPlatform) {
@@ -107,7 +106,7 @@ export default function OverviewTopBar() {
       </div>
 
       <div className="flex flex-col gap-2 sm:flex-row">
-        {isPro && isOwner && <MigrateProjectToOrg />}
+        {isOwner && <MigrateProjectToOrg />}
         <Link
           href={`/${currentWorkspace.slug}/${currentProject.slug}/settings/general`}
           passHref


### PR DESCRIPTION
### **PR Type**
Enhancement


___

### **Description**
- Simplified the logic for displaying the project migration button in the OverviewTopBar component
- Removed the check for 'Pro' plan, allowing all project owners to see the migration option regardless of their plan
- This change makes the migration feature more accessible to all project owners



___



### **Changes walkthrough** 📝
<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Enhancement</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>OverviewTopBar.tsx</strong><dd><code>Simplify project migration button visibility</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

dashboard/src/features/projects/overview/components/OverviewTopBar/OverviewTopBar.tsx

<li>Removed the <code>isPro</code> variable and its check for the 'Pro' plan<br> <li> Modified the condition for rendering the <code>MigrateProjectToOrg</code> component <br>to only check if the user is an owner<br>


</details>


  </td>
  <td><a href="https://github.com/nhost/nhost/pull/2934/files#diff-0d63ce62740eea0a2acf94178a326e3786a703a9902501f3f00c917e49e7b605">+1/-2</a>&nbsp; &nbsp; &nbsp; </td>

</tr>                    
</table></td></tr></tr></tbody></table>

___

> 💡 **PR-Agent usage**: Comment `/help "your question"` on any pull request to receive relevant information