### PR TITLE
fix useNotFoundRedirect to exclude /account path

### DIFF
--- a/dashboard/src/features/projects/common/hooks/useNotFoundRedirect/useNotFoundRedirect.ts
+++ b/dashboard/src/features/projects/common/hooks/useNotFoundRedirect/useNotFoundRedirect.ts
@@ -26,6 +26,7 @@ export default function useNotFoundRedirect() {
       // If we're already on the 404 page, we don't want to redirect to 404
       router.pathname === '/404' ||
       router.pathname === '/' ||
+      router.pathname === '/account' ||
       orgSlug ||
       (orgSlug && appSubdomain) ||
       // If we are on a valid workspace and project, we don't want to redirect to 404


### PR DESCRIPTION
### **PR Type**
Bug fix


___

### **Description**
- Fixed the `useNotFoundRedirect` hook to exclude the `/account` path from being redirected to the 404 page.



___



### **Changes walkthrough** 📝
<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Bug fix</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>useNotFoundRedirect.ts</strong><dd><code>Exclude `/account` path from 404 redirection</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

dashboard/src/features/projects/common/hooks/useNotFoundRedirect/useNotFoundRedirect.ts

<li>Added a condition to exclude the <code>/account</code> path from the 404 <br>redirection logic.<br>


</details>


  </td>
  <td><a href="https://github.com/nhost/nhost/pull/2935/files#diff-837279cf43199053bca09913f62c4af019063a2e8dc7bfb7643ec54b7cecd29d">+1/-0</a>&nbsp; &nbsp; &nbsp; </td>

</tr>                    
</table></td></tr></tr></tbody></table>

___

> 💡 **PR-Agent usage**: Comment `/help "your question"` on any pull request to receive relevant information