### PR TITLE
fix: disable migrate project submit button when form is not dirty

### DIFF
--- a/.changeset/violet-teachers-agree.md
+++ b/.changeset/violet-teachers-agree.md
@@ -1,0 +1,5 @@
+---
+'@nhost/dashboard': patch
+---
+
+fix: disable migrate button when no organization is selected

--- a/.github/workflows/changesets.yaml
+++ b/.github/workflows/changesets.yaml
@@ -66,8 +66,6 @@ jobs:
   publish-vercel:
     name: Publish to Vercel
     runs-on: ubuntu-latest
-    needs:
-      - test
     steps:
       - name: Checkout repository
         uses: actions/checkout@v3

--- a/.github/workflows/changesets.yaml
+++ b/.github/workflows/changesets.yaml
@@ -66,6 +66,8 @@ jobs:
   publish-vercel:
     name: Publish to Vercel
     runs-on: ubuntu-latest
+    needs:
+      - test
     steps:
       - name: Checkout repository
         uses: actions/checkout@v3

--- a/dashboard/src/features/orgs/components/MigrateProjectToOrg/MigrateProjectToOrg.tsx
+++ b/dashboard/src/features/orgs/components/MigrateProjectToOrg/MigrateProjectToOrg.tsx
@@ -83,7 +83,13 @@ export default function MigrateProjectToOrg() {
   };
 
   return (
-    <Dialog open={open} onOpenChange={setOpen}>
+    <Dialog
+      open={open}
+      onOpenChange={(value) => {
+        form.reset();
+        setOpen(value);
+      }}
+    >
       <DialogTrigger asChild>
         <Button className="flex items-center gap-2 py-1 text-base">
           Migrate to an Organization
@@ -161,11 +167,19 @@ export default function MigrateProjectToOrg() {
                 variant="secondary"
                 type="button"
                 disabled={form.formState.isSubmitting}
-                onClick={() => setOpen(false)}
+                onClick={() => {
+                  form.reset();
+                  setOpen(false);
+                }}
               >
                 Cancel
               </Button>
-              <Button type="submit" disabled={form.formState.isSubmitting}>
+              <Button
+                type="submit"
+                disabled={
+                  form.formState.isSubmitting || !form.formState.isDirty
+                }
+              >
                 {form.formState.isSubmitting ? (
                   <ActivityIndicator />
                 ) : (

--- a/dashboard/src/features/orgs/projects/resources/settings/components/ResourcesConfirmationDialog/ResourcesConfirmationDialog.tsx
+++ b/dashboard/src/features/orgs/projects/resources/settings/components/ResourcesConfirmationDialog/ResourcesConfirmationDialog.tsx
@@ -124,8 +124,8 @@ export default function ResourcesConfirmationDialog({
         </Text>
       ) : (
         <Text className="text-center">
-          By confirming this you will go back to the original amount of
-          resources of the {proPlan.name} plan.
+          By confirming this you will go back to the original shared resources
+          included in the {proPlan.name} plan.
         </Text>
       )}
 
@@ -220,10 +220,12 @@ export default function ResourcesConfirmationDialog({
 
           <Text>{enabled ? `$${updatedPrice.toFixed(2)}/mo` : `$0/mo`}</Text>
         </Box>
-        <Text className="text-xs text-gray-400">
-          Note: Your organization&apos;s $15 worth of credits cover for both
-          shared and dedicated compute.
-        </Text>
+        {enabled && (
+          <Text className="text-xs text-gray-400">
+            Note: Your organization&apos;s $15 worth of credits cover for both
+            shared and dedicated compute.
+          </Text>
+        )}
       </Box>
 
       <Box className="grid grid-flow-row gap-2">

--- a/dashboard/src/features/orgs/projects/resources/settings/components/ResourcesConfirmationDialog/ResourcesConfirmationDialog.tsx
+++ b/dashboard/src/features/orgs/projects/resources/settings/components/ResourcesConfirmationDialog/ResourcesConfirmationDialog.tsx
@@ -75,7 +75,7 @@ export default function ResourcesConfirmationDialog({
         priceForTotalAvailableVCPU,
         (billableResources.vcpu / RESOURCE_VCPU_MULTIPLIER) *
           RESOURCE_VCPU_PRICE,
-      // ) + proPlan.price
+        // ) + proPlan.price
       )
     : proPlan.price;
 
@@ -130,13 +130,13 @@ export default function ResourcesConfirmationDialog({
       )}
 
       <Box className="grid grid-flow-row gap-4">
-        {/* <Box className="grid grid-flow-col justify-between gap-2">
+        {/* <Box className="grid justify-between grid-flow-col gap-2">
           <Text className="font-medium">{proPlan.name} Plan</Text>
           <Text>${proPlan.price.toFixed(2)}/mo</Text>
         </Box> */}
 
         <Box className="grid grid-flow-row gap-1.5">
-          <Box className="grid grid-flow-col items-center justify-between gap-2">
+          <Box className="grid items-center justify-between grid-flow-col gap-2">
             <Box className="grid grid-flow-row gap-0.5">
               <Text className="font-medium">Dedicated Resources</Text>
             </Box>
@@ -151,7 +151,7 @@ export default function ResourcesConfirmationDialog({
           </Box>
 
           <Box className="grid w-full grid-flow-row gap-1.5">
-            <Box className="grid grid-flow-col justify-between gap-2">
+            <Box className="grid justify-between grid-flow-col gap-2">
               <Text className="text-xs" color="secondary">
                 PostgreSQL Database
               </Text>
@@ -163,7 +163,7 @@ export default function ResourcesConfirmationDialog({
               </Text>
             </Box>
 
-            <Box className="grid grid-flow-col justify-between gap-2">
+            <Box className="grid justify-between grid-flow-col gap-2">
               <Text className="text-xs" color="secondary">
                 Hasura GraphQL
               </Text>
@@ -174,7 +174,7 @@ export default function ResourcesConfirmationDialog({
               </Text>
             </Box>
 
-            <Box className="grid grid-flow-col justify-between gap-2">
+            <Box className="grid justify-between grid-flow-col gap-2">
               <Text className="text-xs" color="secondary">
                 Auth
               </Text>
@@ -184,7 +184,7 @@ export default function ResourcesConfirmationDialog({
                   : authResources}
               </Text>
             </Box>
-            <Box className="grid grid-flow-col justify-between gap-2">
+            <Box className="grid justify-between grid-flow-col gap-2">
               <Text className="text-xs" color="secondary">
                 Storage
               </Text>
@@ -195,7 +195,7 @@ export default function ResourcesConfirmationDialog({
               </Text>
             </Box>
 
-            <Box className="grid grid-flow-col justify-between gap-2">
+            <Box className="grid justify-between grid-flow-col gap-2">
               <Text className="text-xs font-medium" color="secondary">
                 Total
               </Text>
@@ -209,20 +209,20 @@ export default function ResourcesConfirmationDialog({
 
         <Divider />
 
-        <Box className="grid grid-flow-col justify-between gap-2">
+        <Box className="grid justify-between grid-flow-col gap-2">
           <Box className="grid grid-flow-col items-center gap-1.5">
             <Text className="font-medium">Approximate Cost</Text>
 
             <Tooltip title="$0.0012/minute for every 1 vCPU and 2 GiB of RAM">
-              <InfoIcon aria-label="Info" className="h-4 w-4" color="primary" />
+              <InfoIcon aria-label="Info" className="w-4 h-4" color="primary" />
             </Tooltip>
           </Box>
 
-          <Text>${updatedPrice.toFixed(2)}/mo</Text>
+          <Text>{enabled ? `$${updatedPrice.toFixed(2)}/mo` : `$0/mo`}</Text>
         </Box>
         <Text className="text-xs text-gray-400">
-          Note: Your organization&apos;s $15 worth of credits cover for both shared
-          and dedicated compute.
+          Note: Your organization&apos;s $15 worth of credits cover for both
+          shared and dedicated compute.
         </Text>
       </Box>
 

--- a/dashboard/src/features/orgs/projects/resources/settings/components/ResourcesForm/ResourcesFormFooter.tsx
+++ b/dashboard/src/features/orgs/projects/resources/settings/components/ResourcesForm/ResourcesFormFooter.tsx
@@ -72,12 +72,10 @@ export default function ResourcesFormFooter() {
     }
 
     if (enabled) {
-      return (
-        Math.max(
-          priceForTotalAvailableVCPU,
-          (billableResources.vcpu / RESOURCE_VCPU_MULTIPLIER) *
-            RESOURCE_VCPU_PRICE,
-        )
+      return Math.max(
+        priceForTotalAvailableVCPU,
+        (billableResources.vcpu / RESOURCE_VCPU_MULTIPLIER) *
+          RESOURCE_VCPU_PRICE,
       );
     }
 
@@ -103,25 +101,31 @@ export default function ResourcesFormFooter() {
         </Link>
       </Text>
 
-      {(enabled) && (
+      {(enabled || isDirty) && (
         <Box className="grid items-center justify-between grid-flow-col gap-4">
-          <Box className="grid grid-flow-col items-center gap-1.5">
-            <Text>
-              Approximate cost:{' '}
-              <span className="font-medium">
-                ${computeUpdatedPrice().toFixed(2)}/mo
-              </span>
-            </Text>
+          {enabled && (
+            <Box className="grid grid-flow-col items-center gap-1.5">
+              <Text>
+                Approximate cost:{' '}
+                <span className="font-medium">
+                  ${computeUpdatedPrice().toFixed(2)}/mo
+                </span>
+              </Text>
 
-            <Tooltip title="$0.0012/minute for every 1 vCPU and 2 GiB of RAM">
-              <InfoIcon aria-label="Info" className="w-4 h-4" color="primary" />
-            </Tooltip>
-          </Box>
+              <Tooltip title="$0.0012/minute for every 1 vCPU and 2 GiB of RAM">
+                <InfoIcon
+                  aria-label="Info"
+                  className="w-4 h-4"
+                  color="primary"
+                />
+              </Tooltip>
+            </Box>
+          )}
 
           <Button
             type="submit"
-            variant='outlined'
-            color='secondary'
+            variant={isDirty ? 'contained' : 'outlined'}
+            color={isDirty ? 'primary' : 'secondary'}
             disabled={!isDirty}
           >
             Save

--- a/dashboard/src/tests/orgs/mocks.ts
+++ b/dashboard/src/tests/orgs/mocks.ts
@@ -49,7 +49,7 @@ export const mockApplication = {
   name: 'Test Project',
   slug: 'test-project',
   appStates: [],
-  subdomain: '',
+  subdomain: 'test-project',
   region: {
     name: 'us-east-1',
     city: 'New York',

--- a/package.json
+++ b/package.json
@@ -157,7 +157,8 @@
       "@graphiql/react": "^0.22.3",
       "send": "^0.19.0",
       "dset": "^3.1.4",
-      "rollup": "^4.24.0"
+      "rollup": "^4.24.0",
+      "http-proxy-middleware": "^2.0.7"
     }
   }
 }

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -63,6 +63,7 @@ overrides:
   send: ^0.19.0
   dset: ^3.1.4
   rollup: ^4.24.0
+  http-proxy-middleware: ^2.0.7
 
 importers:
 
@@ -1157,7 +1158,7 @@ importers:
         version: 4.2.19
       svelte-check:
         specifier: ^3.6.8
-        version: 3.8.6(@babel/core@7.25.2)(postcss@8.4.47)(svelte@4.2.19)
+        version: 3.8.6(postcss@8.4.47)(svelte@4.2.19)
       tailwindcss:
         specifier: ^3.4.3
         version: 3.4.10
@@ -1166,7 +1167,7 @@ importers:
         version: 5.5.4
       vite:
         specifier: ^5.4.6
-        version: 5.4.6(@types/node@16.18.106)(sass@1.32.0)
+        version: 5.4.6(@types/node@16.18.106)
       vitest:
         specifier: ^0.25.8
         version: 0.25.8
@@ -2114,10 +2115,10 @@ importers:
         version: 9.7.0(react@18.2.0)
       '@nhost/react':
         specifier: ^3.5.4
-        version: 3.6.0(@types/react@18.3.4)(react-dom@18.2.0)(react@18.2.0)
+        version: link:../../../packages/react
       '@nhost/react-apollo':
         specifier: ^12.0.4
-        version: 12.0.6(@apollo/client@3.11.4)(@nhost/react@3.6.0)(react-dom@18.2.0)(react@18.2.0)
+        version: 12.0.6(@apollo/client@3.11.4)(@nhost/react@packages+react)(react-dom@18.2.0)(react@18.2.0)
       '@radix-ui/react-dialog':
         specifier: ^1.1.1
         version: 1.1.1(@types/react-dom@18.3.0)(@types/react@18.3.4)(react-dom@18.2.0)(react@18.2.0)
@@ -2240,10 +2241,10 @@ importers:
         version: 3.11.4(@types/react@18.3.4)(react-dom@18.2.0)(react@18.2.0)
       '@nhost/react':
         specifier: ^3.5.2
-        version: 3.6.0(@types/react@18.3.4)(react-dom@18.2.0)(react@18.2.0)
+        version: link:../../../packages/react
       '@nhost/react-apollo':
         specifier: ^12.0.2
-        version: 12.0.6(@apollo/client@3.11.4)(@nhost/react@3.6.0)(react-dom@18.2.0)(react@18.2.0)
+        version: 12.0.6(@apollo/client@3.11.4)(@nhost/react@packages+react)(react-dom@18.2.0)(react@18.2.0)
       '@react-native-async-storage/async-storage':
         specifier: ^1.23.1
         version: 1.24.0(react-native@0.73.7)
@@ -7039,7 +7040,7 @@ packages:
   /@graphql-typed-document-node/core@3.2.0(graphql@16.8.1):
     resolution: {integrity: sha512-mB9oAsNCm9aM3/SOv4YtBMqZbYj10R7dkq8byBqxGY/ncFwhf2oQzMV+LCRlWoDSEBJ3COiR1yeDvMtsoOsuFQ==}
     peerDependencies:
-      graphql: 16.8.1
+      graphql: '>=16.8.1'
     dependencies:
       graphql: 16.8.1
 
@@ -8936,6 +8937,7 @@ packages:
       jwt-decode: 4.0.0
     transitivePeerDependencies:
       - encoding
+    dev: true
 
   /@nhost/hasura-auth-js@2.6.0:
     resolution: {integrity: sha512-gy2H/JlwSzpfFdpczFaVwheGq95SxmyzxJVTimBLCdVTl2yrnCZ3Zvk8gDpCcGLga/u+HjgRK+ymjH+RdNgiTg==}
@@ -8947,6 +8949,7 @@ packages:
       xstate: 4.38.3
     transitivePeerDependencies:
       - encoding
+    dev: true
 
   /@nhost/hasura-storage-js@2.5.1:
     resolution: {integrity: sha512-I3rOSa095lcR9BUmNw7dOoXLPWL39WOcrb0paUBFX4h3ltR92ILEHTZ38hN6bZSv157ZdqkIFNL/M2G45SSf7g==}
@@ -8957,6 +8960,7 @@ packages:
       xstate: 4.38.3
     transitivePeerDependencies:
       - encoding
+    dev: true
 
   /@nhost/nhost-js@3.1.10(graphql@16.8.1):
     resolution: {integrity: sha512-9KOX1krHu1UYAxTCUuRgRlaD97Nylzstck9YRSYwW27dHqDKhWUM5OWwOmOxJ2/W+Ty0V6EYbxuW2LRzrsdt1A==}
@@ -8970,8 +8974,9 @@ packages:
       isomorphic-unfetch: 3.1.0
     transitivePeerDependencies:
       - encoding
+    dev: true
 
-  /@nhost/react-apollo@12.0.6(@apollo/client@3.11.4)(@nhost/react@3.6.0)(react-dom@18.2.0)(react@18.2.0):
+  /@nhost/react-apollo@12.0.6(@apollo/client@3.11.4)(@nhost/react@packages+react)(react-dom@18.2.0)(react@18.2.0):
     resolution: {integrity: sha512-6Q4uN7PvC6UqS4YPKbjv/q/9FMP4SECdEcZFrfaKfJrcWyoAA5MRwJeQwDnD3uhx+npEUNgTbBxezXHjYH3AYw==}
     peerDependencies:
       '@apollo/client': ^3.7.10
@@ -8982,30 +8987,11 @@ packages:
     dependencies:
       '@apollo/client': 3.11.4(@types/react@18.3.4)(react-dom@18.2.0)(react@18.2.0)
       '@nhost/apollo': 7.1.6(@apollo/client@3.11.4)
-      '@nhost/react': 3.6.0(@types/react@18.3.4)(react-dom@18.2.0)(react@18.2.0)
+      '@nhost/react': link:packages/react
       react: 18.2.0
       react-dom: 18.2.0(react@18.2.0)
     transitivePeerDependencies:
       - '@nhost/nhost-js'
-    dev: false
-
-  /@nhost/react@3.6.0(@types/react@18.3.4)(react-dom@18.2.0)(react@18.2.0):
-    resolution: {integrity: sha512-siJ7oHeN0xmwtuN3U6sK9tMdBB9Nr7rIQy/UvqgIuVfbqrNyFfyrzMKzY7EYb61TpBNzyiOFfJl78s6jZmIl1g==}
-    peerDependencies:
-      react: 18.2.0
-      react-dom: 18.2.0
-    dependencies:
-      '@nhost/nhost-js': 3.1.10(graphql@16.8.1)
-      '@xstate/react': 3.2.2(@types/react@18.3.4)(react@18.2.0)(xstate@4.38.3)
-      jwt-decode: 4.0.0
-      react: 18.2.0
-      react-dom: 18.2.0(react@18.2.0)
-      xstate: 4.38.3
-    transitivePeerDependencies:
-      - '@types/react'
-      - '@xstate/fsm'
-      - encoding
-      - graphql
     dev: false
 
   /@nicolo-ribaudo/eslint-scope-5-internals@5.1.1-v1:
@@ -12830,7 +12816,7 @@ packages:
       svelte: 4.2.19
       tiny-glob: 0.2.9
       undici: 5.28.4
-      vite: 5.4.6(@types/node@16.18.106)(sass@1.32.0)
+      vite: 5.4.6(@types/node@16.18.106)
     transitivePeerDependencies:
       - supports-color
     dev: true
@@ -12846,7 +12832,7 @@ packages:
       '@sveltejs/vite-plugin-svelte': 2.5.3(svelte@4.2.19)(vite@5.4.6)
       debug: 4.3.7
       svelte: 4.2.19
-      vite: 5.4.6(@types/node@16.18.106)(sass@1.32.0)
+      vite: 5.4.6(@types/node@16.18.106)
     transitivePeerDependencies:
       - supports-color
     dev: true
@@ -12865,7 +12851,7 @@ packages:
       magic-string: 0.30.11
       svelte: 4.2.19
       svelte-hmr: 0.15.3(svelte@4.2.19)
-      vite: 5.4.6(@types/node@16.18.106)(sass@1.32.0)
+      vite: 5.4.6(@types/node@16.18.106)
       vitefu: 0.2.5(vite@5.4.6)
     transitivePeerDependencies:
       - supports-color
@@ -14768,7 +14754,7 @@ packages:
       '@babel/plugin-transform-react-jsx-source': 7.24.7(@babel/core@7.25.2)
       magic-string: 0.27.0
       react-refresh: 0.14.2
-      vite: 5.4.6(@types/node@18.19.46)
+      vite: 5.4.6(@types/node@16.18.106)(sass@1.32.0)
     transitivePeerDependencies:
       - supports-color
     dev: true
@@ -21478,7 +21464,7 @@ packages:
     resolution: {integrity: sha512-FdSNcu2QQcWnM2VNvSCCDCVS5PpPqpzgFT8+GXzqJuoDd0CBncxCY278u4mhRO7tMgo2JjgJA5aZ+nWSQ/Z+xg==}
     engines: {node: '>=10'}
     peerDependencies:
-      graphql: 16.8.1
+      graphql: '>=16.8.1'
     dependencies:
       graphql: 16.8.1
       tslib: 2.7.0
@@ -22173,8 +22159,8 @@ packages:
       - supports-color
     dev: true
 
-  /http-proxy-middleware@2.0.6(@types/express@4.17.21):
-    resolution: {integrity: sha512-ya/UeJ6HVBYxrgYotAZo1KvPWlgB48kUJLDePFeneHsVujFaW5WNj2NgWCAE//B1Dl02BIfYlpNgBy8Kf8Rjmw==}
+  /http-proxy-middleware@2.0.7(@types/express@4.17.21):
+    resolution: {integrity: sha512-fgVY8AV7qU7z/MmXJ/rxwbrtQH4jBQ9m7kp3llF0liB7glmFeVZFBepQb32T3y8n8k2+AEYuMPCpinYW+/CuRA==}
     engines: {node: '>=12.0.0'}
     peerDependencies:
       '@types/express': ^4.17.13
@@ -22962,7 +22948,7 @@ packages:
   /isomorphic-unfetch@3.1.0:
     resolution: {integrity: sha512-geDJjpoZ8N0kWexiwkX8F9NkTsXhetLPVbZFQ+JTW239QNOwvB0gniuR1Wc6f0AMTn7/mFGyXvHTifrCp/GH8Q==}
     dependencies:
-      node-fetch: 2.7.0(encoding@0.1.13)
+      node-fetch: 2.7.0
       unfetch: 4.2.0
     transitivePeerDependencies:
       - encoding
@@ -26825,6 +26811,17 @@ packages:
     dependencies:
       whatwg-url: 5.0.0
 
+  /node-fetch@2.7.0:
+    resolution: {integrity: sha512-c4FRfUm/dbcWZ7U+1Wq0AwCyFL+3nt2bEw05wfxSz+DWpWsitgmSgYmy2dQdWyKC1694ELPqMs/YzUSNozLt8A==}
+    engines: {node: 4.x || >=6.0.0}
+    peerDependencies:
+      encoding: ^0.1.0
+    peerDependenciesMeta:
+      encoding:
+        optional: true
+    dependencies:
+      whatwg-url: 5.0.0
+
   /node-fetch@2.7.0(encoding@0.1.13):
     resolution: {integrity: sha512-c4FRfUm/dbcWZ7U+1Wq0AwCyFL+3nt2bEw05wfxSz+DWpWsitgmSgYmy2dQdWyKC1694ELPqMs/YzUSNozLt8A==}
     engines: {node: 4.x || >=6.0.0}
@@ -28066,6 +28063,22 @@ packages:
       postcss: 8.4.47
       yaml: 1.10.2
     dev: true
+
+  /postcss-load-config@4.0.2(postcss@8.4.47):
+    resolution: {integrity: sha512-bSVhyJGL00wMVoPUzAVAnbEoWyqRxkjv64tUl427SKnPrENtq6hJwUojroMz2VB+Q1edmi4IfrAPpami5VVgMQ==}
+    engines: {node: '>= 14'}
+    peerDependencies:
+      postcss: '>=8.4.31'
+      ts-node: '>=9.0.0'
+    peerDependenciesMeta:
+      postcss:
+        optional: true
+      ts-node:
+        optional: true
+    dependencies:
+      lilconfig: 3.1.2
+      postcss: 8.4.47
+      yaml: 2.5.0
 
   /postcss-load-config@4.0.2(postcss@8.4.47)(ts-node@10.9.2):
     resolution: {integrity: sha512-bSVhyJGL00wMVoPUzAVAnbEoWyqRxkjv64tUl427SKnPrENtq6hJwUojroMz2VB+Q1edmi4IfrAPpami5VVgMQ==}
@@ -31989,7 +32002,7 @@ packages:
     resolution: {integrity: sha512-ot0WnXS9fgdkgIcePe6RHNk1WA8+muPa6cSjeR3V8K27q9BB1rTE3R1p7Hv0z1ZyAc8s6Vvv8DIyWf681MAt0w==}
     engines: {node: '>= 0.4'}
 
-  /svelte-check@3.8.6(@babel/core@7.25.2)(postcss@8.4.47)(svelte@4.2.19):
+  /svelte-check@3.8.6(postcss@8.4.47)(svelte@4.2.19):
     resolution: {integrity: sha512-ij0u4Lw/sOTREP13BdWZjiXD/BlHE6/e2e34XzmVmsp5IN4kVa3PWP65NM32JAgwjZlwBg/+JtiNV1MM8khu0Q==}
     hasBin: true
     peerDependencies:
@@ -32000,7 +32013,7 @@ packages:
       picocolors: 1.1.0
       sade: 1.8.1
       svelte: 4.2.19
-      svelte-preprocess: 5.1.4(@babel/core@7.25.2)(postcss@8.4.47)(svelte@4.2.19)(typescript@5.5.4)
+      svelte-preprocess: 5.1.4(postcss@8.4.47)(svelte@4.2.19)(typescript@5.5.4)
       typescript: 5.5.4
     transitivePeerDependencies:
       - '@babel/core'
@@ -32040,7 +32053,7 @@ packages:
       svelte: 4.2.19
     dev: true
 
-  /svelte-preprocess@5.1.4(@babel/core@7.25.2)(postcss@8.4.47)(svelte@4.2.19)(typescript@5.5.4):
+  /svelte-preprocess@5.1.4(postcss@8.4.47)(svelte@4.2.19)(typescript@5.5.4):
     resolution: {integrity: sha512-IvnbQ6D6Ao3Gg6ftiM5tdbR6aAETwjhHV+UKGf5bHGYR69RQvF1ho0JKPcbUON4vy4R7zom13jPjgdOWCQ5hDA==}
     engines: {node: '>= 16.0.0'}
     requiresBuild: true
@@ -32078,7 +32091,6 @@ packages:
       typescript:
         optional: true
     dependencies:
-      '@babel/core': 7.25.2
       '@types/pug': 2.0.10
       detect-indent: 6.1.0
       magic-string: 0.30.11
@@ -32256,7 +32268,7 @@ packages:
       postcss: 8.4.47
       postcss-import: 15.1.0(postcss@8.4.47)
       postcss-js: 4.0.1(postcss@8.4.47)
-      postcss-load-config: 4.0.2(postcss@8.4.47)(ts-node@10.9.2)
+      postcss-load-config: 4.0.2(postcss@8.4.47)
       postcss-nested: 6.2.0(postcss@8.4.47)
       postcss-selector-parser: 6.1.2
       resolve: 1.22.8
@@ -34055,6 +34067,45 @@ packages:
       - typescript
     dev: true
 
+  /vite@5.4.6(@types/node@16.18.106):
+    resolution: {integrity: sha512-IeL5f8OO5nylsgzd9tq4qD2QqI0k2CQLGrWD0rCN0EQJZpBK5vJAx0I+GDkMOXxQX/OfFHMuLIx6ddAxGX/k+Q==}
+    engines: {node: ^18.0.0 || >=20.0.0}
+    hasBin: true
+    peerDependencies:
+      '@types/node': ^18.0.0 || >=20.0.0
+      less: '*'
+      lightningcss: ^1.21.0
+      sass: '*'
+      sass-embedded: '*'
+      stylus: '*'
+      sugarss: '*'
+      terser: ^5.4.0
+    peerDependenciesMeta:
+      '@types/node':
+        optional: true
+      less:
+        optional: true
+      lightningcss:
+        optional: true
+      sass:
+        optional: true
+      sass-embedded:
+        optional: true
+      stylus:
+        optional: true
+      sugarss:
+        optional: true
+      terser:
+        optional: true
+    dependencies:
+      '@types/node': 16.18.106
+      esbuild: 0.21.5
+      postcss: 8.4.47
+      rollup: 4.24.0
+    optionalDependencies:
+      fsevents: 2.3.3
+    dev: true
+
   /vite@5.4.6(@types/node@16.18.106)(sass@1.32.0):
     resolution: {integrity: sha512-IeL5f8OO5nylsgzd9tq4qD2QqI0k2CQLGrWD0rCN0EQJZpBK5vJAx0I+GDkMOXxQX/OfFHMuLIx6ddAxGX/k+Q==}
     engines: {node: ^18.0.0 || >=20.0.0}
@@ -34141,7 +34192,7 @@ packages:
       vite:
         optional: true
     dependencies:
-      vite: 5.4.6(@types/node@16.18.106)(sass@1.32.0)
+      vite: 5.4.6(@types/node@16.18.106)
     dev: true
 
   /vitest@0.25.8:
@@ -34179,7 +34230,7 @@ packages:
       tinybench: 2.9.0
       tinypool: 0.3.1
       tinyspy: 1.1.1
-      vite: 5.4.6(@types/node@16.18.106)(sass@1.32.0)
+      vite: 5.4.6(@types/node@16.18.106)
     transitivePeerDependencies:
       - less
       - lightningcss
@@ -34658,7 +34709,7 @@ packages:
       express: 4.20.0
       graceful-fs: 4.2.11
       html-entities: 2.5.2
-      http-proxy-middleware: 2.0.6(@types/express@4.17.21)
+      http-proxy-middleware: 2.0.7(@types/express@4.17.21)
       ipaddr.js: 2.2.0
       launch-editor: 2.8.1
       open: 8.4.2

--- a/templates/cra-template-nhost-react-apollo-template/template/package-lock.json
+++ b/templates/cra-template-nhost-react-apollo-template/template/package-lock.json
@@ -17259,7 +17259,7 @@
         "express": "^4.17.3",
         "graceful-fs": "^4.2.6",
         "html-entities": "^2.3.2",
-        "http-proxy-middleware": "^2.0.3",
+        "http-proxy-middleware": "^2.0.7",
         "ipaddr.js": "^2.0.1",
         "launch-editor": "^2.6.0",
         "open": "^8.0.9",


### PR DESCRIPTION
### **User description**
fixes https://github.com/nhost/nhost/issues/2939


___

### **PR Type**
Enhancement, Bug fix


___

### **Description**
- Reset the form state when the migration dialog is opened or closed to ensure a clean state.
- Disable the 'Migrate' button if the form is not dirty to prevent submission without changes.
- Ensure the 'Cancel' button also resets the form state to avoid unintended data retention.



___



### **Changes walkthrough** 📝
<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Enhancement</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>MigrateProjectToOrg.tsx</strong><dd><code>Improve form handling and validation in migration modal</code>&nbsp; &nbsp; </dd></summary>
<hr>

dashboard/src/features/orgs/components/MigrateProjectToOrg/MigrateProjectToOrg.tsx

<li>Reset form state when dialog is opened or closed.<br> <li> Disable 'Migrate' button if form is not dirty.<br> <li> Ensure 'Cancel' button also resets form state.<br>


</details>


  </td>
  <td><a href="https://github.com/nhost/nhost/pull/2941/files#diff-d7ea08597de731b82ce33cea7c30a0017d28e936157247ac989aee9dfdea26e1">+17/-3</a>&nbsp; &nbsp; </td>

</tr>                    
</table></td></tr></tr></tbody></table>

___

> 💡 **PR-Agent usage**: Comment `/help "your question"` on any pull request to receive relevant information