### PR TITLE
fix (docs): update commands in nhost cli quickstart

### DIFF
--- a/.changeset/fresh-clouds-roll.md
+++ b/.changeset/fresh-clouds-roll.md
@@ -1,0 +1,5 @@
+---
+'@nhost/docs': minor
+---
+
+fix: copy to clipboard commands in nhost cli getting started

--- a/docs/development/cli/getting-started.mdx
+++ b/docs/development/cli/getting-started.mdx
@@ -9,10 +9,10 @@ icon: square-terminal
 To install the Nhost CLI copy the following command and paste it into your terminal:
 
 ```bash
-> sudo curl -L https://raw.githubusercontent.com/nhost/cli/main/get.sh | bash
+sudo curl -L https://raw.githubusercontent.com/nhost/cli/main/get.sh | bash
 ```
 
-The `get.sh` script checks for both the architecture and operating system and installs the right binary. 
+The `get.sh` script checks for both the architecture and operating system and installs the right binary.
 
 ### Supported Platforms:
 
@@ -30,8 +30,8 @@ The `get.sh` script checks for both the architecture and operating system and in
 
 Update an existing installation to the latest version.
 
-```bash Terminal
-> nhost sw upgrade
+```bash
+nhost sw upgrade
 ```
 
 ## Running Nhost

--- a/docs/development/cli/getting-started.mdx
+++ b/docs/development/cli/getting-started.mdx
@@ -12,7 +12,7 @@ To install the Nhost CLI copy the following command and paste it into your termi
 sudo curl -L https://raw.githubusercontent.com/nhost/cli/main/get.sh | bash
 ```
 
-The `get.sh` script checks for both the architecture and operating system and installs the right binary.
+The `get.sh` script checks for both the architecture and operating system and installs the right binary. 
 
 ### Supported Platforms:
 
@@ -30,7 +30,7 @@ The `get.sh` script checks for both the architecture and operating system and in
 
 Update an existing installation to the latest version.
 
-```bash
+```bash Terminal
 nhost sw upgrade
 ```
 


### PR DESCRIPTION
Removed '>' in commands for nhost CLI installation. 

This way if you click the copy to clipboard button you can paste and run the command directly (you don't have to erase the '>' prepended)