### PR TITLE
fix (dashboard): 'find text' in TOML configuration editor can only find search text inside viewport

### DIFF
--- a/.changeset/sixty-sheep-ring.md
+++ b/.changeset/sixty-sheep-ring.md
@@ -1,0 +1,5 @@
+---
+'@nhost/dashboard': minor
+---
+
+fix: find text inside TOML editor indexes configuration partially

--- a/dashboard/src/features/orgs/projects/common/components/settings/TOMLEditor/TOMLEditor.tsx
+++ b/dashboard/src/features/orgs/projects/common/components/settings/TOMLEditor/TOMLEditor.tsx
@@ -159,9 +159,6 @@ export default function TOMLEditor() {
             height="100%"
             width="100%"
             theme={theme.palette.mode === 'light' ? bbedit : githubDark}
-            basicSetup={{
-              searchKeymap: false,
-            }}
             extensions={[StreamLanguage.define(toml)]}
             onChange={onChange}
           />

--- a/dashboard/src/features/projects/common/components/settings/TOMLEditor/TOMLEditor.tsx
+++ b/dashboard/src/features/projects/common/components/settings/TOMLEditor/TOMLEditor.tsx
@@ -159,9 +159,6 @@ export default function TOMLEditor() {
             height="100%"
             width="100%"
             theme={theme.palette.mode === 'light' ? bbedit : githubDark}
-            basicSetup={{
-              searchKeymap: false,
-            }}
             extensions={[StreamLanguage.define(toml)]}
             onChange={onChange}
           />


### PR DESCRIPTION
Fixes #2911 