### PR TITLE
fix(templates/react-native): resolve dependency issue with `react-dom` in react-native example

### DIFF
--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -2270,6 +2270,9 @@ importers:
       react:
         specifier: 18.2.0
         version: 18.2.0
+      react-dom:
+        specifier: 18.2.0
+        version: 18.2.0(react@18.2.0)
       react-hook-form:
         specifier: ^7.51.2
         version: 7.53.0(react@18.2.0)

--- a/templates/react-native/package.json
+++ b/templates/react-native/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@nhost/react-native-template",
-	"version": "0.0.14",
+	"version": "0.0.15",
 	"description": "A template project to get you up to speed on how to use Nhost with React Native",
 	"main": "index.js",
 	"scripts": {

--- a/templates/react-native/template/package.json
+++ b/templates/react-native/template/package.json
@@ -18,6 +18,7 @@
 		"@react-navigation/native-stack": "^6.9.26",
 		"base-64": "^1.0.0",
 		"react": "18.2.0",
+    "react-dom": "18.2.0",
 		"react-hook-form": "^7.51.2",
 		"react-native": "0.73.7",
 		"react-native-document-picker": "^9.2.0",


### PR DESCRIPTION
### **PR Type**
Bug fix, Enhancement


___

### **Description**
- Added `react-dom` dependency to the React Native template to resolve dependency issues.
- Ensured compatibility between `react` and `react-dom` versions.



___



### **Changes walkthrough** 📝
<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Enhancement</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>package.json</strong><dd><code>Add `react-dom` dependency to React Native template</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

templates/react-native/template/package.json

<li>Added <code>react-dom</code> dependency with version <code>18.2.0</code>.<br> <li> Ensured compatibility with <code>react</code> version <code>18.2.0</code>.<br>


</details>


  </td>
  <td><a href="https://github.com/nhost/nhost/pull/3025/files#diff-e7f64b1356bbc3320367367ffe24b51239596a562600d715c8e5cfc5192bafb7">+1/-0</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

___

> 💡 **PR-Agent usage**: Comment `/help "your question"` on any pull request to receive relevant information