### PR TITLE
fix(hasura-auth-js, nhost-js): use a unique `broadcastKey` per nhost client for synchronizing authentication state across browser tabs

### DIFF
--- a/.changeset/poor-kangaroos-know.md
+++ b/.changeset/poor-kangaroos-know.md
@@ -1,0 +1,6 @@
+---
+'@nhost/hasura-auth-js': minor
+'@nhost/nhost-js': minor
+---
+
+fix: use a unique `broadcastKey` per nhost client for synchronizing authentication state across browser tabs

--- a/packages/hasura-auth-js/src/hasura-auth-client.ts
+++ b/packages/hasura-auth-js/src/hasura-auth-client.ts
@@ -79,8 +79,7 @@ export class HasuraAuthClient {
   readonly url: string
   constructor({
     url,
-    subdomain,
-    region,
+    broadcastKey,
     autoRefreshToken = true,
     autoSignIn = true,
     clientStorage,
@@ -91,9 +90,8 @@ export class HasuraAuthClient {
     this.url = url
     this._client = new AuthClient({
       backendUrl: url,
-      subdomain,
-      region,
       clientUrl: (typeof window !== 'undefined' && window.location?.origin) || '',
+      broadcastKey,
       autoRefreshToken,
       autoSignIn,
       start,

--- a/packages/hasura-auth-js/src/hasura-auth-client.ts
+++ b/packages/hasura-auth-js/src/hasura-auth-client.ts
@@ -79,6 +79,8 @@ export class HasuraAuthClient {
   readonly url: string
   constructor({
     url,
+    subdomain,
+    region,
     autoRefreshToken = true,
     autoSignIn = true,
     clientStorage,
@@ -89,6 +91,8 @@ export class HasuraAuthClient {
     this.url = url
     this._client = new AuthClient({
       backendUrl: url,
+      subdomain,
+      region,
       clientUrl: (typeof window !== 'undefined' && window.location?.origin) || '',
       autoRefreshToken,
       autoSignIn,

--- a/packages/hasura-auth-js/src/internal-client.ts
+++ b/packages/hasura-auth-js/src/internal-client.ts
@@ -34,6 +34,8 @@ export class AuthClient {
     autoRefreshToken = true,
     start = true,
     backendUrl,
+    subdomain,
+    region,
     clientUrl,
     devTools,
     ...defaultOptions
@@ -47,7 +49,9 @@ export class AuthClient {
       clientUrl,
       clientStorageType,
       autoSignIn,
-      autoRefreshToken
+      autoRefreshToken,
+      subdomain,
+      region
     })
 
     if (start) {
@@ -58,7 +62,7 @@ export class AuthClient {
       try {
         // TODO the same refresh token is used and refreshed by all tabs
         // * Ideally, a single tab should autorefresh and share the new jwt
-        this._channel = new BroadcastChannel('nhost')
+        this._channel = new BroadcastChannel(`${subdomain}${region}`)
 
         if (autoSignIn) {
           this._channel?.addEventListener('message', (event) => {

--- a/packages/hasura-auth-js/src/internal-client.ts
+++ b/packages/hasura-auth-js/src/internal-client.ts
@@ -34,9 +34,8 @@ export class AuthClient {
     autoRefreshToken = true,
     start = true,
     backendUrl,
-    subdomain,
-    region,
     clientUrl,
+    broadcastKey,
     devTools,
     ...defaultOptions
   }: NhostClientOptions) {
@@ -47,22 +46,21 @@ export class AuthClient {
       ...defaultOptions,
       backendUrl,
       clientUrl,
+      broadcastKey,
       clientStorageType,
       autoSignIn,
-      autoRefreshToken,
-      subdomain,
-      region
+      autoRefreshToken
     })
 
     if (start) {
       this.start({ devTools })
     }
 
-    if (typeof window !== 'undefined') {
+    if (typeof window !== 'undefined' && broadcastKey) {
       try {
         // TODO the same refresh token is used and refreshed by all tabs
         // * Ideally, a single tab should autorefresh and share the new jwt
-        this._channel = new BroadcastChannel(`${subdomain}${region}`)
+        this._channel = new BroadcastChannel(broadcastKey)
 
         if (autoSignIn) {
           this._channel?.addEventListener('message', (event) => {

--- a/packages/hasura-auth-js/src/machines/authentication/machine.ts
+++ b/packages/hasura-auth-js/src/machines/authentication/machine.ts
@@ -57,6 +57,8 @@ import { AuthEvents } from './events'
 
 export interface AuthMachineOptions extends AuthOptions {
   backendUrl: string
+  subdomain: string
+  region?: string
   clientUrl: string
 }
 
@@ -81,6 +83,8 @@ type AuthServices = {
 
 export const createAuthMachine = ({
   backendUrl,
+  subdomain,
+  region,
   clientUrl,
   clientStorageType = 'web',
   clientStorage,
@@ -687,7 +691,7 @@ export const createAuthMachine = ({
         broadcastToken: (context) => {
           if (autoSignIn) {
             try {
-              const channel = new BroadcastChannel('nhost')
+              const channel = new BroadcastChannel(`${subdomain}${region}`)
               // ? broadcat session instead of token ?
               channel.postMessage({
                 type: 'broadcast_token',
@@ -903,7 +907,7 @@ export const createAuthMachine = ({
           )
 
           try {
-            const channel = new BroadcastChannel('nhost')
+            const channel = new BroadcastChannel(`${subdomain}${region}`)
             // ? broadcast the signout event to other tabs to remove the accessToken
             channel.postMessage({ type: 'signout' })
           } catch (error) {

--- a/packages/hasura-auth-js/src/types/client.ts
+++ b/packages/hasura-auth-js/src/types/client.ts
@@ -58,8 +58,6 @@ export interface SignInPasswordlessSmsOtpParams {
 
 export interface NhostAuthConstructorParams extends AuthOptions {
   url: string
-  subdomain: string
-  region?: string
   start?: boolean
   /** @internal @deprecated @alias autoSignIn - use autoSignIn instead  */
   autoLogin?: boolean
@@ -121,6 +119,8 @@ export type AuthChangedFunction = (event: AuthChangeEvent, session: NhostSession
 export type OnTokenChangedFunction = (session: NhostSession | null) => void
 
 export interface AuthOptions {
+  /** Unique key used for inter-tab communication to synchronize authentication state. */
+  broadcastKey?: string
   /** Time interval until token refreshes, in seconds */
   refreshIntervalTime?: number
   /**

--- a/packages/hasura-auth-js/src/types/client.ts
+++ b/packages/hasura-auth-js/src/types/client.ts
@@ -58,6 +58,8 @@ export interface SignInPasswordlessSmsOtpParams {
 
 export interface NhostAuthConstructorParams extends AuthOptions {
   url: string
+  subdomain: string
+  region?: string
   start?: boolean
   /** @internal @deprecated @alias autoSignIn - use autoSignIn instead  */
   autoLogin?: boolean

--- a/packages/nhost-js/src/clients/auth.ts
+++ b/packages/nhost-js/src/clients/auth.ts
@@ -13,5 +13,10 @@ export function createAuthClient(params: NhostClientConstructorParams) {
     throw new Error('Please provide `subdomain` or `authUrl`.')
   }
 
-  return new HasuraAuthClient({ url: authUrl, ...params })
+  return new HasuraAuthClient({
+    url: authUrl,
+    subdomain: params.subdomain as string,
+    region: params.region,
+    ...params
+  })
 }

--- a/packages/nhost-js/src/clients/auth.ts
+++ b/packages/nhost-js/src/clients/auth.ts
@@ -9,14 +9,15 @@ import { NhostClientConstructorParams } from '../utils/types'
 export function createAuthClient(params: NhostClientConstructorParams) {
   const authUrl = 'subdomain' in params ? urlFromSubdomain(params, 'auth') : params.authUrl
 
+  const { subdomain, region } = params
+
   if (!authUrl) {
     throw new Error('Please provide `subdomain` or `authUrl`.')
   }
 
   return new HasuraAuthClient({
     url: authUrl,
-    subdomain: params.subdomain as string,
-    region: params.region,
+    broadcastKey: `${subdomain}${region ?? 'local'}`,
     ...params
   })
 }

--- a/packages/nhost-js/src/clients/nhost.ts
+++ b/packages/nhost-js/src/clients/nhost.ts
@@ -28,7 +28,7 @@ export class NhostClient {
    *
    * ```ts
    * // Create a new Nhost client from individual service URLs (custom domains, self-hosting, etc).
-   * const nhost = new NhostClient({ 
+   * const nhost = new NhostClient({
    *   authUrl: "my-auth-service-url",
    *   storageUrl: "my-storage-service-url",
    *   graphqlUrl: "my-graphql-service-url",

--- a/packages/nhost-js/src/utils/types.ts
+++ b/packages/nhost-js/src/utils/types.ts
@@ -61,7 +61,7 @@ export type ServiceUrls = {
 export interface NhostClientConstructorParams
   extends Partial<Subdomain>,
     Partial<ServiceUrls>,
-    Omit<NhostAuthConstructorParams, 'url'> {
+    Omit<NhostAuthConstructorParams, 'url' | 'subdomain' | 'region'> {
   /**
    * When set, the admin secret is sent as a header, `x-hasura-admin-secret`,
    * for all requests to GraphQL, Storage, and Serverless Functions.

--- a/packages/nhost-js/src/utils/types.ts
+++ b/packages/nhost-js/src/utils/types.ts
@@ -61,7 +61,7 @@ export type ServiceUrls = {
 export interface NhostClientConstructorParams
   extends Partial<Subdomain>,
     Partial<ServiceUrls>,
-    Omit<NhostAuthConstructorParams, 'url' | 'subdomain' | 'region'> {
+    Omit<NhostAuthConstructorParams, 'url' | 'broadcastKey'> {
   /**
    * When set, the admin secret is sent as a header, `x-hasura-admin-secret`,
    * for all requests to GraphQL, Storage, and Serverless Functions.


### PR DESCRIPTION
### **User description**
Fixes https://github.com/nhost/nhost/issues/3019

___

### **PR Type**
Bug fix, Enhancement


___

### **Description**
- Added `broadcastKey` parameter to `HasuraAuthClient`, `AuthClient`, and `createAuthMachine` constructors to ensure unique keys for synchronizing authentication state across browser tabs.
- Modified `BroadcastChannel` initialization to use the new `broadcastKey` parameter.
- Updated `NhostClientConstructorParams` to omit `broadcastKey`.
- Added changeset documentation for the new `broadcastKey` feature.



___



### **Changes walkthrough** 📝
<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Enhancement</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>hasura-auth-client.ts</strong><dd><code>Add `broadcastKey` parameter to `HasuraAuthClient` constructor</code></dd></summary>
<hr>

packages/hasura-auth-js/src/hasura-auth-client.ts

<li>Added <code>broadcastKey</code> parameter to <code>HasuraAuthClient</code> constructor.<br> <li> Passed <code>broadcastKey</code> to <code>AuthClient</code> configuration.<br> <li> Modified <code>BroadcastChannel</code> initialization to use <code>broadcastKey</code>.<br>


</details>


  </td>
  <td><a href="https://github.com/nhost/nhost/pull/3028/files#diff-0dbc30932ed723b7fd458066893f29f2f77658436c84adf42613813ea042c992">+2/-0</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>internal-client.ts</strong><dd><code>Add `broadcastKey` parameter to `AuthClient` constructor</code>&nbsp; </dd></summary>
<hr>

packages/hasura-auth-js/src/internal-client.ts

<li>Added <code>broadcastKey</code> parameter to <code>AuthClient</code> constructor.<br> <li> Modified <code>BroadcastChannel</code> initialization to use <code>broadcastKey</code>.<br>


</details>


  </td>
  <td><a href="https://github.com/nhost/nhost/pull/3028/files#diff-e726a23b4f62ae8d40f4bebf7cffd7a559ff64defe779d072e9f69cea360515c">+4/-2</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>machine.ts</strong><dd><code>Add `broadcastKey` parameter to `createAuthMachine`</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

packages/hasura-auth-js/src/machines/authentication/machine.ts

<li>Added <code>broadcastKey</code> parameter to <code>createAuthMachine</code>.<br> <li> Modified <code>BroadcastChannel</code> initialization to use <code>broadcastKey</code>.<br>


</details>


  </td>
  <td><a href="https://github.com/nhost/nhost/pull/3028/files#diff-a8fdfee087ad5a72ea0a64667e2a0c7f25baa84eaaf73ebfee3f5a5a1b7584d1">+11/-9</a>&nbsp; &nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>client.ts</strong><dd><code>Add `broadcastKey` property to `AuthOptions` interface</code>&nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

packages/hasura-auth-js/src/types/client.ts

- Added `broadcastKey` property to `AuthOptions` interface.



</details>


  </td>
  <td><a href="https://github.com/nhost/nhost/pull/3028/files#diff-e77914eac7c393e18a702ff5d00b5a56b48aaca2a3885b346dc2e5a0311f9357">+2/-0</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>auth.ts</strong><dd><code>Generate and pass `broadcastKey` to `HasuraAuthClient`</code>&nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

packages/nhost-js/src/clients/auth.ts

<li>Added <code>broadcastKey</code> generation using <code>subdomain</code> and <code>region</code>.<br> <li> Passed <code>broadcastKey</code> to <code>HasuraAuthClient</code> constructor.<br>


</details>


  </td>
  <td><a href="https://github.com/nhost/nhost/pull/3028/files#diff-8fe7df7908e4472b1e686396ef4ea1afdad6e4339eb324c708abb202d470d21f">+7/-1</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>types.ts</strong><dd><code>Update `NhostClientConstructorParams` to omit `broadcastKey`</code></dd></summary>
<hr>

packages/nhost-js/src/utils/types.ts

- Updated `NhostClientConstructorParams` to omit `broadcastKey`.



</details>


  </td>
  <td><a href="https://github.com/nhost/nhost/pull/3028/files#diff-8b10f48831e3144ecfca41bb6187a009d917ba72bdc4e5bb802599a6cdfbcc8c">+1/-1</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr><tr><td><strong>Formatting</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>nhost.ts</strong><dd><code>Code comments formatting</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

packages/nhost-js/src/clients/nhost.ts

- Formatting changes in code comments.



</details>


  </td>
  <td><a href="https://github.com/nhost/nhost/pull/3028/files#diff-c0fb9ddea444ab13a033d797389ea237a24a4b65d9e2c2544482e65d895180d4">+1/-1</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr><tr><td><strong>Documentation</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>poor-kangaroos-know.md</strong><dd><code>Add changeset for `broadcastKey` feature</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

.changeset/poor-kangaroos-know.md

- Added changeset for the new `broadcastKey` feature.



</details>


  </td>
  <td><a href="https://github.com/nhost/nhost/pull/3028/files#diff-53d433f190d52ce0378150012b69defa1e50f57753d1e1b6f89daf37a408f5ca">+6/-0</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

___

> 💡 **PR-Agent usage**: Comment `/help "your question"` on any pull request to receive relevant information