### PR TITLE
fix (dashboard): correct billing estimate when amount due is zero

### DIFF
--- a/.changeset/strange-poems-live.md
+++ b/.changeset/strange-poems-live.md
@@ -1,0 +1,5 @@
+---
+'@nhost/dashboard': minor
+---
+
+fix: corrected billing estimate when amount due is zero

--- a/dashboard/src/features/orgs/components/billing/components/BillingEstimate/components/Estimate/Estimate.tsx
+++ b/dashboard/src/features/orgs/components/billing/components/BillingEstimate/components/Estimate/Estimate.tsx
@@ -14,9 +14,6 @@ export default function Estimate() {
 
   const amountDue = useMemo(() => {
     const amount = data?.billingGetNextInvoice?.AmountDue;
-    if (!amount) {
-      return 'N/A';
-    }
     if (typeof amount !== 'number') {
       return 'N/A';
     }


### PR DESCRIPTION
### **PR Type**
Bug fix, Other


___

### **Description**
- Fixed the billing estimate calculation by removing the check for `amount` being falsy and directly checking if `amount` is not a number.
- Added a changeset entry to document the fix.



___



### **Changes walkthrough** 📝
<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Bug fix</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>Estimate.tsx</strong><dd><code>Fix billing estimate calculation when amount due is zero</code>&nbsp; </dd></summary>
<hr>

dashboard/src/features/orgs/components/billing/components/BillingEstimate/components/Estimate/Estimate.tsx

<li>Removed check for <code>amount</code> being falsy before returning 'N/A'.<br> <li> Simplified the logic to directly check if <code>amount</code> is not a number.<br>


</details>


  </td>
  <td><a href="https://github.com/nhost/nhost/pull/3042/files#diff-54e0d52021728a03593fc793304277ec57ef133369b9d9d283404b54d96922b6">+0/-3</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr><tr><td><strong>Other</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>strange-poems-live.md</strong><dd><code>Add changeset for billing estimate fix</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

.changeset/strange-poems-live.md

- Added changeset entry for the billing estimate fix.



</details>


  </td>
  <td><a href="https://github.com/nhost/nhost/pull/3042/files#diff-e911256cbe111b3fbfcddb20efbcb770287f8ebaa05f67f86ae0bba681c705b2">+5/-0</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

___

> 💡 **PR-Agent usage**: Comment `/help "your question"` on any pull request to receive relevant information