### PR TITLE
chore (ci): remove unnecessary/unsafe permissions to gen_ai_review

### DIFF
--- a/.github/workflows/gen_ai_review.yaml
+++ b/.github/workflows/gen_ai_review.yaml
@@ -12,7 +12,6 @@ jobs:
     permissions:
       issues: write
       pull-requests: write
-      contents: write
     name: Run pr agent on every pull request, respond to user comments
     steps:
       - name: PR Agent action step


### PR DESCRIPTION
### **PR Type**
enhancement


___

### **Description**
- Removed the 'contents: write' permission from the GitHub Actions workflow to enhance security by limiting permissions to only those necessary for the job.
- The change ensures that the workflow runs with minimal permissions, reducing potential security risks.



___



### **Changes walkthrough** 📝
<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Enhancement</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>gen_ai_review.yaml</strong><dd><code>Remove unnecessary permissions from GitHub Actions workflow</code></dd></summary>
<hr>

.github/workflows/gen_ai_review.yaml

<li>Removed 'contents: write' permission from the workflow.<br> <li> Ensured only necessary permissions are retained for the job.<br>


</details>


  </td>
  <td><a href="https://github.com/nhost/nhost/pull/3067/files#diff-d1e4c772e0acb5ce4891df2dd94ba58ffaf6393e8f75493ec7e10cbce1c4992c">+0/-1</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

___

> 💡 **PR-Agent usage**: Comment `/help "your question"` on any pull request to receive relevant information