### PR TITLE
fix: improve`useProject` hook to use proper caching and refetching

### DIFF
--- a/.changeset/stale-avocados-shake.md
+++ b/.changeset/stale-avocados-shake.md
@@ -1,0 +1,5 @@
+---
+'@nhost/dashboard': patch
+---
+
+fix: improve project polling logic and unify usage across components

--- a/dashboard/src/features/orgs/hooks/useRemoteApplicationGQLClient/useRemoteApplicationGQLClient.tsx
+++ b/dashboard/src/features/orgs/hooks/useRemoteApplicationGQLClient/useRemoteApplicationGQLClient.tsx
@@ -9,7 +9,7 @@ import { useMemo } from 'react';
  * @returns A function that returns a new ApolloClient instance.
  */
 export default function useRemoteApplicationGQLClient() {
-  const { project, loading } = useProject({ target: 'user-project' });
+  const { project, loading } = useProject();
   const serviceUrl = generateAppServiceUrl(
     project?.subdomain,
     project?.region,

--- a/dashboard/src/features/orgs/projects/graphql/common/hooks/useGetAppUsers.ts
+++ b/dashboard/src/features/orgs/projects/graphql/common/hooks/useGetAppUsers.ts
@@ -26,7 +26,7 @@ export default function useGetAppUsers({
   offset = 0,
   options = {},
 }: UseFilesOptions) {
-  const { project } = useProject({ target: 'user-project' });
+  const { project } = useProject();
   const userApplicationClient = useRemoteApplicationGQLClient();
   const { data, error, loading } = useRemoteAppGetUsersCustomQuery({
     ...options,

--- a/dashboard/src/features/orgs/projects/hooks/useAppClient/useAppClient.ts
+++ b/dashboard/src/features/orgs/projects/hooks/useAppClient/useAppClient.ts
@@ -24,7 +24,7 @@ export default function useAppClient(
   options?: UseAppClientOptions,
 ): UseAppClientReturn {
   const isPlatform = useIsPlatform();
-  const { project } = useProject({ target: 'user-project' });
+  const { project } = useProject();
 
   if (!isPlatform) {
     return new NhostClient({

--- a/dashboard/src/features/orgs/projects/storage/dataGrid/components/DataGridPreviewCell/DataGridPreviewCell.tsx
+++ b/dashboard/src/features/orgs/projects/storage/dataGrid/components/DataGridPreviewCell/DataGridPreviewCell.tsx
@@ -166,7 +166,7 @@ export default function DataGridPreviewCell<TData extends object>({
   value: { fetchBlob, id, mimeType, alt, blob },
   fallbackPreview = null,
 }: DataGridPreviewCellProps<TData>) {
-  const { project } = useProject({ target: 'user-project' });
+  const { project } = useProject();
   const appClient = useAppClient();
   const { objectUrl, loading, error } = useBlob({ fetchBlob, blob, mimeType });
   const [showModal, setShowModal] = useState(false);

--- a/dashboard/src/features/orgs/projects/storage/dataGrid/components/FilesDataGrid/FilesDataGrid.tsx
+++ b/dashboard/src/features/orgs/projects/storage/dataGrid/components/FilesDataGrid/FilesDataGrid.tsx
@@ -13,10 +13,10 @@ import { FilesDataGridControls } from '@/features/orgs/projects/storage/dataGrid
 import { useBuckets } from '@/features/orgs/projects/storage/dataGrid/hooks/useBuckets';
 import { useFiles } from '@/features/orgs/projects/storage/dataGrid/hooks/useFiles';
 import { useFilesAggregate } from '@/features/orgs/projects/storage/dataGrid/hooks/useFilesAggregate';
-import { getHasuraAdminSecret } from '@/utils/env';
-import { showLoadingToast, triggerToast } from '@/utils/toast';
 import type { Files } from '@/utils/__generated__/graphql';
 import { Order_By as OrderBy } from '@/utils/__generated__/graphql';
+import { getHasuraAdminSecret } from '@/utils/env';
+import { showLoadingToast, triggerToast } from '@/utils/toast';
 import debounce from 'lodash.debounce';
 import { useRouter } from 'next/router';
 import type { ChangeEvent } from 'react';
@@ -32,7 +32,7 @@ export type FilesDataGridProps = Partial<DataGridProps<StoredFile>>;
 
 export default function FilesDataGrid(props: FilesDataGridProps) {
   const router = useRouter();
-  const { project } = useProject({ target: 'user-project' });
+  const { project } = useProject();
   const appClient = useAppClient();
   const [searchString, setSearchString] = useState<string | null>(null);
   const [currentOffset, setCurrentOffset] = useState<number | null>(
@@ -118,7 +118,7 @@ export default function FilesDataGrid(props: FilesDataGridProps) {
           DataGridPreviewCell({
             ...cellProps,
             fallbackPreview: (
-              <FilePreviewIcon className="w-5 h-5 fill-current" />
+              <FilePreviewIcon className="h-5 w-5 fill-current" />
             ),
           }),
         minWidth: 80,

--- a/dashboard/src/features/orgs/projects/storage/dataGrid/components/FilesDataGridControls/FilesDataGridControls.tsx
+++ b/dashboard/src/features/orgs/projects/storage/dataGrid/components/FilesDataGridControls/FilesDataGridControls.tsx
@@ -12,9 +12,9 @@ import { useAppClient } from '@/features/orgs/projects/hooks/useAppClient';
 import { useProject } from '@/features/orgs/projects/hooks/useProject';
 import type { FileUploadButtonProps } from '@/features/orgs/projects/storage/dataGrid/components/FileUploadButton';
 import { FileUploadButton } from '@/features/orgs/projects/storage/dataGrid/components/FileUploadButton';
+import type { Files } from '@/utils/__generated__/graphql';
 import { getHasuraAdminSecret } from '@/utils/env';
 import { triggerToast } from '@/utils/toast';
-import type { Files } from '@/utils/__generated__/graphql';
 import type { PropsWithoutRef } from 'react';
 import { useState } from 'react';
 import type { Row } from 'react-table';
@@ -38,7 +38,7 @@ export default function FilesDataGridControls({
   ...props
 }: FilesDataGridControlsProps) {
   const { openAlertDialog } = useDialog();
-  const { project } = useProject({ target: 'user-project' });
+  const { project } = useProject();
   const appClient = useAppClient();
   const [deleteLoading, setDeleteLoading] = useState(false);
 
@@ -160,7 +160,7 @@ export default function FilesDataGridControls({
           </Button>
         </div>
       ) : (
-        <div className="grid w-full grid-cols-12 gap-2 mx-auto">
+        <div className="mx-auto grid w-full grid-cols-12 gap-2">
           <Input
             className={twMerge(
               'col-span-12 xs+:col-span-12 md:col-span-9 xl:col-span-10',
@@ -170,7 +170,7 @@ export default function FilesDataGridControls({
             {...restFilterProps}
           />
 
-          <div className="grid grid-flow-col col-span-12 gap-2 md:col-span-3 xl:col-span-2">
+          <div className="col-span-12 grid grid-flow-col gap-2 md:col-span-3 xl:col-span-2">
             <DataGridPagination
               className={twMerge('col-span-6', paginationClassName)}
               {...restPaginationProps}

--- a/dashboard/src/features/orgs/projects/storage/dataGrid/hooks/useFiles/useFiles.ts
+++ b/dashboard/src/features/orgs/projects/storage/dataGrid/hooks/useFiles/useFiles.ts
@@ -1,11 +1,11 @@
 import { generateAppServiceUrl } from '@/features/orgs/projects/common/utils/generateAppServiceUrl';
 import { useProject } from '@/features/orgs/projects/hooks/useProject';
-import { getHasuraAdminSecret } from '@/utils/env';
 import type {
   Files_Order_By as FilesOrderBy,
   GetFilesQuery,
 } from '@/utils/__generated__/graphql';
 import { useGetFilesQuery } from '@/utils/__generated__/graphql';
+import { getHasuraAdminSecret } from '@/utils/env';
 import type { QueryHookOptions } from '@apollo/client';
 
 export type UseFilesOptions = {
@@ -38,7 +38,7 @@ export default function useFiles({
   orderBy,
   options = {},
 }: UseFilesOptions) {
-  const { project } = useProject({ target: 'user-project' });
+  const { project } = useProject();
   const { data, previousData, ...rest } = useGetFilesQuery({
     variables: {
       where: searchString

--- a/dashboard/src/pages/orgs/[orgSlug]/projects/[appSubdomain]/graphql.tsx
+++ b/dashboard/src/pages/orgs/[orgSlug]/projects/[appSubdomain]/graphql.tsx
@@ -117,7 +117,7 @@ function GraphiQLHeader({ onUserChange, onRoleChange }: GraphiQLHeaderProps) {
   }
 
   return (
-    <header className="grid items-end grid-flow-row gap-2 p-2 md:grid-flow-col md:justify-between">
+    <header className="grid grid-flow-row items-end gap-2 p-2 md:grid-flow-col md:justify-between">
       <div className="grid grid-flow-row gap-2 md:grid-flow-col md:items-end">
         <div className="grid grid-cols-2 gap-2 md:grid-flow-col md:grid-cols-[initial]">
           <UserSelect
@@ -250,7 +250,7 @@ function GraphiQLEditor({ onHeaderChange }: GraphiQLEditorProps) {
 }
 
 export default function GraphQLPage() {
-  const { project } = useProject({ target: 'user-project' });
+  const { project } = useProject();
   const [userHeaders, setUserHeaders] = useState<Record<string, any>>({});
 
   if (!project?.subdomain || !project?.config?.hasura.adminSecret) {


### PR DESCRIPTION
### **PR Type**
Bug fix, Enhancement


___

### **Description**
- Removed the `target` option from multiple `useProject` hook calls across various components to simplify usage.
- Enhanced the `useProject` hook by improving project fetching logic with `useMemo` and adjusting refetching and caching strategies.
- Made minor formatting adjustments in several files for consistency.
- Added a changeset documenting the improvements in project polling logic.



___



### **Changes walkthrough** 📝
<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Enhancement</strong></td><td><details><summary>9 files</summary><table>
<tr>
  <td>
    <details>
      <summary><strong>useRemoteApplicationGQLClient.tsx</strong><dd><code>Simplified `useProject` hook usage by removing `target` option</code></dd></summary>
<hr>

dashboard/src/features/orgs/hooks/useRemoteApplicationGQLClient/useRemoteApplicationGQLClient.tsx

- Removed the `target` option from the `useProject` hook call.



</details>


  </td>
  <td><a href="https://github.com/nhost/nhost/pull/3085/files#diff-3323409c3168ed8475247d08c5b868de300441b3363ae647fa298a90c4e3c973">+1/-1</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>useGetAppUsers.ts</strong><dd><code>Simplified `useProject` hook usage by removing `target` option</code></dd></summary>
<hr>

dashboard/src/features/orgs/projects/graphql/common/hooks/useGetAppUsers.ts

- Removed the `target` option from the `useProject` hook call.



</details>


  </td>
  <td><a href="https://github.com/nhost/nhost/pull/3085/files#diff-8408473ab849d4b41515ef0387ce66851205c28244bd1c962f72f14e7f74d27a">+1/-1</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>useAppClient.ts</strong><dd><code>Simplified `useProject` hook usage by removing `target` option</code></dd></summary>
<hr>

dashboard/src/features/orgs/projects/hooks/useAppClient/useAppClient.ts

- Removed the `target` option from the `useProject` hook call.



</details>


  </td>
  <td><a href="https://github.com/nhost/nhost/pull/3085/files#diff-0aa83222c0e0eac6f0058070de2b199e5e78514cbba405eb98d3693329a93e65">+1/-1</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>useProject.ts</strong><dd><code>Enhanced project fetching logic and caching in `useProject` hook</code></dd></summary>
<hr>

dashboard/src/features/orgs/projects/hooks/useProject/useProject.ts

<li>Removed <code>target</code> option from <code>useProject</code> hook.<br> <li> Improved project fetching logic with <code>useMemo</code>.<br> <li> Adjusted refetching and caching strategies.<br>


</details>


  </td>
  <td><a href="https://github.com/nhost/nhost/pull/3085/files#diff-ef96f340af7a87a1fc60c42d8f4de846a2a54fde830a9461c64cfbc99dc11128">+30/-27</a>&nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>DataGridPreviewCell.tsx</strong><dd><code>Simplified `useProject` hook usage by removing `target` option</code></dd></summary>
<hr>

dashboard/src/features/orgs/projects/storage/dataGrid/components/DataGridPreviewCell/DataGridPreviewCell.tsx

- Removed the `target` option from the `useProject` hook call.



</details>


  </td>
  <td><a href="https://github.com/nhost/nhost/pull/3085/files#diff-d7bffe5896d2c9bac505fa9675790c59549d4fb35a2ad0cce903cc0aa31a8321">+1/-1</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>FilesDataGrid.tsx</strong><dd><code>Simplified `useProject` hook usage and formatting adjustments</code></dd></summary>
<hr>

dashboard/src/features/orgs/projects/storage/dataGrid/components/FilesDataGrid/FilesDataGrid.tsx

<li>Removed the <code>target</code> option from the <code>useProject</code> hook call.<br> <li> Minor formatting adjustments.<br>


</details>


  </td>
  <td><a href="https://github.com/nhost/nhost/pull/3085/files#diff-18c8df727e1a4fc6a94d03bd4a3a7a8cb3ad44d754803c4c7988c1c00a4b7caf">+4/-4</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>FilesDataGridControls.tsx</strong><dd><code>Simplified `useProject` hook usage and formatting adjustments</code></dd></summary>
<hr>

dashboard/src/features/orgs/projects/storage/dataGrid/components/FilesDataGridControls/FilesDataGridControls.tsx

<li>Removed the <code>target</code> option from the <code>useProject</code> hook call.<br> <li> Minor formatting adjustments.<br>


</details>


  </td>
  <td><a href="https://github.com/nhost/nhost/pull/3085/files#diff-b85b40168e9c149331a68cb1a0cbec570c75233fa34385945e094b8f4c032974">+4/-4</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>useFiles.ts</strong><dd><code>Simplified `useProject` hook usage by removing `target` option</code></dd></summary>
<hr>

dashboard/src/features/orgs/projects/storage/dataGrid/hooks/useFiles/useFiles.ts

- Removed the `target` option from the `useProject` hook call.



</details>


  </td>
  <td><a href="https://github.com/nhost/nhost/pull/3085/files#diff-ed71bc1eff3e4515937f01dec41686108466c8272d974628483103ea4dd0b1ed">+2/-2</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>graphql.tsx</strong><dd><code>Simplified `useProject` hook usage and formatting adjustments</code></dd></summary>
<hr>

dashboard/src/pages/orgs/[orgSlug]/projects/[appSubdomain]/graphql.tsx

<li>Removed the <code>target</code> option from the <code>useProject</code> hook call.<br> <li> Minor formatting adjustments.<br>


</details>


  </td>
  <td><a href="https://github.com/nhost/nhost/pull/3085/files#diff-6e3410ca11e10761fa7e9fbac46fa88089ed697b58aae7a2c58245d24208fbb1">+2/-2</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></details></td></tr><tr><td><strong>Documentation</strong></td><td><details><summary>1 files</summary><table>
<tr>
  <td>
    <details>
      <summary><strong>stale-avocados-shake.md</strong><dd><code>Documented changeset for project polling improvements</code>&nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

.changeset/stale-avocados-shake.md

- Added changeset for project polling logic improvements.



</details>


  </td>
  <td><a href="https://github.com/nhost/nhost/pull/3085/files#diff-d70925481a44dd2deb12d1b3af17bebf4d25becb0d133e82a1410a8070f42471">+5/-0</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></details></td></tr></tr></tbody></table>

___

> 💡 **PR-Agent usage**: Comment `/help "your question"` on any pull request to receive relevant information