### PR TITLE
chore (dashboard): warn run volumes losing data on project pause

### DIFF
--- a/.changeset/purple-trains-itch.md
+++ b/.changeset/purple-trains-itch.md
@@ -1,0 +1,5 @@
+---
+'@nhost/dashboard': minor
+---
+
+chore: add warning when pausing a project about losing Run services persistent volume data

--- a/dashboard/src/pages/orgs/[orgSlug]/projects/[appSubdomain]/settings/index.tsx
+++ b/dashboard/src/pages/orgs/[orgSlug]/projects/[appSubdomain]/settings/index.tsx
@@ -65,7 +65,7 @@ export default function SettingsGeneralPage() {
     }
 
     return services?.some(
-      (service) => service.config.resources.storage.length > 0,
+      (service) => service?.config?.resources?.storage?.length > 0,
     );
   }, [org?.plan?.isFree, services]);
 


### PR DESCRIPTION
### **User description**
Resolves #3048


___

### **PR Type**
Enhancement


___

### **Description**
- Added a warning message when pausing a project with Run services that have persistent volume data.
- The warning is displayed in an Alert component within the pause confirmation dialog.
- Implemented logic to determine when to show the warning based on the project's plan and Run services configuration.
- Updated the pause confirmation dialog to include more detailed information and styling.
- Added a changeset file to document the minor version bump for this feature.



___



### **Changes walkthrough** 📝
<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Enhancement</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>index.tsx</strong><dd><code>Add warning for Run service data loss on project pause</code>&nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

dashboard/src/pages/orgs/[orgSlug]/projects/[appSubdomain]/settings/index.tsx

<li>Added imports for new UI components (Alert, Link, Text)<br> <li> Implemented <code>useRunServices</code> hook and <code>showWarning</code> logic<br> <li> Enhanced the pause project dialog with a warning about data loss for <br>Run services<br> <li> Added conditional rendering of the warning alert


</details>


  </td>
  <td><a href="https://github.com/nhost/nhost/pull/3104/files#diff-b4185be97a505e25badcdefe31ea86fa9d69f72264c4bb35eae17fba936a3d47">+61/-3</a>&nbsp; &nbsp; </td>

</tr>
</table></td></tr><tr><td><strong>Documentation</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>purple-trains-itch.md</strong><dd><code>Add changeset for Run services warning feature</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

.changeset/purple-trains-itch.md

<li>Added a changeset file to document the minor version bump<br> <li> Described the new feature of warning about data loss when pausing a <br>project


</details>


  </td>
  <td><a href="https://github.com/nhost/nhost/pull/3104/files#diff-e810895b65f5a519690acf26c92d7f534ddab07a3baf619556674561d965b026">+5/-0</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

___

> 💡 **PR-Agent usage**: Comment `/help "your question"` on any pull request to receive relevant information