### PR TITLE
feat (dashboard): allow to change postgres settings if project is paused

### DIFF
--- a/.changeset/shy-geckos-switch.md
+++ b/.changeset/shy-geckos-switch.md
@@ -1,0 +1,5 @@
+---
+'@nhost/dashboard': minor
+---
+
+feat: allow to change postgres settings if project is paused

--- a/dashboard/src/features/orgs/projects/common/hooks/useProjectRedirectWhenReady/useProjectRedirectWhenReady.ts
+++ b/dashboard/src/features/orgs/projects/common/hooks/useProjectRedirectWhenReady/useProjectRedirectWhenReady.ts
@@ -24,7 +24,7 @@ export default function useProjectRedirectWhenReady(
   const { data, client, startPolling, ...rest } = useGetApplicationStateQuery({
     ...options,
     variables: { ...options.variables, appId: project?.id },
-    skip: !project.id,
+    skip: !project?.id,
   });
 
   useEffect(() => {

--- a/dashboard/src/features/orgs/projects/database/settings/components/DatabaseConnectionInfo/DatabaseConnectionInfo.tsx
+++ b/dashboard/src/features/orgs/projects/database/settings/components/DatabaseConnectionInfo/DatabaseConnectionInfo.tsx
@@ -118,8 +118,8 @@ export default function DatabaseConnectionInfo() {
   }
 
   const postgresHost = generateAppServiceUrl(
-    project.subdomain,
-    project.region,
+    project?.subdomain,
+    project?.region,
     'db',
   ).replace('https://', '');
 

--- a/dashboard/src/features/orgs/projects/database/settings/components/DatabaseServiceVersionSettings/DatabaseServiceVersionSettings.tsx
+++ b/dashboard/src/features/orgs/projects/database/settings/components/DatabaseServiceVersionSettings/DatabaseServiceVersionSettings.tsx
@@ -196,9 +196,13 @@ export default function DatabaseServiceVersionSettings() {
 
   const applicationLive = state === ApplicationStatus.Live;
   const applicationPaused = state === ApplicationStatus.Paused;
+  const applicationPausing = state === ApplicationStatus.Pausing;
 
   const applicationUnhealthy =
-    !applicationLive && !applicationPaused && !applicationUpdating;
+    !applicationLive &&
+    !applicationPaused &&
+    !applicationPausing &&
+    !applicationUpdating;
   const isMajorVersionDirty = formState?.dirtyFields?.majorVersion;
   const isMinorVersionDirty = formState?.dirtyFields?.minorVersion;
   const isDirty = isMajorVersionDirty || isMinorVersionDirty;

--- a/dashboard/src/features/orgs/projects/database/settings/components/DatabaseStorageCapacity/DatabaseStorageCapacity.tsx
+++ b/dashboard/src/features/orgs/projects/database/settings/components/DatabaseStorageCapacity/DatabaseStorageCapacity.tsx
@@ -25,6 +25,7 @@ import * as Yup from 'yup';
 
 const validationSchema = Yup.object({
   capacity: Yup.number()
+    .integer('Capacity must be an integer')
     .typeError('You must specify a number')
     .min(1, 'Capacity must be greater than 0')
     .required('Capacity is required'),

--- a/dashboard/src/features/orgs/projects/database/settings/components/DatabaseStorageCapacity/DatabaseStorageCapacity.tsx
+++ b/dashboard/src/features/orgs/projects/database/settings/components/DatabaseStorageCapacity/DatabaseStorageCapacity.tsx
@@ -4,6 +4,7 @@ import { SettingsContainer } from '@/components/layout/SettingsContainer';
 import { ActivityIndicator } from '@/components/ui/v2/ActivityIndicator';
 import { Box } from '@/components/ui/v2/Box';
 import { Input } from '@/components/ui/v2/Input';
+import { InputAdornment } from '@/components/ui/v2/InputAdornment';
 import { UpgradeNotification } from '@/features/orgs/projects/common/components/UpgradeNotification';
 import { useAppState } from '@/features/orgs/projects/common/hooks/useAppState';
 import { useIsPlatform } from '@/features/orgs/projects/common/hooks/useIsPlatform';
@@ -23,7 +24,10 @@ import { FormProvider, useForm } from 'react-hook-form';
 import * as Yup from 'yup';
 
 const validationSchema = Yup.object({
-  capacity: Yup.number().required().min(10),
+  capacity: Yup.number()
+    .typeError('You must specify a number')
+    .min(1, 'Capacity must be greater than 0')
+    .required('Capacity is required'),
 });
 
 export type DatabaseStorageCapacityFormValues = Yup.InferType<
@@ -162,17 +166,17 @@ export default function DatabaseStorageCapacity() {
               {...register('capacity')}
               id="capacity"
               name="capacity"
-              type="number"
+              type="text"
+              endAdornment={
+                <InputAdornment className="absolute right-2" position="end">
+                  GB
+                </InputAdornment>
+              }
               fullWidth
               disabled={project.legacyPlan?.isFree}
               className="lg:col-span-2"
               error={Boolean(formState.errors.capacity?.message)}
               helperText={formState.errors.capacity?.message}
-              slotProps={{
-                inputRoot: {
-                  min: 10,
-                },
-              }}
             />
           </Box>
           {!project.legacyPlan?.isFree && (

--- a/dashboard/src/features/orgs/projects/database/settings/components/DatabaseStorageCapacity/DatabaseStorageCapacity.tsx
+++ b/dashboard/src/features/orgs/projects/database/settings/components/DatabaseStorageCapacity/DatabaseStorageCapacity.tsx
@@ -64,6 +64,9 @@ export default function DatabaseStorageCapacity() {
 
   const { state } = useAppState();
 
+  const applicationPause =
+    state === ApplicationStatus.Paused || state === ApplicationStatus.Pausing;
+
   const { formState, register, reset, watch } = form;
   const isDirty = Object.keys(formState.dirtyFields).length > 0;
   const newCapacity = watch('capacity');
@@ -79,12 +82,12 @@ export default function DatabaseStorageCapacity() {
       return true;
     }
 
-    if (decreasingSize && state !== ApplicationStatus.Paused) {
+    if (decreasingSize && !applicationPause) {
       return true;
     }
 
     return false;
-  }, [isDirty, maintenanceActive, decreasingSize, state]);
+  }, [isDirty, maintenanceActive, decreasingSize, applicationPause]);
 
   useEffect(() => {
     if (data && !loading) {

--- a/dashboard/src/features/orgs/projects/database/settings/components/DatabaseStorageCapacityWarning/DatabaseStorageCapacityWarning.tsx
+++ b/dashboard/src/features/orgs/projects/database/settings/components/DatabaseStorageCapacityWarning/DatabaseStorageCapacityWarning.tsx
@@ -13,6 +13,9 @@ export default function DatabaseStorageCapacityWarning({
   decreasingSize,
   isDirty,
 }: DatabaseStorageCapacityWarningProps) {
+  const applicationPause =
+    state === ApplicationStatus.Paused || state === ApplicationStatus.Pausing;
+
   if (!isDirty) {
     return null;
   }
@@ -47,7 +50,7 @@ export default function DatabaseStorageCapacityWarning({
       </Alert>
     );
   }
-  if (state === ApplicationStatus.Paused && decreasingSize) {
+  if (applicationPause && decreasingSize) {
     return (
       <Alert severity="warning" className="flex flex-col gap-3 text-left">
         <div className="flex flex-col gap-2 lg:flex-row lg:justify-between">

--- a/dashboard/src/features/orgs/projects/database/settings/components/DatabaseStorageCapacityWarning/DatabaseStorageCapacityWarning.tsx
+++ b/dashboard/src/features/orgs/projects/database/settings/components/DatabaseStorageCapacityWarning/DatabaseStorageCapacityWarning.tsx
@@ -1,0 +1,70 @@
+import { Alert } from '@/components/ui/v2/Alert';
+import { Text } from '@/components/ui/v2/Text';
+import { ApplicationStatus } from '@/types/application';
+
+interface DatabaseStorageCapacityWarningProps {
+  state: ApplicationStatus;
+  decreasingSize: boolean;
+  isDirty: boolean;
+}
+
+export default function DatabaseStorageCapacityWarning({
+  state,
+  decreasingSize,
+  isDirty,
+}: DatabaseStorageCapacityWarningProps) {
+  if (!isDirty) {
+    return null;
+  }
+
+  if (state === ApplicationStatus.Live && !decreasingSize) {
+    return (
+      <Alert severity="warning" className="flex flex-col gap-3 text-left">
+        <div className="flex flex-col gap-2 lg:flex-row lg:justify-between">
+          <Text className="flex items-start gap-1 font-semibold">
+            <span>⚠</span> Warning: Increasing disk size
+          </Text>
+        </div>
+        <div>
+          <Text>
+            Due to AWS limitations, disk size can only be modified once every 6
+            hours. Please ensure you increase capacity sufficiently to cover
+            your needs during this period.
+          </Text>
+        </div>
+      </Alert>
+    );
+  }
+  if (state === ApplicationStatus.Live && decreasingSize) {
+    return (
+      <Alert severity="warning" className="flex flex-col gap-3 text-left">
+        <div className="flex flex-col gap-2 lg:flex-row lg:justify-between">
+          <Text className="flex items-start gap-1 font-semibold">
+            <span>⚠</span> Warning: Decreasing disk size requires project to be
+            paused first.
+          </Text>
+        </div>
+      </Alert>
+    );
+  }
+  if (state === ApplicationStatus.Paused && decreasingSize) {
+    return (
+      <Alert severity="warning" className="flex flex-col gap-3 text-left">
+        <div className="flex flex-col gap-2 lg:flex-row lg:justify-between">
+          <Text className="flex items-start gap-1 font-semibold">
+            <span>⚠</span> Warning: Ensure enough space before downsizing.
+          </Text>
+        </div>
+        <div>
+          <Text>
+            Before downsizing, ensure enough space for your database, WAL files,
+            and other supporting data to prevent issues when unpausing your
+            project.
+          </Text>
+        </div>
+      </Alert>
+    );
+  }
+
+  return null;
+}

--- a/dashboard/src/features/orgs/projects/database/settings/components/DatabaseStorageCapacityWarning/index.ts
+++ b/dashboard/src/features/orgs/projects/database/settings/components/DatabaseStorageCapacityWarning/index.ts
@@ -1,0 +1,1 @@
+export { default as DatabaseStorageCapacityWarning } from './DatabaseStorageCapacityWarning';


### PR DESCRIPTION
### **User description**
Resolves #3049


___

### **PR Type**
Enhancement


___

### **Description**
- Allow changing Postgres settings for paused projects

- Implement new warnings for disk size changes

- Improve validation for Postgres version selection

- Fix null subdomain error in project redirect


___



### **Changes walkthrough** 📝
<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Bug fix</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>useProjectRedirectWhenReady.ts</strong><dd><code>Fix null subdomain error in project redirect</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

dashboard/src/features/orgs/projects/common/hooks/useProjectRedirectWhenReady/useProjectRedirectWhenReady.ts

- Fixed null check for project.id to prevent error


</details>


  </td>
  <td><a href="https://github.com/nhost/nhost/pull/3106/files#diff-a234bc908266de3091b23b5134a01fd769f96759eb52aa108d2ad4b796b0303f">+1/-1</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>DatabaseConnectionInfo.tsx</strong><dd><code>Add null checks for project properties</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

dashboard/src/features/orgs/projects/database/settings/components/DatabaseConnectionInfo/DatabaseConnectionInfo.tsx

- Added optional chaining for project.subdomain and project.region


</details>


  </td>
  <td><a href="https://github.com/nhost/nhost/pull/3106/files#diff-b89287fb76d3112b8bc2b0f04181993512fbb537e618abd228d14b18ce6deb59">+2/-2</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr><tr><td><strong>Enhancement</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>DatabaseServiceVersionSettings.tsx</strong><dd><code>Enhance Postgres version settings and validation</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

dashboard/src/features/orgs/projects/database/settings/components/DatabaseServiceVersionSettings/DatabaseServiceVersionSettings.tsx

<li>Added validation for Postgres major version<br> <li> Updated logic for showing migrate warning<br> <li> Modified version change handling for paused projects<br> <li> Improved error handling and UI for version selection


</details>


  </td>
  <td><a href="https://github.com/nhost/nhost/pull/3106/files#diff-a982b817513fc173371f7468ad642f99ee0c914e5990a48992fc1fa5e230765f">+25/-12</a>&nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>DatabaseStorageCapacity.tsx</strong><dd><code>Implement new disk size change logic and warnings</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

dashboard/src/features/orgs/projects/database/settings/components/DatabaseStorageCapacity/DatabaseStorageCapacity.tsx

<li>Implemented logic for disk size changes based on project state<br> <li> Added new warning component for storage capacity changes<br> <li> Updated form validation and submission logic


</details>


  </td>
  <td><a href="https://github.com/nhost/nhost/pull/3106/files#diff-097a59d13b44816051386182a444eadfe2dcacd69b88c121af6733d7eca3ee43">+41/-13</a>&nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>DatabaseStorageCapacityWarning.tsx</strong><dd><code>Add new DatabaseStorageCapacityWarning component</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

dashboard/src/features/orgs/projects/database/settings/components/DatabaseStorageCapacityWarning/DatabaseStorageCapacityWarning.tsx

<li>Created new component for displaying warnings related to storage <br>capacity changes<br> <li> Implemented conditional rendering based on project state and size <br>change


</details>


  </td>
  <td><a href="https://github.com/nhost/nhost/pull/3106/files#diff-c7f0b8cda5cce08920512f5f6099c88becf526b9772a204c00c8e1d84b921b79">+73/-0</a>&nbsp; &nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>index.ts</strong><dd><code>Export DatabaseStorageCapacityWarning component</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

dashboard/src/features/orgs/projects/database/settings/components/DatabaseStorageCapacityWarning/index.ts

- Added export for DatabaseStorageCapacityWarning component


</details>


  </td>
  <td><a href="https://github.com/nhost/nhost/pull/3106/files#diff-2891fa2b87799b7b1294c0471f80b48f08708c934a93da0317ffeceaf6402d4c">+1/-0</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr><tr><td><strong>Documentation</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>shy-geckos-switch.md</strong><dd><code>Add changeset for new Postgres settings feature</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

.changeset/shy-geckos-switch.md

<li>Added changeset for new feature allowing Postgres settings changes for <br>paused projects


</details>


  </td>
  <td><a href="https://github.com/nhost/nhost/pull/3106/files#diff-a740ce1ccaa6300b5d912f274e2a2483722179e0a44ca58bccff59c96c989ad9">+5/-0</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

___

> 💡 **PR-Agent usage**: Comment `/help "your question"` on any pull request to receive relevant information