### PR TITLE
feat(hasura-auth-js): feat: add`initWithSession` to initialize auth client with existing session

### DIFF
--- a/.changeset/flat-apes-shake.md
+++ b/.changeset/flat-apes-shake.md
@@ -1,0 +1,5 @@
+---
+'@nhost-examples/nextjs-server-components': minor
+---
+
+chore: simplify Nhost client initialization with session and remove xstate dependency

--- a/.changeset/long-guests-sparkle.md
+++ b/.changeset/long-guests-sparkle.md
@@ -1,0 +1,5 @@
+---
+'@nhost/hasura-auth-js': minor
+---
+
+feat: introduce `initWithSession` to initialize auth client with an existing session

--- a/examples/quickstarts/nextjs-server-components/package.json
+++ b/examples/quickstarts/nextjs-server-components/package.json
@@ -24,8 +24,7 @@
     "react-dom": "^18.2.0",
     "tailwind-merge": "^1.14.0",
     "tailwindcss": "3.3.3",
-    "typescript": "5.2.2",
-    "xstate": "^4.38.3"
+    "typescript": "5.2.2"
   },
   "devDependencies": {
     "@types/js-cookie": "^3.0.6",

--- a/examples/quickstarts/nextjs-server-components/src/utils/nhost.ts
+++ b/examples/quickstarts/nextjs-server-components/src/utils/nhost.ts
@@ -1,10 +1,6 @@
 import { AuthErrorPayload, NhostClient, NhostSession } from '@nhost/nhost-js'
 import { cookies } from 'next/headers'
-
 import { NextRequest, NextResponse } from 'next/server'
-import { type StateFrom } from 'xstate/lib/types'
-import { waitFor } from 'xstate/lib/waitFor'
-
 export const NHOST_SESSION_KEY = 'nhostSession'
 
 export const getNhost = async (request?: NextRequest) => {
@@ -20,9 +16,7 @@ export const getNhost = async (request?: NextRequest) => {
   const sessionCookieValue = $cookies.get(NHOST_SESSION_KEY)?.value || ''
   const initialSession: NhostSession = JSON.parse(atob(sessionCookieValue) || 'null')
 
-  nhost.auth.client.start({ initialSession })
-  await waitFor(nhost.auth.client.interpreter!, (state: StateFrom<any>) => !state.hasTag('loading'))
-
+  await nhost.auth.initWithSession({ session: initialSession })
   return nhost
 }
 

--- a/packages/hasura-auth-js/src/hasura-auth-client.ts
+++ b/packages/hasura-auth-js/src/hasura-auth-client.ts
@@ -55,6 +55,7 @@ import {
   JWTHasuraClaims,
   LinkIdTokenParams,
   NhostAuthConstructorParams,
+  NhostSession,
   NhostSessionResponse,
   OnTokenChangedFunction,
   ResetPasswordParams,
@@ -855,6 +856,23 @@ export class HasuraAuthClient {
    */
   getSession() {
     return getSession(this._client.interpreter?.getSnapshot()?.context)
+  }
+
+  /**
+   * Initialize the auth client with an existing session
+   *
+   * @example
+   * ### Initialize with an existing Nhost session
+   * ```ts
+   * await nhost.auth.initWithSession({ session: initialSession })
+   * ```
+   *
+   * @param session - The Nhost session object to initialize the client with
+   * @docs https://docs.nhost.io/reference/javascript/auth/init-with-session
+   */
+  async initWithSession({ session }: { session: NhostSession }): Promise<void> {
+    this.client.start({ initialSession: session })
+    await this.waitUntilReady()
   }
 
   /**

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -1086,9 +1086,6 @@ importers:
       typescript:
         specifier: 5.2.2
         version: 5.2.2
-      xstate:
-        specifier: ^4.38.3
-        version: 4.38.3
     devDependencies:
       '@types/js-cookie':
         specifier: ^3.0.6


### PR DESCRIPTION
### **User description**
resolves https://github.com/nhost/nhost/issues/2319


___

### **PR Type**
Enhancement


___

### **Description**
- Added new `initWithSession()` method to `@nhost/hasura-auth-js` package, allowing initialization of auth client with an existing session
- Simplified Nhost client initialization in Next.js server components example by using the new `initWithSession()` method
- Removed xstate dependency from Next.js server components example
- Updated changesets to document the new feature and changes in the Next.js example
- Improved code organization and reduced complexity in the Next.js example



___



### **Changes walkthrough** 📝
<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Enhancement</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>nhost.ts</strong><dd><code>Simplify Nhost client initialization in Next.js</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

examples/quickstarts/nextjs-server-components/src/utils/nhost.ts

<li>Removed xstate dependency imports<br> <li> Replaced <code>nhost.auth.client.start()</code> and <code>waitFor()</code> with new <br><code>nhost.auth.initWithSession()</code> method<br> <li> Simplified initialization of Nhost client with existing session


</details>


  </td>
  <td><a href="https://github.com/nhost/nhost/pull/3108/files#diff-e13ecdf248c9041902e5e8a79555ccefc225eb7df3d717cc1b61ce0d5da092db">+1/-7</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>hasura-auth-client.ts</strong><dd><code>Add initWithSession method to HasuraAuthClient</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

packages/hasura-auth-js/src/hasura-auth-client.ts

<li>Added <code>NhostSession</code> import<br> <li> Implemented new <code>initWithSession()</code> method in <code>HasuraAuthClient</code> class<br> <li> Added JSDoc comments for the new method


</details>


  </td>
  <td><a href="https://github.com/nhost/nhost/pull/3108/files#diff-0dbc30932ed723b7fd458066893f29f2f77658436c84adf42613813ea042c992">+18/-0</a>&nbsp; &nbsp; </td>

</tr>
</table></td></tr><tr><td><strong>Documentation</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>flat-apes-shake.md</strong><dd><code>Add changeset for Next.js example updates</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

.changeset/flat-apes-shake.md

<li>Added changeset for Next.js server components example<br> <li> Describes simplification of Nhost client initialization and removal of <br>xstate dependency


</details>


  </td>
  <td><a href="https://github.com/nhost/nhost/pull/3108/files#diff-ee9361d5d0dad7378328ba9e63937d85fbe91156790a50764aaa285fab6b4db1">+5/-0</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>long-guests-sparkle.md</strong><dd><code>Add changeset for new initWithSession feature</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

.changeset/long-guests-sparkle.md

<li>Added changeset for @nhost/hasura-auth-js package<br> <li> Describes the addition of <code>initWithSession</code> method


</details>


  </td>
  <td><a href="https://github.com/nhost/nhost/pull/3108/files#diff-e7c748ca311b610d130750f4d24256383ef064c1ee2f1a9981060fd274335a1c">+5/-0</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr><tr><td><strong>Dependencies</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>package.json</strong><dd><code>Remove xstate dependency from Next.js example</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

examples/quickstarts/nextjs-server-components/package.json

- Removed "xstate" dependency from the project


</details>


  </td>
  <td><a href="https://github.com/nhost/nhost/pull/3108/files#diff-04889f3402d5191034459febd340282af1c718175c3b0b14ff03fb2ab46cf9b3">+1/-2</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

___

> 💡 **PR-Agent usage**: Comment `/help "your question"` on any pull request to receive relevant information