### PR TITLE
fix (dashboard): correct StorageErrorPayload TypeScript typing

### DIFF
--- a/.changeset/wet-pants-promise.md
+++ b/.changeset/wet-pants-promise.md
@@ -1,0 +1,5 @@
+---
+'@nhost/hasura-storage-js': minor
+---
+
+fix: correct StorageErrorPayload TypeScript typing

--- a/packages/hasura-storage-js/src/utils/upload.ts
+++ b/packages/hasura-storage-js/src/utils/upload.ts
@@ -92,13 +92,14 @@ export const fetchUpload = async (
 
     xhr.onload = () => {
       if (xhr.status < 200 || xhr.status >= 300) {
+        const error: StorageErrorPayload = {
+          error: xhr.response?.error?.message ?? xhr.response?.error ?? xhr.response,
+          message: xhr.response?.error?.message ?? xhr.response,
+          status: xhr.status
+        }
         return resolve({
           fileMetadata: null,
-          error: {
-            error: xhr.response?.error?.message ?? xhr.response?.error ?? xhr.response,
-            message: xhr.response?.error?.message ?? xhr.response,
-            status: xhr.status
-          }
+          error
         })
       }
       return resolve({ fileMetadata: xhr.response, error: null })
@@ -106,9 +107,14 @@ export const fetchUpload = async (
 
     xhr.onerror = () => {
       // only triggers if the request couldn't be made at all e.g. network error
+      const error: StorageErrorPayload = {
+        error: xhr.statusText,
+        message: xhr.statusText,
+        status: xhr.status
+      }
       return resolve({
         fileMetadata: null,
-        error: { error: xhr.statusText, message: xhr.statusText, status: xhr.status }
+        error
       })
     }
 

--- a/packages/hasura-storage-js/src/utils/upload.ts
+++ b/packages/hasura-storage-js/src/utils/upload.ts
@@ -95,7 +95,7 @@ export const fetchUpload = async (
         return resolve({
           fileMetadata: null,
           error: {
-            error: xhr.response?.error ?? xhr.response,
+            error: xhr.response?.error?.message ?? xhr.response?.error ?? xhr.response,
             message: xhr.response?.error?.message ?? xhr.response,
             status: xhr.status
           }


### PR DESCRIPTION
### **User description**
Resolves #2440


___

### **PR Type**
Bug fix


___

### **Description**
- Corrected StorageErrorPayload TypeScript typing

- Refactored error handling in file upload

- Improved consistency of error object structure

- Added changeset for version bump


___



### **Changes walkthrough** 📝
<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Bug fix</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>upload.ts</strong><dd><code>Refactor error handling in file upload</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

packages/hasura-storage-js/src/utils/upload.ts

<li>Refactored error handling in <code>fetchUpload</code> function<br> <li> Created consistent <code>StorageErrorPayload</code> object<br> <li> Updated error object structure in both success and error callbacks<br> <li> Improved type safety and error message handling


</details>


  </td>
  <td><a href="https://github.com/nhost/nhost/pull/3137/files#diff-806cf228c0fefb0c00e2b79108f101e2a26776c19578512ffc3d47ecafe59a5a">+12/-6</a>&nbsp; &nbsp; </td>

</tr>
</table></td></tr><tr><td><strong>Documentation</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>wet-pants-promise.md</strong><dd><code>Add changeset for StorageErrorPayload fix</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

.changeset/wet-pants-promise.md

<li>Added new changeset file<br> <li> Specified minor version bump for '@nhost/hasura-storage-js'<br> <li> Described fix for StorageErrorPayload TypeScript typing


</details>


  </td>
  <td><a href="https://github.com/nhost/nhost/pull/3137/files#diff-db6f7027a4f2f3488291bc300959e7ba746107dbac4ac36aed6872d84d9039e9">+5/-0</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

___

> 💡 **PR-Agent usage**: Comment `/help "your question"` on any pull request to receive relevant information