### PR TITLE
fix (dashboard): invalid slug/subdomain should open 404

### DIFF
--- a/.changeset/heavy-eyes-smile.md
+++ b/.changeset/heavy-eyes-smile.md
@@ -1,0 +1,5 @@
+---
+'@nhost/dashboard': minor
+---
+
+fix: invalid slug subdomain should open 404 page, disable inaccessible pages in local cli dashboard

--- a/dashboard/Dockerfile
+++ b/dashboard/Dockerfile
@@ -33,7 +33,7 @@ ENV NEXT_PUBLIC_NHOST_CONFIGSERVER_URL=__NEXT_PUBLIC_NHOST_CONFIGSERVER_URL__
 RUN yarn global add pnpm@9.15.0
 COPY .gitignore .gitignore
 COPY --from=pruner /app/out/json/ .
-COPY --from=pruner /app/out/pnpm-*.yaml .
+COPY --from=pruner /app/out/pnpm-*.yaml ./
 RUN pnpm install --frozen-lockfile
 
 COPY --from=pruner /app/out/full/ .

--- a/dashboard/src/components/layout/Header/OrgPagesComboBox.tsx
+++ b/dashboard/src/components/layout/Header/OrgPagesComboBox.tsx
@@ -18,6 +18,7 @@ import {
   PopoverTrigger,
 } from '@/components/ui/v3/popover';
 
+import { useIsPlatform } from '@/features/orgs/projects/common/hooks/useIsPlatform';
 import { Check, ChevronsUpDown } from 'lucide-react';
 import { useEffect, useMemo, useState } from 'react';
 
@@ -39,6 +40,8 @@ export default function OrgPagesComboBox() {
     push,
     asPath,
   } = useRouter();
+
+  const isPlatform = useIsPlatform();
 
   const pathSegments = useMemo(() => asPath.split('/'), [asPath]);
   const orgPageFromUrl = pathSegments[3] || null;
@@ -64,7 +67,7 @@ export default function OrgPagesComboBox() {
 
   return (
     <Popover open={open} onOpenChange={setOpen}>
-      <PopoverTrigger asChild>
+      <PopoverTrigger disabled={!isPlatform} asChild>
         <Button
           variant="ghost"
           size="sm"

--- a/dashboard/src/components/layout/Header/ProjectPagesComboBox.tsx
+++ b/dashboard/src/components/layout/Header/ProjectPagesComboBox.tsx
@@ -32,6 +32,7 @@ import {
   PopoverContent,
   PopoverTrigger,
 } from '@/components/ui/v3/popover';
+import { useIsPlatform } from '@/features/orgs/projects/common/hooks/useIsPlatform';
 import { cn } from '@/lib/utils';
 import { useRouter } from 'next/router';
 import { useEffect, useMemo, useState, type ReactElement } from 'react';
@@ -40,88 +41,10 @@ type Option = {
   value: string;
   label: string;
   icon: ReactElement;
+  disabled: boolean;
 };
 
-const projectPages = [
-  {
-    label: 'Overview',
-    value: 'overview',
-    icon: <HomeIcon className="h-4 w-4" />,
-    slug: '',
-  },
-  {
-    label: 'Database',
-    value: 'database',
-    icon: <DatabaseIcon className="h-4 w-4" />,
-    slug: '/database/browser/default',
-  },
-  {
-    label: 'GraphQL',
-    value: 'graphql',
-    icon: <GraphQLIcon className="h-4 w-4" />,
-    slug: 'graphql',
-  },
-  {
-    label: 'Hasura',
-    value: 'hasura',
-    icon: <HasuraIcon className="h-4 w-4" />,
-    slug: 'hasura',
-  },
-  {
-    label: 'Auth',
-    value: 'users',
-    icon: <UserIcon className="h-4 w-4" />,
-    slug: 'users',
-  },
-  {
-    label: 'Storage',
-    value: 'storage',
-    icon: <StorageIcon className="h-4 w-4" />,
-    slug: 'storage',
-  },
-  {
-    label: 'Run',
-    value: 'run',
-    icon: <ServicesIcon className="h-4 w-4" />,
-    slug: 'run',
-  },
-  {
-    label: 'AI',
-    value: 'ai',
-    icon: <AIIcon className="h-4 w-4" />,
-    slug: 'ai/auto-embeddings',
-  },
-  {
-    label: 'Deployments',
-    value: 'deployments',
-    icon: <RocketIcon className="h-4 w-4" />,
-    slug: 'deployments',
-  },
-  {
-    label: 'Backups',
-    value: 'backups',
-    icon: <CloudIcon className="h-4 w-4" />,
-    slug: 'backups',
-  },
-  {
-    label: 'Logs',
-    value: 'logs',
-    icon: <FileTextIcon className="h-4 w-4" />,
-    slug: 'logs',
-  },
-  {
-    label: 'Metrics',
-    value: 'metrics',
-    icon: <GaugeIcon className="h-4 w-4" />,
-    slug: 'metrics',
-  },
-  {
-    label: 'Settings',
-    value: 'settings',
-    icon: <CogIcon className="h-4 w-4" />,
-    slug: 'settings',
-  },
-];
+type SelectedOption = Omit<Option, 'disabled'>;
 
 export default function ProjectPagesComboBox() {
   const {
@@ -130,6 +53,105 @@ export default function ProjectPagesComboBox() {
     asPath,
   } = useRouter();
 
+  const isPlatform = useIsPlatform();
+
+  const projectPages = useMemo(
+    () => [
+      {
+        label: 'Overview',
+        value: 'overview',
+        icon: <HomeIcon className="h-4 w-4" />,
+        slug: '',
+        disabled: false,
+      },
+      {
+        label: 'Database',
+        value: 'database',
+        icon: <DatabaseIcon className="h-4 w-4" />,
+        slug: '/database/browser/default',
+        disabled: false,
+      },
+      {
+        label: 'GraphQL',
+        value: 'graphql',
+        icon: <GraphQLIcon className="h-4 w-4" />,
+        slug: 'graphql',
+        disabled: false,
+      },
+      {
+        label: 'Hasura',
+        value: 'hasura',
+        icon: <HasuraIcon className="h-4 w-4" />,
+        slug: 'hasura',
+        disabled: false,
+      },
+      {
+        label: 'Auth',
+        value: 'users',
+        icon: <UserIcon className="h-4 w-4" />,
+        slug: 'users',
+        disabled: false,
+      },
+      {
+        label: 'Storage',
+        value: 'storage',
+        icon: <StorageIcon className="h-4 w-4" />,
+        slug: 'storage',
+        disabled: false,
+      },
+      {
+        label: 'Run',
+        value: 'run',
+        icon: <ServicesIcon className="h-4 w-4" />,
+        slug: 'run',
+        disabled: false,
+      },
+      {
+        label: 'AI',
+        value: 'ai',
+        icon: <AIIcon className="h-4 w-4" />,
+        slug: 'ai/auto-embeddings',
+        disabled: false,
+      },
+      {
+        label: 'Deployments',
+        value: 'deployments',
+        icon: <RocketIcon className="h-4 w-4" />,
+        slug: 'deployments',
+        disabled: !isPlatform,
+      },
+      {
+        label: 'Backups',
+        value: 'backups',
+        icon: <CloudIcon className="h-4 w-4" />,
+        slug: 'backups',
+        disabled: !isPlatform,
+      },
+      {
+        label: 'Logs',
+        value: 'logs',
+        icon: <FileTextIcon className="h-4 w-4" />,
+        slug: 'logs',
+        disabled: !isPlatform,
+      },
+      {
+        label: 'Metrics',
+        value: 'metrics',
+        icon: <GaugeIcon className="h-4 w-4" />,
+        slug: 'metrics',
+        disabled: !isPlatform,
+      },
+      {
+        label: 'Settings',
+        value: 'settings',
+        icon: <CogIcon className="h-4 w-4" />,
+        slug: 'settings',
+        disabled: false,
+      },
+    ],
+    [isPlatform],
+  );
+
   const pathSegments = useMemo(() => asPath.split('/'), [asPath]);
   const projectPageFromUrl = appSubdomain
     ? pathSegments[5] || 'overview'
@@ -137,9 +159,8 @@ export default function ProjectPagesComboBox() {
   const selectedProjectPageFromUrl = projectPages.find(
     (item) => item.value === projectPageFromUrl,
   );
-  const [selectedProjectPage, setSelectedProjectPage] = useState<Option | null>(
-    null,
-  );
+  const [selectedProjectPage, setSelectedProjectPage] =
+    useState<SelectedOption | null>(null);
 
   useEffect(() => {
     if (selectedProjectPageFromUrl) {
@@ -155,6 +176,7 @@ export default function ProjectPagesComboBox() {
     label: app.label,
     value: app.slug,
     icon: app.icon,
+    disabled: app.disabled,
   }));
 
   const [open, setOpen] = useState(false);
@@ -188,6 +210,7 @@ export default function ProjectPagesComboBox() {
                 <CommandItem
                   key={option.value}
                   value={option.label}
+                  disabled={option.disabled}
                   onSelect={() => {
                     setSelectedProjectPage(option);
                     setOpen(false);

--- a/dashboard/src/features/projects/common/hooks/useNotFoundRedirect/useNotFoundRedirect.ts
+++ b/dashboard/src/features/projects/common/hooks/useNotFoundRedirect/useNotFoundRedirect.ts
@@ -1,16 +1,36 @@
+import { useIsPlatform } from '@/features/orgs/projects/common/hooks/useIsPlatform';
+import { useCurrentOrg } from '@/features/orgs/projects/hooks/useCurrentOrg';
+import { useProject } from '@/features/orgs/projects/hooks/useProject';
 import { useCurrentWorkspaceAndProject } from '@/features/projects/common/hooks/useCurrentWorkspaceAndProject';
 import { useRouter } from 'next/router';
 import { useEffect } from 'react';
 
 /**
- * Redirects to 404 page if either currentWorkspace/currentProject resolves to undefined.
+ * Redirects to 404 page if either currentWorkspace/currentProject resolves to undefined
+ * or if the current pathname is not a valid organization/project.
+ * Not applicable if running dashboard with local Nhost backend.
  */
 export default function useNotFoundRedirect() {
   const router = useRouter();
   const {
-    query: { orgSlug, workspaceSlug, appSubdomain, updating, appSlug },
+    query: {
+      orgSlug: urlOrgSlug,
+      workspaceSlug: urlWorkspaceSlug,
+      appSubdomain: urlAppSubdomain,
+      updating,
+      appSlug: urlAppSlug,
+    },
     isReady,
   } = router;
+
+  console.log('router.pathname:', router.pathname);
+
+  const { project, loading: projectLoading } = useProject();
+  const isPlatform = useIsPlatform();
+  const { org, loading: orgLoading } = useCurrentOrg();
+
+  const { subdomain: projectSubdomain } = project || {};
+  const { slug: currentOrgSlug } = org || {};
 
   const { currentProject, currentWorkspace, loading } =
     useCurrentWorkspaceAndProject();
@@ -23,6 +43,10 @@ export default function useNotFoundRedirect() {
       !isReady ||
       // If the current workspace and project are not loaded, we don't want to redirect to 404
       loading ||
+      // If the project is loading, we don't want to redirect to 404
+      projectLoading ||
+      // If the org is loading, we don't want to redirect to 404
+      orgLoading ||
       // If we're already on the 404 page, we don't want to redirect to 404
       router.pathname === '/404' ||
       router.pathname === '/' ||
@@ -31,12 +55,16 @@ export default function useNotFoundRedirect() {
       router.pathname === '/run-one-click-install' ||
       router.pathname.includes('/orgs/_') ||
       router.pathname.includes('/orgs/_/projects/_') ||
-      orgSlug ||
-      (orgSlug && appSubdomain) ||
+      (!isPlatform && router.pathname.includes('/orgs/local')) ||
+      (!isPlatform && router.pathname.includes('/orgs/[orgSlug]/projects')) ||
+      // If we are on a valid org and project, we don't want to redirect to 404
+      (urlOrgSlug && currentOrgSlug && urlAppSubdomain && projectSubdomain) ||
+      // If we are on a valid org and no project is selected, we don't want to redirect to 404
+      (urlOrgSlug && currentOrgSlug && !urlAppSubdomain && !projectSubdomain) ||
       // If we are on a valid workspace and project, we don't want to redirect to 404
-      (workspaceSlug && currentWorkspace && appSlug && currentProject) ||
+      (urlWorkspaceSlug && currentWorkspace && urlAppSlug && currentProject) ||
       // If we are on a valid workspace and no project is selected, we don't want to redirect to 404
-      (workspaceSlug && currentWorkspace && !appSlug && !currentProject)
+      (urlWorkspaceSlug && currentWorkspace && !urlAppSlug && !currentProject)
     ) {
       return;
     }
@@ -47,11 +75,16 @@ export default function useNotFoundRedirect() {
     currentWorkspace,
     isReady,
     loading,
-    appSubdomain,
-    appSlug,
+    urlAppSubdomain,
+    urlAppSlug,
     router,
     updating,
-    workspaceSlug,
-    orgSlug,
+    projectLoading,
+    orgLoading,
+    currentOrgSlug,
+    projectSubdomain,
+    urlWorkspaceSlug,
+    urlOrgSlug,
+    isPlatform,
   ]);
 }

--- a/dashboard/src/features/projects/common/hooks/useNotFoundRedirect/useNotFoundRedirect.ts
+++ b/dashboard/src/features/projects/common/hooks/useNotFoundRedirect/useNotFoundRedirect.ts
@@ -23,8 +23,6 @@ export default function useNotFoundRedirect() {
     isReady,
   } = router;
 
-  console.log('router.pathname:', router.pathname);
-
   const { project, loading: projectLoading } = useProject();
   const isPlatform = useIsPlatform();
   const { org, loading: orgLoading } = useCurrentOrg();


### PR DESCRIPTION
### **User description**
Fixes #3119


___

### **PR Type**
Bug fix, Enhancement


___

### **Description**
- Fix invalid slug/subdomain to open 404 page

- Disable inaccessible pages in local CLI dashboard

- Improve project page navigation and accessibility

- Enhance not found redirect logic


___



### **Changes walkthrough** 📝
<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Enhancement</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>OrgPagesComboBox.tsx</strong><dd><code>Disable organization pages combo box for non-platform use</code></dd></summary>
<hr>

dashboard/src/components/layout/Header/OrgPagesComboBox.tsx

<li>Import useIsPlatform hook<br> <li> Disable PopoverTrigger when not on platform


</details>


  </td>
  <td><a href="https://github.com/nhost/nhost/pull/3172/files#diff-b70a46a4233201c9a2650c930192b4417f35a27303ff5c78872c05a41a92c8ac">+4/-1</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>ProjectPagesComboBox.tsx</strong><dd><code>Enhance project pages combo box with platform-specific disabling</code></dd></summary>
<hr>

dashboard/src/components/layout/Header/ProjectPagesComboBox.tsx

<li>Refactor projectPages to use useMemo<br> <li> Add 'disabled' property to project page options<br> <li> Disable certain pages based on isPlatform value


</details>


  </td>
  <td><a href="https://github.com/nhost/nhost/pull/3172/files#diff-70b3af41358f0a22b83e502409a70a0df15e8946d958dbaee4c32b6ebdb38cf6">+106/-83</a></td>

</tr>
</table></td></tr><tr><td><strong>Bug fix</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>useNotFoundRedirect.ts</strong><dd><code>Improve 404 redirect logic for invalid slugs and subdomains</code></dd></summary>
<hr>

dashboard/src/features/projects/common/hooks/useNotFoundRedirect/useNotFoundRedirect.ts

<li>Add checks for valid organization and project<br> <li> Implement platform-specific redirect logic<br> <li> Include additional loading states in redirect decision


</details>


  </td>
  <td><a href="https://github.com/nhost/nhost/pull/3172/files#diff-837279cf43199053bca09913f62c4af019063a2e8dc7bfb7643ec54b7cecd29d">+41/-10</a>&nbsp; </td>

</tr>
</table></td></tr><tr><td><strong>Documentation</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>heavy-eyes-smile.md</strong><dd><code>Add changeset for dashboard improvements</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

.changeset/heavy-eyes-smile.md

<li>Add changeset for @nhost/dashboard package<br> <li> Describe fix for invalid slug/subdomain and local CLI dashboard


</details>


  </td>
  <td><a href="https://github.com/nhost/nhost/pull/3172/files#diff-9a0418cf1a2622ce3bbec8df535fa44974433329d5386f0a90eee7e60167b1c6">+5/-0</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

___

> <details> <summary>  Need help?</summary><li>Type <code>/help how to ...</code> in the comments thread for any questions about PR-Agent usage.</li><li>Check out the <a href="https://qodo-merge-docs.qodo.ai/usage-guide/">documentation</a> for more information.</li></details>