### PR TITLE
chore: update to pnpm@9.15.5

### DIFF
--- a/.github/actions/install-dependencies/action.yaml
+++ b/.github/actions/install-dependencies/action.yaml
@@ -14,7 +14,7 @@ runs:
   steps:
     - uses: pnpm/action-setup@v4
       with:
-        version: 9.15.0
+        version: 9.15.5
         run_install: false
     - name: Get pnpm cache directory
       id: pnpm-cache-dir

--- a/package.json
+++ b/package.json
@@ -92,7 +92,7 @@
   "resolutions": {
     "graphql": "16.8.1"
   },
-  "packageManager": "pnpm@9.15.0",
+  "packageManager": "pnpm@9.15.5",
   "engines": {
     "node": ">=20"
   },


### PR DESCRIPTION
Fixes pnpm signature when deploying `example-sveltekit`