### PR TITLE
fix (dashboard): stop content overflowing in projects and database permissions page

### DIFF
--- a/.changeset/proud-mugs-speak.md
+++ b/.changeset/proud-mugs-speak.md
@@ -1,0 +1,5 @@
+---
+'@nhost/dashboard': minor
+---
+
+fix: stop content overflowing in projects and database permissions page

--- a/dashboard/src/components/ui/v3/command.tsx
+++ b/dashboard/src/components/ui/v3/command.tsx
@@ -49,10 +49,8 @@ const CommandInput = React.forwardRef<
     <Search className="mr-2 h-4 w-4 shrink-0 opacity-50" />
     {prefix && (
       <span
-        className={cn(
-          'pointer-events-none text-muted-foreground',
-          prefixClassName,
-        )}
+        title={prefix}
+        className={cn('text-muted-foreground', prefixClassName)}
       >
         {prefix}
       </span>

--- a/dashboard/src/components/ui/v3/command.tsx
+++ b/dashboard/src/components/ui/v3/command.tsx
@@ -35,16 +35,25 @@ const CommandDialog = ({ children, ...props }: CommandDialogProps) => {
   );
 };
 
+interface CommandInputProps {
+  prefix?: React.ReactNode;
+  prefixClassName?: string;
+}
+
 const CommandInput = React.forwardRef<
   React.ElementRef<typeof CommandPrimitive.Input>,
-  React.ComponentPropsWithoutRef<typeof CommandPrimitive.Input> & {
-    prefix?: React.ReactNode;
-  }
->(({ className, prefix, ...props }, ref) => (
+  React.ComponentPropsWithoutRef<typeof CommandPrimitive.Input> &
+    CommandInputProps
+>(({ className, prefix, prefixClassName, ...props }, ref) => (
   <div className="flex items-center border-b px-3" cmdk-input-wrapper="">
     <Search className="mr-2 h-4 w-4 shrink-0 opacity-50" />
     {prefix && (
-      <span className="pointer-events-none flex items-center text-muted-foreground">
+      <span
+        className={cn(
+          'pointer-events-none text-muted-foreground',
+          prefixClassName,
+        )}
+      >
         {prefix}
       </span>
     )}

--- a/dashboard/src/features/orgs/components/projects/projects-grid/projects-grid.tsx
+++ b/dashboard/src/features/orgs/components/projects/projects-grid/projects-grid.tsx
@@ -27,7 +27,7 @@ function ProjectCard({ project }: { project: Project }) {
     >
       <div className="flex flex-row items-start gap-2">
         <Box className="mt-[2px] h-5 w-5 flex-shrink-0" />
-        <div className="flex w-full flex-col">
+        <div className="flex w-full flex-col overflow-hidden">
           <p className="truncate font-bold">{project.name}</p>
           <span className="text-xs text-muted-foreground">
             {project.region.name}

--- a/dashboard/src/features/orgs/components/projects/projects-grid/projects-grid.tsx
+++ b/dashboard/src/features/orgs/components/projects/projects-grid/projects-grid.tsx
@@ -28,7 +28,9 @@ function ProjectCard({ project }: { project: Project }) {
       <div className="flex flex-row items-start gap-2">
         <Box className="mt-[2px] h-5 w-5 flex-shrink-0" />
         <div className="flex w-full flex-col overflow-hidden">
-          <p className="truncate font-bold">{project.name}</p>
+          <p title={project.name} className="truncate font-bold">
+            {project.name}
+          </p>
           <span className="text-xs text-muted-foreground">
             {project.region.name}
           </span>

--- a/dashboard/src/features/orgs/projects/database/dataGrid/components/ColumnAutocomplete/ColumnAutocomplete.tsx
+++ b/dashboard/src/features/orgs/projects/database/dataGrid/components/ColumnAutocomplete/ColumnAutocomplete.tsx
@@ -198,7 +198,14 @@ function ColumnAutocomplete(
 
   return (
     <Popover open={open} onOpenChange={setOpen}>
-      <PopoverTrigger asChild>
+      <PopoverTrigger
+        asChild
+        title={
+          buttonPrefix
+            ? `${buttonPrefix}.${selectedColumn?.label}`
+            : selectedColumn?.label || 'Select a column'
+        }
+      >
         <Button
           ref={ref}
           disabled={disabled}
@@ -207,20 +214,18 @@ function ColumnAutocomplete(
           aria-expanded={open}
           className="w-full justify-between"
         >
-          <div className="flex min-w-0 items-center gap-0">
-            {buttonPrefix ? (
-              <div className="flex min-w-0 flex-shrink items-center gap-0">
-                <span className="flex-shrink truncate text-sm text-muted-foreground lg:max-w-[200px]">
-                  {buttonPrefix}.
-                </span>
-                <span className="truncate">{selectedColumn?.label}</span>
-              </div>
-            ) : (
-              <span className="truncate">
-                {selectedColumn?.label || 'Select a column'}
+          {buttonPrefix ? (
+            <div className="flex min-w-0 flex-shrink items-center gap-0">
+              <span className="flex-shrink truncate text-sm text-muted-foreground lg:max-w-[200px]">
+                {buttonPrefix}.
               </span>
-            )}
-          </div>
+              <span className="truncate">{selectedColumn?.label}</span>
+            </div>
+          ) : (
+            <span className="truncate">
+              {selectedColumn?.label || 'Select a column'}
+            </span>
+          )}
           <ChevronsUpDown className="ml-2 h-5 w-5 shrink-0 opacity-50" />
         </Button>
       </PopoverTrigger>
@@ -248,12 +253,11 @@ function ColumnAutocomplete(
             placeholder=""
             prefix={
               relationshipDotNotation
-                ? `
-              ${selectedTable}.${relationshipDotNotation}.`
-                : ``
+                ? `${selectedTable}.${relationshipDotNotation}.`
+                : ''
             }
-            className="min-w-0"
-            prefixClassName="truncate max-w-[60%]"
+            className="w-auto min-w-0 flex-grow items-center gap-0 pl-0"
+            prefixClassName="flex-shrink truncate max-w-[200px]"
           />
           {pages?.length > 0 ? (
             <div className="flex flex-row items-center gap-2 px-2 py-1.5">
@@ -292,7 +296,10 @@ function ColumnAutocomplete(
                         )}
                       />
                       <div className="flex gap-3">
-                        <span className="line-clamp-2 break-all">
+                        <span
+                          title={option.label}
+                          className="line-clamp-2 break-all"
+                        >
                           {option.label}
                         </span>
                         <div className="flex items-center">
@@ -336,7 +343,10 @@ function ColumnAutocomplete(
                         )}
                       />
                       <div className="flex gap-3">
-                        <span className="line-clamp-2 break-all">
+                        <span
+                          title={option.label}
+                          className="line-clamp-2 break-all"
+                        >
                           {option.label}
                         </span>
                         <div className="flex items-center">

--- a/dashboard/src/features/orgs/projects/database/dataGrid/components/ColumnAutocomplete/ColumnAutocomplete.tsx
+++ b/dashboard/src/features/orgs/projects/database/dataGrid/components/ColumnAutocomplete/ColumnAutocomplete.tsx
@@ -205,18 +205,22 @@ function ColumnAutocomplete(
           variant="outline"
           role="combobox"
           aria-expanded={open}
-          className="justify-between"
+          className="w-full justify-between"
         >
-          {buttonPrefix ? (
-            <div className="flex flex-shrink-0 gap-0 truncate">
-              <span className="flex-shrink-0 truncate text-sm text-muted-foreground lg:max-w-[200px]">
-                {buttonPrefix}.
+          <div className="flex min-w-0 items-center gap-0">
+            {buttonPrefix ? (
+              <div className="flex min-w-0 flex-shrink items-center gap-0">
+                <span className="flex-shrink truncate text-sm text-muted-foreground lg:max-w-[200px]">
+                  {buttonPrefix}.
+                </span>
+                <span className="truncate">{selectedColumn?.label}</span>
+              </div>
+            ) : (
+              <span className="truncate">
+                {selectedColumn?.label || 'Select a column'}
               </span>
-              {selectedColumn?.label}
-            </div>
-          ) : (
-            selectedColumn?.label || 'Select a column'
-          )}
+            )}
+          </div>
           <ChevronsUpDown className="ml-2 h-5 w-5 shrink-0 opacity-50" />
         </Button>
       </PopoverTrigger>
@@ -248,6 +252,8 @@ function ColumnAutocomplete(
               ${selectedTable}.${relationshipDotNotation}.`
                 : ``
             }
+            className="min-w-0"
+            prefixClassName="truncate max-w-[60%]"
           />
           {pages?.length > 0 ? (
             <div className="flex flex-row items-center gap-2 px-2 py-1.5">


### PR DESCRIPTION
### **User description**
Fixes #3200


___

### **PR Type**
Bug fix


___

### **Description**
- Fix text overflow in projects overview page

- Truncate text in role table permissions page

- Adjust command input component for better text handling

- Improve layout and styling for better text containment


___



### **Changes walkthrough** 📝
<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Enhancement</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>command.tsx</strong><dd><code>Enhance CommandInput component for better text handling</code>&nbsp; &nbsp; </dd></summary>
<hr>

dashboard/src/components/ui/v3/command.tsx

<li>Added new CommandInputProps interface<br> <li> Enhanced CommandInput component with prefixClassName prop<br> <li> Improved styling for prefix element in CommandInput


</details>


  </td>
  <td><a href="https://github.com/nhost/nhost/pull/3240/files#diff-a25693951624c06ba6f8aa7b734d235f48dbd63e984b7487674e64f3e0585556">+14/-5</a>&nbsp; &nbsp; </td>

</tr>
</table></td></tr><tr><td><strong>Bug fix</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>projects-grid.tsx</strong><dd><code>Fix text overflow in project cards</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

dashboard/src/features/orgs/components/projects/projects-grid/projects-grid.tsx

- Added overflow-hidden class to project card container


</details>


  </td>
  <td><a href="https://github.com/nhost/nhost/pull/3240/files#diff-fb28557d0c8fd3a64ab16de7da710e3a28383313ca2cda956fe1e20e30d798a0">+1/-1</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>ColumnAutocomplete.tsx</strong><dd><code>Enhance ColumnAutocomplete to prevent text overflow</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

dashboard/src/features/orgs/projects/database/dataGrid/components/ColumnAutocomplete/ColumnAutocomplete.tsx

<li>Improved layout and styling of ColumnAutocomplete component<br> <li> Added truncate classes to prevent text overflow<br> <li> Adjusted width and flex properties for better text containment


</details>


  </td>
  <td><a href="https://github.com/nhost/nhost/pull/3240/files#diff-c89efa530042890e7d6277c2e3c763cb7c9b9fc1d7c14c62839f4cf7c42528f7">+16/-10</a>&nbsp; </td>

</tr>
</table></td></tr><tr><td><strong>Documentation</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>proud-mugs-speak.md</strong><dd><code>Add changeset for dashboard package update</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

.changeset/proud-mugs-speak.md

- Added changeset file for version bump and change description


</details>


  </td>
  <td><a href="https://github.com/nhost/nhost/pull/3240/files#diff-4c08340a54bac8858e7dd2f252dce9de2b33e1c60fa2e487bfb97b9e381eb2ab">+5/-0</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

___

> <details> <summary>  Need help?</summary><li>Type <code>/help how to ...</code> in the comments thread for any questions about PR-Agent usage.</li><li>Check out the <a href="https://qodo-merge-docs.qodo.ai/usage-guide/">documentation</a> for more information.</li></details>