### PR TITLE
chore (observability): make alerts less sensitive

### DIFF
--- a/observability/grafana/rules_nhost.yaml
+++ b/observability/grafana/rules_nhost.yaml
@@ -51,9 +51,9 @@ groups:
                 maxDataPoints: 43200
                 refId: B
                 type: threshold
-          noDataState: NoData
-          execErrState: Error
-          for: 5m
+          noDataState: Alerting
+          execErrState: Alerting
+          for: 15m
           annotations:
             runbook_url: https://docs.nhost.io/platform/cloud/compute-resources
             Project Subdomain: {{ .Subdomain }}
@@ -123,9 +123,9 @@ groups:
                 maxDataPoints: 43200
                 refId: B
                 type: threshold
-          noDataState: NoData
-          execErrState: Error
-          for: 5m
+          noDataState: Alerting
+          execErrState: Alerting
+          for: 15m
           annotations:
             runbook_url: https://docs.nhost.io/products/database/configuring-postgres
             Subdomain: {{ .Subdomain }}
@@ -195,9 +195,9 @@ groups:
                 maxDataPoints: 43200
                 refId: B
                 type: threshold
-          noDataState: NoData
-          execErrState: Error
-          for: 5m
+          noDataState: Alerting
+          execErrState: Alerting
+          for: 15m
           annotations:
             runbook_url: https://docs.nhost.io/platform/cloud/compute-resources
             Subdomain: {{ .Subdomain }}
@@ -268,7 +268,7 @@ groups:
                 refId: B
                 type: threshold
           noDataState: OK
-          execErrState: Error
+          execErrState: OK
           for: 0s
           annotations:
             summary: |
@@ -342,9 +342,9 @@ groups:
                 maxDataPoints: 43200
                 refId: B
                 type: threshold
-          noDataState: OK
-          execErrState: Error
-          for: 5m
+          noDataState: Alerting
+          execErrState: Alerting
+          for: 15m
           annotations:
             Subdomain: {{ .Subdomain }}
             Project Name: {{ .ProjectName }}


### PR DESCRIPTION
### **PR Type**
Enhancement


___

### **Description**
- Increase alert sensitivity time from 5m to 15m

- Change NoData state to Alerting for most rules

- Modify execErrState to Alerting or OK

- Adjust noDataState for specific alert rules


___



### **Changes walkthrough** 📝
<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Configuration changes</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>rules_nhost.yaml</strong><dd><code>Adjust alert sensitivity and error handling configurations</code></dd></summary>
<hr>

observability/grafana/rules_nhost.yaml

<li>Increased 'for' duration from 5m to 15m for multiple alerts<br> <li> Changed 'noDataState' from NoData to Alerting for most rules<br> <li> Modified 'execErrState' to Alerting or OK depending on the rule<br> <li> Adjusted 'noDataState' for specific alert rules (e.g., OK to Alerting)


</details>


  </td>
  <td><a href="https://github.com/nhost/nhost/pull/3310/files#diff-27165812186176e21d13a35136e43511b837700a599d3a00c61a1f6b36c55af2">+13/-13</a>&nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

___

> <details> <summary>  Need help?</summary><li>Type <code>/help how to ...</code> in the comments thread for any questions about PR-Agent usage.</li><li>Check out the <a href="https://qodo-merge-docs.qodo.ai/usage-guide/">documentation</a> for more information.</li></details>