### PR TITLE
fix (dashboard ci): stop playwright e2e tests run after first failure

### DIFF
--- a/.changeset/wild-stingrays-help.md
+++ b/.changeset/wild-stingrays-help.md
@@ -2,4 +2,4 @@
 '@nhost/dashboard': minor
 ---
 
-fix: reload metadata for graphite's remote schemas before e2e tests
+fix: e2e tests, stop on error when refreshing metadata

--- a/.changeset/wild-stingrays-help.md
+++ b/.changeset/wild-stingrays-help.md
@@ -1,0 +1,5 @@
+---
+'@nhost/dashboard': minor
+---
+
+fix: reload metadata for graphite's remote schemas before e2e tests

--- a/dashboard/e2e/setup/refresh-metadata.setup.ts
+++ b/dashboard/e2e/setup/refresh-metadata.setup.ts
@@ -16,7 +16,6 @@ setup('refresh metadata', async () => {
             {
               type: 'reload_metadata',
               args: {
-                reload_remote_schemas: ['graphite'],
                 reload_sources: false,
               },
             },
@@ -40,8 +39,9 @@ setup('refresh metadata', async () => {
       if (isConsistent) {
         console.log('Metadata is consistent.');
       } else {
-        console.log('Metadata is not consistent.');
-        console.log(body[0].inconsistent_objects);
+        console.error('Metadata is not consistent.');
+        console.error(body[0].inconsistent_objects);
+        throw new Error('Metadata is not consistent');
       }
     }
   } catch (error) {

--- a/dashboard/e2e/setup/refresh-metadata.setup.ts
+++ b/dashboard/e2e/setup/refresh-metadata.setup.ts
@@ -16,6 +16,7 @@ setup('refresh metadata', async () => {
             {
               type: 'reload_metadata',
               args: {
+                reload_remote_schemas: ['graphite'],
                 reload_sources: false,
               },
             },

--- a/dashboard/package.json
+++ b/dashboard/package.json
@@ -16,7 +16,7 @@
     "storybook": "start-storybook -p 6006 -s public",
     "build-storybook": "build-storybook",
     "install-browsers": "pnpm playwright install && pnpm playwright install-deps",
-    "e2e:tests": "pnpm install-browsers && pnpm playwright test --config=playwright.config.ts",
+    "e2e:tests": "pnpm install-browsers && pnpm playwright test --config=playwright.config.ts -x",
     "e2e": "pnpm e2e:tests --project=main",
     "e2e:local": "pnpm e2e:tests --project=local",
     "e2e:upgrade-project": "pnpm e2e:tests --project=upgrade-project"


### PR DESCRIPTION
### **PR Type**
Bug fix, Enhancement


___

### **Description**
- Reload metadata for Graphite's remote schemas in e2e tests

- Add 'reload_remote_schemas' parameter to metadata reload

- Include Changeset for version tracking


___



### **Changes walkthrough** 📝
<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Enhancement</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>refresh-metadata.setup.ts</strong><dd><code>Add Graphite remote schema to metadata reload</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

dashboard/e2e/setup/refresh-metadata.setup.ts

<li>Add 'reload_remote_schemas' parameter with value ['graphite']<br> <li> Include Graphite remote schema in metadata reload


</details>


  </td>
  <td><a href="https://github.com/nhost/nhost/pull/3334/files#diff-e32371f0138a80b833384d09a2b1fcc0de848b555823c16c0e9a96ed441edc8a">+1/-0</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr><tr><td><strong>Documentation</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>wild-stingrays-help.md</strong><dd><code>Add changeset for dashboard version update</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

.changeset/wild-stingrays-help.md

<li>Create new changeset file<br> <li> Specify minor version bump for '@nhost/dashboard'<br> <li> Add description of the fix


</details>


  </td>
  <td><a href="https://github.com/nhost/nhost/pull/3334/files#diff-b5a0c57a4f2bd08515f9feef3c38804e7f948ffb4b76418f6549131f61cf20fd">+5/-0</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

___

> <details> <summary>  Need help?</summary><li>Type <code>/help how to ...</code> in the comments thread for any questions about PR-Agent usage.</li><li>Check out the <a href="https://qodo-merge-docs.qodo.ai/usage-guide/">documentation</a> for more information.</li></details>