### PR TITLE
fix (dashboard): collapsed main navigation sidebar overlaps mobile navbar 

### DIFF
--- a/.changeset/small-dragons-tell.md
+++ b/.changeset/small-dragons-tell.md
@@ -1,0 +1,5 @@
+---
+'@nhost/dashboard': minor
+---
+
+fix: collapsed main navigation sidebar overlaps mobile navbar

--- a/dashboard/src/components/layout/MainNav/MainNav.tsx
+++ b/dashboard/src/components/layout/MainNav/MainNav.tsx
@@ -41,7 +41,7 @@ export default function MainNav({ container }: MainNavProps) {
   return (
     <Sheet open={open} onOpenChange={setOpen}>
       <div
-        className="min- absolute left-0 z-50 flex h-full w-6 justify-center border-r-[1px] bg-background pt-1 hover:bg-accent"
+        className="min- absolute left-0 z-[39] flex h-full w-6 justify-center border-r-[1px] bg-background pt-1 hover:bg-accent"
         onMouseEnter={() => setOpen(true)}
       >
         <Menu className="h-4 w-4" />


### PR DESCRIPTION
### **User description**
Fixes #3244


___

### **PR Type**
Bug fix


___

### **Description**
- Fixed mobile navbar overlay issue

- Adjusted z-index of main navigation sidebar

- Improved mobile responsiveness of dashboard layout


___



### **Changes walkthrough** 📝
<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Bug fix</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>MainNav.tsx</strong><dd><code>Adjust z-index to prevent navbar overlap</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

dashboard/src/components/layout/MainNav/MainNav.tsx

- Changed z-index of main navigation sidebar from 50 to 39


</details>


  </td>
  <td><a href="https://github.com/nhost/nhost/pull/3341/files#diff-8a552e1cae4ec4725740e006ec406aa60057db39c9580a31d938709d17d4b2c3">+1/-1</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr><tr><td><strong>Documentation</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>small-dragons-tell.md</strong><dd><code>Add changeset for mobile navbar fix</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

.changeset/small-dragons-tell.md

<li>Added changeset file for version bump<br> <li> Described fix for collapsed main navigation sidebar overlap


</details>


  </td>
  <td><a href="https://github.com/nhost/nhost/pull/3341/files#diff-8cad90bbebee08b416a11241462057e0938f037bb88c204dd9d1652541eba21c">+5/-0</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

___

> <details> <summary>  Need help?</summary><li>Type <code>/help how to ...</code> in the comments thread for any questions about PR-Agent usage.</li><li>Check out the <a href="https://qodo-merge-docs.qodo.ai/usage-guide/">documentation</a> for more information.</li></details>