### PR TITLE
fix (docs): remove nodejs18

### DIFF
--- a/.changeset/brave-garlics-act.md
+++ b/.changeset/brave-garlics-act.md
@@ -1,0 +1,5 @@
+---
+'@nhost/docs': patch
+---
+
+fix: remove nodejs18

--- a/docs/products/functions/runtimes.mdx
+++ b/docs/products/functions/runtimes.mdx
@@ -8,21 +8,12 @@ icon: person-running
 
 The following runtimes are supported:
 
-- [Node.js 18](https://nodejs.org)
 - [Node.js 20](https://nodejs.org)
 - [Node.js 22](https://nodejs.org)
 
 To select your preferred runtime ensure the following configuration is present in your `nhost.toml` file:
 
 <Tabs>
-  <Tab title="Node.js 18">
-
-```toml
-[functions.node]
-version = 18
-```
-
-  </Tab>
   <Tab title="Node.js 20">
 
 ```toml


### PR DESCRIPTION
### **PR Type**
Documentation


___

### **Description**
- Remove Node.js 18 runtime from supported versions

- Update documentation to reflect current runtimes

- Remove Node.js 18 configuration example

- Add changeset for patch update to @nhost/docs


___



### **Changes walkthrough** 📝
<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Documentation</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>brave-garlics-act.md</strong><dd><code>Add changeset for removing Node.js 18</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

.changeset/brave-garlics-act.md

<li>Add new changeset file for @nhost/docs patch update<br> <li> Describe fix to remove Node.js 18


</details>


  </td>
  <td><a href="https://github.com/nhost/nhost/pull/3343/files#diff-af4dedaee65af3f90491e3eea21a6996fec17988247ad9779ed1b623f386eba6">+5/-0</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>runtimes.mdx</strong><dd><code>Update runtimes documentation to remove Node.js 18</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

docs/products/functions/runtimes.mdx

<li>Remove Node.js 18 from list of supported runtimes<br> <li> Delete Node.js 18 configuration example<br> <li> Update supported versions to Node.js 20 and 22


</details>


  </td>
  <td><a href="https://github.com/nhost/nhost/pull/3343/files#diff-41cc586838cadca39a91bf32878fb7cc5473d5815dec595547a4089684b5d489">+0/-9</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

___

> <details> <summary>  Need help?</summary><li>Type <code>/help how to ...</code> in the comments thread for any questions about PR-Agent usage.</li><li>Check out the <a href="https://qodo-merge-docs.qodo.ai/usage-guide/">documentation</a> for more information.</li></details>