### PR TITLE
fix(examples/docker-compose): fix postgres persistent data storage path

### DIFF
--- a/examples/docker-compose/docker-compose.yaml
+++ b/examples/docker-compose/docker-compose.yaml
@@ -398,7 +398,7 @@ services:
         volumes:
             - type: volume
               source: pgdata
-              target: /var/lib/postgresql/
+              target: /var/lib/postgresql/data/
               read_only: false
             - type: bind
               source: ./initdb.d


### PR DESCRIPTION
With the current path it won't persist the data across restarts, so here's a fix for it :P