### PR TITLE
chore (dashboard): re-enable upgrade project e2e tests

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -172,11 +172,10 @@ jobs:
       - name: Set Dashboard Preview URL
         if: steps.fetch-dashboard-preview-url.outputs.preview_url != ''
         run: echo "NHOST_TEST_DASHBOARD_URL=https://${{ steps.fetch-dashboard-preview-url.outputs.preview_url }}" >> $GITHUB_ENV
-      # Turning it off temporarly
-      # - name: Run Upgrade project Dashboard e2e tests
-      #   if: matrix.package.path == 'dashboard'
-      #   timeout-minutes: 10
-      #   run: pnpm --filter="${{ matrix.package.name }}" run e2e:upgrade-project
+      - name: Run Upgrade project Dashboard e2e tests
+        if: matrix.package.path == 'dashboard'
+        timeout-minutes: 10
+        run: pnpm --filter="${{ matrix.package.name }}" run e2e:upgrade-project
       # * Run the `ci` script of the current package of the matrix. Dependencies build is cached by Turborepo
       - name: Run e2e tests
         timeout-minutes: 20


### PR DESCRIPTION
### **PR Type**
Enhancement, Tests


___

### **Description**
- Re-enable upgrade project e2e tests for dashboard

- Remove temporary comment disabling the tests

- Adjust CI workflow to include upgrade tests


___

### Diagram Walkthrough


```mermaid
flowchart LR
  A["Disabled Tests"] -- "Re-enable" --> B["Upgrade Project E2E Tests"]
  B -- "Include in" --> C["CI Workflow"]
```



<details> <summary><h3> File Walkthrough</h3></summary>

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Enhancement</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>ci.yaml</strong><dd><code>Re-enable Dashboard upgrade project e2e tests in CI</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

.github/workflows/ci.yaml

<ul><li>Removed comments disabling upgrade project e2e tests<br> <li> Re-enabled the "Run Upgrade project Dashboard e2e tests" step<br> <li> Kept the timeout and filter conditions unchanged</ul>


</details>


  </td>
  <td><a href="https://github.com/nhost/nhost/pull/3401/files#diff-944291df2c9c06359d37cc8833d182d705c9e8c3108e7cfe132d61a06e9133dd">+4/-5</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

</details>

___

