### PR TITLE
fix: dashboard: don't upgrade to starter

### DIFF
--- a/dashboard/src/features/orgs/components/billing/components/SubscriptionPlan/SubscriptionPlan.tsx
+++ b/dashboard/src/features/orgs/components/billing/components/SubscriptionPlan/SubscriptionPlan.tsx
@@ -234,30 +234,36 @@ export default function SubscriptionPlan() {
                         className="flex flex-col space-y-1"
                       >
                         {plans.map((plan) => {
-                          const isStarterPlan = plan.name === 'Starter' || plan.isFree;
-                          
-                          return (
-                          <FormItem key={plan.id}>
-                            <FormLabel className={`flex w-full cursor-pointer flex-row items-center justify-between space-y-0 rounded-md border p-3 ${isStarterPlan ? 'opacity-50 cursor-not-allowed' : ''}`}>
-                              <div className="flex flex-row items-center space-x-3">
-                                <FormControl>
-                                  <RadioGroupItem value={plan.id} disabled={isStarterPlan} />
-                                </FormControl>
-                                <div className="flex flex-col space-y-2">
-                                  <div className="text-md font-semibold">
-                                    {plan.name}
-                                  </div>
-                                  <FormDescription className="w-2/3 text-xs">
-                                    {planDescriptions[plan.name]}
-                                  </FormDescription>
-                                </div>
-                              </div>
+                          const isStarterPlan =
+                            plan.name === 'Starter' || plan.isFree;
 
-                              <div className="mt-0 flex h-full items-center text-xl font-semibold">
-                                {isFreeOrg ? 'Free' : `${plan.price}/mo`}
-                              </div>
-                            </FormLabel>
-                          </FormItem>
+                          return (
+                            <FormItem key={plan.id}>
+                              <FormLabel
+                                className={`flex w-full cursor-pointer flex-row items-center justify-between space-y-0 rounded-md border p-3 ${isStarterPlan ? 'cursor-not-allowed opacity-50' : ''}`}
+                              >
+                                <div className="flex flex-row items-center space-x-3">
+                                  <FormControl>
+                                    <RadioGroupItem
+                                      value={plan.id}
+                                      disabled={isStarterPlan}
+                                    />
+                                  </FormControl>
+                                  <div className="flex flex-col space-y-2">
+                                    <div className="text-md font-semibold">
+                                      {plan.name}
+                                    </div>
+                                    <FormDescription className="w-2/3 text-xs">
+                                      {planDescriptions[plan.name]}
+                                    </FormDescription>
+                                  </div>
+                                </div>
+
+                                <div className="mt-0 flex h-full items-center text-xl font-semibold">
+                                  {isFreeOrg ? 'Free' : `${plan.price}/mo`}
+                                </div>
+                              </FormLabel>
+                            </FormItem>
                           );
                         })}
 

--- a/dashboard/src/features/orgs/components/billing/components/SubscriptionPlan/SubscriptionPlan.tsx
+++ b/dashboard/src/features/orgs/components/billing/components/SubscriptionPlan/SubscriptionPlan.tsx
@@ -233,12 +233,15 @@ export default function SubscriptionPlan() {
                         defaultValue={field.value}
                         className="flex flex-col space-y-1"
                       >
-                        {plans.map((plan) => (
+                        {plans.map((plan) => {
+                          const isStarterPlan = plan.name === 'Starter' || plan.isFree;
+                          
+                          return (
                           <FormItem key={plan.id}>
-                            <FormLabel className="flex w-full cursor-pointer flex-row items-center justify-between space-y-0 rounded-md border p-3">
+                            <FormLabel className={`flex w-full cursor-pointer flex-row items-center justify-between space-y-0 rounded-md border p-3 ${isStarterPlan ? 'opacity-50 cursor-not-allowed' : ''}`}>
                               <div className="flex flex-row items-center space-x-3">
                                 <FormControl>
-                                  <RadioGroupItem value={plan.id} />
+                                  <RadioGroupItem value={plan.id} disabled={isStarterPlan} />
                                 </FormControl>
                                 <div className="flex flex-col space-y-2">
                                   <div className="text-md font-semibold">
@@ -255,7 +258,8 @@ export default function SubscriptionPlan() {
                               </div>
                             </FormLabel>
                           </FormItem>
-                        ))}
+                          );
+                        })}
 
                         <div>
                           <div className="flex w-full cursor-pointer flex-row items-center justify-between space-y-0 rounded-md border p-3">


### PR DESCRIPTION
### **PR Type**
Enhancement


___

### **Description**
- Disable upgrade to Starter plan

- Add visual cues for disabled Starter plan

- Improve user interface for plan selection

- Enhance accessibility and user experience


___

### Diagram Walkthrough


```mermaid
flowchart LR
  A["Plan Selection"] --> B["Identify Starter Plan"]
  B --> C["Disable Starter Option"]
  C --> D["Visual Feedback"]
  D --> E["Improved UX"]
```



<details> <summary><h3> File Walkthrough</h3></summary>

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Enhancement</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>SubscriptionPlan.tsx</strong><dd><code>Disable and style Starter plan in subscription selection</code>&nbsp; </dd></summary>
<hr>

dashboard/src/features/orgs/components/billing/components/SubscriptionPlan/SubscriptionPlan.tsx

<ul><li>Added logic to identify Starter plan<br> <li> Disabled radio button for Starter plan<br> <li> Applied opacity and cursor styles to Starter plan<br> <li> Refactored plan mapping for better readability</ul>


</details>


  </td>
  <td><a href="https://github.com/nhost/nhost/pull/3407/files#diff-2a5f070869055286b669e382b18d656935752803b9a1ef13390ac028c2a48ac4">+8/-4</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

</details>

___

