### PR TITLE
fix (dashboard): support page, can scroll all the way down in Chrome for iOS

### DIFF
--- a/.changeset/stupid-phones-act.md
+++ b/.changeset/stupid-phones-act.md
@@ -1,0 +1,5 @@
+---
+'@nhost/dashboard': minor
+---
+
+fix: support page, can scroll all the way down in Chrome for iOS

--- a/dashboard/src/pages/support/index.tsx
+++ b/dashboard/src/pages/support/index.tsx
@@ -10,7 +10,7 @@ import { Text } from '@/components/ui/v2/Text';
 
 function SupportPage() {
   return (
-    <Box className="h-screen overflow-auto pb-4">
+    <Box className="h-full overflow-auto pb-4">
       <Box className="flex w-full justify-start border-b-1 px-4 py-3">
         <Logo className="w-6 cursor-pointer" />
       </Box>


### PR DESCRIPTION
### **PR Type**
Bug fix


___

### **Description**
- Fixed scrolling issue on support page for Chrome iOS

- Changed container height from 'h-screen' to 'h-full'

- Added changeset for version tracking


___

### Diagram Walkthrough


```mermaid
flowchart LR
  A["Support Page"] -- "Height Change" --> B["Full Scrolling"]
  C["Changeset"] -- "Version Update" --> D["@nhost/dashboard"]
```



<details> <summary><h3> File Walkthrough</h3></summary>

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Bug fix</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>index.tsx</strong><dd><code>Adjust support page container height for better scrolling</code></dd></summary>
<hr>

dashboard/src/pages/support/index.tsx

<ul><li>Changed container height from 'h-screen' to 'h-full'<br> <li> Allows full scrolling on Chrome for iOS</ul>


</details>


  </td>
  <td><a href="https://github.com/nhost/nhost/pull/3408/files#diff-64adb32f73092cbba8aedac54225398c237222d9ba03a702bbe9d676edcde49c">+1/-1</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr><tr><td><strong>Documentation</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>stupid-phones-act.md</strong><dd><code>Add changeset for version tracking</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

.changeset/stupid-phones-act.md

<ul><li>Added new changeset file<br> <li> Specifies minor version bump for '@nhost/dashboard'<br> <li> Describes the fix for support page scrolling</ul>


</details>


  </td>
  <td><a href="https://github.com/nhost/nhost/pull/3408/files#diff-d1565f8c90f9f343f6fa81c720ab14a81c4842c292ec51ff531089f121539d45">+5/-0</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

</details>

___

