### PR TITLE
fix (dashboard): show run service name in logs page

### DIFF
--- a/.changeset/six-parents-pump.md
+++ b/.changeset/six-parents-pump.md
@@ -1,0 +1,5 @@
+---
+'@nhost/dashboard': minor
+---
+
+fix: show Run service name in logs page

--- a/dashboard/src/features/orgs/projects/logs/components/LogsBody/LogsBody.tsx
+++ b/dashboard/src/features/orgs/projects/logs/components/LogsBody/LogsBody.tsx
@@ -77,11 +77,9 @@ function TextCell({ getValue }: { getValue: () => string }) {
 }
 
 function ServiceCell({ getValue }: { getValue: () => string }) {
-  return (
-    <Text className="font-mono text-xs-">
-      {LOGS_SERVICE_TO_LABEL[getValue()]}
-    </Text>
-  );
+  const serviceLabel = LOGS_SERVICE_TO_LABEL[getValue()] ?? getValue();
+
+  return <Text className="font-mono text-xs-">{serviceLabel}</Text>;
 }
 
 const columns = [


### PR DESCRIPTION
Fixes that Run service's name were not showing up inside the logs page in the `Service` column.

<img width="786" height="359" alt="Screenshot 2025-08-07 at 18 19 30" src="https://github.com/user-attachments/assets/6b1e5057-3649-46b4-bd94-12448db5ceeb" />
