### PR TITLE
fix (dashboard): allow permission variables with in operator

### DIFF
--- a/.changeset/dry-snails-type.md
+++ b/.changeset/dry-snails-type.md
@@ -1,0 +1,5 @@
+---
+'@nhost/dashboard': patch
+---
+
+fix (dashboard): allow permission variables with in operator

--- a/dashboard/src/components/ui/v3/fancy-multi-select.tsx
+++ b/dashboard/src/components/ui/v3/fancy-multi-select.tsx
@@ -13,16 +13,17 @@ import { cn } from '@/lib/utils';
 import { Command as CommandPrimitive } from 'cmdk';
 import {
   useCallback,
+  useEffect,
   useMemo,
   useRef,
   useState,
   type KeyboardEvent,
 } from 'react';
 
-type Option = Record<'value' | 'label', string>;
+export type Option = Record<'value' | 'label', string>;
 
 interface FancyMultiSelectProps {
-  defaultValue?: Option[];
+  value?: Option[];
   options?: Option[];
   creatable?: boolean;
   className?: string;
@@ -30,7 +31,7 @@ interface FancyMultiSelectProps {
 }
 
 export function FancyMultiSelect({
-  defaultValue = [],
+  value = [],
   options = [],
   creatable = false,
   className,
@@ -38,8 +39,12 @@ export function FancyMultiSelect({
 }: FancyMultiSelectProps) {
   const inputRef = useRef<HTMLInputElement>(null);
   const [open, setOpen] = useState(false);
-  const [selected, setSelected] = useState<Option[]>(defaultValue);
+  const [selected, setSelected] = useState<Option[]>(value);
   const [inputValue, setInputValue] = useState('');
+
+  useEffect(() => {
+    setSelected(value);
+  }, [value]);
 
   const handleUnselect = useCallback((option: Option) => {
     setSelected((prev) => prev.filter((s) => s.value !== option.value));
@@ -64,17 +69,12 @@ export function FancyMultiSelect({
     }
   }, []);
 
-  const handleSelect = useCallback(
-    (option: Option) => {
-      setInputValue('');
-      setSelected((prev) => {
-        const newSelected = [...prev, option];
-        onChange?.(newSelected);
-        return newSelected;
-      });
-    },
-    [onChange],
-  );
+  function handleSelect(option: Option) {
+    setInputValue('');
+    const newSelected = [...selected, option];
+    setSelected(newSelected);
+    onChange?.(newSelected);
+  }
 
   const selectables = useMemo(() => {
     const filtered = options.filter(
@@ -87,7 +87,7 @@ export function FancyMultiSelect({
       return [
         ...filtered,
         {
-          value: inputValue.toLowerCase(),
+          value: inputValue,
           label: inputValue,
         },
       ];
@@ -115,7 +115,10 @@ export function FancyMultiSelect({
                 key={option.value}
                 variant="outline"
               >
-                <span className="overflow-x-hidden text-ellipsis whitespace-nowrap break-words font-medium">
+                <span
+                  className="overflow-x-hidden text-ellipsis whitespace-nowrap break-words font-medium"
+                  data-testid={`badge-${option.label}`}
+                >
                   {option.label}
                 </span>
                 <button

--- a/dashboard/src/features/orgs/projects/database/dataGrid/components/RuleGroupEditor/RuleValueInput.test.tsx
+++ b/dashboard/src/features/orgs/projects/database/dataGrid/components/RuleGroupEditor/RuleValueInput.test.tsx
@@ -1,0 +1,181 @@
+import * as useProject from '@/features/orgs/projects/hooks/useProject';
+import {
+  mockPointerEvent,
+  render,
+  screen,
+  TestUserEvent,
+  waitFor,
+} from '@/tests/testUtils';
+import { useMemo } from 'react';
+import { FormProvider, useForm } from 'react-hook-form';
+import { beforeEach, describe, expect, it, vi, type Mock } from 'vitest';
+import RuleValueInput from './RuleValueInput';
+import * as useRuleGroupEditor from './useRuleGroupEditor';
+
+vi.mock('./useRuleGroupEditor');
+vi.mock('@/features/orgs/projects/hooks/useProject');
+
+const mocks = vi.hoisted(() => ({
+  useGetRolesPermissionsQuery: vi.fn(),
+  useForm: vi.fn(),
+  setValueMock: vi.fn(),
+}));
+
+vi.mock('@/utils/__generated__/graphql', async () => {
+  const actual = await vi.importActual<any>('@/utils/__generated__/graphql');
+  return {
+    ...actual,
+    useGetRolesPermissionsQuery: mocks.useGetRolesPermissionsQuery,
+  };
+});
+
+const mockUseRuleGroupEditor = useRuleGroupEditor.default as Mock;
+const mockUseProject = useProject.useProject as Mock;
+
+function TestWrapper({
+  children,
+  defaultValues = {},
+}: {
+  children: React.ReactNode;
+  defaultValues?: Record<string, any>;
+}) {
+  const form = useForm({
+    defaultValues: {
+      test: {
+        operator: '_in',
+        value: [],
+        ...defaultValues,
+      },
+    },
+  });
+
+  const formSpy = useMemo(
+    () => ({
+      ...form,
+      setValue: mocks.setValueMock,
+    }),
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+    [],
+  );
+
+  return <FormProvider {...formSpy}>{children}</FormProvider>;
+}
+
+const mockPermissionsData = {
+  config: {
+    auth: {
+      session: {
+        accessToken: {
+          customClaims: [{ key: 'Role', isSystemVariable: true }],
+        },
+      },
+    },
+  },
+};
+
+describe('RuleValueInput', () => {
+  beforeEach(() => {
+    mockPointerEvent();
+
+    mockUseRuleGroupEditor.mockReturnValue({
+      schema: 'public',
+      table: 'users',
+      disabled: false,
+    });
+
+    mockUseProject.mockReturnValue({
+      project: { id: 'test-project-id' },
+    });
+  });
+
+  it('should pass selected x-hasura-variables as string', async () => {
+    mocks.useGetRolesPermissionsQuery.mockImplementation(() => ({
+      data: mockPermissionsData,
+      loading: false,
+    }));
+
+    render(
+      <TestWrapper defaultValues={{ operator: '_in', value: [] }}>
+        <RuleValueInput name="test" selectedTablePath="public.users" />
+      </TestWrapper>,
+    );
+    const user = new TestUserEvent();
+
+    const multiSelect = screen.getByPlaceholderText('Select options...');
+    await user.click(multiSelect);
+    await waitFor(() => {
+      expect(screen.getByText('X-Hasura-User-Id')).toBeInTheDocument();
+    });
+
+    const allowedIdsOption = screen.getByText('X-Hasura-User-Id');
+    await user.click(allowedIdsOption);
+    expect(
+      await screen.findByTestId('badge-X-Hasura-User-Id'),
+    ).toBeInTheDocument();
+
+    expect(mocks.setValueMock).toHaveBeenCalledWith(
+      'test.value',
+      'X-Hasura-User-Id',
+      {
+        shouldDirty: true,
+      },
+    );
+  });
+
+  it('should pass simple values as string array', async () => {
+    mocks.useGetRolesPermissionsQuery.mockImplementation(() => ({
+      data: mockPermissionsData,
+      loading: false,
+    }));
+
+    render(
+      <TestWrapper defaultValues={{ operator: '_in', value: [] }}>
+        <RuleValueInput name="test" selectedTablePath="public.users" />
+      </TestWrapper>,
+    );
+    const user = new TestUserEvent();
+
+    const multiSelect = screen.getByPlaceholderText('Select options...');
+    await user.click(multiSelect);
+    await waitFor(() => {
+      expect(screen.getByText('X-Hasura-Role')).toBeInTheDocument();
+    });
+
+    const allowedIdsOption = screen.getByText('X-Hasura-Role');
+    await user.click(allowedIdsOption);
+
+    expect(screen.getByTestId('badge-X-Hasura-Role')).toBeInTheDocument();
+    mocks.setValueMock.mockClear();
+    await user.type(
+      screen.getByPlaceholderText('Select options...'),
+      'my-variable{Enter}',
+    );
+
+    expect(
+      screen.queryByTestId('badge-X-Hasura-User-Id'),
+    ).not.toBeInTheDocument();
+    expect(screen.getByTestId('badge-my-variable')).toBeInTheDocument();
+
+    expect(mocks.setValueMock).toHaveBeenCalledWith(
+      'test.value',
+      ['my-variable'],
+      {
+        shouldDirty: true,
+      },
+    );
+
+    mocks.setValueMock.mockClear();
+    await user.type(
+      screen.getByPlaceholderText('Select options...'),
+      'my-variable-2{Enter}',
+    );
+
+    expect(mocks.setValueMock).toHaveBeenCalledWith(
+      'test.value',
+      ['my-variable', 'my-variable-2'],
+      {
+        shouldDirty: true,
+      },
+    );
+  });
+});

--- a/dashboard/src/pages/signup.tsx
+++ b/dashboard/src/pages/signup.tsx
@@ -94,8 +94,6 @@ export default function SignUpPage() {
     if (window.gtag) {
       return;
     }
-    // eslint-disable-next-line no-console
-    console.log('Initializing...');
     window.dataLayer = window.dataLayer || [];
     function gtag(...args: any[]) {
       window.dataLayer.push(args);
@@ -121,8 +119,6 @@ export default function SignUpPage() {
     };
 
     document.head.appendChild(script);
-    // eslint-disable-next-line no-console
-    console.log('Finished...');
   }, []);
 
   return (


### PR DESCRIPTION
### **PR Type**
Bug fix, Tests, Enhancement


___

### **Description**
- Refactor FancyMultiSelect to controlled component

- Enhance RuleValueInput `_in` operator for system variables

- Add unit tests for RuleValueInput variable selection

- Include `Allowed-Ids` in permission variables list


___

### Diagram Walkthrough


```mermaid
flowchart LR
  FV["Form value"]
  GD["getDefaultValueForMultiSelect"]
  FMS["FancyMultiSelect"]
  OC["handleOnChange"]
  SV["setValue"]
  FV -- "parsed by" --> GD
  GD -- "initializes" --> FMS
  FMS -- "user selects" --> OC
  OC -- "updates" --> SV
```



<details> <summary><h3> File Walkthrough</h3></summary>

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Enhancement</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>fancy-multi-select.tsx</strong><dd><code>Make FancyMultiSelect controlled and test-friendly</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

dashboard/src/components/ui/v3/fancy-multi-select.tsx

<ul><li>Export <code>Option</code> type<br> <li> Use controlled <code>value</code> instead of <code>defaultValue</code><br> <li> Sync selected via <code>useEffect</code> on <code>value</code> changes<br> <li> Add <code>data-testid</code> to badge span</ul>


</details>


  </td>
  <td><a href="https://github.com/nhost/nhost/pull/3461/files#diff-6e6a7965a2c8e30e9a2c021a5009ff79e71de73892b86a3468d3474163dfeb03">+13/-5</a>&nbsp; &nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>getAllPermissionVariables.ts</strong><dd><code>Add Allowed-Ids system variable</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

dashboard/src/features/orgs/projects/permissions/settings/utils/getAllPermissionVariables/getAllPermissionVariables.ts

- Include `Allowed-Ids` as system variable


</details>


  </td>
  <td><a href="https://github.com/nhost/nhost/pull/3461/files#diff-9973106a26aa99d744772d8dfb09281b3f4f2cdaa3f865b2510f47fb9061089c">+6/-0</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr><tr><td><strong>Bug fix</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>RuleValueInput.tsx</strong><dd><code>Enhance RuleValueInput for in-operator variables</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

dashboard/src/features/orgs/projects/database/dataGrid/components/RuleGroupEditor/RuleValueInput.tsx

<ul><li>Import <code>Option</code> type<br> <li> Add <code>getDefaultValueForMultiSelect</code> util<br> <li> Implement <code>handleOnChange</code> for permission variables<br> <li> Switch <code>FancyMultiSelect</code> to use controlled props</ul>


</details>


  </td>
  <td><a href="https://github.com/nhost/nhost/pull/3461/files#diff-e3198b245b5963e81e4566758b7d60c8d2784a7ca0ad0b17b354b33074ef1bb0">+57/-11</a>&nbsp; </td>

</tr>
</table></td></tr><tr><td><strong>Tests</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>RuleValueInput.test.tsx</strong><dd><code>Add tests for RuleValueInput selection logic</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

dashboard/src/features/orgs/projects/database/dataGrid/components/RuleGroupEditor/RuleValueInput.test.tsx

<ul><li>Add tests for <code>_in</code> operator variable selection<br> <li> Mock project and permissions hooks<br> <li> Verify system and custom variable behaviors</ul>


</details>


  </td>
  <td><a href="https://github.com/nhost/nhost/pull/3461/files#diff-cbb7789d45602230164e65506d0b2132b420b0cddead70ab8b012b0bb5897162">+170/-0</a>&nbsp; </td>

</tr>
</table></td></tr><tr><td><strong>Miscellaneous</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>signup.tsx</strong><dd><code>Cleanup console logs in signup page</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

dashboard/src/pages/signup.tsx

- Remove debugging `console.log` statements


</details>


  </td>
  <td><a href="https://github.com/nhost/nhost/pull/3461/files#diff-fc2b5989e3bbafda1d3d8b2317d24c39ef2b8cec0c4dc410170fa2da13464f68">+0/-4</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr><tr><td><strong>Configuration changes</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>dry-snails-type.md</strong><dd><code>Add changelog for permission variables fix</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

.changeset/dry-snails-type.md

- Add changeset entry for dashboard patch


</details>


  </td>
  <td><a href="https://github.com/nhost/nhost/pull/3461/files#diff-ccdfc53a10fb172936e239d895569a94a5413d1f8a6d1d81270bcd4051ba64e1">+5/-0</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

</details>

___

