### PR TITLE
fix (dashboard): Parse tablename correctly into SQL query

### DIFF
--- a/.changeset/mean-cheetahs-greet.md
+++ b/.changeset/mean-cheetahs-greet.md
@@ -1,0 +1,5 @@
+---
+'@nhost/dashboard': patch
+---
+
+fix (dashboard): Parse tablename correctly into SQL query

--- a/dashboard/e2e/database/create-table.test.ts
+++ b/dashboard/e2e/database/create-table.test.ts
@@ -1,6 +1,6 @@
 import { TEST_ORGANIZATION_SLUG, TEST_PROJECT_SUBDOMAIN } from '@/e2e/env';
 import { expect, test } from '@/e2e/fixtures/auth-hook';
-import { prepareTable } from '@/e2e/utils';
+import { prepareTable, toPascalCase } from '@/e2e/utils';
 import { faker } from '@faker-js/faker';
 import { snakeCase } from 'snake-case';
 
@@ -16,7 +16,7 @@ test('should create a simple table', async ({
   await page.getByRole('button', { name: /new table/i }).click();
   await expect(page.getByText(/create a new table/i)).toBeVisible();
 
-  const tableName = snakeCase(faker.lorem.words(3));
+  const tableName = toPascalCase(faker.lorem.words(3));
 
   await prepareTable({
     page,
@@ -38,6 +38,7 @@ test('should create a simple table', async ({
   await expect(
     page.getByRole('link', { name: tableName, exact: true }),
   ).toBeVisible();
+  await expect(page.getByRole('columnheader', { name: 'id' })).toBeVisible();
 });
 
 test('should create a table with unique constraints', async ({

--- a/dashboard/e2e/utils.ts
+++ b/dashboard/e2e/utils.ts
@@ -312,3 +312,10 @@ export async function loginWithFreeUser(page: Page) {
     timeout: 20000,
   });
 }
+
+export function toPascalCase(str: string, divider = ' ') {
+  return str
+    .split(divider)
+    .map((word) => word.charAt(0).toUpperCase() + word.slice(1).toLowerCase())
+    .join('');
+}

--- a/dashboard/src/features/orgs/components/projects/projects-grid/projects-grid.tsx
+++ b/dashboard/src/features/orgs/components/projects/projects-grid/projects-grid.tsx
@@ -31,7 +31,7 @@ function ProjectCard({ project }: { project: Project }) {
             {project.region.name}
           </span>
         </div>
-        <ProjectStatusIndicator status={project.appStates[0].stateId} />
+        <ProjectStatusIndicator status={project.appStates[0]?.stateId} />
       </div>
 
       <div className="flex flex-1 flex-row items-start gap-2">

--- a/dashboard/src/features/orgs/projects/database/dataGrid/hooks/useTableQuery/fetchTable.ts
+++ b/dashboard/src/features/orgs/projects/database/dataGrid/hooks/useTableQuery/fetchTable.ts
@@ -144,7 +144,7 @@ export default async function fetchTable({
                     (
                         SELECT PG_CATALOG.COL_DESCRIPTION(CLS.OID, COLS.ORDINAL_POSITION::INT)
                         FROM PG_CATALOG.PG_CLASS CLS
-                        WHERE CLS.OID = (SELECT '%1$s.%2$s'::REGCLASS::OID) AND CLS.RELNAME = COLS.TABLE_NAME
+                        WHERE CLS.OID = (SELECT '%1$I.%2$I'::REGCLASS::OID) AND CLS.RELNAME = COLS.TABLE_NAME
                     ) AS COLUMN_COMMENT
                 FROM INFORMATION_SCHEMA.COLUMNS COLS
                 WHERE TABLE_SCHEMA = %1$L AND TABLE_NAME = %2$L


### PR DESCRIPTION
### **PR Type**
Bug fix, Tests


___

### **Description**
- Fix SQL identifier placeholder to parse table names correctly

- Add `toPascalCase` utility and use in E2E tests

- Update create-table test to assert `id` column header


___

### Diagram Walkthrough


```mermaid
flowchart LR
  A["toPascalCase utility"] --> B["create-table.test uses PascalCase"]
  B --> C["prepareTable creates table"]
  C --> D["fetchTable uses %I placeholders"]
```



<details> <summary><h3> File Walkthrough</h3></summary>

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Tests</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>create-table.test.ts</strong><dd><code>Update E2E test to use PascalCase table names</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

dashboard/e2e/database/create-table.test.ts

<ul><li>Imported <code>toPascalCase</code> from utils<br> <li> Switched tableName generation from snakeCase to PascalCase<br> <li> Added assertion for <code>id</code> column presence</ul>


</details>


  </td>
  <td><a href="https://github.com/nhost/nhost/pull/3483/files#diff-1e7aa9f3e379ca90a94b82c14be48e2c98a722d85ee1b0785a082b7076d8e58c">+3/-2</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr><tr><td><strong>Enhancement</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>utils.ts</strong><dd><code>Add toPascalCase utility function</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

dashboard/e2e/utils.ts

<ul><li>Introduced <code>toPascalCase</code> function for string conversion<br> <li> Default divider set to space for word splitting</ul>


</details>


  </td>
  <td><a href="https://github.com/nhost/nhost/pull/3483/files#diff-490448aa83585151d8c61d698273c43486fdcac6a5d28a9b7e5be2729bbffd12">+7/-0</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr><tr><td><strong>Bug fix</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>fetchTable.ts</strong><dd><code>Use identifier placeholders in SQL query generation</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

dashboard/src/features/orgs/projects/database/dataGrid/hooks/useTableQuery/fetchTable.ts

<ul><li>Replaced <code>%1$s</code> with <code>%1$I</code> identifier placeholders<br> <li> Ensures proper REGCLASS SQL parsing for table names</ul>


</details>


  </td>
  <td><a href="https://github.com/nhost/nhost/pull/3483/files#diff-a58cb7660972ff84991cdd9777de5cf0834485072cbd421f8809638227c36820">+1/-1</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr><tr><td><strong>Configuration changes</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>mean-cheetahs-greet.md</strong><dd><code>Add changeset for SQL table parsing fix</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

.changeset/mean-cheetahs-greet.md

<ul><li>Added changeset entry for dashboard patch version<br> <li> Documented SQL table name parsing fix</ul>


</details>


  </td>
  <td><a href="https://github.com/nhost/nhost/pull/3483/files#diff-601e4fafd8d53cc5c99ed7e520180b2310cfa3ac5eb0d256c28cd5f7d8aaedc3">+5/-0</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

</details>

___

