### PR TITLE
fix(ci): fixed ci_create_release.yaml

### DIFF
--- a/.github/workflows/ci_create_release.yaml
+++ b/.github/workflows/ci_create_release.yaml
@@ -66,6 +66,8 @@ jobs:
           exit 1
         fi
 
+        cd $PROJECT
+
         PROJECT_NAME=$(make release-tag-name)
 
         echo "project=$PROJECT" >> $GITHUB_OUTPUT

--- a/build/makefiles/release.makefile
+++ b/build/makefiles/release.makefile
@@ -8,7 +8,7 @@ changelog-init:  ## Initialize changelog using git-cliff
 
 .PHONY: changelog-next-version
 changelog-next-version:  ## Get next version using git-cliff
-	@git cliff -u --bumped-version --tag-pattern $(TAG_PATTERN) $(CLIFF_OPTS) | awk -F\@ '{print $$2}'
+	@git cliff -u --bumped-version --tag-pattern $(TAG_PATTERN) $(CLIFF_OPTS) | sed 's/.*@//'
 
 .PHONY: changelog-get-released
 changelog-get-released:  ## Get changelog for the latest release using git-cliff


### PR DESCRIPTION
### **PR Type**
Bug fix


___

### **Description**
- Add `cd $PROJECT` before make in CI workflow

- Ensure `make release-tag-name` runs in correct directory


___

### Diagram Walkthrough


```mermaid
flowchart LR
  A["Extract VERSION"] --> B["Change to project directory"]
  B --> C["Run make release-tag-name"]
  C --> D["Set project_name output"]
```



<details> <summary><h3> File Walkthrough</h3></summary>

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Bug fix</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>ci_create_release.yaml</strong><dd><code>Change to project directory before make</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

.github/workflows/ci_create_release.yaml

<ul><li>Insert <code>cd $PROJECT</code> before <code>make release-tag-name</code><br> <li> Ensure <code>make</code> runs in the repository subdirectory</ul>


</details>


  </td>
  <td><a href="https://github.com/nhost/nhost/pull/3493/files#diff-9f32bd5671fcb04c5f1b35ea33677c4704302536e0c4ff9e06b514dc9b3d4f0c">+2/-0</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

</details>

___

