### PR TITLE
fix(ci): specify base when bumping the dashboard in the cli

### DIFF
--- a/.github/workflows/dashboard_wf_release.yaml
+++ b/.github/workflows/dashboard_wf_release.yaml
@@ -98,6 +98,7 @@ jobs:
           committer: GitHub <noreply@github.com>
           author: ${{ github.actor }} <${{ github.actor }}@users.noreply.github.com>
           body: |
-            This PR bumps the Nhost Dashboard Docker image to version ${{ needs.version.outputs.dashboardVersion }}.
+            This PR bumps the Nhost Dashboard Docker image to version ${{ inputs.VERSION }}.
           branch: bump-dashboard-version
+          base: main
           delete-branch: true


### PR DESCRIPTION
### **PR Type**
Bug fix


___

### **Description**
- Update PR body to reference inputs.VERSION

- Add base: main to the create-pull-request step


___



<details> <summary><h3> File Walkthrough</h3></summary>

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Configuration changes</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>dashboard_wf_release.yaml</strong><dd><code>Use inputs.VERSION and set base to main</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

.github/workflows/dashboard_wf_release.yaml

<ul><li>Changed PR body to use <code>inputs.VERSION</code> instead of dashboardVersion <br>output<br> <li> Added <code>base: main</code> to target the main branch</ul>


</details>


  </td>
  <td><a href="https://github.com/nhost/nhost/pull/3532/files#diff-0154025cb19cefd117b80826a8667b0bd194b5cc2796fc401b4e0f30806a39ae">+2/-1</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

</details>

___

