### PR TITLE
fix(dashboard): update remote schemas url tooltip

### DIFF
--- a/dashboard/src/features/orgs/projects/remote-schemas/components/BaseRemoteSchemaForm/GraphQLServiceURLInput.tsx
+++ b/dashboard/src/features/orgs/projects/remote-schemas/components/BaseRemoteSchemaForm/GraphQLServiceURLInput.tsx
@@ -16,7 +16,7 @@ export default function GraphQLServiceURLInput() {
     <Box className="space-y-2">
       <Box className="flex flex-row items-center space-x-2">
         <Text>GraphQL Service URL</Text>
-        <Tooltip title="The URL of the GraphQL service to be used as a remote schemaEnvironment variables and secrets are available using the {{VARIABLE}} tag. Environment variable templating is available for this field. Example: https://{{ENV_VAR}}/endpoint_url.">
+        <Tooltip title="The URL of the GraphQL service to be used as a remote schema. Environment variables and secrets are available using the {{VARIABLE}} tag. Example: https://{{ENV_VAR}}/endpoint_url.">
           <InfoIcon aria-label="Info" className="h-4 w-4" color="primary" />
         </Tooltip>
       </Box>

--- a/dashboard/src/features/orgs/projects/remote-schemas/components/RemoteSchemaDetails/RemoteSchemaDetails.tsx
+++ b/dashboard/src/features/orgs/projects/remote-schemas/components/RemoteSchemaDetails/RemoteSchemaDetails.tsx
@@ -89,7 +89,7 @@ export default function RemoteSchemaDetails() {
                 ? 'GraphQL Service URL'
                 : 'GraphQL Service URL (from environment)'}
             </Text>
-            <Tooltip title="The URL of the GraphQL service to be used as a remote schemaEnvironment variables and secrets are available using the {{VARIABLE}} tag. Environment variable templating is available for this field. Example: https://{{ENV_VAR}}/endpoint_url.">
+            <Tooltip title="The URL of the GraphQL service to be used as a remote schema.">
               <InfoIcon aria-label="Info" className="h-4 w-4" color="primary" />
             </Tooltip>
           </Box>


### PR DESCRIPTION
### **PR Type**
Enhancement


___

### **Description**
- Fix tooltip punctuation in `GraphQLServiceURLInput.tsx`

- Simplify `RemoteSchemaDetails.tsx` tooltip text


___



<details> <summary><h3> File Walkthrough</h3></summary>

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Enhancement</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>GraphQLServiceURLInput.tsx</strong><dd><code>Fix tooltip punctuation and formatting</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

dashboard/src/features/orgs/projects/remote-schemas/components/BaseRemoteSchemaForm/GraphQLServiceURLInput.tsx

<ul><li>Added missing period after "remote schema."<br> <li> Inserted space before "Environment variables and secrets"<br> <li> Clarified env variable templating example</ul>


</details>


  </td>
  <td><a href="https://github.com/nhost/nhost/pull/3540/files#diff-2f2d315050ae90a048dee08d844acb426fc716c0b7345bcc41934916df8c8e55">+1/-1</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>RemoteSchemaDetails.tsx</strong><dd><code>Simplify URL tooltip text</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

dashboard/src/features/orgs/projects/remote-schemas/components/RemoteSchemaDetails/RemoteSchemaDetails.tsx

<ul><li>Removed detailed env templating info from tooltip<br> <li> Shortened description to just "remote schema"</ul>


</details>


  </td>
  <td><a href="https://github.com/nhost/nhost/pull/3540/files#diff-0c3889220358754f6c7bcc701a3450ca2797e161afc0e9da4d2a8dcbcb485051">+1/-1</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

</details>

___

