### PR TITLE
fix(examples/docker-compose): added missing .env.example

### DIFF
--- a/examples/docker-compose/.env.example
+++ b/examples/docker-compose/.env.example
@@ -1,0 +1,28 @@
+# Nhost Docker Compose Environment Configuration
+# Copy this file to .env and update the values as needed
+
+# Service URLs
+AUTH_URL=local.auth.local.nhost.run
+DASHBOARD_URL=local.dashboard.local.nhost.run
+DB_URL=local.db.local.nhost.run
+FUNCTIONS_URL=local.functions.local.nhost.run
+GRAPHQL_URL=local.graphql.local.nhost.run
+MAILHOG_URL=local.mailhog.local.nhost.run
+STORAGE_URL=local.storage.local.nhost.run
+
+# Security Secrets
+# IMPORTANT: Change these values for production use
+GRAPHQL_ADMIN_SECRET=change-me
+POSTGRES_PASSWORD=postgres
+
+# JWT Secret Configuration
+# Format: {"type":"HS256","key":"<your-secret-key>"}
+# You can generate a new key with `openssl rand -base10 32`
+JWT_SECRET={"type":"HS256","key":"0f987876650b4a085e64594fae9219e7781b17506bec02489ad061fba8cb22db"}
+
+# Storage Configuration
+STORAGE_ACCESS_KEY=minioaccesskey123
+STORAGE_SECRET_KEY=miniosecretkey123
+
+# Auth Configuration
+AUTH_EMAIL_SIGNIN_EMAIL_VERIFIED_REQUIRED=false


### PR DESCRIPTION
### **PR Type**
Documentation


___

### **Description**
- Add .env.example for docker-compose example

- Provide default service URLs environment variables

- Include security secrets and JWT config placeholders


___



<details> <summary><h3> File Walkthrough</h3></summary>

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Configuration changes</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>.env.example</strong><dd><code>Add Docker Compose .env example file</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

examples/docker-compose/.env.example

<ul><li>Create new environment example file<br> <li> Add default service URL placeholders<br> <li> Define security secrets placeholders<br> <li> Document JWT, storage, auth config</ul>


</details>


  </td>
  <td><a href="https://github.com/nhost/nhost/pull/3548/files#diff-08ca7f9ad9d499c71a30703d1bb00c4c599646480cfcc311972bfaa654530c45">+28/-0</a>&nbsp; &nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

</details>

___

