### PR TITLE
fix(cli): disable tls on AUTH_SERVER_URL when auth uses custom port

### DIFF
--- a/cli/dockercompose/auth.go
+++ b/cli/dockercompose/auth.go
@@ -41,7 +41,7 @@ func auth( //nolint:funlen
 	envars, err := appconfig.HasuraAuthEnv(
 		cfg,
 		"http://graphql:8080/v1/graphql",
-		URL(subdomain, "auth", httpPort, useTLS)+"/v1",
+		URL(subdomain, "auth", httpPort, useTLS && exposePort == 0)+"/v1",
 		"postgres://nhost_hasura@postgres:5432/local",
 		"postgres://nhost_auth_admin@postgres:5432/local",
 		&model.ConfigSmtp{

--- a/cli/dockercompose/auth_test.go
+++ b/cli/dockercompose/auth_test.go
@@ -132,7 +132,7 @@ func expectedAuth() *Service {
 			"AUTH_RATE_LIMIT_SMS_INTERVAL":              "5m",
 			"AUTH_REFRESH_TOKEN_EXPIRES_IN":             "99",
 			"AUTH_REQUIRE_ELEVATED_CLAIM":               "required",
-			"AUTH_SERVER_URL":                           "http://dev.auth.local.nhost.run:1336/v1",
+			"AUTH_SERVER_URL":                           "https://dev.auth.local.nhost.run:1336/v1",
 			"AUTH_SMS_PASSWORDLESS_ENABLED":             "true",
 			"AUTH_SMS_PROVIDER":                         "twilio",
 			"AUTH_SMS_TWILIO_ACCOUNT_SID":               "smsAccountSid",
@@ -186,7 +186,7 @@ func expectedAuth() *Service {
 			"traefik.http.routers.auth.entrypoints":               "web",
 			"traefik.http.routers.auth.rule":                      "(HostRegexp(`^.+\\.auth\\.local\\.nhost\\.run$`) || Host(`local.auth.nhost.run`))",
 			"traefik.http.routers.auth.service":                   "auth",
-			"traefik.http.routers.auth.tls":                       "false",
+			"traefik.http.routers.auth.tls":                       "true",
 			"traefik.http.services.auth.loadbalancer.server.port": "4000",
 		},
 		Ports:   nil,
@@ -216,7 +216,7 @@ func TestAuth(t *testing.T) {
 		{
 			name:       "default",
 			cfg:        getConfig,
-			useTlS:     false,
+			useTlS:     true,
 			exposePort: 0,
 			expected:   expectedAuth,
 		},
@@ -227,7 +227,7 @@ func TestAuth(t *testing.T) {
 				cfg.Auth.Version = ptr("0.21.3")
 				return cfg
 			},
-			useTlS:     false,
+			useTlS:     true,
 			exposePort: 0,
 			expected: func() *Service {
 				svc := expectedAuth()
@@ -243,7 +243,7 @@ func TestAuth(t *testing.T) {
 		{
 			name:       "custom port",
 			cfg:        getConfig,
-			useTlS:     false,
+			useTlS:     true,
 			exposePort: 8080,
 			expected: func() *Service {
 				svc := expectedAuth()


### PR DESCRIPTION
### **PR Type**
Bug fix, Tests


___

### **Description**
- Disable TLS only when custom port is used

- Enable Traefik TLS label when TLS true

- Update tests to expect HTTPS URLs


___

### Diagram Walkthrough


```mermaid
flowchart LR
  cfg["Config: useTLS & exposePort"]
  gen["URL generation with TLS condition"]
  env["Service ENV: AUTH_SERVER_URL"]
  traefik["Traefik TLS label"]
  test["Auth tests update"]
  cfg -- "input to" --> gen
  gen -- "produces" --> env
  env -- "drives" --> traefik
  traefik -- "verified by" --> test
```



<details> <summary><h3> File Walkthrough</h3></summary>

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Bug fix</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>auth.go</strong><dd><code>Integrate exposePort into TLS URL logic</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

cli/dockercompose/auth.go

<ul><li>Change URL call to use <code>useTLS && exposePort == 0</code><br> <li> Ensure TLS disabled when a custom port is exposed<br> <li> Leave default TLS behavior unchanged for port 0</ul>


</details>


  </td>
  <td><a href="https://github.com/nhost/nhost/pull/3549/files#diff-de06e1248b85002f913d7a22cac6fc2016c9c4ead4a3c3f40b29b11a289196c7">+1/-1</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr><tr><td><strong>Tests</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>auth_test.go</strong><dd><code>Update tests for HTTPS and TLS label</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

cli/dockercompose/auth_test.go

<ul><li>Update expected <code>AUTH_SERVER_URL</code> to HTTPS<br> <li> Set <code>useTLS: true</code> in default and custom-port tests<br> <li> Change <code>traefik.http.routers.auth.tls</code> to "true"</ul>


</details>


  </td>
  <td><a href="https://github.com/nhost/nhost/pull/3549/files#diff-1874a94e8b512be4b38e47f3a0ab0848a0d9630e8668d95d41100f17a7bf7fc8">+5/-5</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

</details>

___

