### PR TITLE
fix(cli): workaround os.Rename issues when src and dst are on different partitions

### DIFF
--- a/cli/cmd/software/upgrade.go
+++ b/cli/cmd/software/upgrade.go
@@ -2,10 +2,13 @@ package software
 
 import (
 	"context"
+	"errors"
 	"fmt"
+	"io"
 	"os"
 	"runtime"
 	"strings"
+	"syscall"
 
 	"github.com/nhost/nhost/cli/clienv"
 	"github.com/nhost/nhost/cli/software"
@@ -92,14 +95,66 @@ func install(cmd *cli.Command, ce *clienv.CliEnv, tmpFile string) error {
 
 	ce.Infoln("Copying to %s...", curBin)
 
-	if err := os.Rename(tmpFile, curBin); err != nil {
-		return fmt.Errorf("failed to rename %s to %s: %w", tmpFile, curBin, err)
+	if err := moveOrCopyFile(tmpFile, curBin); err != nil {
+		return fmt.Errorf("failed to move %s to %s: %w", tmpFile, curBin, err)
 	}
 
 	ce.Infoln("Setting permissions...")
 
 	if err := os.Chmod(curBin, 0o755); err != nil { //nolint:mnd
 		return fmt.Errorf("failed to set permissions on %s: %w", curBin, err)
+	}
+
+	return nil
+}
+
+func moveOrCopyFile(src, dst string) error {
+	if err := os.Rename(src, dst); err != nil {
+		var linkErr *os.LinkError
+		// this happens when moving across different filesystems
+		if errors.As(err, &linkErr) && errors.Is(linkErr.Err, syscall.EXDEV) {
+			if err := hardMove(src, dst); err != nil {
+				return fmt.Errorf("failed to hard move: %w", err)
+			}
+
+			return nil
+		}
+
+		return fmt.Errorf("failed to rename: %w", err)
+	}
+
+	return nil
+}
+
+func hardMove(src, dst string) error {
+	srcFile, err := os.Open(src)
+	if err != nil {
+		return fmt.Errorf("failed to open source file: %w", err)
+	}
+	defer srcFile.Close()
+
+	dstFile, err := os.Create(dst)
+	if err != nil {
+		return fmt.Errorf("failed to create destination file: %w", err)
+	}
+	defer dstFile.Close()
+
+	if _, err := io.Copy(dstFile, srcFile); err != nil {
+		return fmt.Errorf("failed to copy file contents: %w", err)
+	}
+
+	fi, err := os.Stat(src)
+	if err != nil {
+		return fmt.Errorf("failed to stat source file: %w", err)
+	}
+
+	err = os.Chmod(dst, fi.Mode())
+	if err != nil {
+		return fmt.Errorf("failed to set file permissions: %w", err)
+	}
+
+	if err := os.Remove(src); err != nil {
+		return fmt.Errorf("failed to remove source file: %w", err)
 	}
 
 	return nil


### PR DESCRIPTION
Fixes #3597