### PR TITLE
feat(auth): if the callback state is wrong send back to the redirectTo as provider_state

### DIFF
--- a/services/auth/go/controller/sign_in_provider_callback_get_test.go
+++ b/services/auth/go/controller/sign_in_provider_callback_get_test.go
@@ -666,7 +666,7 @@ func TestSignInProviderCallback(t *testing.T) { //nolint:maintidx
 			},
 			expectedResponse: controller.ErrorRedirectResponse{
 				Headers: struct{ Location string }{
-					Location: `http://localhost:3000?error=invalid-state&errorDescription=Invalid+state`,
+					Location: `^http://localhost:3000\?error=invalid-state&errorDescription=Invalid\+state&provider_state=wrong-state$`, //nolint:lll
 				},
 			},
 			expectedJWT:       nil,


### PR DESCRIPTION
### **PR Type**
Enhancement


___

### **Description**
- Add `provider_state` query parameter to redirect URL when OAuth state validation fails

- Refactor URL query parameter handling by introducing `attachURLValues` helper function

- Update error handling to consistently use new helper for attaching query parameters

- Modify test expectations to validate new `provider_state` parameter in error redirects


___

### Diagram Walkthrough


```mermaid
flowchart LR
  A["OAuth Callback"] --> B["State Validation"]
  B -- "Invalid State" --> C["attachURLValues Helper"]
  C --> D["Redirect with provider_state"]
  B -- "Provider Error" --> C
  B -- "Valid State" --> E["Continue Sign-in Flow"]
```



<details> <summary><h3> File Walkthrough</h3></summary>

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Enhancement</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>sign_in_provider_callback_get.go</strong><dd><code>Enhance OAuth error handling with provider_state parameter</code></dd></summary>
<hr>

services/auth/go/controller/sign_in_provider_callback_get.go

<ul><li>Added <code>attachURLValues</code> helper function to simplify URL query parameter <br>manipulation<br> <li> Modified state validation error handling to include <code>provider_state</code> <br>parameter in redirect<br> <li> Refactored provider error handling to use new <code>attachURLValues</code> helper<br> <li> Updated state parameter attachment logic to use helper function</ul>


</details>


  </td>
  <td><a href="https://github.com/nhost/nhost/pull/3649/files#diff-9e238e788812ed538d76f2a9e40e6bd1ae998d1b63a2d5190bed5bf685dbc426">+23/-9</a>&nbsp; &nbsp; </td>

</tr>
</table></td></tr><tr><td><strong>Tests</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>sign_in_provider_callback_get_test.go</strong><dd><code>Update test to verify provider_state parameter</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

services/auth/go/controller/sign_in_provider_callback_get_test.go

<ul><li>Updated test expectation to validate <code>provider_state</code> query parameter in <br>error redirect URL</ul>


</details>


  </td>
  <td><a href="https://github.com/nhost/nhost/pull/3649/files#diff-b17006540ebd75d24d292ec72f27612363c1d629e4e844e06c0a70b116bee81a">+1/-1</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

</details>

___

