### PR TITLE
chore(nixops): set system libraries consistently on darwin

### DIFF
--- a/nixops/lib/go/go.nix
+++ b/nixops/lib/go/go.nix
@@ -62,10 +62,10 @@ in
       ] ++ goCheckDeps ++ buildInputs;
 
       shellHook = shellHook + pkgs.lib.optionalString pkgs.stdenv.isDarwin ''
-        export SDKROOT=${pkgs.apple-sdk_26}
-        export SDKROOT_FOR_TARGET=${pkgs.apple-sdk_26}
-        export DEVELOPER_DIR=${pkgs.apple-sdk_26}
-        export DEVELOPER_DIR_FOR_TARGET=${pkgs.apple-sdk_26}
+        export SDKROOT=${pkgs.apple-sdk_12}
+        export SDKROOT_FOR_TARGET=${pkgs.apple-sdk_12}
+        export DEVELOPER_DIR=${pkgs.apple-sdk_12}
+        export DEVELOPER_DIR_FOR_TARGET=${pkgs.apple-sdk_12}
       '';
     };
 


### PR DESCRIPTION
### **PR Type**
Enhancement


___

### **Description**
- Configure Apple SDK environment variables for Darwin builds

- Set `SDKROOT` and `DEVELOPER_DIR` to `apple-sdk_12`

- Apply SDK configuration conditionally on Darwin platform


___

### Diagram Walkthrough


```mermaid
flowchart LR
  A["devShell function"] --> B["Add Darwin SDK check"]
  B --> C["Set SDKROOT variables"]
  B --> D["Set DEVELOPER_DIR variables"]
```



<details> <summary><h3> File Walkthrough</h3></summary>

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Configuration changes</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>go.nix</strong><dd><code>Add Apple SDK 12 environment configuration for Darwin</code>&nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

nixops/lib/go/go.nix

<ul><li>Added conditional Darwin SDK environment variable configuration<br> <li> Set <code>SDKROOT</code> and <code>DEVELOPER_DIR</code> to <code>apple-sdk_12</code> path<br> <li> Moved <code>shellHook</code> definition after <code>buildInputs</code> declaration</ul>


</details>


  </td>
  <td><a href="https://github.com/nhost/nhost/pull/3656/files#diff-711b0f2dfff3f38b941381bf6af354bcb322ef967cc0280aaf5a76677f2d375e">+7/-2</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

</details>

___

