### PR TITLE
fix(ci): match the version exactly to avoid matching on pre-releases

### DIFF
--- a/.github/workflows/ci_update_changelog.yaml
+++ b/.github/workflows/ci_update_changelog.yaml
@@ -40,7 +40,7 @@ jobs:
         cd ${{ matrix.project }}
         TAG_NAME=$(make release-tag-name)
         VERSION=$(nix develop .\#cliff -c make changelog-next-version)
-        if git tag | grep -q "$TAG_NAME@$VERSION"; then
+        if git tag | grep -qx "$TAG_NAME@$VERSION"; then
           echo "Tag $TAG_NAME@$VERSION already exists, skipping release preparation"
         else
           echo "Tag $TAG_NAME@$VERSION does not exist, proceeding with release preparation"


### PR DESCRIPTION
### **PR Type**
Bug fix


___

### **Description**
- Modified version tag matching to use exact match (`-qx`) instead of substring match (`-q`)

- Prevents false positives when checking for existing tags with pre-release versions


___

### Diagram Walkthrough


```mermaid
flowchart LR
  A["Git tag check"] -- "changed from substring to exact match" --> B["Prevents pre-release false positives"]
```



<details> <summary><h3> File Walkthrough</h3></summary>

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Bug fix</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>ci_update_changelog.yaml</strong><dd><code>Fix exact version tag matching in CI workflow</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

.github/workflows/ci_update_changelog.yaml

<ul><li>Changed <code>grep -q</code> to <code>grep -qx</code> for exact tag name matching<br> <li> Prevents matching on pre-release versions when checking if tag exists</ul>


</details>


  </td>
  <td><a href="https://github.com/nhost/nhost/pull/3666/files#diff-399add8ac39ae1cd7ae2f4f8ceb89290f6f43e25b7b2c499da61dd68a5cf2f16">+1/-1</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

</details>

___

