### PR TITLE
chore(ci): replace the correct string on .github/workflows/dashboard_wf_release.yaml

### DIFF
--- a/.github/workflows/dashboard_wf_release.yaml
+++ b/.github/workflows/dashboard_wf_release.yaml
@@ -88,7 +88,7 @@ jobs:
       - name: Bump version in source code
         run: |
           find cli -type f -exec sed -i 's/"nhost\/dashboard:[^"]*"/"nhost\/dashboard:${{ inputs.VERSION }}"/g' {} +
-          sed -i 's/"nhost\/dashboard:[^"]*"/"nhost\/dashboard:${{ inputs.VERSION }}"/g' docs/reference/cli/commands.mdx
+          sed -i 's/nhost\/dashboard:[^)]*/nhost\/dashboard:${{ inputs.VERSION }}/g' docs/reference/cli/commands.mdx
 
       - name: "Create Pull Request"
         uses: peter-evans/create-pull-request@v7


### PR DESCRIPTION
### **PR Type**
Bug fix


___

### **Description**
- Fixed sed pattern in dashboard release workflow to match unquoted version strings

- Updated regex to correctly replace `nhost/dashboard:X.Y.Z)` format in docs file

- Ensures docs/reference/cli/commands.mdx gets updated during dashboard releases


___

### Diagram Walkthrough


```mermaid
flowchart LR
  A["Dashboard Release Workflow"] --> B["sed command"]
  B --> C["docs/reference/cli/commands.mdx"]
  C --> D["Version string updated correctly"]
```



<details> <summary><h3> File Walkthrough</h3></summary>

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Bug fix</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>dashboard_wf_release.yaml</strong><dd><code>Fix sed pattern for unquoted dashboard version strings</code>&nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

.github/workflows/dashboard_wf_release.yaml

<ul><li>Modified sed pattern to match unquoted version strings with closing <br>parenthesis<br> <li> Changed from <code>"nhost\/dashboard:[^"]*"</code> to <code>nhost\/dashboard:[0-9.]*)</code><br> <li> Fixes version replacement in docs/reference/cli/commands.mdx file</ul>


</details>


  </td>
  <td><a href="https://github.com/nhost/nhost/pull/3670/files#diff-0154025cb19cefd117b80826a8667b0bd194b5cc2796fc401b4e0f30806a39ae">+1/-1</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

</details>

___

