### PR TITLE
fix(dashboard): Display the correct application state for new projects

### DIFF
--- a/dashboard/src/features/orgs/layout/OrgLayout/ProjectViewWithState.tsx
+++ b/dashboard/src/features/orgs/layout/OrgLayout/ProjectViewWithState.tsx
@@ -8,6 +8,7 @@ import { ApplicationStatus } from '@/types/application';
 import { useRouter } from 'next/router';
 import { type PropsWithChildren, useMemo } from 'react';
 
+import { isNotEmptyValue } from '@/lib/utils';
 import PausedProjectContent from './PausedProjectContent';
 
 function ProjectViewWithState({ children }: PropsWithChildren) {
@@ -26,10 +27,23 @@ function ProjectViewWithState({ children }: PropsWithChildren) {
     }
 
     switch (state) {
-      case ApplicationStatus.Empty:
+      case ApplicationStatus.Empty: {
+        const newProjectData = sessionStorage.getItem('newProject');
+        // eslint-disable-next-line no-console
+        console.log('new project request sent state is empty');
+        if (
+          isNotEmptyValue(newProjectData) &&
+          JSON.parse(newProjectData).subdomain === appSubdomain
+        ) {
+          return <ApplicationProvisioning />;
+        }
+
         return null;
-      case ApplicationStatus.Provisioning:
+      }
+      case ApplicationStatus.Provisioning: {
+        sessionStorage.removeItem('newProject');
         return <ApplicationProvisioning />;
+      }
       case ApplicationStatus.Errored:
         if (isOnOverviewPage) {
           return (

--- a/dashboard/src/pages/onboarding/project.tsx
+++ b/dashboard/src/pages/onboarding/project.tsx
@@ -140,6 +140,7 @@ export default function OnboardingProjectPage() {
 
           // clear onboarding flow and redirect to project dashboard
           sessionStorage.removeItem('onboarding');
+          sessionStorage.setItem('newProject', JSON.stringify({ subdomain }));
           router.push(`/orgs/${selectedOrg?.slug}/projects/${subdomain}`);
         }
       },

--- a/dashboard/src/pages/orgs/[orgSlug]/projects/new.tsx
+++ b/dashboard/src/pages/orgs/[orgSlug]/projects/new.tsx
@@ -121,7 +121,7 @@ export function NewProjectPageContent({
             regionId: selectedRegion.id,
             regionName: selectedRegion.name,
           });
-
+          sessionStorage.setItem('newProject', JSON.stringify({ subdomain }));
           await router.push(`/orgs/${selectedOrg.slug}/projects/${subdomain}`);
         }
       },


### PR DESCRIPTION
### **User description**
### Checklist

- [ ] No breaking changes
- [ ] Tests pass
- [ ] New features have new tests
- [ ] Documentation is updated (if applicable)
- [ ] Title of the PR is in the correct format (see below)


___

### **PR Type**
Bug fix


___

### **Description**
- Store new project data in `sessionStorage` to track project creation state

- Display provisioning UI for newly created projects even when backend returns `Empty` state

- Clear stored project data when provisioning state is reached

- Add utility import for value validation


___

### Diagram Walkthrough


```mermaid
flowchart LR
  A["Project Creation"] --> B["Store in sessionStorage"]
  B --> C["Navigate to Project Page"]
  C --> D{"Backend State?"}
  D -- "Empty + sessionStorage match" --> E["Show Provisioning UI"]
  D -- "Provisioning" --> F["Clear sessionStorage & Show Provisioning"]
  D -- "Other" --> G["Show Default Content"]
```



<details> <summary><h3> File Walkthrough</h3></summary>

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Bug fix</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>ProjectViewWithState.tsx</strong><dd><code>Handle new project state with sessionStorage check</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

dashboard/src/features/orgs/layout/OrgLayout/ProjectViewWithState.tsx

<ul><li>Import <code>isNotEmptyValue</code> utility for validation<br> <li> Check <code>sessionStorage</code> for new project data when state is <code>Empty</code><br> <li> Display provisioning UI if subdomain matches stored new project<br> <li> Clear <code>sessionStorage</code> when provisioning state is reached</ul>


</details>


  </td>
  <td><a href="https://github.com/nhost/nhost/pull/3678/files#diff-552483dc05a5828b39b1f92f1c4b72977d7916055f6e185c88b029ea7240ff7c">+16/-2</a>&nbsp; &nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>project.tsx</strong><dd><code>Store new project data during onboarding flow</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

dashboard/src/pages/onboarding/project.tsx

<ul><li>Store new project subdomain in <code>sessionStorage</code> before navigation<br> <li> Persist project creation state across page transitions</ul>


</details>


  </td>
  <td><a href="https://github.com/nhost/nhost/pull/3678/files#diff-6a46f6d8761861d2e5a1d7c902e3ea9b5b604c62c02597942fa0e78e2c0f3309">+1/-0</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>new.tsx</strong><dd><code>Store new project data in project creation flow</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

dashboard/src/pages/orgs/[orgSlug]/projects/new.tsx

<ul><li>Store new project subdomain in <code>sessionStorage</code> after creation<br> <li> Enable state tracking for newly created projects</ul>


</details>


  </td>
  <td><a href="https://github.com/nhost/nhost/pull/3678/files#diff-ef97470126e3edc146dda51337aaec556387e2f8a37afa70810d1dc94958f4fd">+1/-1</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

</details>

___

