### PR TITLE
chore(cli): bump nhost/dashboard to 2.42.0

### DIFF
--- a/cli/cmd/dev/cloud.go
+++ b/cli/cmd/dev/cloud.go
@@ -56,7 +56,7 @@ func CommandCloud() *cli.Command {
 			&cli.StringFlag{ //nolint:exhaustruct
 				Name:    flagDashboardVersion,
 				Usage:   "Dashboard version to use",
-				Value:   "nhost/dashboard:2.41.0",
+				Value:   "nhost/dashboard:2.42.0",
 				Sources: cli.EnvVars("NHOST_DASHBOARD_VERSION"),
 			},
 			&cli.StringFlag{ //nolint:exhaustruct

--- a/cli/cmd/dev/up.go
+++ b/cli/cmd/dev/up.go
@@ -111,7 +111,7 @@ func CommandUp() *cli.Command { //nolint:funlen
 			&cli.StringFlag{ //nolint:exhaustruct
 				Name:    flagDashboardVersion,
 				Usage:   "Dashboard version to use",
-				Value:   "nhost/dashboard:2.41.0",
+				Value:   "nhost/dashboard:2.42.0",
 				Sources: cli.EnvVars("NHOST_DASHBOARD_VERSION"),
 			},
 			&cli.StringFlag{ //nolint:exhaustruct

--- a/docs/reference/cli/commands.mdx
+++ b/docs/reference/cli/commands.mdx
@@ -254,7 +254,7 @@ Start local development environment
 
 **--ca-certificates**="": Mounts and everrides path to CA certificates in the containers
 
-**--dashboard-version**="": Dashboard version to use (default: nhost/dashboard:2.41.0)
+**--dashboard-version**="": Dashboard version to use (default: nhost/dashboard:2.42.0)
 
 **--disable-tls**: Disable TLS
 
@@ -284,7 +284,7 @@ Start local development environment connected to an Nhost Cloud project (BETA)
 
 **--ca-certificates**="": Mounts and everrides path to CA certificates in the containers
 
-**--dashboard-version**="": Dashboard version to use (default: nhost/dashboard:2.41.0)
+**--dashboard-version**="": Dashboard version to use (default: nhost/dashboard:2.42.0)
 
 **--disable-tls**: Disable TLS
 


### PR DESCRIPTION
### **User description**
This PR bumps the Nhost Dashboard Docker image to version 2.42.0.


___

### **PR Type**
Other


___

### **Description**
- Updated Nhost Dashboard Docker image from version 2.41.0 to 2.42.0

- Modified default dashboard version flag in CLI commands

- Updated documentation to reflect new dashboard version


___

### Diagram Walkthrough


```mermaid
flowchart LR
  A["CLI Commands"] --> B["Dashboard Version Flag"]
  B --> C["Updated to 2.42.0"]
  D["Documentation"] --> C
```



<details> <summary><h3> File Walkthrough</h3></summary>

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Dependencies</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>cloud.go</strong><dd><code>Update dashboard version in cloud command</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

cli/cmd/dev/cloud.go

<ul><li>Updated default dashboard version flag value from <br><code>nhost/dashboard:2.41.0</code> to <code>nhost/dashboard:2.42.0</code></ul>


</details>


  </td>
  <td><a href="https://github.com/nhost/nhost/pull/3693/files#diff-0aa21d03307f40a2eb705aaea99deb3acc2df96f775007127cb1c3a0dbe974b1">+1/-1</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>up.go</strong><dd><code>Update dashboard version in up command</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

cli/cmd/dev/up.go

<ul><li>Updated default dashboard version flag value from <br><code>nhost/dashboard:2.41.0</code> to <code>nhost/dashboard:2.42.0</code></ul>


</details>


  </td>
  <td><a href="https://github.com/nhost/nhost/pull/3693/files#diff-92566687c489a1d085a135fa208ff65d6f9b9bd72199b9646b7b8741896b99a5">+1/-1</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr><tr><td><strong>Documentation</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>commands.mdx</strong><dd><code>Update dashboard version in CLI documentation</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

docs/reference/cli/commands.mdx

<ul><li>Updated documentation for <code>--dashboard-version</code> flag default value to <br><code>nhost/dashboard:2.42.0</code> in both <code>dev up</code> and <code>dev cloud</code> commands</ul>


</details>


  </td>
  <td><a href="https://github.com/nhost/nhost/pull/3693/files#diff-82bce0030fa5e1a8f54552707c2619cd59af0109c2ae1566350a173e62495185">+2/-2</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

</details>

___

