### PR TITLE
chore(docs): typo

### DIFF
--- a/docs/platform/cloud/git.mdx
+++ b/docs/platform/cloud/git.mdx
@@ -29,7 +29,7 @@ After authorizing the GitHub integration, you'll need to tell Nhost a couple of 
 
 ### Base Directory
 
-This is the folder in your repository where your Nhost folder lives. If your Nhost foder is in the root of your repository, you can leave this as `/`. If it is in a subfolder (like `/backend`), specify that path here.
+This is the folder in your repository where your Nhost folder lives. If your Nhost folder is in the root of your repository, you can leave this as `/`. If it is in a subfolder (like `/backend`), specify that path here.
 
 ### Deployment Branch
 


### PR DESCRIPTION
### **User description**
Corrected a typo in the documentation regarding the Nhost folder.


___

### **PR Type**
Documentation


___

### **Description**
- Fixed typo in Nhost folder documentation ('foder' → 'folder')


___



<details> <summary><h3> File Walkthrough</h3></summary>

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Documentation</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>git.mdx</strong><dd><code>Fix typo in Base Directory documentation</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

docs/platform/cloud/git.mdx

<ul><li>Corrected spelling error in Base Directory section ('foder' changed to <br>'folder')</ul>


</details>


  </td>
  <td><a href="https://github.com/nhost/nhost/pull/3702/files#diff-d427ee2887e5cae303ce21a0b08300a82955c0f7f231ecea2ee198b69b0feb8d">+1/-1</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

</details>

___

