### PR TITLE
fix(auth): apply middleware in the correct order

### DIFF
--- a/services/auth/go/cmd/serve.go
+++ b/services/auth/go/cmd/serve.go
@@ -1332,7 +1332,7 @@ func getGoServer(
 	}
 
 	if cmd.String(flagTurnstileSecret) != "" {
-		router.Use(middleware.Tunrstile( //nolint:contextcheck
+		router.Use(middleware.Turnstile( //nolint:contextcheck
 			cmd.String(flagTurnstileSecret), cmd.String(flagAPIPrefix),
 		))
 	}

--- a/services/auth/go/middleware/turnstile.go
+++ b/services/auth/go/middleware/turnstile.go
@@ -65,7 +65,7 @@ func makeTurnstileRequest(
 	return &turnstileResponse, nil
 }
 
-func Tunrstile(secret string, prefix string) gin.HandlerFunc {
+func Turnstile(secret string, prefix string) gin.HandlerFunc {
 	cl := http.Client{} //nolint:exhaustruct
 
 	return func(ctx *gin.Context) {


### PR DESCRIPTION
### **PR Type**
Bug fix


___

### **Description**
- Reorder middleware registration to apply before route handlers

- Move Turnstile and rate limiter middleware before `RegisterHandlersWithOptions`

- Ensure middleware executes in correct sequence for proper request processing


___

### Diagram Walkthrough


```mermaid
flowchart LR
  A["Create Router"] --> B["Apply Turnstile Middleware"]
  B --> C["Apply Rate Limiter Middleware"]
  C --> D["Register API Handlers"]
  D --> E["Register Additional Routes"]
```



<details> <summary><h3> File Walkthrough</h3></summary>

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Bug fix</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>serve.go</strong><dd><code>Reorder middleware to execute before route handlers</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

services/auth/go/cmd/serve.go

<ul><li>Moved Turnstile middleware registration before API handler <br>registration<br> <li> Moved rate limiter middleware registration before API handler <br>registration<br> <li> Changed middleware application order to ensure proper execution <br>sequence</ul>


</details>


  </td>
  <td><a href="https://github.com/nhost/nhost/pull/3741/files#diff-f02fb00efb7106ea7ed8b21cbac6e073f7b33b9c4d79fd0dde1848c30a79ba2f">+10/-10</a>&nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

</details>

___

