### PR TITLE
fix(dashboard): fix tracking multiple foreign keys

### DIFF
--- a/dashboard/e2e/database/multiple-foreign-keys.test.ts
+++ b/dashboard/e2e/database/multiple-foreign-keys.test.ts
@@ -1,0 +1,329 @@
+import { TEST_ORGANIZATION_SLUG, TEST_PROJECT_SUBDOMAIN } from '@/e2e/env';
+import { expect, test } from '@/e2e/fixtures/auth-hook';
+import { prepareTable } from '@/e2e/utils';
+import { faker } from '@faker-js/faker';
+import { snakeCase } from 'snake-case';
+
+test.beforeEach(async ({ authenticatedNhostPage: page }) => {
+  const databaseRoute = `/orgs/${TEST_ORGANIZATION_SLUG}/projects/${TEST_PROJECT_SUBDOMAIN}/database/browser/default`;
+  await page.goto(databaseRoute);
+  await page.waitForURL(databaseRoute);
+});
+
+test('should create table with multiple foreign keys, then edit by removing one and adding a new one', async ({
+  authenticatedNhostPage: page,
+}) => {
+  await page.getByRole('button', { name: /new table/i }).click();
+  await expect(page.getByText(/create a new table/i)).toBeVisible();
+
+  const firstRefTableName = snakeCase(faker.lorem.words(3));
+
+  await prepareTable({
+    page,
+    name: firstRefTableName,
+    primaryKeys: [],
+    columns: [{ name: 'name', type: 'text' }],
+  });
+
+  await page.getByRole('button', { name: /create/i }).click();
+
+  await page.waitForURL(
+    `/orgs/${TEST_ORGANIZATION_SLUG}/projects/${TEST_PROJECT_SUBDOMAIN}/database/browser/default/public/${firstRefTableName}`,
+  );
+
+  await page.getByRole('button', { name: /new table/i }).click();
+  await expect(page.getByText(/create a new table/i)).toBeVisible();
+
+  const secondRefTableName = snakeCase(faker.lorem.words(3));
+
+  await prepareTable({
+    page,
+    name: secondRefTableName,
+    primaryKeys: [],
+    columns: [{ name: 'title', type: 'text' }],
+  });
+
+  await page.getByRole('button', { name: /create/i }).click();
+
+  await page.waitForURL(
+    `/orgs/${TEST_ORGANIZATION_SLUG}/projects/${TEST_PROJECT_SUBDOMAIN}/database/browser/default/public/${secondRefTableName}`,
+  );
+
+  await page.getByRole('button', { name: /new table/i }).click();
+  await expect(page.getByText(/create a new table/i)).toBeVisible();
+
+  const thirdRefTableName = snakeCase(faker.lorem.words(3));
+
+  await prepareTable({
+    page,
+    name: thirdRefTableName,
+    primaryKeys: [],
+    columns: [{ name: 'category', type: 'text' }],
+  });
+
+  await page.getByRole('button', { name: /create/i }).click();
+
+  await page.waitForURL(
+    `/orgs/${TEST_ORGANIZATION_SLUG}/projects/${TEST_PROJECT_SUBDOMAIN}/database/browser/default/public/${thirdRefTableName}`,
+  );
+
+  await page.getByRole('button', { name: /new table/i }).click();
+  await expect(page.getByText(/create a new table/i)).toBeVisible();
+
+  const mainTableName = snakeCase(faker.lorem.words(3));
+
+  await prepareTable({
+    page,
+    name: mainTableName,
+    primaryKeys: [],
+    columns: [
+      { name: 'title', type: 'text' },
+      { name: 'author_id', type: 'uuid' },
+      { name: 'publisher_id', type: 'uuid' },
+      { name: 'category_id', type: 'uuid' },
+    ],
+  });
+
+  await page.getByRole('button', { name: /add foreign key/i }).click();
+
+  await page.locator('#columnName').click();
+  await page.getByRole('option', { name: /author_id/i }).click();
+
+  await page.getByLabel('Schema').click();
+  await page.getByRole('option', { name: /public/i }).click();
+
+  await page.getByLabel('Table').click();
+  await page
+    .getByRole('option', { name: firstRefTableName, exact: true })
+    .click();
+
+  await page.locator('#referencedColumn').click();
+  await page.getByRole('option', { name: /id/i }).click();
+
+  await page.getByRole('button', { name: /add/i }).click();
+
+  await expect(
+    page.getByTestId('foreignKeyFormSubmitButton'),
+  ).not.toBeVisible();
+
+  await expect(
+    page.getByText(`public.${firstRefTableName}.id`, { exact: true }),
+  ).toBeVisible();
+
+  // Add second foreign key (publisher_id -> secondRefTableName)
+  await page.getByRole('button', { name: /add foreign key/i }).click();
+
+  await page.locator('#columnName').click();
+  await page.getByRole('option', { name: /publisher_id/i }).click();
+
+  await page.getByLabel('Schema').click();
+  await page.getByRole('option', { name: /public/i }).click();
+
+  await page.getByLabel('Table').click();
+  await page
+    .getByRole('option', { name: secondRefTableName, exact: true })
+    .click();
+
+  await page.locator('#referencedColumn').click();
+  await page.getByRole('option', { name: /id/i }).click();
+
+  await page.getByRole('button', { name: /add/i }).click();
+
+  await expect(
+    page.getByTestId('foreignKeyFormSubmitButton'),
+  ).not.toBeVisible();
+
+  await expect(
+    page.getByText(`public.${secondRefTableName}.id`, { exact: true }),
+  ).toBeVisible();
+
+  // Create the table
+  await page.getByRole('button', { name: /create/i }).click();
+
+  await page.waitForURL(
+    `/orgs/${TEST_ORGANIZATION_SLUG}/projects/${TEST_PROJECT_SUBDOMAIN}/database/browser/default/public/${mainTableName}`,
+  );
+
+  await expect(
+    page.getByRole('link', { name: mainTableName, exact: true }),
+  ).toBeVisible();
+
+  // Now reopen the table to edit foreign keys
+  await page
+    .locator(
+      `li:has-text("${mainTableName}") #table-management-menu-${mainTableName}`,
+    )
+    .click();
+  await page.getByText('Edit Table').click();
+  await expect(page.locator('h2:has-text("Edit Table")')).toBeVisible();
+
+  // Verify both foreign keys are present
+  await expect(
+    page.getByText(`public.${firstRefTableName}.id`, { exact: true }),
+  ).toBeVisible();
+  await expect(
+    page.getByText(`public.${secondRefTableName}.id`, { exact: true }),
+  ).toBeVisible();
+
+  await page
+    .getByRole('button', { name: /add foreign key/i })
+    .scrollIntoViewIfNeeded();
+
+  await page.getByText('Delete', { exact: true }).nth(1).click();
+  await expect(
+    page.getByText(`public.${secondRefTableName}.id`, { exact: true }),
+  ).not.toBeVisible();
+
+  await page.getByRole('button', { name: /add foreign key/i }).click();
+
+  await page.locator('#columnName').click();
+  await page.getByRole('option', { name: /category_id/i }).click();
+
+  await page.getByLabel('Schema').click();
+  await page.getByRole('option', { name: /public/i }).click();
+
+  await page.getByLabel('Table').click();
+  await page
+    .getByRole('option', { name: thirdRefTableName, exact: true })
+    .click();
+
+  await page.locator('#referencedColumn').click();
+  await page.getByRole('option', { name: /id/i }).click();
+
+  await page.getByRole('button', { name: /add/i }).click();
+
+  await expect(
+    page.getByTestId('foreignKeyFormSubmitButton'),
+  ).not.toBeVisible();
+
+  await expect(
+    page.getByText(`public.${thirdRefTableName}.id`, { exact: true }),
+  ).toBeVisible();
+
+  await expect(
+    page.getByText(`public.${firstRefTableName}.id`, { exact: true }),
+  ).toBeVisible();
+  await expect(
+    page.getByText(`public.${thirdRefTableName}.id`, { exact: true }),
+  ).toBeVisible();
+  await expect(
+    page.getByText(`public.${secondRefTableName}.id`, { exact: true }),
+  ).not.toBeVisible();
+
+  await page.getByRole('button', { name: /save/i }).click();
+
+  await expect(page.getByText(/error/i)).not.toBeVisible();
+  await expect(page.locator('h2:has-text("Edit Table")')).not.toBeVisible();
+
+  await expect(
+    page.getByRole('link', { name: mainTableName, exact: true }),
+  ).toBeVisible();
+});
+
+test('should create table with multiple foreign keys pointing to the same column in the same table', async ({
+  authenticatedNhostPage: page,
+}) => {
+  await page.getByRole('button', { name: /new table/i }).click();
+  await expect(page.getByText(/create a new table/i)).toBeVisible();
+
+  const addressTableName = snakeCase(faker.lorem.words(2));
+
+  await prepareTable({
+    page,
+    name: addressTableName,
+    primaryKeys: [],
+    columns: [
+      { name: 'street', type: 'text' },
+      { name: 'city', type: 'text' },
+      { name: 'postal_code', type: 'text' },
+    ],
+  });
+
+  await page.getByRole('button', { name: /create/i }).click();
+
+  await page.waitForURL(
+    `/orgs/${TEST_ORGANIZATION_SLUG}/projects/${TEST_PROJECT_SUBDOMAIN}/database/browser/default/public/${addressTableName}`,
+  );
+
+  await page.getByRole('button', { name: /new table/i }).click();
+  await expect(page.getByText(/create a new table/i)).toBeVisible();
+
+  const userTableName = snakeCase(faker.lorem.words(2));
+
+  await prepareTable({
+    page,
+    name: userTableName,
+    primaryKeys: [],
+    columns: [
+      { name: 'name', type: 'text' },
+      { name: 'primary_address_id', type: 'uuid' },
+      { name: 'secondary_address_id', type: 'uuid' },
+    ],
+  });
+
+  await page.getByRole('button', { name: /add foreign key/i }).click();
+
+  await page.locator('#columnName').click();
+  await page.getByRole('option', { name: /primary_address_id/i }).click();
+
+  await page.getByLabel('Schema').click();
+  await page.getByRole('option', { name: /public/i }).click();
+
+  await page.getByLabel('Table').click();
+  await page
+    .getByRole('option', { name: addressTableName, exact: true })
+    .click();
+
+  await page.locator('#referencedColumn').click();
+  await page.getByRole('option', { name: /id/i }).click();
+
+  await page.getByRole('button', { name: /add/i }).click();
+
+  await expect(
+    page.getByTestId('foreignKeyFormSubmitButton'),
+  ).not.toBeVisible();
+
+  await expect(
+    page.getByText(`public.${addressTableName}.id`, { exact: true }),
+  ).toBeVisible();
+
+  await page.getByRole('button', { name: /add foreign key/i }).click();
+
+  await page.locator('#columnName').click();
+  await page.getByRole('option', { name: /secondary_address_id/i }).click();
+
+  await page.getByLabel('Schema').click();
+  await page.getByRole('option', { name: /public/i }).click();
+
+  await page.getByLabel('Table').click();
+  await page
+    .getByRole('option', { name: addressTableName, exact: true })
+    .click();
+
+  await page.locator('#referencedColumn').click();
+  await page.getByRole('option', { name: /id/i }).click();
+
+  await page.getByRole('button', { name: /add/i }).click();
+
+  await expect(
+    page.getByTestId('foreignKeyFormSubmitButton'),
+  ).not.toBeVisible();
+
+  const foreignKeyReferences = page.getByText(`public.${addressTableName}.id`, {
+    exact: true,
+  });
+  await expect(foreignKeyReferences).toHaveCount(2);
+
+  await page.getByRole('button', { name: /create/i }).click();
+
+  await expect(page.getByText(/error/i)).not.toBeVisible();
+  await expect(page.getByText(/create a new table/i)).not.toBeVisible();
+
+  await page.waitForURL(
+    `/orgs/${TEST_ORGANIZATION_SLUG}/projects/${TEST_PROJECT_SUBDOMAIN}/database/browser/default/public/${userTableName}`,
+  );
+
+  await expect(
+    page.getByRole('link', { name: userTableName, exact: true }),
+  ).toBeVisible();
+});

--- a/dashboard/src/features/orgs/projects/database/dataGrid/components/BaseTableForm/ColumnEditorTable.tsx
+++ b/dashboard/src/features/orgs/projects/database/dataGrid/components/BaseTableForm/ColumnEditorTable.tsx
@@ -29,7 +29,7 @@ export default function ColumnEditorTable() {
         role="table"
         className="col-span-8 overflow-x-auto min-[900px]:overflow-x-visible"
       >
-        <div className="sticky top-0 z-10 flex w-full gap-2 pb-2 pt-1">
+        <div className="sticky top-0 z-10 flex w-full gap-2 bg-paper pb-2 pt-1">
           <div role="columnheader" className="w-52 flex-none">
             <InputLabel as="span">
               Name

--- a/dashboard/src/features/orgs/projects/database/dataGrid/components/CreateTableForm/CreateTableForm.tsx
+++ b/dashboard/src/features/orgs/projects/database/dataGrid/components/CreateTableForm/CreateTableForm.tsx
@@ -116,7 +116,7 @@ export default function CreateTableForm({
 
       if (isNotEmptyValue(table.foreignKeyRelations)) {
         await trackForeignKeyRelation({
-          foreignKeyRelations: table.foreignKeyRelations,
+          unTrackedForeignKeyRelations: table.foreignKeyRelations,
           schema,
           table: table.name,
         });

--- a/dashboard/src/features/orgs/projects/database/dataGrid/components/EditTableForm/EditTableForm.tsx
+++ b/dashboard/src/features/orgs/projects/database/dataGrid/components/EditTableForm/EditTableForm.tsx
@@ -16,6 +16,7 @@ import type {
   DatabaseTable,
   NormalizedQueryDataRow,
 } from '@/features/orgs/projects/database/dataGrid/types/dataBrowser';
+import { getUntrackedForeignKeyRelations } from '@/features/orgs/projects/database/dataGrid/utils/getUntrackedForeignKeyRelations';
 import { normalizeDatabaseColumn } from '@/features/orgs/projects/database/dataGrid/utils/normalizeDatabaseColumn';
 import { isNotEmptyValue } from '@/lib/utils';
 import { triggerToast } from '@/utils/toast';
@@ -174,11 +175,17 @@ export default function EditTableForm({
         updatedTable,
       });
 
-      if (isNotEmptyValue(updatedTable.foreignKeyRelations)) {
+      const unTrackedForeignKeyRelations = getUntrackedForeignKeyRelations(
+        foreignKeyRelations,
+        updatedTable.foreignKeyRelations,
+      );
+
+      if (isNotEmptyValue(unTrackedForeignKeyRelations)) {
         await trackForeignKeyRelations({
-          foreignKeyRelations: updatedTable.foreignKeyRelations,
+          unTrackedForeignKeyRelations,
           schema,
           table: updatedTable.name,
+          trackedForeignKeyRelations: foreignKeyRelations,
         });
       }
 

--- a/dashboard/src/features/orgs/projects/database/dataGrid/hooks/useTrackForeignKeyRelationsMutation/fetchExistingRelationships.test.ts
+++ b/dashboard/src/features/orgs/projects/database/dataGrid/hooks/useTrackForeignKeyRelationsMutation/fetchExistingRelationships.test.ts
@@ -1,0 +1,1401 @@
+import * as metadataQuery from '@/features/orgs/projects/database/dataGrid/hooks/useMetadataQuery';
+import type { ForeignKeyRelation } from '@/features/orgs/projects/database/dataGrid/types/dataBrowser';
+import { vi } from 'vitest';
+import fetchExistingRelationships from './fetchExistingRelationships';
+
+vi.mock(
+  '@/features/orgs/projects/database/dataGrid/hooks/useMetadataQuery',
+  () => ({
+    fetchMetadata: vi.fn(),
+  }),
+);
+
+const TEST_DATA_SOURCE = 'default';
+const TEST_SCHEMA = 'public';
+const TEST_APP_URL = 'http://localhost';
+const TEST_ADMIN_SECRET = 'test-secret';
+
+describe('fetchExistingRelationships', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    vi.mocked(metadataQuery.fetchMetadata).mockResolvedValue({
+      resourceVersion: 1,
+      tables: [],
+    });
+  });
+
+  it('should fetch existing object relationship from current table', async () => {
+    vi.mocked(metadataQuery.fetchMetadata).mockResolvedValue({
+      resourceVersion: 1,
+      name: TEST_DATA_SOURCE,
+      kind: 'postgres',
+      tables: [
+        {
+          table: {
+            name: 'books',
+            schema: TEST_SCHEMA,
+          },
+          configuration: {},
+          object_relationships: [
+            {
+              name: 'author',
+              using: {
+                foreign_key_constraint_on: 'author_id',
+              },
+            },
+          ],
+        },
+      ],
+    });
+
+    const foreignKeys: ForeignKeyRelation[] = [
+      {
+        name: 'books_author_id_fkey',
+        columnName: 'author_id',
+        referencedSchema: TEST_SCHEMA,
+        referencedTable: 'authors',
+        referencedColumn: 'id',
+        updateAction: 'RESTRICT',
+        deleteAction: 'RESTRICT',
+      },
+    ];
+
+    const result = await fetchExistingRelationships({
+      dataSource: TEST_DATA_SOURCE,
+      schema: TEST_SCHEMA,
+      table: 'books',
+      appUrl: TEST_APP_URL,
+      adminSecret: TEST_ADMIN_SECRET,
+      foreignKeys,
+    });
+
+    expect(result.size).toBe(1);
+    expect(result.has(`${TEST_SCHEMA}.books.author`)).toBe(true);
+    expect(result.get(`${TEST_SCHEMA}.books.author`)).toEqual(foreignKeys[0]);
+  });
+
+  it('should handle multiple object relationships from current table', async () => {
+    vi.mocked(metadataQuery.fetchMetadata).mockResolvedValue({
+      resourceVersion: 1,
+      name: TEST_DATA_SOURCE,
+      kind: 'postgres',
+      tables: [
+        {
+          table: {
+            name: 'books',
+            schema: TEST_SCHEMA,
+          },
+          configuration: {},
+          object_relationships: [
+            {
+              name: 'author',
+              using: {
+                foreign_key_constraint_on: 'author_id',
+              },
+            },
+            {
+              name: 'publisher',
+              using: {
+                foreign_key_constraint_on: 'publisher_id',
+              },
+            },
+          ],
+        },
+      ],
+    });
+
+    const foreignKeys: ForeignKeyRelation[] = [
+      {
+        name: 'books_author_id_fkey',
+        columnName: 'author_id',
+        referencedSchema: TEST_SCHEMA,
+        referencedTable: 'authors',
+        referencedColumn: 'id',
+        updateAction: 'RESTRICT',
+        deleteAction: 'RESTRICT',
+      },
+      {
+        name: 'books_publisher_id_fkey',
+        columnName: 'publisher_id',
+        referencedSchema: TEST_SCHEMA,
+        referencedTable: 'publishers',
+        referencedColumn: 'id',
+        updateAction: 'RESTRICT',
+        deleteAction: 'RESTRICT',
+      },
+    ];
+
+    const result = await fetchExistingRelationships({
+      dataSource: TEST_DATA_SOURCE,
+      schema: TEST_SCHEMA,
+      table: 'books',
+      appUrl: TEST_APP_URL,
+      adminSecret: TEST_ADMIN_SECRET,
+      foreignKeys,
+    });
+
+    expect(result.size).toBe(2);
+    expect(result.has(`${TEST_SCHEMA}.books.author`)).toBe(true);
+    expect(result.has(`${TEST_SCHEMA}.books.publisher`)).toBe(true);
+  });
+
+  it('should not match object relationships when column names differ', async () => {
+    vi.mocked(metadataQuery.fetchMetadata).mockResolvedValue({
+      resourceVersion: 1,
+      name: TEST_DATA_SOURCE,
+      kind: 'postgres',
+      tables: [
+        {
+          table: {
+            name: 'books',
+            schema: TEST_SCHEMA,
+          },
+          configuration: {},
+          object_relationships: [
+            {
+              name: 'author',
+              using: {
+                foreign_key_constraint_on: 'different_column',
+              },
+            },
+          ],
+        },
+      ],
+    });
+
+    const foreignKeys: ForeignKeyRelation[] = [
+      {
+        name: 'books_author_id_fkey',
+        columnName: 'author_id',
+        referencedSchema: TEST_SCHEMA,
+        referencedTable: 'authors',
+        referencedColumn: 'id',
+        updateAction: 'RESTRICT',
+        deleteAction: 'RESTRICT',
+      },
+    ];
+
+    const result = await fetchExistingRelationships({
+      dataSource: TEST_DATA_SOURCE,
+      schema: TEST_SCHEMA,
+      table: 'books',
+      appUrl: TEST_APP_URL,
+      adminSecret: TEST_ADMIN_SECRET,
+      foreignKeys,
+    });
+
+    expect(result.size).toBe(0);
+  });
+
+  it('should fetch existing array relationship from referenced table', async () => {
+    vi.mocked(metadataQuery.fetchMetadata).mockResolvedValue({
+      resourceVersion: 1,
+      name: TEST_DATA_SOURCE,
+      kind: 'postgres',
+      tables: [
+        {
+          table: {
+            name: 'books',
+            schema: TEST_SCHEMA,
+          },
+          configuration: {},
+        },
+        {
+          table: {
+            name: 'authors',
+            schema: TEST_SCHEMA,
+          },
+          configuration: {},
+          array_relationships: [
+            {
+              name: 'books',
+              using: {
+                foreign_key_constraint_on: {
+                  column: 'author_id',
+                  table: {
+                    name: 'books',
+                    schema: TEST_SCHEMA,
+                  },
+                },
+              },
+            },
+          ],
+        },
+      ],
+    });
+
+    const foreignKeys: ForeignKeyRelation[] = [
+      {
+        name: 'books_author_id_fkey',
+        columnName: 'author_id',
+        referencedSchema: TEST_SCHEMA,
+        referencedTable: 'authors',
+        referencedColumn: 'id',
+        updateAction: 'RESTRICT',
+        deleteAction: 'RESTRICT',
+      },
+    ];
+
+    const result = await fetchExistingRelationships({
+      dataSource: TEST_DATA_SOURCE,
+      schema: TEST_SCHEMA,
+      table: 'books',
+      appUrl: TEST_APP_URL,
+      adminSecret: TEST_ADMIN_SECRET,
+      foreignKeys,
+    });
+
+    expect(result.size).toBe(1);
+    expect(result.has(`${TEST_SCHEMA}.authors.books`)).toBe(true);
+    expect(result.get(`${TEST_SCHEMA}.authors.books`)).toEqual(foreignKeys[0]);
+  });
+
+  it('should handle multiple array relationships from referenced table', async () => {
+    vi.mocked(metadataQuery.fetchMetadata).mockResolvedValue({
+      resourceVersion: 1,
+      name: TEST_DATA_SOURCE,
+      kind: 'postgres',
+      tables: [
+        {
+          table: {
+            name: 'books',
+            schema: TEST_SCHEMA,
+          },
+          configuration: {},
+        },
+        {
+          table: {
+            name: 'authors',
+            schema: TEST_SCHEMA,
+          },
+          configuration: {},
+          array_relationships: [
+            {
+              name: 'books',
+              using: {
+                foreign_key_constraint_on: {
+                  column: 'author_id',
+                  table: {
+                    name: 'books',
+                    schema: TEST_SCHEMA,
+                  },
+                },
+              },
+            },
+          ],
+        },
+        {
+          table: {
+            name: 'publishers',
+            schema: TEST_SCHEMA,
+          },
+          configuration: {},
+          array_relationships: [
+            {
+              name: 'books',
+              using: {
+                foreign_key_constraint_on: {
+                  column: 'publisher_id',
+                  table: {
+                    name: 'books',
+                    schema: TEST_SCHEMA,
+                  },
+                },
+              },
+            },
+          ],
+        },
+      ],
+    });
+
+    const foreignKeys: ForeignKeyRelation[] = [
+      {
+        name: 'books_author_id_fkey',
+        columnName: 'author_id',
+        referencedSchema: TEST_SCHEMA,
+        referencedTable: 'authors',
+        referencedColumn: 'id',
+        updateAction: 'RESTRICT',
+        deleteAction: 'RESTRICT',
+      },
+      {
+        name: 'books_publisher_id_fkey',
+        columnName: 'publisher_id',
+        referencedSchema: TEST_SCHEMA,
+        referencedTable: 'publishers',
+        referencedColumn: 'id',
+        updateAction: 'RESTRICT',
+        deleteAction: 'RESTRICT',
+      },
+    ];
+
+    const result = await fetchExistingRelationships({
+      dataSource: TEST_DATA_SOURCE,
+      schema: TEST_SCHEMA,
+      table: 'books',
+      appUrl: TEST_APP_URL,
+      adminSecret: TEST_ADMIN_SECRET,
+      foreignKeys,
+    });
+
+    expect(result.size).toBe(2);
+    expect(result.has(`${TEST_SCHEMA}.authors.books`)).toBe(true);
+    expect(result.has(`${TEST_SCHEMA}.publishers.books`)).toBe(true);
+  });
+
+  it('should not match array relationships when table name differs', async () => {
+    vi.mocked(metadataQuery.fetchMetadata).mockResolvedValue({
+      resourceVersion: 1,
+      name: TEST_DATA_SOURCE,
+      kind: 'postgres',
+      tables: [
+        {
+          table: {
+            name: 'books',
+            schema: TEST_SCHEMA,
+          },
+          configuration: {},
+        },
+        {
+          table: {
+            name: 'authors',
+            schema: TEST_SCHEMA,
+          },
+          configuration: {},
+          array_relationships: [
+            {
+              name: 'books',
+              using: {
+                foreign_key_constraint_on: {
+                  column: 'author_id',
+                  table: {
+                    name: 'different_table',
+                    schema: TEST_SCHEMA,
+                  },
+                },
+              },
+            },
+          ],
+        },
+      ],
+    });
+
+    const foreignKeys: ForeignKeyRelation[] = [
+      {
+        name: 'books_author_id_fkey',
+        columnName: 'author_id',
+        referencedSchema: TEST_SCHEMA,
+        referencedTable: 'authors',
+        referencedColumn: 'id',
+        updateAction: 'RESTRICT',
+        deleteAction: 'RESTRICT',
+      },
+    ];
+
+    const result = await fetchExistingRelationships({
+      dataSource: TEST_DATA_SOURCE,
+      schema: TEST_SCHEMA,
+      table: 'books',
+      appUrl: TEST_APP_URL,
+      adminSecret: TEST_ADMIN_SECRET,
+      foreignKeys,
+    });
+
+    expect(result.size).toBe(0);
+  });
+
+  it('should not match array relationships when schema differs', async () => {
+    vi.mocked(metadataQuery.fetchMetadata).mockResolvedValue({
+      resourceVersion: 1,
+      name: TEST_DATA_SOURCE,
+      kind: 'postgres',
+      tables: [
+        {
+          table: {
+            name: 'books',
+            schema: TEST_SCHEMA,
+          },
+          configuration: {},
+        },
+        {
+          table: {
+            name: 'authors',
+            schema: TEST_SCHEMA,
+          },
+          configuration: {},
+          array_relationships: [
+            {
+              name: 'books',
+              using: {
+                foreign_key_constraint_on: {
+                  column: 'author_id',
+                  table: {
+                    name: 'books',
+                    schema: 'different_schema',
+                  },
+                },
+              },
+            },
+          ],
+        },
+      ],
+    });
+
+    const foreignKeys: ForeignKeyRelation[] = [
+      {
+        name: 'books_author_id_fkey',
+        columnName: 'author_id',
+        referencedSchema: TEST_SCHEMA,
+        referencedTable: 'authors',
+        referencedColumn: 'id',
+        updateAction: 'RESTRICT',
+        deleteAction: 'RESTRICT',
+      },
+    ];
+
+    const result = await fetchExistingRelationships({
+      dataSource: TEST_DATA_SOURCE,
+      schema: TEST_SCHEMA,
+      table: 'books',
+      appUrl: TEST_APP_URL,
+      adminSecret: TEST_ADMIN_SECRET,
+      foreignKeys,
+    });
+
+    expect(result.size).toBe(0);
+  });
+
+  it('should not match array relationships when column name differs', async () => {
+    vi.mocked(metadataQuery.fetchMetadata).mockResolvedValue({
+      resourceVersion: 1,
+      name: TEST_DATA_SOURCE,
+      kind: 'postgres',
+      tables: [
+        {
+          table: {
+            name: 'books',
+            schema: TEST_SCHEMA,
+          },
+          configuration: {},
+        },
+        {
+          table: {
+            name: 'authors',
+            schema: TEST_SCHEMA,
+          },
+          configuration: {},
+          array_relationships: [
+            {
+              name: 'books',
+              using: {
+                foreign_key_constraint_on: {
+                  column: 'different_column',
+                  table: {
+                    name: 'books',
+                    schema: TEST_SCHEMA,
+                  },
+                },
+              },
+            },
+          ],
+        },
+      ],
+    });
+
+    const foreignKeys: ForeignKeyRelation[] = [
+      {
+        name: 'books_author_id_fkey',
+        columnName: 'author_id',
+        referencedSchema: TEST_SCHEMA,
+        referencedTable: 'authors',
+        referencedColumn: 'id',
+        updateAction: 'RESTRICT',
+        deleteAction: 'RESTRICT',
+      },
+    ];
+
+    const result = await fetchExistingRelationships({
+      dataSource: TEST_DATA_SOURCE,
+      schema: TEST_SCHEMA,
+      table: 'books',
+      appUrl: TEST_APP_URL,
+      adminSecret: TEST_ADMIN_SECRET,
+      foreignKeys,
+    });
+
+    expect(result.size).toBe(0);
+  });
+
+  it('should fetch existing object relationship from referenced table for one-to-one', async () => {
+    vi.mocked(metadataQuery.fetchMetadata).mockResolvedValue({
+      resourceVersion: 1,
+      name: TEST_DATA_SOURCE,
+      kind: 'postgres',
+      tables: [
+        {
+          table: {
+            name: 'books',
+            schema: TEST_SCHEMA,
+          },
+          configuration: {},
+        },
+        {
+          table: {
+            name: 'book_metadata',
+            schema: TEST_SCHEMA,
+          },
+          configuration: {},
+          object_relationships: [
+            {
+              name: 'book',
+              using: {
+                foreign_key_constraint_on: {
+                  column: 'id',
+                  table: {
+                    name: 'books',
+                    schema: TEST_SCHEMA,
+                  },
+                },
+              },
+            },
+          ],
+        },
+      ],
+    });
+
+    const foreignKeys: ForeignKeyRelation[] = [
+      {
+        name: 'books_id_fkey',
+        columnName: 'id',
+        referencedSchema: TEST_SCHEMA,
+        referencedTable: 'book_metadata',
+        referencedColumn: 'id',
+        updateAction: 'RESTRICT',
+        deleteAction: 'RESTRICT',
+        oneToOne: true,
+      },
+    ];
+
+    const result = await fetchExistingRelationships({
+      dataSource: TEST_DATA_SOURCE,
+      schema: TEST_SCHEMA,
+      table: 'books',
+      appUrl: TEST_APP_URL,
+      adminSecret: TEST_ADMIN_SECRET,
+      foreignKeys,
+    });
+
+    expect(result.size).toBe(1);
+    expect(result.has(`${TEST_SCHEMA}.book_metadata.book`)).toBe(true);
+    expect(result.get(`${TEST_SCHEMA}.book_metadata.book`)).toEqual(
+      foreignKeys[0],
+    );
+  });
+
+  it('should handle both object relationships for one-to-one constraint', async () => {
+    vi.mocked(metadataQuery.fetchMetadata).mockResolvedValue({
+      resourceVersion: 1,
+      name: TEST_DATA_SOURCE,
+      kind: 'postgres',
+      tables: [
+        {
+          table: {
+            name: 'books',
+            schema: TEST_SCHEMA,
+          },
+          configuration: {},
+          object_relationships: [
+            {
+              name: 'book_metadatum',
+              using: {
+                foreign_key_constraint_on: 'id',
+              },
+            },
+          ],
+        },
+        {
+          table: {
+            name: 'book_metadata',
+            schema: TEST_SCHEMA,
+          },
+          configuration: {},
+          object_relationships: [
+            {
+              name: 'book',
+              using: {
+                foreign_key_constraint_on: {
+                  column: 'id',
+                  table: {
+                    name: 'books',
+                    schema: TEST_SCHEMA,
+                  },
+                },
+              },
+            },
+          ],
+        },
+      ],
+    });
+
+    const foreignKeys: ForeignKeyRelation[] = [
+      {
+        name: 'books_id_fkey',
+        columnName: 'id',
+        referencedSchema: TEST_SCHEMA,
+        referencedTable: 'book_metadata',
+        referencedColumn: 'id',
+        updateAction: 'RESTRICT',
+        deleteAction: 'RESTRICT',
+        oneToOne: true,
+      },
+    ];
+
+    const result = await fetchExistingRelationships({
+      dataSource: TEST_DATA_SOURCE,
+      schema: TEST_SCHEMA,
+      table: 'books',
+      appUrl: TEST_APP_URL,
+      adminSecret: TEST_ADMIN_SECRET,
+      foreignKeys,
+    });
+
+    expect(result.size).toBe(2);
+    expect(result.has(`${TEST_SCHEMA}.books.book_metadatum`)).toBe(true);
+    expect(result.has(`${TEST_SCHEMA}.book_metadata.book`)).toBe(true);
+  });
+
+  it('should handle relationships across different schemas', async () => {
+    vi.mocked(metadataQuery.fetchMetadata).mockResolvedValue({
+      resourceVersion: 1,
+      name: TEST_DATA_SOURCE,
+      kind: 'postgres',
+      tables: [
+        {
+          table: {
+            name: 'books',
+            schema: 'public',
+          },
+          configuration: {},
+          object_relationships: [
+            {
+              name: 'category',
+              using: {
+                foreign_key_constraint_on: 'category_id',
+              },
+            },
+          ],
+        },
+        {
+          table: {
+            name: 'categories',
+            schema: 'catalog',
+          },
+          configuration: {},
+          array_relationships: [
+            {
+              name: 'books',
+              using: {
+                foreign_key_constraint_on: {
+                  column: 'category_id',
+                  table: {
+                    name: 'books',
+                    schema: 'public',
+                  },
+                },
+              },
+            },
+          ],
+        },
+      ],
+    });
+
+    const foreignKeys: ForeignKeyRelation[] = [
+      {
+        name: 'books_category_id_fkey',
+        columnName: 'category_id',
+        referencedSchema: 'catalog',
+        referencedTable: 'categories',
+        referencedColumn: 'id',
+        updateAction: 'RESTRICT',
+        deleteAction: 'RESTRICT',
+      },
+    ];
+
+    const result = await fetchExistingRelationships({
+      dataSource: TEST_DATA_SOURCE,
+      schema: 'public',
+      table: 'books',
+      appUrl: TEST_APP_URL,
+      adminSecret: TEST_ADMIN_SECRET,
+      foreignKeys,
+    });
+
+    expect(result.size).toBe(2);
+    expect(result.has('public.books.category')).toBe(true);
+    expect(result.has('catalog.categories.books')).toBe(true);
+  });
+  it('should fetch all relationships (object and array) for multiple foreign keys', async () => {
+    vi.mocked(metadataQuery.fetchMetadata).mockResolvedValue({
+      resourceVersion: 1,
+      name: TEST_DATA_SOURCE,
+      kind: 'postgres',
+      tables: [
+        {
+          table: {
+            name: 'books',
+            schema: TEST_SCHEMA,
+          },
+          configuration: {},
+          object_relationships: [
+            {
+              name: 'author',
+              using: {
+                foreign_key_constraint_on: 'author_id',
+              },
+            },
+            {
+              name: 'publisher',
+              using: {
+                foreign_key_constraint_on: 'publisher_id',
+              },
+            },
+          ],
+        },
+        {
+          table: {
+            name: 'authors',
+            schema: TEST_SCHEMA,
+          },
+          configuration: {},
+          array_relationships: [
+            {
+              name: 'books',
+              using: {
+                foreign_key_constraint_on: {
+                  column: 'author_id',
+                  table: {
+                    name: 'books',
+                    schema: TEST_SCHEMA,
+                  },
+                },
+              },
+            },
+          ],
+        },
+        {
+          table: {
+            name: 'publishers',
+            schema: TEST_SCHEMA,
+          },
+          configuration: {},
+          array_relationships: [
+            {
+              name: 'books',
+              using: {
+                foreign_key_constraint_on: {
+                  column: 'publisher_id',
+                  table: {
+                    name: 'books',
+                    schema: TEST_SCHEMA,
+                  },
+                },
+              },
+            },
+          ],
+        },
+      ],
+    });
+
+    const foreignKeys: ForeignKeyRelation[] = [
+      {
+        name: 'books_author_id_fkey',
+        columnName: 'author_id',
+        referencedSchema: TEST_SCHEMA,
+        referencedTable: 'authors',
+        referencedColumn: 'id',
+        updateAction: 'RESTRICT',
+        deleteAction: 'RESTRICT',
+      },
+      {
+        name: 'books_publisher_id_fkey',
+        columnName: 'publisher_id',
+        referencedSchema: TEST_SCHEMA,
+        referencedTable: 'publishers',
+        referencedColumn: 'id',
+        updateAction: 'RESTRICT',
+        deleteAction: 'RESTRICT',
+      },
+    ];
+
+    const result = await fetchExistingRelationships({
+      dataSource: TEST_DATA_SOURCE,
+      schema: TEST_SCHEMA,
+      table: 'books',
+      appUrl: TEST_APP_URL,
+      adminSecret: TEST_ADMIN_SECRET,
+      foreignKeys,
+    });
+
+    expect(result.size).toBe(4);
+    expect(result.has(`${TEST_SCHEMA}.books.author`)).toBe(true);
+    expect(result.has(`${TEST_SCHEMA}.books.publisher`)).toBe(true);
+    expect(result.has(`${TEST_SCHEMA}.authors.books`)).toBe(true);
+    expect(result.has(`${TEST_SCHEMA}.publishers.books`)).toBe(true);
+  });
+
+  it('should handle mixed one-to-many and one-to-one relationships', async () => {
+    vi.mocked(metadataQuery.fetchMetadata).mockResolvedValue({
+      resourceVersion: 1,
+      name: TEST_DATA_SOURCE,
+      kind: 'postgres',
+      tables: [
+        {
+          table: {
+            name: 'books',
+            schema: TEST_SCHEMA,
+          },
+          configuration: {},
+          object_relationships: [
+            {
+              name: 'author',
+              using: {
+                foreign_key_constraint_on: 'author_id',
+              },
+            },
+            {
+              name: 'book_metadatum',
+              using: {
+                foreign_key_constraint_on: 'metadata_id',
+              },
+            },
+          ],
+        },
+        {
+          table: {
+            name: 'authors',
+            schema: TEST_SCHEMA,
+          },
+          configuration: {},
+          array_relationships: [
+            {
+              name: 'books',
+              using: {
+                foreign_key_constraint_on: {
+                  column: 'author_id',
+                  table: {
+                    name: 'books',
+                    schema: TEST_SCHEMA,
+                  },
+                },
+              },
+            },
+          ],
+        },
+        {
+          table: {
+            name: 'book_metadata',
+            schema: TEST_SCHEMA,
+          },
+          configuration: {},
+          object_relationships: [
+            {
+              name: 'book',
+              using: {
+                foreign_key_constraint_on: {
+                  column: 'metadata_id',
+                  table: {
+                    name: 'books',
+                    schema: TEST_SCHEMA,
+                  },
+                },
+              },
+            },
+          ],
+        },
+      ],
+    });
+
+    const foreignKeys: ForeignKeyRelation[] = [
+      {
+        name: 'books_author_id_fkey',
+        columnName: 'author_id',
+        referencedSchema: TEST_SCHEMA,
+        referencedTable: 'authors',
+        referencedColumn: 'id',
+        updateAction: 'RESTRICT',
+        deleteAction: 'RESTRICT',
+      },
+      {
+        name: 'books_metadata_id_fkey',
+        columnName: 'metadata_id',
+        referencedSchema: TEST_SCHEMA,
+        referencedTable: 'book_metadata',
+        referencedColumn: 'id',
+        updateAction: 'RESTRICT',
+        deleteAction: 'RESTRICT',
+        oneToOne: true,
+      },
+    ];
+
+    const result = await fetchExistingRelationships({
+      dataSource: TEST_DATA_SOURCE,
+      schema: TEST_SCHEMA,
+      table: 'books',
+      appUrl: TEST_APP_URL,
+      adminSecret: TEST_ADMIN_SECRET,
+      foreignKeys,
+    });
+
+    expect(result.size).toBe(4);
+    expect(result.has(`${TEST_SCHEMA}.books.author`)).toBe(true);
+    expect(result.has(`${TEST_SCHEMA}.books.book_metadatum`)).toBe(true);
+    expect(result.has(`${TEST_SCHEMA}.authors.books`)).toBe(true);
+    expect(result.has(`${TEST_SCHEMA}.book_metadata.book`)).toBe(true);
+  });
+
+  it('should return empty map when no foreign keys provided', async () => {
+    vi.mocked(metadataQuery.fetchMetadata).mockResolvedValue({
+      resourceVersion: 1,
+      name: TEST_DATA_SOURCE,
+      kind: 'postgres',
+      tables: [
+        {
+          table: {
+            name: 'books',
+            schema: TEST_SCHEMA,
+          },
+          configuration: {},
+          object_relationships: [
+            {
+              name: 'author',
+              using: {
+                foreign_key_constraint_on: 'author_id',
+              },
+            },
+          ],
+        },
+      ],
+    });
+
+    const result = await fetchExistingRelationships({
+      dataSource: TEST_DATA_SOURCE,
+      schema: TEST_SCHEMA,
+      table: 'books',
+      appUrl: TEST_APP_URL,
+      adminSecret: TEST_ADMIN_SECRET,
+      foreignKeys: [],
+    });
+
+    expect(result.size).toBe(0);
+  });
+
+  it('should return empty map when metadata has no tables', async () => {
+    vi.mocked(metadataQuery.fetchMetadata).mockResolvedValue({
+      resourceVersion: 1,
+      tables: undefined,
+    });
+
+    const foreignKeys: ForeignKeyRelation[] = [
+      {
+        name: 'books_author_id_fkey',
+        columnName: 'author_id',
+        referencedSchema: TEST_SCHEMA,
+        referencedTable: 'authors',
+        referencedColumn: 'id',
+        updateAction: 'RESTRICT',
+        deleteAction: 'RESTRICT',
+      },
+    ];
+
+    const result = await fetchExistingRelationships({
+      dataSource: TEST_DATA_SOURCE,
+      schema: TEST_SCHEMA,
+      table: 'books',
+      appUrl: TEST_APP_URL,
+      adminSecret: TEST_ADMIN_SECRET,
+      foreignKeys,
+    });
+
+    expect(result.size).toBe(0);
+  });
+
+  it('should return empty map when current table not found in metadata', async () => {
+    vi.mocked(metadataQuery.fetchMetadata).mockResolvedValue({
+      resourceVersion: 1,
+      name: TEST_DATA_SOURCE,
+      kind: 'postgres',
+      tables: [
+        {
+          table: {
+            name: 'different_table',
+            schema: TEST_SCHEMA,
+          },
+          configuration: {},
+        },
+      ],
+    });
+
+    const foreignKeys: ForeignKeyRelation[] = [
+      {
+        name: 'books_author_id_fkey',
+        columnName: 'author_id',
+        referencedSchema: TEST_SCHEMA,
+        referencedTable: 'authors',
+        referencedColumn: 'id',
+        updateAction: 'RESTRICT',
+        deleteAction: 'RESTRICT',
+      },
+    ];
+
+    const result = await fetchExistingRelationships({
+      dataSource: TEST_DATA_SOURCE,
+      schema: TEST_SCHEMA,
+      table: 'books',
+      appUrl: TEST_APP_URL,
+      adminSecret: TEST_ADMIN_SECRET,
+      foreignKeys,
+    });
+
+    expect(result.size).toBe(0);
+  });
+
+  it('should handle current table with no relationships defined', async () => {
+    vi.mocked(metadataQuery.fetchMetadata).mockResolvedValue({
+      resourceVersion: 1,
+      name: TEST_DATA_SOURCE,
+      kind: 'postgres',
+      tables: [
+        {
+          table: {
+            name: 'books',
+            schema: TEST_SCHEMA,
+          },
+          configuration: {},
+        },
+      ],
+    });
+
+    const foreignKeys: ForeignKeyRelation[] = [
+      {
+        name: 'books_author_id_fkey',
+        columnName: 'author_id',
+        referencedSchema: TEST_SCHEMA,
+        referencedTable: 'authors',
+        referencedColumn: 'id',
+        updateAction: 'RESTRICT',
+        deleteAction: 'RESTRICT',
+      },
+    ];
+
+    const result = await fetchExistingRelationships({
+      dataSource: TEST_DATA_SOURCE,
+      schema: TEST_SCHEMA,
+      table: 'books',
+      appUrl: TEST_APP_URL,
+      adminSecret: TEST_ADMIN_SECRET,
+      foreignKeys,
+    });
+
+    expect(result.size).toBe(0);
+  });
+
+  it('should handle referenced table not found in metadata', async () => {
+    vi.mocked(metadataQuery.fetchMetadata).mockResolvedValue({
+      resourceVersion: 1,
+      name: TEST_DATA_SOURCE,
+      kind: 'postgres',
+      tables: [
+        {
+          table: {
+            name: 'books',
+            schema: TEST_SCHEMA,
+          },
+          configuration: {},
+          object_relationships: [
+            {
+              name: 'author',
+              using: {
+                foreign_key_constraint_on: 'author_id',
+              },
+            },
+          ],
+        },
+      ],
+    });
+
+    const foreignKeys: ForeignKeyRelation[] = [
+      {
+        name: 'books_author_id_fkey',
+        columnName: 'author_id',
+        referencedSchema: TEST_SCHEMA,
+        referencedTable: 'authors',
+        referencedColumn: 'id',
+        updateAction: 'RESTRICT',
+        deleteAction: 'RESTRICT',
+      },
+    ];
+
+    const result = await fetchExistingRelationships({
+      dataSource: TEST_DATA_SOURCE,
+      schema: TEST_SCHEMA,
+      table: 'books',
+      appUrl: TEST_APP_URL,
+      adminSecret: TEST_ADMIN_SECRET,
+      foreignKeys,
+    });
+
+    expect(result.size).toBe(1);
+    expect(result.has(`${TEST_SCHEMA}.books.author`)).toBe(true);
+  });
+
+  it('should handle referenced table with no relationships defined', async () => {
+    vi.mocked(metadataQuery.fetchMetadata).mockResolvedValue({
+      resourceVersion: 1,
+      name: TEST_DATA_SOURCE,
+      kind: 'postgres',
+      tables: [
+        {
+          table: {
+            name: 'books',
+            schema: TEST_SCHEMA,
+          },
+          configuration: {},
+          object_relationships: [
+            {
+              name: 'author',
+              using: {
+                foreign_key_constraint_on: 'author_id',
+              },
+            },
+          ],
+        },
+        {
+          table: {
+            name: 'authors',
+            schema: TEST_SCHEMA,
+          },
+          configuration: {},
+        },
+      ],
+    });
+
+    const foreignKeys: ForeignKeyRelation[] = [
+      {
+        name: 'books_author_id_fkey',
+        columnName: 'author_id',
+        referencedSchema: TEST_SCHEMA,
+        referencedTable: 'authors',
+        referencedColumn: 'id',
+        updateAction: 'RESTRICT',
+        deleteAction: 'RESTRICT',
+      },
+    ];
+
+    const result = await fetchExistingRelationships({
+      dataSource: TEST_DATA_SOURCE,
+      schema: TEST_SCHEMA,
+      table: 'books',
+      appUrl: TEST_APP_URL,
+      adminSecret: TEST_ADMIN_SECRET,
+      foreignKeys,
+    });
+
+    expect(result.size).toBe(1);
+    expect(result.has(`${TEST_SCHEMA}.books.author`)).toBe(true);
+  });
+
+  it('should handle foreign key with null referenced schema', async () => {
+    vi.mocked(metadataQuery.fetchMetadata).mockResolvedValue({
+      resourceVersion: 1,
+      name: TEST_DATA_SOURCE,
+      kind: 'postgres',
+      tables: [
+        {
+          table: {
+            name: 'books',
+            schema: TEST_SCHEMA,
+          },
+          configuration: {},
+          object_relationships: [
+            {
+              name: 'author',
+              using: {
+                foreign_key_constraint_on: 'author_id',
+              },
+            },
+          ],
+        },
+        {
+          table: {
+            name: 'authors',
+            schema: TEST_SCHEMA,
+          },
+          configuration: {},
+          array_relationships: [
+            {
+              name: 'books',
+              using: {
+                foreign_key_constraint_on: {
+                  column: 'author_id',
+                  table: {
+                    name: 'books',
+                    schema: TEST_SCHEMA,
+                  },
+                },
+              },
+            },
+          ],
+        },
+      ],
+    });
+
+    const foreignKeys: ForeignKeyRelation[] = [
+      {
+        name: 'books_author_id_fkey',
+        columnName: 'author_id',
+        referencedSchema: null,
+        referencedTable: 'authors',
+        referencedColumn: 'id',
+        updateAction: 'RESTRICT',
+        deleteAction: 'RESTRICT',
+      },
+    ];
+
+    const result = await fetchExistingRelationships({
+      dataSource: TEST_DATA_SOURCE,
+      schema: TEST_SCHEMA,
+      table: 'books',
+      appUrl: TEST_APP_URL,
+      adminSecret: TEST_ADMIN_SECRET,
+      foreignKeys,
+    });
+
+    expect(result.size).toBe(1);
+    expect(result.has(`${TEST_SCHEMA}.books.author`)).toBe(true);
+  });
+
+  it('should call fetchMetadata with correct parameters', async () => {
+    vi.mocked(metadataQuery.fetchMetadata).mockResolvedValue({
+      resourceVersion: 1,
+      tables: [],
+    });
+
+    const foreignKeys: ForeignKeyRelation[] = [];
+
+    await fetchExistingRelationships({
+      dataSource: TEST_DATA_SOURCE,
+      schema: TEST_SCHEMA,
+      table: 'books',
+      appUrl: TEST_APP_URL,
+      adminSecret: TEST_ADMIN_SECRET,
+      foreignKeys,
+    });
+
+    expect(metadataQuery.fetchMetadata).toHaveBeenCalledTimes(1);
+    expect(metadataQuery.fetchMetadata).toHaveBeenCalledWith({
+      dataSource: TEST_DATA_SOURCE,
+      appUrl: TEST_APP_URL,
+      adminSecret: TEST_ADMIN_SECRET,
+    });
+  });
+
+  it('should handle multiple object relationships to the same referenced table', async () => {
+    vi.mocked(metadataQuery.fetchMetadata).mockResolvedValue({
+      resourceVersion: 1,
+      name: TEST_DATA_SOURCE,
+      kind: 'postgres',
+      tables: [
+        {
+          table: {
+            name: 'orders',
+            schema: TEST_SCHEMA,
+          },
+          configuration: {},
+          object_relationships: [
+            {
+              name: 'customer',
+              using: {
+                foreign_key_constraint_on: 'customer_id',
+              },
+            },
+            {
+              name: 'seller',
+              using: {
+                foreign_key_constraint_on: 'seller_id',
+              },
+            },
+          ],
+        },
+        {
+          table: {
+            name: 'users',
+            schema: TEST_SCHEMA,
+          },
+          configuration: {},
+          array_relationships: [
+            {
+              name: 'orders_as_customer',
+              using: {
+                foreign_key_constraint_on: {
+                  column: 'customer_id',
+                  table: {
+                    name: 'orders',
+                    schema: TEST_SCHEMA,
+                  },
+                },
+              },
+            },
+            {
+              name: 'orders_as_seller',
+              using: {
+                foreign_key_constraint_on: {
+                  column: 'seller_id',
+                  table: {
+                    name: 'orders',
+                    schema: TEST_SCHEMA,
+                  },
+                },
+              },
+            },
+          ],
+        },
+      ],
+    });
+
+    const foreignKeys: ForeignKeyRelation[] = [
+      {
+        name: 'orders_customer_id_fkey',
+        columnName: 'customer_id',
+        referencedSchema: TEST_SCHEMA,
+        referencedTable: 'users',
+        referencedColumn: 'id',
+        updateAction: 'RESTRICT',
+        deleteAction: 'RESTRICT',
+      },
+      {
+        name: 'orders_seller_id_fkey',
+        columnName: 'seller_id',
+        referencedSchema: TEST_SCHEMA,
+        referencedTable: 'users',
+        referencedColumn: 'id',
+        updateAction: 'RESTRICT',
+        deleteAction: 'RESTRICT',
+      },
+    ];
+
+    const result = await fetchExistingRelationships({
+      dataSource: TEST_DATA_SOURCE,
+      schema: TEST_SCHEMA,
+      table: 'orders',
+      appUrl: TEST_APP_URL,
+      adminSecret: TEST_ADMIN_SECRET,
+      foreignKeys,
+    });
+
+    expect(result.size).toBe(4);
+    expect(result.has(`${TEST_SCHEMA}.orders.customer`)).toBe(true);
+    expect(result.has(`${TEST_SCHEMA}.orders.seller`)).toBe(true);
+    expect(result.has(`${TEST_SCHEMA}.users.orders_as_customer`)).toBe(true);
+    expect(result.has(`${TEST_SCHEMA}.users.orders_as_seller`)).toBe(true);
+  });
+});

--- a/dashboard/src/features/orgs/projects/database/dataGrid/hooks/useTrackForeignKeyRelationsMutation/fetchExistingRelationships.ts
+++ b/dashboard/src/features/orgs/projects/database/dataGrid/hooks/useTrackForeignKeyRelationsMutation/fetchExistingRelationships.ts
@@ -1,0 +1,147 @@
+import { fetchMetadata } from '@/features/orgs/projects/database/dataGrid/hooks/useMetadataQuery';
+import type {
+  ForeignKeyRelation,
+  HasuraMetadataRelationship,
+} from '@/features/orgs/projects/database/dataGrid/types/dataBrowser';
+
+export interface FetchExistingRelationshipsOptions {
+  dataSource: string;
+  schema: string;
+  table: string;
+  appUrl: string;
+  adminSecret: string;
+  foreignKeys: ForeignKeyRelation[];
+}
+
+/**
+ * Find matching foreign key for relationships in the current table.
+ * These relationships have foreign_key_constraint_on as a string (column name).
+ */
+function findMatchingForeignKeyForCurrentTable(
+  relationship: HasuraMetadataRelationship,
+  foreignKeys: ForeignKeyRelation[],
+): ForeignKeyRelation | null {
+  const { using } = relationship;
+
+  if (typeof using.foreign_key_constraint_on !== 'string') {
+    return null;
+  }
+
+  const columnName = using.foreign_key_constraint_on;
+
+  return foreignKeys.find((fk) => fk.columnName === columnName) || null;
+}
+
+/**
+ * Find matching foreign key for relationships in referenced tables.
+ * These relationships have foreign_key_constraint_on as an object with column and table.
+ */
+function findMatchingForeignKeyForReferencedTable(
+  relationship: HasuraMetadataRelationship,
+  foreignKey: ForeignKeyRelation,
+  currentSchema: string,
+  currentTable: string,
+): ForeignKeyRelation | null {
+  const { using } = relationship;
+
+  if (typeof using.foreign_key_constraint_on === 'string') {
+    return null;
+  }
+
+  const constraint = using.foreign_key_constraint_on;
+
+  if (!constraint) {
+    return null;
+  }
+
+  const matchesTable =
+    constraint.table.name === currentTable &&
+    constraint.table.schema === currentSchema &&
+    constraint.column === foreignKey.columnName;
+
+  return matchesTable ? foreignKey : null;
+}
+
+/**
+ * Fetches existing relationships from Hasura metadata based on foreign keys.
+ * Returns a map of relationship names to their corresponding foreign key relations.
+ *
+ * @param options - Options including table info and foreign keys to match
+ * @returns Map where key is relationship name and value is the foreign key relation
+ */
+export default async function fetchExistingRelationships({
+  dataSource,
+  schema,
+  table,
+  appUrl,
+  adminSecret,
+  foreignKeys,
+}: FetchExistingRelationshipsOptions): Promise<
+  Map<string, ForeignKeyRelation>
+> {
+  const relationshipMap = new Map<string, ForeignKeyRelation>();
+
+  const metadata = await fetchMetadata({
+    dataSource,
+    appUrl,
+    adminSecret,
+  });
+
+  if (!metadata.tables) {
+    return relationshipMap;
+  }
+
+  const currentTable = metadata.tables.find(
+    (t) => t.table.name === table && t.table.schema === schema,
+  );
+
+  if (currentTable?.object_relationships) {
+    currentTable.object_relationships.forEach((relationship) => {
+      const matchingForeignKey = findMatchingForeignKeyForCurrentTable(
+        relationship,
+        foreignKeys,
+      );
+
+      if (matchingForeignKey) {
+        const key = `${schema}.${table}.${relationship.name}`;
+        relationshipMap.set(key, matchingForeignKey);
+      }
+    });
+  }
+
+  foreignKeys.forEach((foreignKey) => {
+    const referencedTable = metadata.tables?.find(
+      (t) =>
+        t.table.name === foreignKey.referencedTable &&
+        t.table.schema === foreignKey.referencedSchema,
+    );
+
+    if (!referencedTable) {
+      return;
+    }
+
+    const relationshipsToCheck = foreignKey.oneToOne
+      ? referencedTable.object_relationships
+      : referencedTable.array_relationships;
+
+    if (!relationshipsToCheck) {
+      return;
+    }
+
+    relationshipsToCheck.forEach((relationship) => {
+      const matchingForeignKey = findMatchingForeignKeyForReferencedTable(
+        relationship,
+        foreignKey,
+        schema,
+        table,
+      );
+
+      if (matchingForeignKey) {
+        const key = `${foreignKey.referencedSchema}.${foreignKey.referencedTable}.${relationship.name}`;
+        relationshipMap.set(key, matchingForeignKey);
+      }
+    });
+  });
+
+  return relationshipMap;
+}

--- a/dashboard/src/features/orgs/projects/database/dataGrid/hooks/useTrackForeignKeyRelationsMutation/prepareTrackForeignKeyRelationsMetadata.test.ts
+++ b/dashboard/src/features/orgs/projects/database/dataGrid/hooks/useTrackForeignKeyRelationsMutation/prepareTrackForeignKeyRelationsMetadata.test.ts
@@ -1,264 +1,971 @@
-import type { HasuraMetadata } from '@/features/orgs/projects/database/dataGrid/types/dataBrowser';
-import { http, HttpResponse } from 'msw';
-import { setupServer } from 'msw/node';
+import * as metadataQuery from '@/features/orgs/projects/database/dataGrid/hooks/useMetadataQuery';
+import { vi } from 'vitest';
 import prepareTrackForeignKeyRelationsMetadata from './prepareTrackForeignKeyRelationsMetadata';
 
-const APP_URL = 'http://localhost';
-const testMetadataResponse: { metadata: HasuraMetadata } = {
-  metadata: {
-    version: 3,
-    sources: [
-      {
-        name: 'default',
-        kind: 'postgres',
-        tables: [
-          {
+// Mock the fetchMetadata module
+vi.mock(
+  '@/features/orgs/projects/database/dataGrid/hooks/useMetadataQuery',
+  () => ({
+    fetchMetadata: vi.fn(),
+  }),
+);
+
+const TEST_DATA_SOURCE = 'default';
+const TEST_SCHEMA = 'public';
+const TEST_APP_URL = 'http://localhost';
+const TEST_ADMIN_SECRET = 'test-secret';
+
+describe('prepareTrackForeignKeyRelationsMetadata', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    vi.mocked(metadataQuery.fetchMetadata).mockResolvedValue({
+      resourceVersion: 1,
+      tables: [],
+    });
+  });
+
+  it('should prepare both object and array relationships for a one-to-many relation', async () => {
+    const response = await prepareTrackForeignKeyRelationsMetadata({
+      dataSource: TEST_DATA_SOURCE,
+      schema: TEST_SCHEMA,
+      table: 'books',
+      appUrl: TEST_APP_URL,
+      adminSecret: TEST_ADMIN_SECRET,
+      unTrackedForeignKeyRelations: [
+        {
+          name: 'authors_author_id_fkey',
+          columnName: 'author_id',
+          referencedSchema: TEST_SCHEMA,
+          referencedTable: 'authors',
+          referencedColumn: 'id',
+          updateAction: 'RESTRICT',
+          deleteAction: 'RESTRICT',
+        },
+      ],
+    });
+
+    expect(response).toHaveLength(2);
+
+    expect(response[0]).toEqual({
+      type: 'pg_create_object_relationship',
+      args: {
+        source: TEST_DATA_SOURCE,
+        table: {
+          name: 'books',
+          schema: TEST_SCHEMA,
+        },
+        name: 'author',
+        using: {
+          foreign_key_constraint_on: 'author_id',
+        },
+      },
+    });
+
+    expect(response[1]).toEqual({
+      type: 'pg_create_array_relationship',
+      args: {
+        name: 'books',
+        source: TEST_DATA_SOURCE,
+        table: {
+          name: 'authors',
+          schema: TEST_SCHEMA,
+        },
+        using: {
+          foreign_key_constraint_on: {
+            column: 'author_id',
             table: {
               name: 'books',
-              schema: 'public',
-            },
-            configuration: {},
-            array_relationships: [],
-            object_relationships: [],
-          },
-        ],
-      },
-    ],
-  },
-};
-
-const metadataHandlers = [
-  http.post(`${APP_URL}/v1/metadata`, () =>
-    HttpResponse.json(testMetadataResponse),
-  ),
-];
-
-const server = setupServer(...metadataHandlers);
-
-beforeAll(() => server.listen());
-afterEach(() => server.resetHandlers());
-afterAll(() => server.close());
-
-test('should only prepare a one-to-many relationship if the table does not have any relationships', async () => {
-  const response = await prepareTrackForeignKeyRelationsMetadata({
-    dataSource: 'default',
-    appUrl: APP_URL,
-    adminSecret: '',
-    schema: 'public',
-    table: 'books',
-    foreignKeyRelations: [
-      {
-        name: 'authors_author_id_fkey',
-        columnName: 'author_id',
-        referencedSchema: 'public',
-        referencedTable: 'authors',
-        referencedColumn: 'id',
-        updateAction: 'RESTRICT',
-        deleteAction: 'RESTRICT',
-      },
-    ],
-  });
-
-  expect(response).toHaveLength(2);
-  expect(response[0].type).toBe('pg_create_object_relationship');
-  expect(response[1].type).toBe('pg_create_array_relationship');
-});
-
-test('should only prepare a one-to-one relationship if the table does not have any relationships', async () => {
-  const response = await prepareTrackForeignKeyRelationsMetadata({
-    dataSource: 'default',
-    appUrl: APP_URL,
-    adminSecret: '',
-    schema: 'public',
-    table: 'books',
-    foreignKeyRelations: [
-      {
-        name: 'book_metadata_id_fkey',
-        columnName: 'id',
-        referencedSchema: 'public',
-        referencedTable: 'book_metadata',
-        referencedColumn: 'id',
-        updateAction: 'RESTRICT',
-        deleteAction: 'RESTRICT',
-        oneToOne: true,
-      },
-    ],
-  });
-
-  expect(response).toHaveLength(2);
-  expect(response[0]).toMatchInlineSnapshot(`
-    {
-      "args": {
-        "name": "book_metadatum",
-        "source": "default",
-        "table": {
-          "name": "books",
-          "schema": "public",
-        },
-        "using": {
-          "foreign_key_constraint_on": "id",
-        },
-      },
-      "type": "pg_create_object_relationship",
-    }
-  `);
-  expect(response[1]).toMatchInlineSnapshot(`
-    {
-      "args": {
-        "name": "book",
-        "source": "default",
-        "table": {
-          "name": "book_metadata",
-          "schema": "public",
-        },
-        "using": {
-          "foreign_key_constraint_on": {
-            "column": "id",
-            "table": {
-              "name": "books",
-              "schema": "public",
+              schema: TEST_SCHEMA,
             },
           },
         },
       },
-      "type": "pg_create_object_relationship",
-    }
-  `);
-});
+    });
+  });
 
-test('should drop existing relationships and prepare a new one-to-many relationship', async () => {
-  server.use(
-    http.post(`${APP_URL}/v1/metadata`, () =>
-      HttpResponse.json({
-        ...testMetadataResponse,
-        metadata: {
-          ...testMetadataResponse.metadata,
-          sources: [
+  it('should prepare two object relationships for a one-to-one relation', async () => {
+    const response = await prepareTrackForeignKeyRelationsMetadata({
+      dataSource: TEST_DATA_SOURCE,
+      schema: TEST_SCHEMA,
+      table: 'books',
+      appUrl: TEST_APP_URL,
+      adminSecret: TEST_ADMIN_SECRET,
+      unTrackedForeignKeyRelations: [
+        {
+          name: 'book_metadata_id_fkey',
+          columnName: 'id',
+          referencedSchema: TEST_SCHEMA,
+          referencedTable: 'book_metadata',
+          referencedColumn: 'id',
+          updateAction: 'RESTRICT',
+          deleteAction: 'RESTRICT',
+          oneToOne: true,
+        },
+      ],
+    });
+
+    expect(response).toHaveLength(2);
+
+    expect(response[0]).toEqual({
+      type: 'pg_create_object_relationship',
+      args: {
+        name: 'book_metadatum',
+        source: TEST_DATA_SOURCE,
+        table: {
+          name: 'books',
+          schema: TEST_SCHEMA,
+        },
+        using: {
+          foreign_key_constraint_on: 'id',
+        },
+      },
+    });
+
+    expect(response[1]).toEqual({
+      type: 'pg_create_object_relationship',
+      args: {
+        name: 'book',
+        source: TEST_DATA_SOURCE,
+        table: {
+          name: 'book_metadata',
+          schema: TEST_SCHEMA,
+        },
+        using: {
+          foreign_key_constraint_on: {
+            column: 'id',
+            table: {
+              name: 'books',
+              schema: TEST_SCHEMA,
+            },
+          },
+        },
+      },
+    });
+  });
+
+  it('should handle multiple foreign key relations', async () => {
+    const response = await prepareTrackForeignKeyRelationsMetadata({
+      dataSource: TEST_DATA_SOURCE,
+      schema: TEST_SCHEMA,
+      table: 'books',
+      appUrl: TEST_APP_URL,
+      adminSecret: TEST_ADMIN_SECRET,
+      unTrackedForeignKeyRelations: [
+        {
+          name: 'books_author_id_fkey',
+          columnName: 'author_id',
+          referencedSchema: TEST_SCHEMA,
+          referencedTable: 'authors',
+          referencedColumn: 'id',
+          updateAction: 'RESTRICT',
+          deleteAction: 'RESTRICT',
+        },
+        {
+          name: 'books_publisher_id_fkey',
+          columnName: 'publisher_id',
+          referencedSchema: TEST_SCHEMA,
+          referencedTable: 'publishers',
+          referencedColumn: 'id',
+          updateAction: 'RESTRICT',
+          deleteAction: 'RESTRICT',
+        },
+      ],
+    });
+
+    expect(response).toHaveLength(4);
+    expect(response[0].type).toBe('pg_create_object_relationship');
+    expect(response[1].type).toBe('pg_create_array_relationship');
+    expect(response[2].type).toBe('pg_create_object_relationship');
+    expect(response[3].type).toBe('pg_create_array_relationship');
+  });
+
+  it('should return empty array when no foreign key relations are provided', async () => {
+    const response = await prepareTrackForeignKeyRelationsMetadata({
+      dataSource: TEST_DATA_SOURCE,
+      schema: TEST_SCHEMA,
+      table: 'books',
+      appUrl: TEST_APP_URL,
+      adminSecret: TEST_ADMIN_SECRET,
+      unTrackedForeignKeyRelations: [],
+    });
+
+    expect(response).toEqual([]);
+  });
+
+  it('should handle tables in different schemas', async () => {
+    const response = await prepareTrackForeignKeyRelationsMetadata({
+      dataSource: TEST_DATA_SOURCE,
+      schema: 'public',
+      table: 'books',
+      appUrl: TEST_APP_URL,
+      adminSecret: TEST_ADMIN_SECRET,
+      unTrackedForeignKeyRelations: [
+        {
+          name: 'books_category_id_fkey',
+          columnName: 'category_id',
+          referencedSchema: 'catalog',
+          referencedTable: 'categories',
+          referencedColumn: 'id',
+          updateAction: 'RESTRICT',
+          deleteAction: 'RESTRICT',
+        },
+      ],
+    });
+
+    expect(response).toHaveLength(2);
+    expect((response[0].args.table as any).schema).toBe('public');
+    expect((response[1].args.table as any).schema).toBe('catalog');
+  });
+
+  it('should append column name to duplicate relationship names', async () => {
+    const response = await prepareTrackForeignKeyRelationsMetadata({
+      dataSource: TEST_DATA_SOURCE,
+      schema: TEST_SCHEMA,
+      table: 'books',
+      appUrl: TEST_APP_URL,
+      adminSecret: TEST_ADMIN_SECRET,
+      unTrackedForeignKeyRelations: [
+        {
+          name: 'books_author_id_fkey',
+          columnName: 'author_id',
+          referencedSchema: TEST_SCHEMA,
+          referencedTable: 'authors',
+          referencedColumn: 'id',
+          updateAction: 'RESTRICT',
+          deleteAction: 'RESTRICT',
+        },
+        {
+          name: 'books_co_author_id_fkey',
+          columnName: 'co_author_id',
+          referencedSchema: TEST_SCHEMA,
+          referencedTable: 'authors',
+          referencedColumn: 'id',
+          updateAction: 'RESTRICT',
+          deleteAction: 'RESTRICT',
+        },
+      ],
+    });
+
+    expect(response).toHaveLength(4);
+
+    expect(response[0].args.name).toBe('author_author_id');
+    expect(response[1].args.name).toBe('books_author_id');
+    expect(response[2].args.name).toBe('author_co_author_id');
+    expect(response[3].args.name).toBe('books_co_author_id');
+  });
+
+  it('should handle multiple duplicate relationships on referenced table side', async () => {
+    const response = await prepareTrackForeignKeyRelationsMetadata({
+      dataSource: TEST_DATA_SOURCE,
+      schema: TEST_SCHEMA,
+      table: 'orders',
+      appUrl: TEST_APP_URL,
+      adminSecret: TEST_ADMIN_SECRET,
+      unTrackedForeignKeyRelations: [
+        {
+          name: 'orders_customer_id_fkey',
+          columnName: 'customer_id',
+          referencedSchema: TEST_SCHEMA,
+          referencedTable: 'users',
+          referencedColumn: 'id',
+          updateAction: 'RESTRICT',
+          deleteAction: 'RESTRICT',
+        },
+        {
+          name: 'orders_seller_id_fkey',
+          columnName: 'seller_id',
+          referencedSchema: TEST_SCHEMA,
+          referencedTable: 'users',
+          referencedColumn: 'id',
+          updateAction: 'RESTRICT',
+          deleteAction: 'RESTRICT',
+        },
+      ],
+    });
+
+    expect(response).toHaveLength(4);
+
+    expect(response[0].args.name).toBe('user_customer_id');
+    expect(response[2].args.name).toBe('user_seller_id');
+
+    expect(response[1].args.name).toBe('orders_customer_id');
+    expect(response[3].args.name).toBe('orders_seller_id');
+  });
+
+  it('should handle three or more duplicate relationships', async () => {
+    const response = await prepareTrackForeignKeyRelationsMetadata({
+      dataSource: TEST_DATA_SOURCE,
+      schema: TEST_SCHEMA,
+      table: 'projects',
+      appUrl: TEST_APP_URL,
+      adminSecret: TEST_ADMIN_SECRET,
+      unTrackedForeignKeyRelations: [
+        {
+          name: 'projects_owner_id_fkey',
+          columnName: 'owner_id',
+          referencedSchema: TEST_SCHEMA,
+          referencedTable: 'users',
+          referencedColumn: 'id',
+          updateAction: 'RESTRICT',
+          deleteAction: 'RESTRICT',
+        },
+        {
+          name: 'projects_manager_id_fkey',
+          columnName: 'manager_id',
+          referencedSchema: TEST_SCHEMA,
+          referencedTable: 'users',
+          referencedColumn: 'id',
+          updateAction: 'RESTRICT',
+          deleteAction: 'RESTRICT',
+        },
+        {
+          name: 'projects_reviewer_id_fkey',
+          columnName: 'reviewer_id',
+          referencedSchema: TEST_SCHEMA,
+          referencedTable: 'users',
+          referencedColumn: 'id',
+          updateAction: 'RESTRICT',
+          deleteAction: 'RESTRICT',
+        },
+      ],
+    });
+
+    expect(response).toHaveLength(6);
+
+    expect(response[0].args.name).toBe('user_owner_id');
+    expect(response[2].args.name).toBe('user_manager_id');
+    expect(response[4].args.name).toBe('user_reviewer_id');
+
+    expect(response[1].args.name).toBe('projects_owner_id');
+    expect(response[3].args.name).toBe('projects_manager_id');
+    expect(response[5].args.name).toBe('projects_reviewer_id');
+  });
+
+  it('should not modify names when there are no duplicates', async () => {
+    const response = await prepareTrackForeignKeyRelationsMetadata({
+      dataSource: TEST_DATA_SOURCE,
+      schema: TEST_SCHEMA,
+      table: 'books',
+      appUrl: TEST_APP_URL,
+      adminSecret: TEST_ADMIN_SECRET,
+      unTrackedForeignKeyRelations: [
+        {
+          name: 'books_author_id_fkey',
+          columnName: 'author_id',
+          referencedSchema: TEST_SCHEMA,
+          referencedTable: 'authors',
+          referencedColumn: 'id',
+          updateAction: 'RESTRICT',
+          deleteAction: 'RESTRICT',
+        },
+        {
+          name: 'books_publisher_id_fkey',
+          columnName: 'publisher_id',
+          referencedSchema: TEST_SCHEMA,
+          referencedTable: 'publishers',
+          referencedColumn: 'id',
+          updateAction: 'RESTRICT',
+          deleteAction: 'RESTRICT',
+        },
+      ],
+    });
+
+    expect(response).toHaveLength(4);
+
+    expect(response[0].args.name).toBe('author');
+    expect(response[1].args.name).toBe('books');
+    expect(response[2].args.name).toBe('publisher');
+    expect(response[3].args.name).toBe('books');
+  });
+
+  it('should handle duplicates with one-to-one relationships', async () => {
+    const response = await prepareTrackForeignKeyRelationsMetadata({
+      dataSource: TEST_DATA_SOURCE,
+      schema: TEST_SCHEMA,
+      table: 'employees',
+      appUrl: TEST_APP_URL,
+      adminSecret: TEST_ADMIN_SECRET,
+      unTrackedForeignKeyRelations: [
+        {
+          name: 'employees_primary_address_id_fkey',
+          columnName: 'primary_address_id',
+          referencedSchema: TEST_SCHEMA,
+          referencedTable: 'addresses',
+          referencedColumn: 'id',
+          updateAction: 'RESTRICT',
+          deleteAction: 'RESTRICT',
+          oneToOne: true,
+        },
+        {
+          name: 'employees_secondary_address_id_fkey',
+          columnName: 'secondary_address_id',
+          referencedSchema: TEST_SCHEMA,
+          referencedTable: 'addresses',
+          referencedColumn: 'id',
+          updateAction: 'RESTRICT',
+          deleteAction: 'RESTRICT',
+          oneToOne: true,
+        },
+      ],
+    });
+
+    expect(response).toHaveLength(4);
+
+    expect(response[0].type).toBe('pg_create_object_relationship');
+    expect(response[0].args.name).toBe('address_primary_address_id');
+
+    expect(response[1].type).toBe('pg_create_object_relationship');
+    expect(response[1].args.name).toBe('employee_primary_address_id');
+
+    expect(response[2].type).toBe('pg_create_object_relationship');
+    expect(response[2].args.name).toBe('address_secondary_address_id');
+
+    expect(response[3].type).toBe('pg_create_object_relationship');
+    expect(response[3].args.name).toBe('employee_secondary_address_id');
+  });
+  it('should append column name when relationship name conflicts with existing relationships on current table', async () => {
+    vi.mocked(metadataQuery.fetchMetadata).mockResolvedValue({
+      resourceVersion: 1,
+      name: TEST_DATA_SOURCE,
+      kind: 'postgres',
+      tables: [
+        {
+          table: {
+            name: 'books',
+            schema: TEST_SCHEMA,
+          },
+          configuration: {},
+          object_relationships: [
             {
-              ...testMetadataResponse.metadata.sources[0],
-              tables: [
-                {
-                  ...testMetadataResponse.metadata.sources[0].tables[0],
-                  object_relationships: [
-                    {
-                      name: 'author',
-                      using: {
-                        foreign_key_constraint_on: 'author_id',
-                      },
-                    },
-                  ],
-                },
-                {
-                  table: {
-                    name: 'authors',
-                    schema: 'public',
-                  },
-                  configuration: {},
-                  array_relationships: [
-                    {
-                      name: 'books',
-                      using: {
-                        foreign_key_constraint_on: {
-                          column: 'author_id',
-                          table: {
-                            name: 'books',
-                            schema: 'public',
-                          },
-                        },
-                      },
-                    },
-                  ],
-                  object_relationships: [],
-                },
-              ],
+              name: 'author',
+              using: {
+                foreign_key_constraint_on: 'existing_author_id',
+              },
             },
           ],
         },
-      }),
-    ),
-  );
+      ],
+    });
 
-  const response = await prepareTrackForeignKeyRelationsMetadata({
-    dataSource: 'default',
-    appUrl: APP_URL,
-    adminSecret: '',
-    schema: 'public',
-    table: 'books',
-    foreignKeyRelations: [
-      {
-        name: 'authors_author_id_fkey',
-        columnName: 'author_id',
-        referencedSchema: 'public',
-        referencedTable: 'authors',
-        referencedColumn: 'id',
-        updateAction: 'RESTRICT',
-        deleteAction: 'RESTRICT',
-      },
-    ],
+    const response = await prepareTrackForeignKeyRelationsMetadata({
+      dataSource: TEST_DATA_SOURCE,
+      schema: TEST_SCHEMA,
+      table: 'books',
+      appUrl: TEST_APP_URL,
+      adminSecret: TEST_ADMIN_SECRET,
+      unTrackedForeignKeyRelations: [
+        {
+          name: 'books_author_id_fkey',
+          columnName: 'author_id',
+          referencedSchema: TEST_SCHEMA,
+          referencedTable: 'authors',
+          referencedColumn: 'id',
+          updateAction: 'RESTRICT',
+          deleteAction: 'RESTRICT',
+        },
+      ],
+      trackedForeignKeyRelations: [
+        {
+          name: 'existing_author_fkey',
+          columnName: 'existing_author_id',
+          referencedSchema: TEST_SCHEMA,
+          referencedTable: 'authors',
+          referencedColumn: 'id',
+          updateAction: 'RESTRICT',
+          deleteAction: 'RESTRICT',
+        },
+      ],
+    });
+
+    expect(response).toHaveLength(2);
+    expect(response[0].args.name).toBe('author_author_id');
+    expect(response[1].args.name).toBe('books');
+
+    expect(metadataQuery.fetchMetadata).toHaveBeenCalledWith({
+      dataSource: TEST_DATA_SOURCE,
+      adminSecret: TEST_ADMIN_SECRET,
+      appUrl: TEST_APP_URL,
+    });
   });
 
-  expect(response).toHaveLength(4);
-  expect(response[0]).toMatchInlineSnapshot(`
-    {
-      "args": {
-        "cascade": false,
-        "relationship": "author",
-        "source": "default",
-        "table": "books",
-      },
-      "type": "pg_drop_relationship",
-    }
-  `);
-  expect(response[1]).toMatchInlineSnapshot(`
-    {
-      "args": {
-        "name": "author",
-        "source": "default",
-        "table": {
-          "name": "books",
-          "schema": "public",
-        },
-        "using": {
-          "foreign_key_constraint_on": "author_id",
-        },
-      },
-      "type": "pg_create_object_relationship",
-    }
-  `);
-  expect(response[2]).toMatchInlineSnapshot(`
-    {
-      "args": {
-        "cascade": false,
-        "relationship": "books",
-        "source": "default",
-        "table": {
-          "name": "authors",
-          "schema": "public",
-        },
-      },
-      "type": "pg_drop_relationship",
-    }
-  `);
-  expect(response[3]).toMatchInlineSnapshot(`
-    {
-      "args": {
-        "name": "books",
-        "source": "default",
-        "table": {
-          "name": "authors",
-          "schema": "public",
-        },
-        "using": {
-          "foreign_key_constraint_on": {
-            "column": "author_id",
-            "table": {
-              "name": "books",
-              "schema": "public",
-            },
+  it('should handle conflicts on referenced table side', async () => {
+    vi.mocked(metadataQuery.fetchMetadata).mockResolvedValue({
+      resourceVersion: 1,
+      name: TEST_DATA_SOURCE,
+      kind: 'postgres',
+      tables: [
+        {
+          table: {
+            name: 'books',
+            schema: TEST_SCHEMA,
           },
+          configuration: {},
         },
-      },
-      "type": "pg_create_array_relationship",
-    }
-  `);
+        {
+          table: {
+            name: 'authors',
+            schema: TEST_SCHEMA,
+          },
+          configuration: {},
+          array_relationships: [
+            {
+              name: 'books',
+              using: {
+                foreign_key_constraint_on: {
+                  column: 'existing_id',
+                  table: {
+                    name: 'books',
+                    schema: TEST_SCHEMA,
+                  },
+                },
+              },
+            },
+          ],
+        },
+      ],
+    });
+
+    const response = await prepareTrackForeignKeyRelationsMetadata({
+      dataSource: TEST_DATA_SOURCE,
+      schema: TEST_SCHEMA,
+      table: 'books',
+      appUrl: TEST_APP_URL,
+      adminSecret: TEST_ADMIN_SECRET,
+      unTrackedForeignKeyRelations: [
+        {
+          name: 'books_author_id_fkey',
+          columnName: 'author_id',
+          referencedSchema: TEST_SCHEMA,
+          referencedTable: 'authors',
+          referencedColumn: 'id',
+          updateAction: 'RESTRICT',
+          deleteAction: 'RESTRICT',
+        },
+      ],
+      trackedForeignKeyRelations: [
+        {
+          name: 'existing_fkey',
+          columnName: 'existing_id',
+          referencedSchema: TEST_SCHEMA,
+          referencedTable: 'authors',
+          referencedColumn: 'id',
+          updateAction: 'RESTRICT',
+          deleteAction: 'RESTRICT',
+        },
+      ],
+    });
+
+    expect(response).toHaveLength(2);
+    expect(response[0].args.name).toBe('author');
+    expect(response[1].args.name).toBe('books_author_id');
+  });
+
+  it('should handle multiple conflicts with existing relationships', async () => {
+    vi.mocked(metadataQuery.fetchMetadata).mockResolvedValue({
+      resourceVersion: 1,
+      name: TEST_DATA_SOURCE,
+      kind: 'postgres',
+      tables: [
+        {
+          table: {
+            name: 'books',
+            schema: TEST_SCHEMA,
+          },
+          configuration: {},
+          object_relationships: [
+            {
+              name: 'author',
+              using: {
+                foreign_key_constraint_on: 'existing_author_id',
+              },
+            },
+          ],
+        },
+        {
+          table: {
+            name: 'authors',
+            schema: TEST_SCHEMA,
+          },
+          configuration: {},
+          array_relationships: [
+            {
+              name: 'books',
+              using: {
+                foreign_key_constraint_on: {
+                  column: 'existing_author_id',
+                  table: {
+                    name: 'books',
+                    schema: TEST_SCHEMA,
+                  },
+                },
+              },
+            },
+          ],
+        },
+      ],
+    });
+
+    const response = await prepareTrackForeignKeyRelationsMetadata({
+      dataSource: TEST_DATA_SOURCE,
+      schema: TEST_SCHEMA,
+      table: 'books',
+      appUrl: TEST_APP_URL,
+      adminSecret: TEST_ADMIN_SECRET,
+      unTrackedForeignKeyRelations: [
+        {
+          name: 'books_author_id_fkey',
+          columnName: 'author_id',
+          referencedSchema: TEST_SCHEMA,
+          referencedTable: 'authors',
+          referencedColumn: 'id',
+          updateAction: 'RESTRICT',
+          deleteAction: 'RESTRICT',
+        },
+      ],
+      trackedForeignKeyRelations: [
+        {
+          name: 'existing_fkey',
+          columnName: 'existing_author_id',
+          referencedSchema: TEST_SCHEMA,
+          referencedTable: 'authors',
+          referencedColumn: 'id',
+          updateAction: 'RESTRICT',
+          deleteAction: 'RESTRICT',
+        },
+      ],
+    });
+
+    expect(response).toHaveLength(2);
+    expect(response[0].args.name).toBe('author_author_id');
+    expect(response[1].args.name).toBe('books_author_id');
+  });
+
+  it('should not call fetchMetadata when trackedForeignKeyRelations is empty', async () => {
+    await prepareTrackForeignKeyRelationsMetadata({
+      dataSource: TEST_DATA_SOURCE,
+      schema: TEST_SCHEMA,
+      table: 'books',
+      appUrl: TEST_APP_URL,
+      adminSecret: TEST_ADMIN_SECRET,
+      unTrackedForeignKeyRelations: [
+        {
+          name: 'books_author_id_fkey',
+          columnName: 'author_id',
+          referencedSchema: TEST_SCHEMA,
+          referencedTable: 'authors',
+          referencedColumn: 'id',
+          updateAction: 'RESTRICT',
+          deleteAction: 'RESTRICT',
+        },
+      ],
+      trackedForeignKeyRelations: [],
+    });
+
+    expect(metadataQuery.fetchMetadata).not.toHaveBeenCalled();
+  });
+
+  it('should not call fetchMetadata when trackedForeignKeyRelations is undefined', async () => {
+    await prepareTrackForeignKeyRelationsMetadata({
+      dataSource: TEST_DATA_SOURCE,
+      schema: TEST_SCHEMA,
+      table: 'books',
+      appUrl: TEST_APP_URL,
+      adminSecret: TEST_ADMIN_SECRET,
+      unTrackedForeignKeyRelations: [
+        {
+          name: 'books_author_id_fkey',
+          columnName: 'author_id',
+          referencedSchema: TEST_SCHEMA,
+          referencedTable: 'authors',
+          referencedColumn: 'id',
+          updateAction: 'RESTRICT',
+          deleteAction: 'RESTRICT',
+        },
+      ],
+      trackedForeignKeyRelations: undefined,
+    });
+
+    expect(metadataQuery.fetchMetadata).not.toHaveBeenCalled();
+  });
+
+  it('should handle combination of duplicate names and existing relationships', async () => {
+    vi.mocked(metadataQuery.fetchMetadata).mockResolvedValue({
+      resourceVersion: 1,
+      name: TEST_DATA_SOURCE,
+      kind: 'postgres',
+      tables: [
+        {
+          table: {
+            name: 'books',
+            schema: TEST_SCHEMA,
+          },
+          configuration: {},
+        },
+        {
+          table: {
+            name: 'authors',
+            schema: TEST_SCHEMA,
+          },
+          configuration: {},
+          array_relationships: [
+            {
+              name: 'books',
+              using: {
+                foreign_key_constraint_on: {
+                  column: 'existing_id',
+                  table: {
+                    name: 'books',
+                    schema: TEST_SCHEMA,
+                  },
+                },
+              },
+            },
+          ],
+        },
+      ],
+    });
+
+    const response = await prepareTrackForeignKeyRelationsMetadata({
+      dataSource: TEST_DATA_SOURCE,
+      schema: TEST_SCHEMA,
+      table: 'books',
+      appUrl: TEST_APP_URL,
+      adminSecret: TEST_ADMIN_SECRET,
+      unTrackedForeignKeyRelations: [
+        {
+          name: 'books_author_id_fkey',
+          columnName: 'author_id',
+          referencedSchema: TEST_SCHEMA,
+          referencedTable: 'authors',
+          referencedColumn: 'id',
+          updateAction: 'RESTRICT',
+          deleteAction: 'RESTRICT',
+        },
+        {
+          name: 'books_co_author_id_fkey',
+          columnName: 'co_author_id',
+          referencedSchema: TEST_SCHEMA,
+          referencedTable: 'authors',
+          referencedColumn: 'id',
+          updateAction: 'RESTRICT',
+          deleteAction: 'RESTRICT',
+        },
+      ],
+      trackedForeignKeyRelations: [
+        {
+          name: 'existing_fkey',
+          columnName: 'existing_id',
+          referencedSchema: TEST_SCHEMA,
+          referencedTable: 'authors',
+          referencedColumn: 'id',
+          updateAction: 'RESTRICT',
+          deleteAction: 'RESTRICT',
+        },
+      ],
+    });
+
+    expect(response).toHaveLength(4);
+
+    expect(response[0].args.name).toBe('author_author_id');
+    expect(response[2].args.name).toBe('author_co_author_id');
+
+    expect(response[1].args.name).toBe('books_author_id');
+    expect(response[3].args.name).toBe('books_co_author_id');
+  });
+
+  it('should handle one-to-one relationships with existing conflicts', async () => {
+    vi.mocked(metadataQuery.fetchMetadata).mockResolvedValue({
+      resourceVersion: 1,
+      name: TEST_DATA_SOURCE,
+      kind: 'postgres',
+      tables: [
+        {
+          table: {
+            name: 'employees',
+            schema: TEST_SCHEMA,
+          },
+          configuration: {},
+          object_relationships: [
+            {
+              name: 'address',
+              using: {
+                foreign_key_constraint_on: 'existing_address_id',
+              },
+            },
+          ],
+        },
+        {
+          table: {
+            name: 'addresses',
+            schema: TEST_SCHEMA,
+          },
+          configuration: {},
+          object_relationships: [
+            {
+              name: 'employee',
+              using: {
+                foreign_key_constraint_on: {
+                  column: 'existing_address_id',
+                  table: {
+                    name: 'employees',
+                    schema: TEST_SCHEMA,
+                  },
+                },
+              },
+            },
+          ],
+        },
+      ],
+    });
+
+    const response = await prepareTrackForeignKeyRelationsMetadata({
+      dataSource: TEST_DATA_SOURCE,
+      schema: TEST_SCHEMA,
+      table: 'employees',
+      appUrl: TEST_APP_URL,
+      adminSecret: TEST_ADMIN_SECRET,
+      unTrackedForeignKeyRelations: [
+        {
+          columnName: 'primary_address_id',
+          referencedSchema: TEST_SCHEMA,
+          referencedTable: 'addresses',
+          referencedColumn: 'id',
+          updateAction: 'RESTRICT',
+          deleteAction: 'RESTRICT',
+          oneToOne: true,
+        },
+      ],
+      trackedForeignKeyRelations: [
+        {
+          name: 'existing_address_fkey',
+          columnName: 'existing_address_id',
+          referencedSchema: TEST_SCHEMA,
+          referencedTable: 'addresses',
+          referencedColumn: 'id',
+          updateAction: 'RESTRICT',
+          deleteAction: 'RESTRICT',
+          oneToOne: true,
+        },
+      ],
+    });
+
+    expect(response).toHaveLength(2);
+    expect(response[0].type).toBe('pg_create_object_relationship');
+    expect(response[0].args.name).toBe('address_primary_address_id');
+    expect(response[1].type).toBe('pg_create_object_relationship');
+    expect(response[1].args.name).toBe('employee_primary_address_id');
+  });
+
+  it('should handle empty metadata tables gracefully', async () => {
+    vi.mocked(metadataQuery.fetchMetadata).mockResolvedValue({
+      resourceVersion: 1,
+      tables: undefined,
+    });
+
+    const response = await prepareTrackForeignKeyRelationsMetadata({
+      dataSource: TEST_DATA_SOURCE,
+      schema: TEST_SCHEMA,
+      table: 'books',
+      appUrl: TEST_APP_URL,
+      adminSecret: TEST_ADMIN_SECRET,
+      unTrackedForeignKeyRelations: [
+        {
+          columnName: 'author_id',
+          referencedSchema: TEST_SCHEMA,
+          referencedTable: 'authors',
+          referencedColumn: 'id',
+          updateAction: 'RESTRICT',
+          deleteAction: 'RESTRICT',
+        },
+      ],
+      trackedForeignKeyRelations: [
+        {
+          name: 'existing_fkey',
+          columnName: 'existing_id',
+          referencedSchema: TEST_SCHEMA,
+          referencedTable: 'authors',
+          referencedColumn: 'id',
+          updateAction: 'RESTRICT',
+          deleteAction: 'RESTRICT',
+        },
+      ],
+    });
+
+    expect(response).toHaveLength(2);
+    expect(response[0].args.name).toBe('author');
+    expect(response[1].args.name).toBe('books');
+  });
+
+  it('should handle cross-schema relationships with existing conflicts', async () => {
+    vi.mocked(metadataQuery.fetchMetadata).mockResolvedValue({
+      resourceVersion: 1,
+      name: TEST_DATA_SOURCE,
+      kind: 'postgres',
+      tables: [
+        {
+          table: {
+            name: 'books',
+            schema: 'public',
+          },
+          configuration: {},
+        },
+        {
+          table: {
+            name: 'categories',
+            schema: 'catalog',
+          },
+          configuration: {},
+          array_relationships: [
+            {
+              name: 'books',
+              using: {
+                foreign_key_constraint_on: {
+                  column: 'existing_category_id',
+                  table: {
+                    name: 'books',
+                    schema: 'public',
+                  },
+                },
+              },
+            },
+          ],
+        },
+      ],
+    });
+
+    const response = await prepareTrackForeignKeyRelationsMetadata({
+      dataSource: TEST_DATA_SOURCE,
+      schema: 'public',
+      table: 'books',
+      appUrl: TEST_APP_URL,
+      adminSecret: TEST_ADMIN_SECRET,
+      unTrackedForeignKeyRelations: [
+        {
+          columnName: 'category_id',
+          referencedSchema: 'catalog',
+          referencedTable: 'categories',
+          referencedColumn: 'id',
+          updateAction: 'RESTRICT',
+          deleteAction: 'RESTRICT',
+        },
+      ],
+      trackedForeignKeyRelations: [
+        {
+          name: 'existing_category_fkey',
+          columnName: 'existing_category_id',
+          referencedSchema: 'catalog',
+          referencedTable: 'categories',
+          referencedColumn: 'id',
+          updateAction: 'RESTRICT',
+          deleteAction: 'RESTRICT',
+        },
+      ],
+    });
+
+    expect(response).toHaveLength(2);
+    expect(response[0].args.name).toBe('category');
+    expect(response[1].args.name).toBe('books_category_id');
+    expect((response[0].args.table as any).schema).toBe('public');
+    expect((response[1].args.table as any).schema).toBe('catalog');
+  });
 });

--- a/dashboard/src/features/orgs/projects/database/dataGrid/hooks/useTrackForeignKeyRelationsMutation/prepareTrackForeignKeyRelationsMetadata.ts
+++ b/dashboard/src/features/orgs/projects/database/dataGrid/hooks/useTrackForeignKeyRelationsMutation/prepareTrackForeignKeyRelationsMetadata.ts
@@ -1,188 +1,184 @@
-import { fetchMetadata } from '@/features/orgs/projects/database/dataGrid/hooks/useMetadataQuery';
 import type {
   ForeignKeyRelation,
   HasuraMetadataRelationship,
   MutationOrQueryBaseOptions,
 } from '@/features/orgs/projects/database/dataGrid/types/dataBrowser';
-import { singular } from 'pluralize';
+import { isNotEmptyValue } from '@/lib/utils';
+import { plural, singular } from 'pluralize';
+import fetchExistingRelationships from './fetchExistingRelationships';
 
-export type ForeignKeyMetadataOperation =
-  | {
-      type: 'pg_create_object_relationship' | 'pg_create_array_relationship';
-      args: HasuraMetadataRelationship & {
-        source: string;
-        table: { name: string; schema: string };
-      };
-    }
-  | {
-      type: 'pg_drop_relationship';
-      args: {
-        source: string;
-        table: { name: string; schema: string } | string;
-        relationship: string;
-        cascade: boolean;
-      };
-    };
+type CreateRelationshipOperation = {
+  type: 'pg_create_object_relationship' | 'pg_create_array_relationship';
+  args: HasuraMetadataRelationship & {
+    source: string;
+    table: { name: string; schema: string };
+  };
+};
 
 export interface PrepareTrackForeignKeyRelationsMetadataVariables
   extends MutationOrQueryBaseOptions {
   /**
    * Foreign key relation to track.
    */
-  foreignKeyRelations: ForeignKeyRelation[];
+  trackedForeignKeyRelations?: ForeignKeyRelation[];
+  /**
+   * Foreign key relation to track.
+   */
+  unTrackedForeignKeyRelations: ForeignKeyRelation[];
+}
+
+function findNonUniqueNameIndexes(
+  operations: CreateRelationshipOperation[],
+): number[] {
+  const nameIndexMap = new Map<string, number[]>();
+
+  operations.forEach((op, index) => {
+    const { name, table } = op.args;
+    const key = `${table.schema}.${table.name}.${name}`;
+
+    const indexes = nameIndexMap.get(key) || [];
+    indexes.push(index);
+    nameIndexMap.set(key, indexes);
+  });
+
+  const duplicateIndexes: number[] = [];
+  nameIndexMap.forEach((indexes) => {
+    if (indexes.length > 1) {
+      duplicateIndexes.push(...indexes);
+    }
+  });
+
+  return duplicateIndexes.sort((a, b) => a - b);
+}
+
+function updateDuplicateRelationshipNames(
+  operations: CreateRelationshipOperation[],
+): CreateRelationshipOperation[] {
+  const duplicateIndexes = new Set(findNonUniqueNameIndexes(operations));
+
+  if (duplicateIndexes.size === 0) {
+    return operations;
+  }
+
+  return operations.map((op, index) => {
+    if (!duplicateIndexes.has(index)) {
+      return op;
+    }
+
+    const columnName =
+      typeof op.args.using.foreign_key_constraint_on === 'string'
+        ? op.args.using.foreign_key_constraint_on
+        : op.args.using.foreign_key_constraint_on?.column;
+
+    if (!columnName) {
+      return op;
+    }
+
+    return {
+      ...op,
+      args: {
+        ...op.args,
+        name: `${op.args.name}_${columnName}`,
+      },
+    };
+  });
 }
 
 export default async function prepareTrackForeignKeyRelationsMetadata({
   dataSource,
-  appUrl,
-  adminSecret,
   schema,
   table,
-  foreignKeyRelations,
+  adminSecret,
+  appUrl,
+  unTrackedForeignKeyRelations,
+  trackedForeignKeyRelations,
 }: PrepareTrackForeignKeyRelationsMetadataVariables) {
-  const metadata = await fetchMetadata({ dataSource, appUrl, adminSecret });
-  const tablesInMetadata = metadata?.tables;
-
-  const foreignKeyRelationsMap = foreignKeyRelations.reduce(
-    (map, foreignKeyRelation) => {
-      if (!foreignKeyRelation) {
-        return map;
-      }
-
-      return map.set(
-        `${foreignKeyRelation.referencedSchema}.${foreignKeyRelation.referencedTable}`,
-        foreignKeyRelation,
-      );
-    },
-    new Map<string, ForeignKeyRelation>(),
-  );
-
-  const existingRelationshipMap = (tablesInMetadata ?? [])
-    .filter(
-      ({ table: { name: tableName, schema: tableSchema } }) =>
-        (tableName === table && tableSchema === schema) ||
-        foreignKeyRelationsMap.has(`${tableSchema}.${tableName}`),
-    )
-    .reduce((relationshipMap, tableInMetadata) => {
-      tableInMetadata.array_relationships?.forEach((relationship) => {
-        relationshipMap.set(relationship.name, relationship);
-      });
-
-      tableInMetadata.object_relationships?.forEach((relationship) => {
-        relationshipMap.set(relationship.name, relationship);
-      });
-
-      return relationshipMap;
-    }, new Map<string, HasuraMetadataRelationship>());
-
-  if (!foreignKeyRelations) {
-    return [];
+  let existingRelationshipMaps: Map<string, ForeignKeyRelation> = new Map<
+    string,
+    ForeignKeyRelation
+  >();
+  if (isNotEmptyValue(trackedForeignKeyRelations)) {
+    existingRelationshipMaps = await fetchExistingRelationships({
+      dataSource,
+      adminSecret,
+      appUrl,
+      foreignKeys: trackedForeignKeyRelations,
+      schema,
+      table,
+    });
   }
 
-  return foreignKeyRelations.reduce<ForeignKeyMetadataOperation[]>(
-    (args, foreignKeyRelation) => {
-      const baseRelationshipName = singular(foreignKeyRelation.referencedTable);
-
-      let relationships: ForeignKeyMetadataOperation[] = [...args];
-
-      if (existingRelationshipMap.has(baseRelationshipName)) {
-        relationships = relationships.concat({
-          type: 'pg_drop_relationship',
-          args: {
-            source: dataSource,
-            table,
-            relationship: baseRelationshipName,
-            cascade: false,
-          },
-        });
-      }
-
-      relationships = relationships.concat({
+  const newRelationshipsOperations: CreateRelationshipOperation[] =
+    unTrackedForeignKeyRelations.flatMap((newForeignKeyRelation) => {
+      const createOwnRelationshipOperation: CreateRelationshipOperation = {
         type: 'pg_create_object_relationship',
         args: {
+          name: singular(newForeignKeyRelation.referencedTable),
           source: dataSource,
-          name: baseRelationshipName,
           table: {
             name: table,
             schema,
           },
           using: {
-            foreign_key_constraint_on: foreignKeyRelation.columnName,
+            foreign_key_constraint_on: newForeignKeyRelation.columnName,
           },
         },
-      });
+      };
 
-      if (foreignKeyRelation.oneToOne) {
-        const oneToOneRelationshipName = singular(table);
-
-        if (existingRelationshipMap.has(oneToOneRelationshipName)) {
-          relationships = relationships.concat({
-            type: 'pg_drop_relationship',
-            args: {
-              source: dataSource,
-              table: foreignKeyRelation.referencedTable,
-              relationship: oneToOneRelationshipName,
-              cascade: false,
-            },
-          });
-        }
-
-        return relationships.concat({
-          type: 'pg_create_object_relationship',
-          args: {
-            source: dataSource,
-            name: oneToOneRelationshipName,
-            table: {
-              name: foreignKeyRelation.referencedTable,
-              schema: foreignKeyRelation.referencedSchema || schema,
-            },
-            using: {
-              foreign_key_constraint_on: {
-                table: { name: table, schema },
-                column: foreignKeyRelation.columnName,
-              },
-            },
-          },
-        });
-      }
-
-      const oneToManyRelationshipName = table;
-
-      if (existingRelationshipMap.has(oneToManyRelationshipName)) {
-        relationships = relationships.concat({
-          type: 'pg_drop_relationship',
-          args: {
-            source: dataSource,
-            table: foreignKeyRelation.referencedSchema
-              ? {
-                  name: foreignKeyRelation.referencedTable,
-                  schema: foreignKeyRelation.referencedSchema,
-                }
-              : foreignKeyRelation.referencedTable,
-            relationship: oneToManyRelationshipName,
-            cascade: false,
-          },
-        });
-      }
-
-      return relationships.concat({
-        type: 'pg_create_array_relationship',
+      const createReferencedTableOperation: CreateRelationshipOperation = {
+        type: newForeignKeyRelation.oneToOne
+          ? 'pg_create_object_relationship'
+          : 'pg_create_array_relationship',
         args: {
+          name: newForeignKeyRelation.oneToOne
+            ? singular(table)
+            : plural(table),
           source: dataSource,
-          name: oneToManyRelationshipName,
           table: {
-            schema: foreignKeyRelation.referencedSchema || schema,
-            name: foreignKeyRelation.referencedTable,
+            name: newForeignKeyRelation.referencedTable,
+            schema: newForeignKeyRelation.referencedSchema!,
           },
           using: {
             foreign_key_constraint_on: {
-              table: { name: table, schema },
-              column: foreignKeyRelation.columnName,
+              column: newForeignKeyRelation.columnName,
+              table: {
+                name: table,
+                schema,
+              },
             },
           },
         },
-      });
-    },
-    [],
+      };
+
+      return [createOwnRelationshipOperation, createReferencedTableOperation];
+    });
+
+  let deduplicatedRelationshipsOperations = updateDuplicateRelationshipNames(
+    newRelationshipsOperations,
   );
+
+  if (existingRelationshipMaps.size > 0) {
+    deduplicatedRelationshipsOperations =
+      deduplicatedRelationshipsOperations.map((relationshipOperation) => {
+        const relationshipKey = `${relationshipOperation.args.table.schema}.${relationshipOperation.args.table.name}.${relationshipOperation.args.name}`;
+        if (existingRelationshipMaps.has(relationshipKey)) {
+          const columnName =
+            typeof relationshipOperation.args.using
+              .foreign_key_constraint_on === 'string'
+              ? relationshipOperation.args.using.foreign_key_constraint_on
+              : relationshipOperation.args.using.foreign_key_constraint_on
+                  ?.column;
+          return {
+            ...relationshipOperation,
+            args: {
+              ...relationshipOperation.args,
+              name: `${relationshipOperation.args.name}_${columnName}`,
+            },
+          };
+        }
+        return relationshipOperation;
+      });
+  }
+
+  return deduplicatedRelationshipsOperations;
 }

--- a/dashboard/src/features/orgs/projects/database/dataGrid/hooks/useTrackForeignKeyRelationsMutation/trackForeignKeyRelations.ts
+++ b/dashboard/src/features/orgs/projects/database/dataGrid/hooks/useTrackForeignKeyRelationsMutation/trackForeignKeyRelations.ts
@@ -10,9 +10,13 @@ import prepareTrackForeignKeyRelationsMetadata from './prepareTrackForeignKeyRel
 
 export interface TrackForeignKeyRelationsVariables {
   /**
+   * Tracked Foreign key relations.
+   */
+  trackedForeignKeyRelations?: ForeignKeyRelation[];
+  /**
    * Foreign key relation to track.
    */
-  foreignKeyRelations: ForeignKeyRelation[];
+  unTrackedForeignKeyRelations: ForeignKeyRelation[];
   /**
    * Schema where the table is located for which the foreign key relation is
    * being tracked.
@@ -33,7 +37,8 @@ export default async function trackForeignKeyRelations({
   table,
   appUrl,
   adminSecret,
-  foreignKeyRelations,
+  unTrackedForeignKeyRelations,
+  trackedForeignKeyRelations,
 }: TrackForeignKeyRelationsOptions & TrackForeignKeyRelationsVariables) {
   const creatableRelationships = await prepareTrackForeignKeyRelationsMetadata({
     dataSource,
@@ -41,7 +46,8 @@ export default async function trackForeignKeyRelations({
     table,
     appUrl,
     adminSecret,
-    foreignKeyRelations,
+    unTrackedForeignKeyRelations,
+    trackedForeignKeyRelations,
   });
 
   const response = await fetch(`${appUrl}/v1/metadata`, {

--- a/dashboard/src/features/orgs/projects/database/dataGrid/hooks/useTrackForeignKeyRelationsMutation/trackForeignKeyRelationsMigration.ts
+++ b/dashboard/src/features/orgs/projects/database/dataGrid/hooks/useTrackForeignKeyRelationsMutation/trackForeignKeyRelationsMigration.ts
@@ -13,7 +13,11 @@ export interface TrackForeignKeyRelationsMigrationVariables {
   /**
    * Foreign key relation to track.
    */
-  foreignKeyRelations: ForeignKeyRelation[];
+  trackedForeignKeyRelations?: ForeignKeyRelation[];
+  /**
+   * Foreign key relation to track.
+   */
+  unTrackedForeignKeyRelations: ForeignKeyRelation[];
   /**
    * Schema where the table is located for which the foreign key relation is
    * being tracked.
@@ -34,16 +38,18 @@ export default async function trackForeignKeyRelationsMigration({
   table,
   appUrl,
   adminSecret,
-  foreignKeyRelations,
+  unTrackedForeignKeyRelations,
+  trackedForeignKeyRelations,
 }: TrackForeignKeyRelationsMigrationOptions &
   TrackForeignKeyRelationsMigrationVariables) {
-  const creatableRelationships = await prepareTrackForeignKeyRelationsMetadata({
+  const creatableRelationships = prepareTrackForeignKeyRelationsMetadata({
     dataSource,
     schema,
     table,
-    appUrl,
     adminSecret,
-    foreignKeyRelations,
+    appUrl,
+    unTrackedForeignKeyRelations,
+    trackedForeignKeyRelations,
   });
 
   const response = await fetch(`${getHasuraMigrationsApiUrl()}`, {

--- a/dashboard/src/features/orgs/projects/database/dataGrid/utils/extractForeignKeyRelation/extractForeignKeyRelation.ts
+++ b/dashboard/src/features/orgs/projects/database/dataGrid/utils/extractForeignKeyRelation/extractForeignKeyRelation.ts
@@ -44,8 +44,10 @@ export default function extractForeignKeyRelation(
     name,
     columnName: columnName.replace(/(^\(|\)$)/gi, '').replaceAll('"', ''),
     referencedSchema,
-    referencedTable,
-    referencedColumn: referencedColumn.replace(/(^\(|\)$)/gi, ''),
+    referencedTable: referencedTable.replaceAll('"', ''),
+    referencedColumn: referencedColumn
+      .replace(/(^\(|\)$)/gi, '')
+      .replaceAll('"', ''),
     updateAction:
       (updateAction?.replace('ON UPDATE ', '') as PostgresReferentialAction) ||
       'NO ACTION',

--- a/dashboard/src/features/orgs/projects/database/dataGrid/utils/getUntrackedForeignKeyRelations/getUntrackedForeignKeyRelations.test.ts
+++ b/dashboard/src/features/orgs/projects/database/dataGrid/utils/getUntrackedForeignKeyRelations/getUntrackedForeignKeyRelations.test.ts
@@ -1,0 +1,310 @@
+import type { ForeignKeyRelation } from '@/features/orgs/projects/database/dataGrid/types/dataBrowser';
+import { describe, expect, it } from 'vitest';
+import getUntrackedForeignKeyRelations from './getUntrackedForeignKeyRelations';
+
+describe('getUntrackedForeignKeyRelations', () => {
+  const createForeignKey = (
+    overrides: Partial<ForeignKeyRelation> = {},
+  ): ForeignKeyRelation => ({
+    columnName: 'user_id',
+    referencedSchema: 'public',
+    referencedTable: 'users',
+    referencedColumn: 'id',
+    updateAction: 'CASCADE' as any,
+    deleteAction: 'CASCADE' as any,
+    oneToOne: false,
+    ...overrides,
+  });
+
+  it('should return all updated relations when original is undefined', () => {
+    const updated: ForeignKeyRelation[] = [
+      createForeignKey({ columnName: 'user_id' }),
+      createForeignKey({ columnName: 'post_id', referencedTable: 'posts' }),
+    ];
+
+    const result = getUntrackedForeignKeyRelations(undefined, updated);
+
+    expect(result).toEqual(updated);
+    expect(result).toHaveLength(2);
+  });
+
+  it('should return all updated relations when original is empty array', () => {
+    const updated: ForeignKeyRelation[] = [
+      createForeignKey({ columnName: 'user_id' }),
+    ];
+
+    const result = getUntrackedForeignKeyRelations([], updated);
+
+    expect(result).toEqual(updated);
+  });
+
+  it('should return empty array when updated is undefined', () => {
+    const original: ForeignKeyRelation[] = [
+      createForeignKey({ columnName: 'user_id' }),
+    ];
+
+    const result = getUntrackedForeignKeyRelations(original, undefined);
+
+    expect(result).toEqual([]);
+  });
+
+  it('should return empty array when updated is empty array', () => {
+    const original: ForeignKeyRelation[] = [
+      createForeignKey({ columnName: 'user_id' }),
+    ];
+
+    const result = getUntrackedForeignKeyRelations(original, []);
+
+    expect(result).toEqual([]);
+  });
+
+  it('should return empty array when relations are identical', () => {
+    const fk = createForeignKey({ columnName: 'user_id' });
+    const original: ForeignKeyRelation[] = [fk];
+    const updated: ForeignKeyRelation[] = [{ ...fk }];
+
+    const result = getUntrackedForeignKeyRelations(original, updated);
+
+    expect(result).toEqual([]);
+  });
+
+  it('should detect change in referencedSchema', () => {
+    const original: ForeignKeyRelation[] = [
+      createForeignKey({ columnName: 'user_id', referencedSchema: 'public' }),
+    ];
+    const updated: ForeignKeyRelation[] = [
+      createForeignKey({ columnName: 'user_id', referencedSchema: 'private' }),
+    ];
+
+    const result = getUntrackedForeignKeyRelations(original, updated);
+
+    expect(result).toHaveLength(1);
+    expect(result[0].referencedSchema).toBe('private');
+  });
+
+  it('should detect change in referencedTable', () => {
+    const original: ForeignKeyRelation[] = [
+      createForeignKey({ columnName: 'user_id', referencedTable: 'users' }),
+    ];
+    const updated: ForeignKeyRelation[] = [
+      createForeignKey({ columnName: 'user_id', referencedTable: 'accounts' }),
+    ];
+
+    const result = getUntrackedForeignKeyRelations(original, updated);
+
+    expect(result).toHaveLength(1);
+    expect(result[0].referencedTable).toBe('accounts');
+  });
+
+  it('should detect change in referencedColumn', () => {
+    const original: ForeignKeyRelation[] = [
+      createForeignKey({ columnName: 'user_id', referencedColumn: 'id' }),
+    ];
+    const updated: ForeignKeyRelation[] = [
+      createForeignKey({ columnName: 'user_id', referencedColumn: 'uuid' }),
+    ];
+
+    const result = getUntrackedForeignKeyRelations(original, updated);
+
+    expect(result).toHaveLength(1);
+    expect(result[0].referencedColumn).toBe('uuid');
+  });
+
+  it('should detect change in updateAction', () => {
+    const original: ForeignKeyRelation[] = [
+      createForeignKey({
+        columnName: 'user_id',
+        updateAction: 'CASCADE' as any,
+      }),
+    ];
+    const updated: ForeignKeyRelation[] = [
+      createForeignKey({
+        columnName: 'user_id',
+        updateAction: 'RESTRICT' as any,
+      }),
+    ];
+
+    const result = getUntrackedForeignKeyRelations(original, updated);
+
+    expect(result).toHaveLength(1);
+    expect(result[0].updateAction).toBe('RESTRICT');
+  });
+
+  it('should detect change in deleteAction', () => {
+    const original: ForeignKeyRelation[] = [
+      createForeignKey({
+        columnName: 'user_id',
+        deleteAction: 'CASCADE' as any,
+      }),
+    ];
+    const updated: ForeignKeyRelation[] = [
+      createForeignKey({
+        columnName: 'user_id',
+        deleteAction: 'SET NULL' as any,
+      }),
+    ];
+
+    const result = getUntrackedForeignKeyRelations(original, updated);
+
+    expect(result).toHaveLength(1);
+    expect(result[0].deleteAction).toBe('SET NULL');
+  });
+
+  it('should detect change in oneToOne', () => {
+    const original: ForeignKeyRelation[] = [
+      createForeignKey({ columnName: 'user_id', oneToOne: false }),
+    ];
+    const updated: ForeignKeyRelation[] = [
+      createForeignKey({ columnName: 'user_id', oneToOne: true }),
+    ];
+
+    const result = getUntrackedForeignKeyRelations(original, updated);
+
+    expect(result).toHaveLength(1);
+    expect(result[0].oneToOne).toBe(true);
+  });
+  it('should return new relations that do not exist in original', () => {
+    const original: ForeignKeyRelation[] = [
+      createForeignKey({ columnName: 'user_id' }),
+    ];
+    const updated: ForeignKeyRelation[] = [
+      createForeignKey({ columnName: 'user_id' }),
+      createForeignKey({ columnName: 'post_id', referencedTable: 'posts' }),
+    ];
+
+    const result = getUntrackedForeignKeyRelations(original, updated);
+
+    expect(result).toHaveLength(1);
+    expect(result[0].columnName).toBe('post_id');
+  });
+
+  it('should return all new relations when original has different columns', () => {
+    const original: ForeignKeyRelation[] = [
+      createForeignKey({ columnName: 'user_id' }),
+    ];
+    const updated: ForeignKeyRelation[] = [
+      createForeignKey({ columnName: 'post_id', referencedTable: 'posts' }),
+      createForeignKey({
+        columnName: 'comment_id',
+        referencedTable: 'comments',
+      }),
+    ];
+
+    const result = getUntrackedForeignKeyRelations(original, updated);
+
+    expect(result).toHaveLength(2);
+    expect(result.map((fk) => fk.columnName)).toEqual([
+      'post_id',
+      'comment_id',
+    ]);
+  });
+  it('should return both changed and new relations', () => {
+    const original: ForeignKeyRelation[] = [
+      createForeignKey({ columnName: 'user_id', referencedTable: 'users' }),
+      createForeignKey({ columnName: 'post_id', referencedTable: 'posts' }),
+    ];
+    const updated: ForeignKeyRelation[] = [
+      createForeignKey({ columnName: 'user_id', referencedTable: 'accounts' }), // changed
+      createForeignKey({ columnName: 'post_id', referencedTable: 'posts' }), // unchanged
+      createForeignKey({
+        columnName: 'comment_id',
+        referencedTable: 'comments',
+      }), // new
+    ];
+
+    const result = getUntrackedForeignKeyRelations(original, updated);
+
+    expect(result).toHaveLength(2);
+    expect(result.map((fk) => fk.columnName).sort()).toEqual([
+      'comment_id',
+      'user_id',
+    ]);
+  });
+
+  it('should handle multiple changes to the same column', () => {
+    const original: ForeignKeyRelation[] = [
+      createForeignKey({
+        columnName: 'user_id',
+        referencedTable: 'users',
+        updateAction: 'CASCADE' as any,
+        deleteAction: 'CASCADE' as any,
+      }),
+    ];
+    const updated: ForeignKeyRelation[] = [
+      createForeignKey({
+        columnName: 'user_id',
+        referencedTable: 'accounts',
+        updateAction: 'RESTRICT' as any,
+        deleteAction: 'SET NULL' as any,
+      }),
+    ];
+
+    const result = getUntrackedForeignKeyRelations(original, updated);
+
+    expect(result).toHaveLength(1);
+    expect(result[0].referencedTable).toBe('accounts');
+    expect(result[0].updateAction).toBe('RESTRICT');
+    expect(result[0].deleteAction).toBe('SET NULL');
+  });
+
+  it('should handle optional fields like id and name', () => {
+    const original: ForeignKeyRelation[] = [
+      createForeignKey({
+        id: '1',
+        name: 'fk_user',
+        columnName: 'user_id',
+      }),
+    ];
+    const updated: ForeignKeyRelation[] = [
+      createForeignKey({
+        id: '1',
+        name: 'fk_user',
+        columnName: 'user_id',
+      }),
+    ];
+
+    const result = getUntrackedForeignKeyRelations(original, updated);
+
+    expect(result).toEqual([]);
+  });
+
+  it('should handle null referencedSchema', () => {
+    const original: ForeignKeyRelation[] = [
+      createForeignKey({ columnName: 'user_id', referencedSchema: null }),
+    ];
+    const updated: ForeignKeyRelation[] = [
+      createForeignKey({ columnName: 'user_id', referencedSchema: null }),
+    ];
+
+    const result = getUntrackedForeignKeyRelations(original, updated);
+
+    expect(result).toEqual([]);
+  });
+  it('should handle both original and updated being undefined', () => {
+    const result = getUntrackedForeignKeyRelations(undefined, undefined);
+
+    expect(result).toEqual([]);
+  });
+
+  it('should handle both original and updated being empty arrays', () => {
+    const result = getUntrackedForeignKeyRelations([], []);
+
+    expect(result).toEqual([]);
+  });
+
+  it('should preserve order of updated relations', () => {
+    const updated: ForeignKeyRelation[] = [
+      createForeignKey({ columnName: 'z_column', referencedTable: 'z_table' }),
+      createForeignKey({ columnName: 'a_column', referencedTable: 'a_table' }),
+      createForeignKey({ columnName: 'm_column', referencedTable: 'm_table' }),
+    ];
+
+    const result = getUntrackedForeignKeyRelations([], updated);
+
+    expect(result.map((fk) => fk.columnName)).toEqual([
+      'z_column',
+      'a_column',
+      'm_column',
+    ]);
+  });
+});

--- a/dashboard/src/features/orgs/projects/database/dataGrid/utils/getUntrackedForeignKeyRelations/getUntrackedForeignKeyRelations.ts
+++ b/dashboard/src/features/orgs/projects/database/dataGrid/utils/getUntrackedForeignKeyRelations/getUntrackedForeignKeyRelations.ts
@@ -1,0 +1,53 @@
+import type { ForeignKeyRelation } from '@/features/orgs/projects/database/dataGrid/types/dataBrowser';
+import { isEmptyValue, isNotEmptyValue } from '@/lib/utils';
+
+function hasForeignKeyRelationChanged(
+  fk1: ForeignKeyRelation,
+  fk2: ForeignKeyRelation,
+): boolean {
+  return !(
+    fk1.columnName === fk2.columnName &&
+    fk1.referencedSchema === fk2.referencedSchema &&
+    fk1.referencedTable === fk2.referencedTable &&
+    fk1.referencedColumn === fk2.referencedColumn &&
+    fk1.updateAction === fk2.updateAction &&
+    fk1.deleteAction === fk2.deleteAction &&
+    fk1.oneToOne === fk2.oneToOne
+  );
+}
+
+function getUntrackedForeignKeyRelations(
+  original?: ForeignKeyRelation[],
+  updated?: ForeignKeyRelation[],
+): ForeignKeyRelation[] {
+  if (isNotEmptyValue(updated) && isEmptyValue(original)) {
+    return updated;
+  }
+
+  if (isEmptyValue(updated)) {
+    return [];
+  }
+  const originalForeignKeyRelations = original as ForeignKeyRelation[];
+  const updatedForeignKeyRelations = updated as ForeignKeyRelation[];
+  let untrackedForeignKeyRelataions: ForeignKeyRelation[] = [];
+  const originalMap = new Map(
+    originalForeignKeyRelations.map((fk) => [fk.columnName, fk]),
+  );
+
+  updatedForeignKeyRelations.forEach((updatedFk) => {
+    const originalFk = originalMap.get(updatedFk.columnName);
+
+    if (
+      (isNotEmptyValue(originalFk) &&
+        hasForeignKeyRelationChanged(originalFk, updatedFk)) ||
+      isEmptyValue(originalFk)
+    ) {
+      untrackedForeignKeyRelataions =
+        untrackedForeignKeyRelataions.concat(updatedFk);
+    }
+  });
+
+  return untrackedForeignKeyRelataions;
+}
+
+export default getUntrackedForeignKeyRelations;

--- a/dashboard/src/features/orgs/projects/database/dataGrid/utils/getUntrackedForeignKeyRelations/index.ts
+++ b/dashboard/src/features/orgs/projects/database/dataGrid/utils/getUntrackedForeignKeyRelations/index.ts
@@ -1,0 +1,1 @@
+export { default as getUntrackedForeignKeyRelations } from './getUntrackedForeignKeyRelations';


### PR DESCRIPTION
### **User description**
### Checklist

- [ ] No breaking changes
- [ ] Tests pass
- [ ] New features have new tests
- [ ] Documentation is updated (if applicable)
- [ ] Title of the PR is in the correct format (see below)


___

### **PR Type**
Bug fix, Tests


___

### **Description**
- Fixed foreign key relationship tracking to properly handle multiple foreign keys

- Refactored relationship metadata preparation logic to drop and recreate relationships correctly

- Enhanced test coverage with comprehensive test cases for various relationship scenarios

- Added background color to sticky header in column editor table


___

### Diagram Walkthrough


```mermaid
flowchart LR
  A["Foreign Key Relations"] --> B["Drop Existing Relationships"]
  B --> C["Create Object Relationships"]
  C --> D["Create Array Relationships"]
  D --> E["Updated Metadata"]
```



<details> <summary><h3> File Walkthrough</h3></summary>

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Enhancement</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>ColumnEditorTable.tsx</strong><dd><code>Add background color to sticky table header</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

dashboard/src/features/orgs/projects/database/dataGrid/components/BaseTableForm/ColumnEditorTable.tsx

- Added `bg-paper` background color to sticky header element


</details>


  </td>
  <td><a href="https://github.com/nhost/nhost/pull/3748/files#diff-4cff130e7f375bf59ccc86eef6c1b48336a35691edd2a3197f37a143680a75d6">+1/-1</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr><tr><td><strong>Tests</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>prepareTrackForeignKeyRelationsMetadata.test.ts</strong><dd><code>Comprehensive test refactoring with new test cases</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

dashboard/src/features/orgs/projects/database/dataGrid/hooks/useTrackForeignKeyRelationsMutation/prepareTrackForeignKeyRelationsMetadata.test.ts

<ul><li>Refactored test structure with helper functions <code>createMetadataResponse</code> <br>and <code>createTableMetadata</code><br> <li> Converted tests to use <code>describe</code> blocks and <code>it</code> syntax<br> <li> Added comprehensive test cases for multiple foreign keys, existing <br>relationships, empty relations, and cross-schema tables<br> <li> Replaced inline snapshots with explicit assertions for better test <br>clarity</ul>


</details>


  </td>
  <td><a href="https://github.com/nhost/nhost/pull/3748/files#diff-0e8ba5557a61eff22c0e030f2e6e2f643d9be5f4f89cec5cfb2ca6ddce7e3fa4">+323/-211</a></td>

</tr>
</table></td></tr><tr><td><strong>Bug fix</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>prepareTrackForeignKeyRelationsMetadata.ts</strong><dd><code>Fix relationship tracking logic for multiple foreign keys</code></dd></summary>
<hr>

dashboard/src/features/orgs/projects/database/dataGrid/hooks/useTrackForeignKeyRelationsMutation/prepareTrackForeignKeyRelationsMetadata.ts

<ul><li>Fixed logic to properly drop existing relationships before creating <br>new ones<br> <li> Simplified relationship creation using <code>flatMap</code> instead of <code>reduce</code><br> <li> Added early return for empty foreign key relations<br> <li> Removed one-to-one relationship special handling, treating all as <br>one-to-many<br> <li> Fixed relationship naming to use plural form for array relationships</ul>


</details>


  </td>
  <td><a href="https://github.com/nhost/nhost/pull/3748/files#diff-55008cc77217aacf9539489fd091ad680b6da87c884dfcaa8c6136eeab56b0ad">+64/-112</a></td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>extractForeignKeyRelation.ts</strong><dd><code>Remove quotes from referenced table names</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

dashboard/src/features/orgs/projects/database/dataGrid/utils/extractForeignKeyRelation/extractForeignKeyRelation.ts

- Added `replaceAll` to remove quotes from referenced table names


</details>


  </td>
  <td><a href="https://github.com/nhost/nhost/pull/3748/files#diff-ff940d21b4207265ccae2acaa2e5b8d2a0edc01fd51f14d1c0f6beed43596c49">+1/-1</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

</details>

___

