### PR TITLE
fix(nixops): scope checks to submodule

### DIFF
--- a/nixops/lib/go/go.nix
+++ b/nixops/lib/go/go.nix
@@ -106,21 +106,22 @@ in
         sha1sum -c $TMPDIR/sum || (echo "❌ ERROR: go generate changed files" && exit 1)
 
         echo "➜ Running code formatters, if there are changes, fail"
-        golines -l --base-formatter=gofumpt . | diff - /dev/null
+        golines -l --base-formatter=gofumpt ${submodule} | diff - /dev/null
 
         echo "➜ Checking for vulnerabilities"
-        govulncheck -scan=package ./...
+        govulncheck -scan=package ./${submodule}/...
 
         echo "➜ Running golangci-lint"
         golangci-lint run \
           --timeout 600s \
-          ./...
+          ./${submodule}/...
 
         echo "➜ Running tests"
         richgo test \
           -tags="${pkgs.lib.strings.concatStringsSep " " tags}" \
           -ldflags="${pkgs.lib.strings.concatStringsSep " " ldflags}" \
-          -v ${goTestFlags} ./...
+          -v ${goTestFlags} \
+          ./${submodule}/...
 
         ${extraCheck}
 


### PR DESCRIPTION
### **PR Type**
Bug fix


___

### **Description**
- Scoped all Go tooling commands to target only the `submodule` directory

- Updated `golines`, `govulncheck`, `golangci-lint`, and `richgo test` to run on submodule path

- Fixed formatting check to prevent scanning entire repository when only submodule is relevant


___

### Diagram Walkthrough


```mermaid
flowchart LR
  A["Go tooling commands"] --> B["Previously: scan entire repo"]
  A --> C["Now: scan submodule only"]
  C --> D["golines formatter"]
  C --> E["govulncheck scanner"]
  C --> F["golangci-lint"]
  C --> G["richgo test"]
```



<details> <summary><h3> File Walkthrough</h3></summary>

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Bug fix</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>go.nix</strong><dd><code>Scope Go tooling commands to submodule directory</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

nixops/lib/go/go.nix

<ul><li>Updated <code>golines</code> formatter to target <code>${submodule}</code> instead of root <br>directory<br> <li> Modified <code>govulncheck</code> to scan <code>./${submodule}/...</code> instead of <code>./...</code><br> <li> Changed <code>golangci-lint</code> to run on <code>./${submodule}/...</code> path<br> <li> Updated <code>richgo test</code> command to execute tests in <code>./${submodule}/...</code></ul>


</details>


  </td>
  <td><a href="https://github.com/nhost/nhost/pull/3751/files#diff-711b0f2dfff3f38b941381bf6af354bcb322ef967cc0280aaf5a76677f2d375e">+5/-4</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

</details>

___

