### PR TITLE
fix(dashboard): make e2e tests more robust

### DIFF
--- a/dashboard/e2e/database/multiple-foreign-keys.test.ts
+++ b/dashboard/e2e/database/multiple-foreign-keys.test.ts
@@ -212,7 +212,7 @@ test('should create table with multiple foreign keys, then edit by removing one 
 
   await page.getByRole('button', { name: /save/i }).click();
 
-  await expect(page.getByText(/error/i)).not.toBeVisible();
+  await expect(page.getByText(/error:/i)).not.toBeVisible();
   await expect(page.locator('h2:has-text("Edit Table")')).not.toBeVisible();
 
   await expect(
@@ -316,7 +316,7 @@ test('should create table with multiple foreign keys pointing to the same column
 
   await page.getByRole('button', { name: /create/i }).click();
 
-  await expect(page.getByText(/error/i)).not.toBeVisible();
+  await expect(page.getByText(/error:/i)).not.toBeVisible();
   await expect(page.getByText(/create a new table/i)).not.toBeVisible();
 
   await page.waitForURL(

--- a/dashboard/e2e/setup/database.setup.ts
+++ b/dashboard/e2e/setup/database.setup.ts
@@ -1,13 +1,13 @@
 import { TEST_ORGANIZATION_SLUG, TEST_PROJECT_SUBDOMAIN } from '@/e2e/env';
-import { expect, test as teardown } from '@/e2e/fixtures/auth-hook';
+import { expect, test as setup } from '@/e2e/fixtures/auth-hook';
 
-teardown.beforeEach(async ({ authenticatedNhostPage: page }) => {
+setup.beforeEach(async ({ authenticatedNhostPage: page }) => {
   const databaseRoute = `/orgs/${TEST_ORGANIZATION_SLUG}/projects/${TEST_PROJECT_SUBDOMAIN}/database/browser/default`;
   await page.goto(databaseRoute);
   await page.waitForURL(databaseRoute);
 });
 
-teardown(
+setup(
   'clean up database tables',
   async ({ authenticatedNhostPage: page }) => {
     await page.getByRole('link', { name: /sql editor/i }).click();

--- a/dashboard/playwright.config.ts
+++ b/dashboard/playwright.config.ts
@@ -28,11 +28,6 @@ export default defineConfig({
     {
       name: 'setup',
       testMatch: ['**/setup/*.setup.ts'],
-      teardown: 'teardown',
-    },
-    {
-      name: 'teardown',
-      testMatch: ['**/teardown/*.teardown.ts'],
     },
     {
       name: 'main',


### PR DESCRIPTION
### **PR Type**
Tests


___

### **Description**
- Improved E2E test error message matching from `/error/i` to `/Error:/i`

- Added database cleanup teardown in setup file

- Removed separate teardown project configuration from Playwright config

- Consolidated test cleanup into setup phase for better reliability


___

### Diagram Walkthrough


```mermaid
flowchart LR
  A["Test Setup"] --> B["Database Cleanup"]
  B --> C["Test Execution"]
  C --> D["Error Validation"]
  D -- "More Specific Match" --> E["Test Completion"]
```



<details> <summary><h3> File Walkthrough</h3></summary>

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Tests</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>multiple-foreign-keys.test.ts</strong><dd><code>Refine error message matching in foreign key tests</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

dashboard/e2e/database/multiple-foreign-keys.test.ts

<ul><li>Changed error message assertion from <code>/error/i</code> to <code>/Error:/i</code> for more <br>precise matching<br> <li> Updated two test cases to use the more specific error text pattern</ul>


</details>


  </td>
  <td><a href="https://github.com/nhost/nhost/pull/3768/files#diff-fb8e9a62fc6518c8449086d935444c957043793919b738fae974f56a36907e53">+2/-2</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>database.setup.ts</strong><dd><code>Add database cleanup teardown in test setup</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

dashboard/e2e/setup/database.setup.ts

<ul><li>Added new teardown test to clean up database tables before tests<br> <li> Implemented SQL script to drop all public schema tables with CASCADE<br> <li> Added navigation to SQL editor and success verification</ul>


</details>


  </td>
  <td><a href="https://github.com/nhost/nhost/pull/3768/files#diff-2293b985b3e30b96bce05df44d2f7b5d31da26e29f8e1c9c669319cbbceef0d0">[link]</a>&nbsp; &nbsp; </td>

</tr>
</table></td></tr><tr><td><strong>Configuration changes</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>playwright.config.ts</strong><dd><code>Remove separate teardown project from Playwright configuration</code></dd></summary>
<hr>

dashboard/playwright.config.ts

<ul><li>Removed separate <code>teardown</code> project configuration<br> <li> Removed <code>teardown</code> property from setup project<br> <li> Simplified project structure by consolidating cleanup into setup</ul>


</details>


  </td>
  <td><a href="https://github.com/nhost/nhost/pull/3768/files#diff-3ce7004405593146d0b9c501fc50a6a5ae2da8bb48b57dee2faf79ca9c09cf62">+0/-5</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

</details>

___

