### PR TITLE
fix(nixops): avoid rebuilding nodePackages

### DIFF
--- a/nixops/overlays/js.nix
+++ b/nixops/overlays/js.nix
@@ -35,7 +35,7 @@ rec{
     };
   };
 
-  nodePackages = nodejs.pkgs;
+  nodePackages = prev.nodejs.pkgs;
 
   buildNpmPackage = prev.buildNpmPackage.override {
     nodejs = prev.nodejs;


### PR DESCRIPTION
### **User description**
### Checklist

- [ ] No breaking changes
- [ ] Tests pass
- [ ] New features have new tests
- [ ] Documentation is updated (if applicable)
- [ ] Title of the PR is in the correct format (see below)


___

### **PR Type**
Bug fix


___

### **Description**
- Fixed reference to `nodePackages` in Nix overlay configuration

- Changed from `nodejs.pkgs` to `prev.nodejs.pkgs` to resolve build error


___

### Diagram Walkthrough


```mermaid
flowchart LR
  A["nodejs overlay"] --> B["nodePackages definition"]
  B --> C["prev.nodejs.pkgs"]
```



<details> <summary><h3> File Walkthrough</h3></summary>

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Bug fix</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>js.nix</strong><dd><code>Fix nodePackages reference in Nix overlay</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

nixops/overlays/js.nix

<ul><li>Corrected <code>nodePackages</code> assignment from <code>nodejs.pkgs</code> to <code>prev.nodejs.pkgs</code><br> <li> Ensures proper reference to previous overlay scope</ul>


</details>


  </td>
  <td><a href="https://github.com/nhost/nhost/pull/3774/files#diff-97e4512702da292a4600b31097cf187d98b18c9af1a9b8a2f6af742b00664c06">+1/-1</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

</details>

___

