### PR TITLE
chore(cli): bump nhost/dashboard to 2.46.3

### DIFF
--- a/cli/cmd/dev/cloud.go
+++ b/cli/cmd/dev/cloud.go
@@ -56,7 +56,7 @@ func CommandCloud() *cli.Command {
 			&cli.StringFlag{ //nolint:exhaustruct
 				Name:    flagDashboardVersion,
 				Usage:   "Dashboard version to use",
-				Value:   "nhost/dashboard:2.44.1",
+				Value:   "nhost/dashboard:2.46.3",
 				Sources: cli.EnvVars("NHOST_DASHBOARD_VERSION"),
 			},
 			&cli.StringFlag{ //nolint:exhaustruct

--- a/cli/cmd/dev/up.go
+++ b/cli/cmd/dev/up.go
@@ -111,7 +111,7 @@ func CommandUp() *cli.Command { //nolint:funlen
 			&cli.StringFlag{ //nolint:exhaustruct
 				Name:    flagDashboardVersion,
 				Usage:   "Dashboard version to use",
-				Value:   "nhost/dashboard:2.44.1",
+				Value:   "nhost/dashboard:2.46.3",
 				Sources: cli.EnvVars("NHOST_DASHBOARD_VERSION"),
 			},
 			&cli.StringFlag{ //nolint:exhaustruct

--- a/docs/reference/cli/commands.mdx
+++ b/docs/reference/cli/commands.mdx
@@ -254,7 +254,7 @@ Start local development environment
 
 **--ca-certificates**="": Mounts and everrides path to CA certificates in the containers
 
-**--dashboard-version**="": Dashboard version to use (default: nhost/dashboard:2.44.1)
+**--dashboard-version**="": Dashboard version to use (default: nhost/dashboard:2.46.3)
 
 **--disable-tls**: Disable TLS
 
@@ -284,7 +284,7 @@ Start local development environment connected to an Nhost Cloud project (BETA)
 
 **--ca-certificates**="": Mounts and everrides path to CA certificates in the containers
 
-**--dashboard-version**="": Dashboard version to use (default: nhost/dashboard:2.44.1)
+**--dashboard-version**="": Dashboard version to use (default: nhost/dashboard:2.46.3)
 
 **--disable-tls**: Disable TLS
 


### PR DESCRIPTION
This PR bumps the Nhost Dashboard Docker image to version 2.46.3.