### PR TITLE
chore(ci): set on pull_request as opencode doesn't support pull_request_target

### DIFF
--- a/.github/workflows/gen_ai_review.yaml
+++ b/.github/workflows/gen_ai_review.yaml
@@ -1,7 +1,8 @@
 ---
 name: "gen: AI review"
 on:
-  pull_request_target:
+  # pull_request_target not supported
+  pull_request:
     types: [opened, reopened, ready_for_review]
   issue_comment:
     types: [created]
@@ -12,7 +13,7 @@ jobs:
   opencode:
     if: |
       (
-        github.event_name == 'pull_request_target' &&
+        github.event_name == 'pull_request' &&
         contains(fromJson('["OWNER","MEMBER"]'), github.event.pull_request.author_association)
       ) ||
       (


### PR DESCRIPTION
Updates the AI review workflow to use `pull_request` trigger instead of `pull_request_target` since OpenCode doesn't support the latter.

## Changes
- Changed trigger from `pull_request_target` to `pull_request` in `.github/workflows/gen_ai_review.yaml`
- Updated the conditional logic to check for `pull_request` event instead of `pull_request_target`
- Added explanatory comment about the limitation

This change ensures the OpenCode AI review workflow can function properly while maintaining the same access controls for repository owners and members.