### PR TITLE
fix(dashboard): prevent undefined property access when deleting row with event trigger

### DIFF
--- a/dashboard/src/features/orgs/projects/database/dataGrid/components/DataBrowserGridControls/DataBrowserGridControls.tsx
+++ b/dashboard/src/features/orgs/projects/database/dataGrid/components/DataBrowserGridControls/DataBrowserGridControls.tsx
@@ -80,7 +80,7 @@ export default function DataBrowserGridControls({
   const eventTriggersCount = eventTriggersByTable?.length ?? 0;
 
   const showInvokeEventTriggerButton =
-    numberOfSelectedRows === 1 && eventTriggersCount > 0;
+    selectedRows?.length === 1 && eventTriggersCount > 0;
 
   async function handleRowDelete() {
     if (!selectedRows?.length) {


### PR DESCRIPTION
## Summary

Fixes a runtime error that occurs when deleting a row in a table with event triggers. After deletion, the `selectedRows` state becomes undefined, but the component was checking a derived property that could mask this state, causing undefined property access when rendering the InvokeEventTriggerButton.

## Changes

- Changed condition from `numberOfSelectedRows === 1` to `selectedRows?.length === 1` in `showInvokeEventTriggerButton` logic
- Ensures the InvokeEventTriggerButton is properly hidden when `selectedRows` becomes undefined after deletion

## Root Cause

The `numberOfSelectedRows` variable falls back to `selectedRowsBeforeDelete.length` when `selectedRows` is undefined, masking the true state. However, the `InvokeEventTriggerButton` component directly accesses `selectedRows[0].values`, causing a runtime error.

<img width="1886" height="398" alt="Error screenshot showing undefined property access" src="https://github.com/user-attachments/assets/10d8483f-d42a-4d13-b550-8006697a71e9" />

### Checklist

- [X] No breaking changes
- [X] Tests pass
- [X] New features have new tests
- [X] Documentation is updated (if applicable)
- [X] Title of the PR is in the correct format (see below)