### PR TITLE
chore(ci): run ci on pull_request and trigger contributors tests with /ok-to-test

### DIFF
--- a/.github/actions/check-pr-authorization/action.yml
+++ b/.github/actions/check-pr-authorization/action.yml
@@ -1,0 +1,48 @@
+name: 'Check PR Authorization'
+description: 'Check if the workflow should run based on author/commenter authorization and get PR details'
+
+outputs:
+  should_run:
+    description: 'Whether the workflow should run (true/false)'
+    value: ${{ steps.check.outputs.should_run }}
+  sha:
+    description: 'The SHA to checkout'
+    value: ${{ steps.pr.outputs.sha }}
+
+runs:
+  using: 'composite'
+  steps:
+    - name: Check authorization
+      id: check
+      shell: bash
+      run: |
+        if [[ "${{ github.event_name }}" == "push" ]]; then
+          echo "should_run=true" >> $GITHUB_OUTPUT
+        elif [[ "${{ github.event_name }}" == "pull_request" ]]; then
+          if [[ "${{ contains(fromJson('["OWNER", "MEMBER"]'), github.event.pull_request.author_association) }}" == "true" ]]; then
+            echo "should_run=true" >> $GITHUB_OUTPUT
+          else
+            echo "should_run=false" >> $GITHUB_OUTPUT
+          fi
+        elif [[ "${{ github.event_name }}" == "issue_comment" ]]; then
+          if [[ "${{ github.event.issue.pull_request && startsWith(github.event.comment.body, '/ok-to-test') && contains(fromJson('["OWNER", "MEMBER"]'), github.event.comment.author_association) }}" == "true" ]]; then
+            echo "should_run=true" >> $GITHUB_OUTPUT
+          else
+            echo "should_run=false" >> $GITHUB_OUTPUT
+          fi
+        else
+          echo "should_run=false" >> $GITHUB_OUTPUT
+        fi
+
+    - name: Get PR SHA
+      id: pr
+      if: steps.check.outputs.should_run == 'true'
+      shell: bash
+      run: |
+        if [[ "${{ github.event_name }}" == "push" ]]; then
+          echo "sha=${{ github.sha }}" >> $GITHUB_OUTPUT
+        elif [[ "${{ github.event_name }}" == "pull_request" ]]; then
+          echo "sha=${{ github.event.pull_request.head.sha }}" >> $GITHUB_OUTPUT
+        elif [[ "${{ github.event_name }}" == "issue_comment" ]]; then
+          echo "sha=refs/pull/${{ github.event.issue.number }}/head" >> $GITHUB_OUTPUT
+        fi

--- a/.github/workflows/auth_checks.yaml
+++ b/.github/workflows/auth_checks.yaml
@@ -1,7 +1,7 @@
 ---
 name: "auth: check and build"
 on:
-  pull_request_target:
+  pull_request:
     paths:
       - '.github/workflows/auth_checks.yaml'
       - '.github/workflows/wf_check.yaml'
@@ -22,35 +22,35 @@ on:
 
       # auth
       - 'services/auth/**'
+  issue_comment:
+    types: [created]
   push:
     branches:
       - main
 
 concurrency:
-  group: ${{ github.workflow }}-${{ github.event_name == 'pull_request' && format('pr-{0}', github.event.pull_request.number) || format('push-{0}', github.sha) }}
-  cancel-in-progress: ${{ github.event_name == 'pull_request' }}
+  group: ${{ github.workflow }}-${{ github.event_name == 'pull_request' && format('pr-{0}', github.event.pull_request.number) || github.event_name == 'issue_comment' && format('pr-{0}', github.event.issue.number) || format('push-{0}', github.sha) }}
+  cancel-in-progress: ${{ github.event_name == 'pull_request' || github.event_name == 'issue_comment' }}
 
 jobs:
-  check-permissions:
+  check-pr-authorization:
     runs-on: ubuntu-latest
+    outputs:
+      should_run: ${{ steps.auth.outputs.should_run }}
+      sha: ${{ steps.auth.outputs.sha }}
     steps:
-      - run: |
-          echo "github.event_name: ${{ github.event_name }}"
-          echo "github.event.pull_request.author_association: ${{ github.event.pull_request.author_association }}"
-      - name: "This task will run and fail if user has no permissions and label safe_to_test isn't present"
-        if: "github.event_name == 'pull_request_target' && ! ( contains(github.event.pull_request.labels.*.name, 'safe_to_test') || contains(fromJson('[\"OWNER\", \"MEMBER\", \"COLLABORATOR\"]'), github.event.pull_request.author_association) )"
-        run: |
-          exit 1
+      - uses: actions/checkout@v6
+      - id: auth
+        uses: ./.github/actions/check-pr-authorization
 
   tests:
+    needs: check-pr-authorization
+    if: needs.check-pr-authorization.outputs.should_run == 'true'
     uses: ./.github/workflows/wf_check.yaml
-    needs:
-      - check-permissions
     with:
       NAME: auth
       PATH: services/auth
-      GIT_REF: ${{ github.event_name == 'pull_request_target' && github.event.pull_request.head.sha || github.sha }}
-
+      GIT_REF: ${{ needs.check-pr-authorization.outputs.sha }}
     secrets:
       AWS_ACCOUNT_ID: ${{ secrets.AWS_PRODUCTION_CORE_ACCOUNT_ID }}
       NIX_CACHE_PUB_KEY: ${{ secrets.NIX_CACHE_PUB_KEY }}
@@ -58,27 +58,16 @@ jobs:
       NHOST_PAT: ${{ secrets.NHOST_PAT }}
 
   build_artifacts:
+    needs: check-pr-authorization
+    if: needs.check-pr-authorization.outputs.should_run == 'true'
     uses: ./.github/workflows/wf_build_artifacts.yaml
-    needs:
-      - check-permissions
     with:
       NAME: auth
       PATH: services/auth
-      GIT_REF: ${{ github.event_name == 'pull_request_target' && github.event.pull_request.head.sha || github.sha }}
+      GIT_REF: ${{ needs.check-pr-authorization.outputs.sha }}
       VERSION: 0.0.0-dev # we use a fixed version here to avoid unnecessary rebuilds
       DOCKER: true
     secrets:
       AWS_ACCOUNT_ID: ${{ secrets.AWS_PRODUCTION_CORE_ACCOUNT_ID }}
       NIX_CACHE_PUB_KEY: ${{ secrets.NIX_CACHE_PUB_KEY }}
       NIX_CACHE_PRIV_KEY: ${{ secrets.NIX_CACHE_PRIV_KEY }}
-
-  remove_label:
-    runs-on: ubuntu-latest
-    needs:
-      - check-permissions
-    steps:
-      - uses: actions-ecosystem/action-remove-labels@v1
-        with:
-          labels: |
-            safe_to_test
-    if: contains(github.event.pull_request.labels.*.name, 'safe_to_test')

--- a/.github/workflows/cli_checks.yaml
+++ b/.github/workflows/cli_checks.yaml
@@ -1,7 +1,7 @@
 ---
 name: "cli: check and build"
 on:
-  pull_request_target:
+  pull_request:
     paths:
       - '.github/workflows/cli_checks.yaml'
       - '.github/workflows/wf_check.yaml'
@@ -22,35 +22,35 @@ on:
 
       # cli
       - 'cli/**'
+  issue_comment:
+    types: [created]
   push:
     branches:
       - main
 
 concurrency:
-  group: ${{ github.workflow }}-${{ github.event_name == 'pull_request' && format('pr-{0}', github.event.pull_request.number) || format('push-{0}', github.sha) }}
-  cancel-in-progress: ${{ github.event_name == 'pull_request' }}
+  group: ${{ github.workflow }}-${{ github.event_name == 'pull_request' && format('pr-{0}', github.event.pull_request.number) || github.event_name == 'issue_comment' && format('pr-{0}', github.event.issue.number) || format('push-{0}', github.sha) }}
+  cancel-in-progress: ${{ github.event_name == 'pull_request' || github.event_name == 'issue_comment' }}
 
 jobs:
-  check-permissions:
+  check-pr-authorization:
     runs-on: ubuntu-latest
+    outputs:
+      should_run: ${{ steps.auth.outputs.should_run }}
+      sha: ${{ steps.auth.outputs.sha }}
     steps:
-      - run: |
-          echo "github.event_name: ${{ github.event_name }}"
-          echo "github.event.pull_request.author_association: ${{ github.event.pull_request.author_association }}"
-      - name: "This task will run and fail if user has no permissions and label safe_to_test isn't present"
-        if: "github.event_name == 'pull_request_target' && ! ( contains(github.event.pull_request.labels.*.name, 'safe_to_test') || contains(fromJson('[\"OWNER\", \"MEMBER\", \"COLLABORATOR\"]'), github.event.pull_request.author_association) )"
-        run: |
-          exit 1
+      - uses: actions/checkout@v6
+      - id: auth
+        uses: ./.github/actions/check-pr-authorization
 
   tests:
+    needs: check-pr-authorization
+    if: needs.check-pr-authorization.outputs.should_run == 'true'
     uses: ./.github/workflows/wf_check.yaml
-    needs:
-      - check-permissions
     with:
       NAME: cli
       PATH: cli
-      GIT_REF: ${{ github.event_name == 'pull_request_target' && github.event.pull_request.head.sha || github.sha }}
-
+      GIT_REF: ${{ needs.check-pr-authorization.outputs.sha }}
     secrets:
       AWS_ACCOUNT_ID: ${{ secrets.AWS_PRODUCTION_CORE_ACCOUNT_ID }}
       NIX_CACHE_PUB_KEY: ${{ secrets.NIX_CACHE_PUB_KEY }}
@@ -58,13 +58,13 @@ jobs:
       NHOST_PAT: ${{ secrets.NHOST_PAT }}
 
   build_artifacts:
+    needs: check-pr-authorization
+    if: needs.check-pr-authorization.outputs.should_run == 'true'
     uses: ./.github/workflows/wf_build_artifacts.yaml
-    needs:
-      - check-permissions
     with:
       NAME: cli
       PATH: cli
-      GIT_REF: ${{ github.event_name == 'pull_request_target' && github.event.pull_request.head.sha || github.sha }}
+      GIT_REF: ${{ needs.check-pr-authorization.outputs.sha }}
       VERSION: 0.0.0-dev # we use a fixed version here to avoid unnecessary rebuilds
       DOCKER: true
     secrets:
@@ -73,28 +73,17 @@ jobs:
       NIX_CACHE_PRIV_KEY: ${{ secrets.NIX_CACHE_PRIV_KEY }}
 
   test_cli_build:
-    uses: ./.github/workflows/cli_wf_test_new_project.yaml
     needs:
-      - check-permissions
+      - check-pr-authorization
       - build_artifacts
+    if: needs.check-pr-authorization.outputs.should_run == 'true'
+    uses: ./.github/workflows/cli_wf_test_new_project.yaml
     with:
       NAME: cli
       PATH: cli
-      GIT_REF: ${{ github.event_name == 'pull_request_target' && github.event.pull_request.head.sha || github.sha }}
-
+      GIT_REF: ${{ needs.check-pr-authorization.outputs.sha }}
     secrets:
       AWS_ACCOUNT_ID: ${{ secrets.AWS_PRODUCTION_CORE_ACCOUNT_ID }}
       NIX_CACHE_PUB_KEY: ${{ secrets.NIX_CACHE_PUB_KEY }}
       NIX_CACHE_PRIV_KEY: ${{ secrets.NIX_CACHE_PRIV_KEY }}
       NHOST_PAT: ${{ secrets.NHOST_PAT }}
-
-  remove_label:
-    runs-on: ubuntu-latest
-    needs:
-      - check-permissions
-    steps:
-      - uses: actions-ecosystem/action-remove-labels@v1
-        with:
-          labels: |
-            safe_to_test
-    if: contains(github.event.pull_request.labels.*.name, 'safe_to_test')

--- a/.github/workflows/codegen_checks.yaml
+++ b/.github/workflows/codegen_checks.yaml
@@ -1,7 +1,7 @@
 ---
 name: "codegen: check and build"
 on:
-  pull_request_target:
+  pull_request:
     paths:
       - '.github/workflows/wf_check.yaml'
       - '.github/workflows/codegen_checks.yaml'
@@ -20,62 +20,51 @@ on:
 
       # codegen
       - 'tools/codegen/**'
+  issue_comment:
+    types: [created]
   push:
     branches:
       - main
 
 concurrency:
-  group: ${{ github.workflow }}-${{ github.event_name == 'pull_request' && format('pr-{0}', github.event.pull_request.number) || format('push-{0}', github.sha) }}
-  cancel-in-progress: ${{ github.event_name == 'pull_request' }}
+  group: ${{ github.workflow }}-${{ github.event_name == 'pull_request' && format('pr-{0}', github.event.pull_request.number) || github.event_name == 'issue_comment' && format('pr-{0}', github.event.issue.number) || format('push-{0}', github.sha) }}
+  cancel-in-progress: ${{ github.event_name == 'pull_request' || github.event_name == 'issue_comment' }}
 
 jobs:
-  check-permissions:
+  check-pr-authorization:
     runs-on: ubuntu-latest
+    outputs:
+      should_run: ${{ steps.auth.outputs.should_run }}
+      sha: ${{ steps.auth.outputs.sha }}
     steps:
-      - run: |
-          echo "github.event_name: ${{ github.event_name }}"
-          echo "github.event.pull_request.author_association: ${{ github.event.pull_request.author_association }}"
-      - name: "This task will run and fail if user has no permissions and label safe_to_test isn't present"
-        if: "github.event_name == 'pull_request_target' && ! ( contains(github.event.pull_request.labels.*.name, 'safe_to_test') || contains(fromJson('[\"OWNER\", \"MEMBER\", \"COLLABORATOR\"]'), github.event.pull_request.author_association) )"
-        run: |
-          exit 1
+      - uses: actions/checkout@v6
+      - id: auth
+        uses: ./.github/actions/check-pr-authorization
 
   tests:
+    needs: check-pr-authorization
+    if: needs.check-pr-authorization.outputs.should_run == 'true'
     uses: ./.github/workflows/wf_check.yaml
-    needs:
-      - check-permissions
     with:
       NAME: codegen
       PATH: tools/codegen
-      GIT_REF: ${{ github.event_name == 'pull_request_target' && github.event.pull_request.head.sha || github.sha }}
-
+      GIT_REF: ${{ needs.check-pr-authorization.outputs.sha }}
     secrets:
       AWS_ACCOUNT_ID: ${{ secrets.AWS_PRODUCTION_CORE_ACCOUNT_ID }}
       NIX_CACHE_PUB_KEY: ${{ secrets.NIX_CACHE_PUB_KEY }}
       NIX_CACHE_PRIV_KEY: ${{ secrets.NIX_CACHE_PRIV_KEY }}
 
   build_artifacts:
+    needs: check-pr-authorization
+    if: needs.check-pr-authorization.outputs.should_run == 'true'
     uses: ./.github/workflows/wf_build_artifacts.yaml
-    needs:
-      - check-permissions
     with:
       NAME: codegen
       PATH: tools/codegen
-      GIT_REF: ${{ github.event_name == 'pull_request_target' && github.event.pull_request.head.sha || github.sha }}
+      GIT_REF: ${{ needs.check-pr-authorization.outputs.sha }}
       VERSION: 0.0.0-dev # we use a fixed version here to avoid unnecessary rebuilds
       DOCKER: false
     secrets:
       AWS_ACCOUNT_ID: ${{ secrets.AWS_PRODUCTION_CORE_ACCOUNT_ID }}
       NIX_CACHE_PUB_KEY: ${{ secrets.NIX_CACHE_PUB_KEY }}
       NIX_CACHE_PRIV_KEY: ${{ secrets.NIX_CACHE_PRIV_KEY }}
-
-  remove_label:
-    runs-on: ubuntu-latest
-    needs:
-      - check-permissions
-    steps:
-      - uses: actions-ecosystem/action-remove-labels@v1
-        with:
-          labels: |
-            safe_to_test
-    if: contains(github.event.pull_request.labels.*.name, 'safe_to_test')

--- a/.github/workflows/dashboard_checks.yaml
+++ b/.github/workflows/dashboard_checks.yaml
@@ -1,7 +1,7 @@
 ---
 name: "dashboard: check and build"
 on:
-  pull_request_target:
+  pull_request:
     paths:
       - '.github/workflows/wf_build_artifacts.yaml'
       - '.github/workflows/wf_check.yaml'
@@ -28,33 +28,34 @@ on:
 
       # nhost-js
       - packages/nhost-js/**
+  issue_comment:
+    types: [created]
   push:
     branches:
       - main
 
 concurrency:
-  group: ${{ github.workflow }}-${{ github.event_name == 'pull_request' && format('pr-{0}', github.event.pull_request.number) || format('push-{0}', github.sha) }}
-  cancel-in-progress: ${{ github.event_name == 'pull_request' }}
+  group: ${{ github.workflow }}-${{ github.event_name == 'pull_request' && format('pr-{0}', github.event.pull_request.number) || github.event_name == 'issue_comment' && format('pr-{0}', github.event.issue.number) || format('push-{0}', github.sha) }}
+  cancel-in-progress: ${{ github.event_name == 'pull_request' || github.event_name == 'issue_comment' }}
 
 jobs:
-  check-permissions:
+  check-pr-authorization:
     runs-on: ubuntu-latest
+    outputs:
+      should_run: ${{ steps.auth.outputs.should_run }}
+      sha: ${{ steps.auth.outputs.sha }}
     steps:
-      - run: |
-          echo "github.event_name: ${{ github.event_name }}"
-          echo "github.event.pull_request.author_association: ${{ github.event.pull_request.author_association }}"
-      - name: "This task will run and fail if user has no permissions and label safe_to_test isn't present"
-        if: "github.event_name == 'pull_request_target' && ! ( contains(github.event.pull_request.labels.*.name, 'safe_to_test') || contains(fromJson('[\"OWNER\", \"MEMBER\", \"COLLABORATOR\"]'), github.event.pull_request.author_association) )"
-        run: |
-          exit 1
+      - uses: actions/checkout@v6
+      - id: auth
+        uses: ./.github/actions/check-pr-authorization
 
   deploy-vercel:
+    needs: check-pr-authorization
+    if: needs.check-pr-authorization.outputs.should_run == 'true'
     uses: ./.github/workflows/wf_deploy_vercel.yaml
-    needs:
-      - check-permissions
     with:
       NAME: dashboard
-      GIT_REF: ${{ github.event_name == 'pull_request_target' && github.event.pull_request.head.sha || github.sha }}
+      GIT_REF: ${{ needs.check-pr-authorization.outputs.sha }}
       ENVIRONMENT: preview
     secrets:
       AWS_ACCOUNT_ID: ${{ secrets.AWS_PRODUCTION_CORE_ACCOUNT_ID }}
@@ -65,15 +66,14 @@ jobs:
       VERCEL_DEPLOY_TOKEN: ${{ secrets.DASHBOARD_VERCEL_DEPLOY_TOKEN }}
       TURBO_TOKEN: ${{ secrets.TURBO_TOKEN }}
 
-
   build_artifacts:
+    needs: check-pr-authorization
+    if: needs.check-pr-authorization.outputs.should_run == 'true'
     uses: ./.github/workflows/wf_build_artifacts.yaml
-    needs:
-      - check-permissions
     with:
       NAME: dashboard
       PATH: dashboard
-      GIT_REF: ${{ github.event_name == 'pull_request_target' && github.event.pull_request.head.sha || github.sha }}
+      GIT_REF: ${{ needs.check-pr-authorization.outputs.sha }}
       VERSION: 0.0.0-dev # we use a fixed version here to avoid unnecessary rebuilds
       DOCKER: true
       OS_MATRIX: '["blacksmith-2vcpu-ubuntu-2404"]'
@@ -82,32 +82,32 @@ jobs:
       NIX_CACHE_PUB_KEY: ${{ secrets.NIX_CACHE_PUB_KEY }}
       NIX_CACHE_PRIV_KEY: ${{ secrets.NIX_CACHE_PRIV_KEY }}
 
-
   tests:
-    uses: ./.github/workflows/wf_check.yaml
     needs:
-      - check-permissions
+      - check-pr-authorization
       - build_artifacts
+    if: needs.check-pr-authorization.outputs.should_run == 'true'
+    uses: ./.github/workflows/wf_check.yaml
     with:
       NAME: dashboard
       PATH: dashboard
-      GIT_REF: ${{ github.event_name == 'pull_request_target' && github.event.pull_request.head.sha || github.sha }}
+      GIT_REF: ${{ needs.check-pr-authorization.outputs.sha }}
     secrets:
       AWS_ACCOUNT_ID: ${{ secrets.AWS_PRODUCTION_CORE_ACCOUNT_ID }}
       NIX_CACHE_PUB_KEY: ${{ secrets.NIX_CACHE_PUB_KEY }}
       NIX_CACHE_PRIV_KEY: ${{ secrets.NIX_CACHE_PRIV_KEY }}
 
-
   e2e_staging:
-    uses: ./.github/workflows/dashboard_wf_e2e_staging.yaml
     needs:
-      - check-permissions
+      - check-pr-authorization
       - deploy-vercel
       - build_artifacts
+    if: needs.check-pr-authorization.outputs.should_run == 'true'
+    uses: ./.github/workflows/dashboard_wf_e2e_staging.yaml
     with:
       NAME: dashboard
       PATH: dashboard
-      GIT_REF: ${{ github.event_name == 'pull_request_target' && github.event.pull_request.head.sha || github.sha }}
+      GIT_REF: ${{ needs.check-pr-authorization.outputs.sha }}
       NHOST_TEST_DASHBOARD_URL: ${{ needs.deploy-vercel.outputs.preview-url }}
       NHOST_TEST_PROJECT_NAME: ${{ vars.NHOST_TEST_PROJECT_NAME }}
       NHOST_TEST_ORGANIZATION_NAME: ${{ vars.NHOST_TEST_ORGANIZATION_NAME }}
@@ -130,14 +130,3 @@ jobs:
       PLAYWRIGHT_REPORT_ENCRYPTION_KEY: ${{ secrets.PLAYWRIGHT_REPORT_ENCRYPTION_KEY }}
       NHOST_TEST_STAGING_SUBDOMAIN: ${{ secrets.NHOST_TEST_STAGING_SUBDOMAIN }}
       NHOST_TEST_STAGING_REGION: ${{ secrets.NHOST_TEST_STAGING_REGION }}
-
-  remove_label:
-    runs-on: ubuntu-latest
-    needs:
-      - check-permissions
-    steps:
-      - uses: actions-ecosystem/action-remove-labels@v1
-        with:
-          labels: |
-            safe_to_test
-    if: contains(github.event.pull_request.labels.*.name, 'safe_to_test')

--- a/.github/workflows/docs_checks.yaml
+++ b/.github/workflows/docs_checks.yaml
@@ -1,7 +1,7 @@
 ---
 name: "docs: check and build"
 on:
-  pull_request_target:
+  pull_request:
     paths:
       - '.github/workflows/wf_check.yaml'
       - '.github/workflows/dashboard_checks.yaml'
@@ -34,48 +34,36 @@ on:
 
       # cli
       - cli/**
+  issue_comment:
+    types: [created]
   push:
     branches:
       - main
 
 concurrency:
-  group: ${{ github.workflow }}-${{ github.event_name == 'pull_request' && format('pr-{0}', github.event.pull_request.number) || format('push-{0}', github.sha) }}
-  cancel-in-progress: ${{ github.event_name == 'pull_request' }}
+  group: ${{ github.workflow }}-${{ github.event_name == 'pull_request' && format('pr-{0}', github.event.pull_request.number) || github.event_name == 'issue_comment' && format('pr-{0}', github.event.issue.number) || format('push-{0}', github.sha) }}
+  cancel-in-progress: ${{ github.event_name == 'pull_request' || github.event_name == 'issue_comment' }}
 
 jobs:
-  check-permissions:
+  check-pr-authorization:
     runs-on: ubuntu-latest
+    outputs:
+      should_run: ${{ steps.auth.outputs.should_run }}
+      sha: ${{ steps.auth.outputs.sha }}
     steps:
-      - run: |
-          echo "github.event_name: ${{ github.event_name }}"
-          echo "github.event.pull_request.author_association: ${{ github.event.pull_request.author_association }}"
-      - name: "This task will run and fail if user has no permissions and label safe_to_test isn't present"
-        if: "github.event_name == 'pull_request_target' && ! ( contains(github.event.pull_request.labels.*.name, 'safe_to_test') || contains(fromJson('[\"OWNER\", \"MEMBER\", \"COLLABORATOR\"]'), github.event.pull_request.author_association) )"
-        run: |
-          exit 1
-
+      - uses: actions/checkout@v6
+      - id: auth
+        uses: ./.github/actions/check-pr-authorization
 
   tests:
+    needs: check-pr-authorization
+    if: needs.check-pr-authorization.outputs.should_run == 'true'
     uses: ./.github/workflows/wf_check.yaml
-    needs:
-      - check-permissions
     with:
       NAME: docs
       PATH: docs
-      GIT_REF: ${{ github.event_name == 'pull_request_target' && github.event.pull_request.head.sha || github.sha }}
+      GIT_REF: ${{ needs.check-pr-authorization.outputs.sha }}
     secrets:
       AWS_ACCOUNT_ID: ${{ secrets.AWS_PRODUCTION_CORE_ACCOUNT_ID }}
       NIX_CACHE_PUB_KEY: ${{ secrets.NIX_CACHE_PUB_KEY }}
       NIX_CACHE_PRIV_KEY: ${{ secrets.NIX_CACHE_PRIV_KEY }}
-
-
-  remove_label:
-    runs-on: ubuntu-latest
-    needs:
-      - check-permissions
-    steps:
-      - uses: actions-ecosystem/action-remove-labels@v1
-        with:
-          labels: |
-            safe_to_test
-    if: contains(github.event.pull_request.labels.*.name, 'safe_to_test')

--- a/.github/workflows/examples_demos_checks.yaml
+++ b/.github/workflows/examples_demos_checks.yaml
@@ -1,7 +1,7 @@
 ---
 name: "examples/demos: check and build"
 on:
-  pull_request_target:
+  pull_request:
     paths:
       - '.github/workflows/wf_check.yaml'
       - '.github/workflows/examples_demos_checks.yaml'
@@ -36,48 +36,48 @@ on:
 
       # demos
       - 'examples/demos/**'
+  issue_comment:
+    types: [created]
   push:
     branches:
       - main
 
 concurrency:
-  group: ${{ github.workflow }}-${{ github.event_name == 'pull_request' && format('pr-{0}', github.event.pull_request.number) || format('push-{0}', github.sha) }}
-  cancel-in-progress: ${{ github.event_name == 'pull_request' }}
+  group: ${{ github.workflow }}-${{ github.event_name == 'pull_request' && format('pr-{0}', github.event.pull_request.number) || github.event_name == 'issue_comment' && format('pr-{0}', github.event.issue.number) || format('push-{0}', github.sha) }}
+  cancel-in-progress: ${{ github.event_name == 'pull_request' || github.event_name == 'issue_comment' }}
 
 jobs:
-  check-permissions:
+  check-pr-authorization:
     runs-on: ubuntu-latest
+    outputs:
+      should_run: ${{ steps.auth.outputs.should_run }}
+      sha: ${{ steps.auth.outputs.sha }}
     steps:
-      - run: |
-          echo "github.event_name: ${{ github.event_name }}"
-          echo "github.event.pull_request.author_association: ${{ github.event.pull_request.author_association }}"
-      - name: "This task will run and fail if user has no permissions and label safe_to_test isn't present"
-        if: "github.event_name == 'pull_request_target' && ! ( contains(github.event.pull_request.labels.*.name, 'safe_to_test') || contains(fromJson('[\"OWNER\", \"MEMBER\", \"COLLABORATOR\"]'), github.event.pull_request.author_association) )"
-        run: |
-          exit 1
+      - uses: actions/checkout@v6
+      - id: auth
+        uses: ./.github/actions/check-pr-authorization
 
   tests:
+    needs: check-pr-authorization
+    if: needs.check-pr-authorization.outputs.should_run == 'true'
     uses: ./.github/workflows/wf_check.yaml
-    needs:
-      - check-permissions
     with:
       NAME: demos
       PATH: examples/demos
-      GIT_REF: ${{ github.event_name == 'pull_request_target' && github.event.pull_request.head.sha || github.sha }}
-
+      GIT_REF: ${{ needs.check-pr-authorization.outputs.sha }}
     secrets:
       AWS_ACCOUNT_ID: ${{ secrets.AWS_PRODUCTION_CORE_ACCOUNT_ID }}
       NIX_CACHE_PUB_KEY: ${{ secrets.NIX_CACHE_PUB_KEY }}
       NIX_CACHE_PRIV_KEY: ${{ secrets.NIX_CACHE_PRIV_KEY }}
 
   build_artifacts:
+    needs: check-pr-authorization
+    if: needs.check-pr-authorization.outputs.should_run == 'true'
     uses: ./.github/workflows/wf_build_artifacts.yaml
-    needs:
-      - check-permissions
     with:
       NAME: demos
       PATH: examples/demos
-      GIT_REF: ${{ github.event_name == 'pull_request_target' && github.event.pull_request.head.sha || github.sha }}
+      GIT_REF: ${{ needs.check-pr-authorization.outputs.sha }}
       VERSION: 0.0.0-dev # we use a fixed version here to avoid unnecessary rebuilds
       DOCKER: false
       OS_MATRIX: '["blacksmith-2vcpu-ubuntu-2404"]'
@@ -85,14 +85,3 @@ jobs:
       AWS_ACCOUNT_ID: ${{ secrets.AWS_PRODUCTION_CORE_ACCOUNT_ID }}
       NIX_CACHE_PUB_KEY: ${{ secrets.NIX_CACHE_PUB_KEY }}
       NIX_CACHE_PRIV_KEY: ${{ secrets.NIX_CACHE_PRIV_KEY }}
-
-  remove_label:
-    runs-on: ubuntu-latest
-    needs:
-      - check-permissions
-    steps:
-      - uses: actions-ecosystem/action-remove-labels@v1
-        with:
-          labels: |
-            safe_to_test
-    if: contains(github.event.pull_request.labels.*.name, 'safe_to_test')

--- a/.github/workflows/examples_guides_checks.yaml
+++ b/.github/workflows/examples_guides_checks.yaml
@@ -1,7 +1,7 @@
 ---
 name: "examples/guides: check and build"
 on:
-  pull_request_target:
+  pull_request:
     paths:
       - '.github/workflows/wf_check.yaml'
       - '.github/workflows/examples_guides_checks.yaml'
@@ -36,48 +36,48 @@ on:
 
       # guides
       - 'examples/guides/**'
+  issue_comment:
+    types: [created]
   push:
     branches:
       - main
 
 concurrency:
-  group: ${{ github.workflow }}-${{ github.event_name == 'pull_request' && format('pr-{0}', github.event.pull_request.number) || format('push-{0}', github.sha) }}
-  cancel-in-progress: ${{ github.event_name == 'pull_request' }}
+  group: ${{ github.workflow }}-${{ github.event_name == 'pull_request' && format('pr-{0}', github.event.pull_request.number) || github.event_name == 'issue_comment' && format('pr-{0}', github.event.issue.number) || format('push-{0}', github.sha) }}
+  cancel-in-progress: ${{ github.event_name == 'pull_request' || github.event_name == 'issue_comment' }}
 
 jobs:
-  check-permissions:
+  check-pr-authorization:
     runs-on: ubuntu-latest
+    outputs:
+      should_run: ${{ steps.auth.outputs.should_run }}
+      sha: ${{ steps.auth.outputs.sha }}
     steps:
-      - run: |
-          echo "github.event_name: ${{ github.event_name }}"
-          echo "github.event.pull_request.author_association: ${{ github.event.pull_request.author_association }}"
-      - name: "This task will run and fail if user has no permissions and label safe_to_test isn't present"
-        if: "github.event_name == 'pull_request_target' && ! ( contains(github.event.pull_request.labels.*.name, 'safe_to_test') || contains(fromJson('[\"OWNER\", \"MEMBER\", \"COLLABORATOR\"]'), github.event.pull_request.author_association) )"
-        run: |
-          exit 1
+      - uses: actions/checkout@v6
+      - id: auth
+        uses: ./.github/actions/check-pr-authorization
 
   tests:
+    needs: check-pr-authorization
+    if: needs.check-pr-authorization.outputs.should_run == 'true'
     uses: ./.github/workflows/wf_check.yaml
-    needs:
-      - check-permissions
     with:
       NAME: guides
       PATH: examples/guides
-      GIT_REF: ${{ github.event_name == 'pull_request_target' && github.event.pull_request.head.sha || github.sha }}
-
+      GIT_REF: ${{ needs.check-pr-authorization.outputs.sha }}
     secrets:
       AWS_ACCOUNT_ID: ${{ secrets.AWS_PRODUCTION_CORE_ACCOUNT_ID }}
       NIX_CACHE_PUB_KEY: ${{ secrets.NIX_CACHE_PUB_KEY }}
       NIX_CACHE_PRIV_KEY: ${{ secrets.NIX_CACHE_PRIV_KEY }}
 
   build_artifacts:
+    needs: check-pr-authorization
+    if: needs.check-pr-authorization.outputs.should_run == 'true'
     uses: ./.github/workflows/wf_build_artifacts.yaml
-    needs:
-      - check-permissions
     with:
       NAME: guides
       PATH: examples/guides
-      GIT_REF: ${{ github.event_name == 'pull_request_target' && github.event.pull_request.head.sha || github.sha }}
+      GIT_REF: ${{ needs.check-pr-authorization.outputs.sha }}
       VERSION: 0.0.0-dev # we use a fixed version here to avoid unnecessary rebuilds
       DOCKER: false
       OS_MATRIX: '["blacksmith-2vcpu-ubuntu-2404"]'
@@ -85,14 +85,3 @@ jobs:
       AWS_ACCOUNT_ID: ${{ secrets.AWS_PRODUCTION_CORE_ACCOUNT_ID }}
       NIX_CACHE_PUB_KEY: ${{ secrets.NIX_CACHE_PUB_KEY }}
       NIX_CACHE_PRIV_KEY: ${{ secrets.NIX_CACHE_PRIV_KEY }}
-
-  remove_label:
-    runs-on: ubuntu-latest
-    needs:
-      - check-permissions
-    steps:
-      - uses: actions-ecosystem/action-remove-labels@v1
-        with:
-          labels: |
-            safe_to_test
-    if: contains(github.event.pull_request.labels.*.name, 'safe_to_test')

--- a/.github/workflows/examples_tutorials_checks.yaml
+++ b/.github/workflows/examples_tutorials_checks.yaml
@@ -1,7 +1,7 @@
 ---
 name: "examples/tutorials: check and build"
 on:
-  pull_request_target:
+  pull_request:
     paths:
       - '.github/workflows/wf_check.yaml'
       - '.github/workflows/examples_tutorials_checks.yaml'
@@ -36,48 +36,48 @@ on:
 
       # tutorials
       - 'examples/tutorials/**'
+  issue_comment:
+    types: [created]
   push:
     branches:
       - main
 
 concurrency:
-  group: ${{ github.workflow }}-${{ github.event_name == 'pull_request' && format('pr-{0}', github.event.pull_request.number) || format('push-{0}', github.sha) }}
-  cancel-in-progress: ${{ github.event_name == 'pull_request' }}
+  group: ${{ github.workflow }}-${{ github.event_name == 'pull_request' && format('pr-{0}', github.event.pull_request.number) || github.event_name == 'issue_comment' && format('pr-{0}', github.event.issue.number) || format('push-{0}', github.sha) }}
+  cancel-in-progress: ${{ github.event_name == 'pull_request' || github.event_name == 'issue_comment' }}
 
 jobs:
-  check-permissions:
+  check-pr-authorization:
     runs-on: ubuntu-latest
+    outputs:
+      should_run: ${{ steps.auth.outputs.should_run }}
+      sha: ${{ steps.auth.outputs.sha }}
     steps:
-      - run: |
-          echo "github.event_name: ${{ github.event_name }}"
-          echo "github.event.pull_request.author_association: ${{ github.event.pull_request.author_association }}"
-      - name: "This task will run and fail if user has no permissions and label safe_to_test isn't present"
-        if: "github.event_name == 'pull_request_target' && ! ( contains(github.event.pull_request.labels.*.name, 'safe_to_test') || contains(fromJson('[\"OWNER\", \"MEMBER\", \"COLLABORATOR\"]'), github.event.pull_request.author_association) )"
-        run: |
-          exit 1
+      - uses: actions/checkout@v6
+      - id: auth
+        uses: ./.github/actions/check-pr-authorization
 
   tests:
+    needs: check-pr-authorization
+    if: needs.check-pr-authorization.outputs.should_run == 'true'
     uses: ./.github/workflows/wf_check.yaml
-    needs:
-      - check-permissions
     with:
       NAME: tutorials
       PATH: examples/tutorials
-      GIT_REF: ${{ github.event_name == 'pull_request_target' && github.event.pull_request.head.sha || github.sha }}
-
+      GIT_REF: ${{ needs.check-pr-authorization.outputs.sha }}
     secrets:
       AWS_ACCOUNT_ID: ${{ secrets.AWS_PRODUCTION_CORE_ACCOUNT_ID }}
       NIX_CACHE_PUB_KEY: ${{ secrets.NIX_CACHE_PUB_KEY }}
       NIX_CACHE_PRIV_KEY: ${{ secrets.NIX_CACHE_PRIV_KEY }}
 
   build_artifacts:
+    needs: check-pr-authorization
+    if: needs.check-pr-authorization.outputs.should_run == 'true'
     uses: ./.github/workflows/wf_build_artifacts.yaml
-    needs:
-      - check-permissions
     with:
       NAME: tutorials
       PATH: examples/tutorials
-      GIT_REF: ${{ github.event_name == 'pull_request_target' && github.event.pull_request.head.sha || github.sha }}
+      GIT_REF: ${{ needs.check-pr-authorization.outputs.sha }}
       VERSION: 0.0.0-dev # we use a fixed version here to avoid unnecessary rebuilds
       DOCKER: false
       OS_MATRIX: '["blacksmith-2vcpu-ubuntu-2404"]'
@@ -85,14 +85,3 @@ jobs:
       AWS_ACCOUNT_ID: ${{ secrets.AWS_PRODUCTION_CORE_ACCOUNT_ID }}
       NIX_CACHE_PUB_KEY: ${{ secrets.NIX_CACHE_PUB_KEY }}
       NIX_CACHE_PRIV_KEY: ${{ secrets.NIX_CACHE_PRIV_KEY }}
-
-  remove_label:
-    runs-on: ubuntu-latest
-    needs:
-      - check-permissions
-    steps:
-      - uses: actions-ecosystem/action-remove-labels@v1
-        with:
-          labels: |
-            safe_to_test
-    if: contains(github.event.pull_request.labels.*.name, 'safe_to_test')

--- a/.github/workflows/nhost-js_checks.yaml
+++ b/.github/workflows/nhost-js_checks.yaml
@@ -1,7 +1,7 @@
 ---
 name: "nhost-js: check and build"
 on:
-  pull_request_target:
+  pull_request:
     paths:
       - '.github/workflows/wf_check.yaml'
       - '.github/workflows/nhost-js_checks.yaml'
@@ -37,62 +37,51 @@ on:
       # apis
       - 'services/auth/docs/openapi.yaml'
       - 'services/storage/controller/openapi.yaml'
+  issue_comment:
+    types: [created]
   push:
     branches:
       - main
 
 concurrency:
-  group: ${{ github.workflow }}-${{ github.event_name == 'pull_request' && format('pr-{0}', github.event.pull_request.number) || format('push-{0}', github.sha) }}
-  cancel-in-progress: ${{ github.event_name == 'pull_request' }}
+  group: ${{ github.workflow }}-${{ github.event_name == 'pull_request' && format('pr-{0}', github.event.pull_request.number) || github.event_name == 'issue_comment' && format('pr-{0}', github.event.issue.number) || format('push-{0}', github.sha) }}
+  cancel-in-progress: ${{ github.event_name == 'pull_request' || github.event_name == 'issue_comment' }}
 
 jobs:
-  check-permissions:
+  check-pr-authorization:
     runs-on: ubuntu-latest
+    outputs:
+      should_run: ${{ steps.auth.outputs.should_run }}
+      sha: ${{ steps.auth.outputs.sha }}
     steps:
-      - run: |
-          echo "github.event_name: ${{ github.event_name }}"
-          echo "github.event.pull_request.author_association: ${{ github.event.pull_request.author_association }}"
-      - name: "This task will run and fail if user has no permissions and label safe_to_test isn't present"
-        if: "github.event_name == 'pull_request_target' && ! ( contains(github.event.pull_request.labels.*.name, 'safe_to_test') || contains(fromJson('[\"OWNER\", \"MEMBER\", \"COLLABORATOR\"]'), github.event.pull_request.author_association) )"
-        run: |
-          exit 1
+      - uses: actions/checkout@v6
+      - id: auth
+        uses: ./.github/actions/check-pr-authorization
 
   tests:
+    needs: check-pr-authorization
+    if: needs.check-pr-authorization.outputs.should_run == 'true'
     uses: ./.github/workflows/wf_check.yaml
-    needs:
-      - check-permissions
     with:
       NAME: nhost-js
       PATH: packages/nhost-js
-      GIT_REF: ${{ github.event_name == 'pull_request_target' && github.event.pull_request.head.sha || github.sha }}
-
+      GIT_REF: ${{ needs.check-pr-authorization.outputs.sha }}
     secrets:
       AWS_ACCOUNT_ID: ${{ secrets.AWS_PRODUCTION_CORE_ACCOUNT_ID }}
       NIX_CACHE_PUB_KEY: ${{ secrets.NIX_CACHE_PUB_KEY }}
       NIX_CACHE_PRIV_KEY: ${{ secrets.NIX_CACHE_PRIV_KEY }}
 
   build_artifacts:
+    needs: check-pr-authorization
+    if: needs.check-pr-authorization.outputs.should_run == 'true'
     uses: ./.github/workflows/wf_build_artifacts.yaml
-    needs:
-      - check-permissions
     with:
       NAME: nhost-js
       PATH: packages/nhost-js
-      GIT_REF: ${{ github.event_name == 'pull_request_target' && github.event.pull_request.head.sha || github.sha }}
+      GIT_REF: ${{ needs.check-pr-authorization.outputs.sha }}
       VERSION: 0.0.0-dev # we use a fixed version here to avoid unnecessary rebuilds
       DOCKER: false
     secrets:
       AWS_ACCOUNT_ID: ${{ secrets.AWS_PRODUCTION_CORE_ACCOUNT_ID }}
       NIX_CACHE_PUB_KEY: ${{ secrets.NIX_CACHE_PUB_KEY }}
       NIX_CACHE_PRIV_KEY: ${{ secrets.NIX_CACHE_PRIV_KEY }}
-
-  remove_label:
-    runs-on: ubuntu-latest
-    needs:
-      - check-permissions
-    steps:
-      - uses: actions-ecosystem/action-remove-labels@v1
-        with:
-          labels: |
-            safe_to_test
-    if: contains(github.event.pull_request.labels.*.name, 'safe_to_test')

--- a/.github/workflows/nixops_checks.yaml
+++ b/.github/workflows/nixops_checks.yaml
@@ -1,7 +1,7 @@
 ---
 name: "nixops: check and build"
 on:
-  pull_request_target:
+  pull_request:
     paths:
       - '.github/workflows/wf_check.yaml'
       - '.github/workflows/nixops_checks.yaml'
@@ -11,63 +11,51 @@ on:
       - 'flake.lock'
       - 'nixops/**'
       - 'build/**'
-
+  issue_comment:
+    types: [created]
   push:
     branches:
       - main
 
 concurrency:
-  group: ${{ github.workflow }}-${{ github.event_name == 'pull_request' && format('pr-{0}', github.event.pull_request.number) || format('push-{0}', github.sha) }}
-  cancel-in-progress: ${{ github.event_name == 'pull_request' }}
+  group: ${{ github.workflow }}-${{ github.event_name == 'pull_request' && format('pr-{0}', github.event.pull_request.number) || github.event_name == 'issue_comment' && format('pr-{0}', github.event.issue.number) || format('push-{0}', github.sha) }}
+  cancel-in-progress: ${{ github.event_name == 'pull_request' || github.event_name == 'issue_comment' }}
 
 jobs:
-  check-permissions:
+  check-pr-authorization:
     runs-on: ubuntu-latest
+    outputs:
+      should_run: ${{ steps.auth.outputs.should_run }}
+      sha: ${{ steps.auth.outputs.sha }}
     steps:
-      - run: |
-          echo "github.event_name: ${{ github.event_name }}"
-          echo "github.event.pull_request.author_association: ${{ github.event.pull_request.author_association }}"
-      - name: "This task will run and fail if user has no permissions and label safe_to_test isn't present"
-        if: "github.event_name == 'pull_request_target' && ! ( contains(github.event.pull_request.labels.*.name, 'safe_to_test') || contains(fromJson('[\"OWNER\", \"MEMBER\", \"COLLABORATOR\"]'), github.event.pull_request.author_association) )"
-        run: |
-          exit 1
+      - uses: actions/checkout@v6
+      - id: auth
+        uses: ./.github/actions/check-pr-authorization
 
   tests:
+    needs: check-pr-authorization
+    if: needs.check-pr-authorization.outputs.should_run == 'true'
     uses: ./.github/workflows/wf_check.yaml
-    needs:
-      - check-permissions
     with:
       NAME: nixops
       PATH: nixops
-      GIT_REF: ${{ github.event_name == 'pull_request_target' && github.event.pull_request.head.sha || github.sha }}
-
+      GIT_REF: ${{ needs.check-pr-authorization.outputs.sha }}
     secrets:
       AWS_ACCOUNT_ID: ${{ secrets.AWS_PRODUCTION_CORE_ACCOUNT_ID }}
       NIX_CACHE_PUB_KEY: ${{ secrets.NIX_CACHE_PUB_KEY }}
       NIX_CACHE_PRIV_KEY: ${{ secrets.NIX_CACHE_PRIV_KEY }}
 
   build_artifacts:
+    needs: check-pr-authorization
+    if: needs.check-pr-authorization.outputs.should_run == 'true'
     uses: ./.github/workflows/wf_build_artifacts.yaml
-    needs:
-      - check-permissions
     with:
       NAME: nixops
       PATH: nixops
-      GIT_REF: ${{ github.event_name == 'pull_request_target' && github.event.pull_request.head.sha || github.sha }}
+      GIT_REF: ${{ needs.check-pr-authorization.outputs.sha }}
       VERSION: 0.0.0-dev # we use a fixed version here to avoid unnecessary rebuilds
       DOCKER: true
     secrets:
       AWS_ACCOUNT_ID: ${{ secrets.AWS_PRODUCTION_CORE_ACCOUNT_ID }}
       NIX_CACHE_PUB_KEY: ${{ secrets.NIX_CACHE_PUB_KEY }}
       NIX_CACHE_PRIV_KEY: ${{ secrets.NIX_CACHE_PRIV_KEY }}
-
-  remove_label:
-    runs-on: ubuntu-latest
-    needs:
-      - check-permissions
-    steps:
-      - uses: actions-ecosystem/action-remove-labels@v1
-        with:
-          labels: |
-            safe_to_test
-    if: contains(github.event.pull_request.labels.*.name, 'safe_to_test')

--- a/.github/workflows/storage_checks.yaml
+++ b/.github/workflows/storage_checks.yaml
@@ -1,7 +1,7 @@
 ---
 name: "storage: check and build"
 on:
-  pull_request_target:
+  pull_request:
     paths:
       - '.github/workflows/storage_checks.yaml'
       - '.github/workflows/wf_check.yaml'
@@ -22,35 +22,35 @@ on:
 
       # storage
       - 'services/storage/**'
+  issue_comment:
+    types: [created]
   push:
     branches:
       - main
 
 concurrency:
-  group: ${{ github.workflow }}-${{ github.event_name == 'pull_request' && format('pr-{0}', github.event.pull_request.number) || format('push-{0}', github.sha) }}
-  cancel-in-progress: ${{ github.event_name == 'pull_request' }}
+  group: ${{ github.workflow }}-${{ github.event_name == 'pull_request' && format('pr-{0}', github.event.pull_request.number) || github.event_name == 'issue_comment' && format('pr-{0}', github.event.issue.number) || format('push-{0}', github.sha) }}
+  cancel-in-progress: ${{ github.event_name == 'pull_request' || github.event_name == 'issue_comment' }}
 
 jobs:
-  check-permissions:
+  check-pr-authorization:
     runs-on: ubuntu-latest
+    outputs:
+      should_run: ${{ steps.auth.outputs.should_run }}
+      sha: ${{ steps.auth.outputs.sha }}
     steps:
-      - run: |
-          echo "github.event_name: ${{ github.event_name }}"
-          echo "github.event.pull_request.author_association: ${{ github.event.pull_request.author_association }}"
-      - name: "This task will run and fail if user has no permissions and label safe_to_test isn't present"
-        if: "github.event_name == 'pull_request_target' && ! ( contains(github.event.pull_request.labels.*.name, 'safe_to_test') || contains(fromJson('[\"OWNER\", \"MEMBER\", \"COLLABORATOR\"]'), github.event.pull_request.author_association) )"
-        run: |
-          exit 1
+      - uses: actions/checkout@v6
+      - id: auth
+        uses: ./.github/actions/check-pr-authorization
 
   tests:
+    needs: check-pr-authorization
+    if: needs.check-pr-authorization.outputs.should_run == 'true'
     uses: ./.github/workflows/wf_check.yaml
-    needs:
-      - check-permissions
     with:
       NAME: storage
       PATH: services/storage
-      GIT_REF: ${{ github.event_name == 'pull_request_target' && github.event.pull_request.head.sha || github.sha }}
-
+      GIT_REF: ${{ needs.check-pr-authorization.outputs.sha }}
     secrets:
       AWS_ACCOUNT_ID: ${{ secrets.AWS_PRODUCTION_CORE_ACCOUNT_ID }}
       NIX_CACHE_PUB_KEY: ${{ secrets.NIX_CACHE_PUB_KEY }}
@@ -58,27 +58,16 @@ jobs:
       NHOST_PAT: ${{ secrets.NHOST_PAT }}
 
   build_artifacts:
+    needs: check-pr-authorization
+    if: needs.check-pr-authorization.outputs.should_run == 'true'
     uses: ./.github/workflows/wf_build_artifacts.yaml
-    needs:
-      - check-permissions
     with:
       NAME: storage
       PATH: services/storage
-      GIT_REF: ${{ github.event_name == 'pull_request_target' && github.event.pull_request.head.sha || github.sha }}
+      GIT_REF: ${{ needs.check-pr-authorization.outputs.sha }}
       VERSION: 0.0.0-dev # we use a fixed version here to avoid unnecessary rebuilds
       DOCKER: true
     secrets:
       AWS_ACCOUNT_ID: ${{ secrets.AWS_PRODUCTION_CORE_ACCOUNT_ID }}
       NIX_CACHE_PUB_KEY: ${{ secrets.NIX_CACHE_PUB_KEY }}
       NIX_CACHE_PRIV_KEY: ${{ secrets.NIX_CACHE_PRIV_KEY }}
-
-  remove_label:
-    runs-on: ubuntu-latest
-    needs:
-      - check-permissions
-    steps:
-      - uses: actions-ecosystem/action-remove-labels@v1
-        with:
-          labels: |
-            safe_to_test
-    if: contains(github.event.pull_request.labels.*.name, 'safe_to_test')


### PR DESCRIPTION
## Summary

This PR modernizes the CI/CD security model by:
- **Replacing `pull_request_target` with `pull_request`** for safer execution of untrusted code
- **Removing dependency on manual `safe_to_test` labels** for streamlined workflow management
- **Introducing `/ok-to-test` comment trigger** for contributors to manually approve external contributions
- **Centralizing authorization logic** in a reusable composite action

## Key Changes

### Security Improvements
- Workflows now run in the PR's context (`pull_request`) instead of the target branch context (`pull_request_target`)\n- Eliminates risk of untrusted code accessing secrets during initial execution\n- External contributors require explicit approval via `/ok-to-test` comment from repository members/owners\n\n### Workflow Automation\n- **New composite action**: `.github/actions/check-pr-authorization` handles all authorization logic\n- **Automatic execution** for repository members and owners\n- **Manual approval workflow** for external contributors via issue comments\n- **Consistent authorization pattern** across all 11 affected workflows\n\n### Breaking Changes\n- **`safe_to_test` label no longer used** - workflows will not run for external contributors without `/ok-to-test` approval\n- **New concurrency grouping** includes issue comment events for proper job cancellation\n\n## Testing\n- [x] Verified authorization logic handles all event types correctly\n- [x] Confirmed proper SHA resolution for different trigger events\n- [x] Tested concurrency grouping with multiple event types\n\n## Migration Impact\n- External contributors will need to wait for `/ok-to-test` approval instead of label assignment\n- Repository members/owners will see immediate workflow execution on PR creation\n- No changes required for existing development workflows