### PR TITLE
fix(nixops): remove references to go binary

### DIFF
--- a/nixops/lib/go/go.nix
+++ b/nixops/lib/go/go.nix
@@ -139,7 +139,7 @@ in
     , nativeBuildInputs
     , postInstall ? ""
     }: (pkgs.buildGoModule.override { go = pkgs.go; } {
-      inherit src version ldflags buildInputs nativeBuildInputs;
+      inherit src version ldflags buildInputs;
 
       pname = name;
 
@@ -148,6 +148,8 @@ in
       doCheck = false;
 
       subPackages = [ submodule ];
+
+      nativeBuildInputs = nativeBuildInputs ++ [ pkgs.removeReferencesTo ];
 
       postInstall = postInstall;
 
@@ -165,6 +167,10 @@ in
           mv $dir/* $dir/..
           rm -rf $dir
         fi
+      '';
+
+      postFixup = (old.postFixup or "") + ''
+        find $out/bin -type f -exec remove-references-to -t ${pkgs.go} {} +
       '';
     });
 


### PR DESCRIPTION
Fixes an issue where Go binaries built through the nixops package function retained references to the Go compiler/toolchain, causing unnecessary dependencies in the final binaries.

## Changes Made

- Add `pkgs.removeReferencesTo` to `nativeBuildInputs` to enable reference removal
- Add `postFixup` step that removes all references to `${pkgs.go}` from compiled binaries using `remove-references-to`
- Fix `nativeBuildInputs` parameter passing in the `buildGoModule` call

This reduces the closure size of Go binaries and prevents runtime dependencies on the Go toolchain, which is typically not needed in production deployments.