### PR TITLE
fix(nixops): re-sign macos binaries after stripping references

### DIFF
--- a/nixops/lib/go/go.nix
+++ b/nixops/lib/go/go.nix
@@ -149,7 +149,11 @@ in
 
       subPackages = [ submodule ];
 
-      nativeBuildInputs = nativeBuildInputs ++ [ pkgs.removeReferencesTo ];
+      nativeBuildInputs = nativeBuildInputs ++ [
+        pkgs.removeReferencesTo
+        pkgs.rcodesign
+        pkgs.file
+      ];
 
       postInstall = postInstall;
 
@@ -171,6 +175,13 @@ in
 
       postFixup = (old.postFixup or "") + ''
         find $out/bin -type f -exec remove-references-to -t ${pkgs.go} {} +
+
+        # Re-sign darwin (Mach-O) binaries after modification to fix invalid signatures
+        for f in $out/bin/*; do
+          if file "$f" | grep -q "Mach-O"; then
+            rcodesign sign "$f"
+          fi
+        done
       '';
     });
 


### PR DESCRIPTION
## Summary

This change fixes invalid code signature issues on macOS binaries built with Nix by re-signing them after the remove-references-to tool modifies the binaries.

## Changes

- Added rcodesign and file to nativeBuildInputs for macOS code signing capabilities
- Added post-fixup step to detect Mach-O binaries and re-sign them with ad-hoc signatures
- Conditional execution ensures the signing only occurs on macOS builds

## Problem Solved

When remove-references-to strips references from Go binaries on macOS, it modifies the binary content which invalidates existing code signatures. This causes runtime errors when trying to execute the binaries. The fix applies new ad-hoc signatures after the reference removal step.