### PR TITLE
fix(dashboard): Do not submit new record form after clicking on cancel

### DIFF
--- a/dashboard/src/features/orgs/projects/database/dataGrid/components/BaseRecordForm/BaseRecordForm.test.tsx
+++ b/dashboard/src/features/orgs/projects/database/dataGrid/components/BaseRecordForm/BaseRecordForm.test.tsx
@@ -1,0 +1,49 @@
+import { FormProvider, useForm } from 'react-hook-form';
+import { vi } from 'vitest';
+import type { DataBrowserGridColumn } from '@/features/orgs/projects/database/dataGrid/types/dataBrowser';
+import { render, screen, TestUserEvent } from '@/tests/testUtils';
+import BaseRecordForm, { type BaseRecordFormProps } from './BaseRecordForm';
+
+const mocks = vi.hoisted(() => ({
+  onSubmit: vi.fn(),
+  onCancel: vi.fn(),
+}));
+
+const mockColumns: DataBrowserGridColumn[] = [
+  {
+    id: 'col1',
+    isPrimary: true,
+    isNullable: false,
+    isIdentity: false,
+    defaultValue: null,
+    type: 'text',
+  },
+] as DataBrowserGridColumn[];
+
+function TestRecordFormWrapper(props: Partial<BaseRecordFormProps>) {
+  const methods = useForm();
+  return (
+    <FormProvider {...methods}>
+      <BaseRecordForm
+        columns={mockColumns}
+        onSubmit={mocks.onSubmit}
+        onCancel={mocks.onCancel}
+        {...props}
+      />
+    </FormProvider>
+  );
+}
+
+describe('BaseRecordForm', () => {
+  it('should not call onSubmit when cancel is clicked', async () => {
+    render(<TestRecordFormWrapper />);
+
+    const user = new TestUserEvent();
+    const cancelButton = screen.getByText(/cancel/i);
+
+    await user.click(cancelButton);
+
+    expect(mocks.onCancel).toHaveBeenCalled();
+    expect(mocks.onSubmit).not.toHaveBeenCalled();
+  });
+});

--- a/dashboard/src/features/orgs/projects/database/dataGrid/components/BaseRecordForm/BaseRecordForm.tsx
+++ b/dashboard/src/features/orgs/projects/database/dataGrid/components/BaseRecordForm/BaseRecordForm.tsx
@@ -166,6 +166,7 @@ export default function BaseRecordForm({
         <Button
           variant="outline"
           className="border-none"
+          type="button"
           size="sm"
           onClick={onCancel}
           tabIndex={isDirty ? -1 : 0}


### PR DESCRIPTION
## Summary

Fixes an issue where clicking the Cancel button in the BaseRecordForm component was inadvertently submitting the form instead of canceling the operation.

## Changes

- Added `type="button"` attribute to the Cancel button in `BaseRecordForm.tsx`
- Prevents the Cancel button from defaulting to `type="submit"` behavior

## Root Cause

Without an explicit `type` attribute, buttons inside HTML forms default to `type="submit"`. This caused the Cancel button to trigger form submission when clicked, creating the unintended behavior of creating new records when users intended to cancel.

## Impact

- **User Experience**: Users can now properly cancel form operations without accidentally creating records
- **Data Integrity**: Prevents unintended database insertions from accidental Cancel button clicks
- **No Breaking Changes**: This is a pure bug fix with no API changes

### Checklist

- [x] No breaking changes
- [ ] Tests pass
- [ ] New features have new tests
- [ ] Documentation is updated (if applicable)
- [x] Title of the PR is in the correct format