### PR TITLE
chore(nixops): update go to 1.25.6 due to CVE

### DIFF
--- a/nixops/overlays/go.nix
+++ b/nixops/overlays/go.nix
@@ -1,11 +1,11 @@
 final: prev: rec {
   go = prev.go_1_25.overrideAttrs
     (finalAttrs: previousAttrs: rec {
-      version = "1.25.5";
+      version = "1.25.6";
 
       src = final.fetchurl {
         url = "https://go.dev/dl/go${version}.src.tar.gz";
-        sha256 = "sha256-IqX9CpHvzSihsFNxBrmVmygEth9Zw3WLUejlQpwalU8=";
+        sha256 = "sha256-WMv3ceRNdt5vVtGeM7d9dFoeSJNAkih15GWFuXXCsFk=";
       };
 
     });


### PR DESCRIPTION
Updates Go runtime from 1.25.5 to 1.25.6 to address critical security vulnerabilities.

## Security Fixes Addressed

This release includes fixes for the following CVEs:
- **CVE-2025-68121**: crypto/tls Config.Clone session ticket key copying issue
- **CVE-2025-61728**: archive/zip denial of service vulnerability  
- **CVE-2025-61726**: net/http memory exhaustion in Request.ParseForm
- **CVE-2025-61731**: cmd/go flag sanitization bypass leading to code execution
- **CVE-2025-68119**: cmd/go unexpected code execution when invoking toolchain

## Changes
- Updated Go version from 1.25.5 to 1.25.6 in nixops/overlays/go.nix
- Updated corresponding SHA256 hash for source tarball verification

## Impact
This is a patch release with no breaking changes. All existing Go code should continue to work without modification.