### PR TITLE
fix(nixops): bump go to 1.25.7 due to cve

### DIFF
--- a/nixops/overlays/go.nix
+++ b/nixops/overlays/go.nix
@@ -1,11 +1,11 @@
 final: prev: rec {
   go = prev.go_1_25.overrideAttrs
     (finalAttrs: previousAttrs: rec {
-      version = "1.25.6";
+      version = "1.25.7";
 
       src = final.fetchurl {
         url = "https://go.dev/dl/go${version}.src.tar.gz";
-        sha256 = "sha256-WMv3ceRNdt5vVtGeM7d9dFoeSJNAkih15GWFuXXCsFk=";
+        sha256 = "sha256-F48oMoICdLQ+F30y8Go+uwEp5CfdIKXkyI3ywXY88Qo=";
       };
 
     });


### PR DESCRIPTION
This PR updates Go from version 1.25.6 to 1.25.7 to address critical security vulnerabilities.

## Security Fixes Included

Go 1.25.7 includes the following security fixes:
- **CVE-2025-61732**: Fixes potential code smuggling using doc comments in the  command
- **crypto/tls**: Fixes session resumption issues on macOS and applies lightweight chain validation
- **crypto/x509**: Resolves single-label excluded DNS name constraints incorrectly matching wildcard SANs

## Changes Made

- Updated Go version from 1.25.6 to 1.25.7
- Updated corresponding SHA256 hash for the new Go release

This update is essential for maintaining security compliance and should be deployed as soon as possible.