### PR TITLE
fix(dashboard): run type check before tests

### DIFF
--- a/dashboard/CLAUDE.md
+++ b/dashboard/CLAUDE.md
@@ -12,7 +12,7 @@ pnpm dev              # Start development server (port 3000)
 pnpm build            # Production build (skips lint)
 pnpm start            # Start production server
 pnpm lint             # Run both Biome and ESLint
-pnpm type-check       # TypeScript type checking
+pnpm test:typecheck       # TypeScript type checking
 ```
 
 ### Testing

--- a/dashboard/package.json
+++ b/dashboard/package.json
@@ -9,10 +9,11 @@
     "analyze": "ANALYZE=true pnpm build",
     "start": "next start",
     "lint": "biome check; b=$?; eslint src/; e=$?; [ $b -eq 0 ] && [ $e -eq 0 ]",
-    "test": "pnpm lint && pnpm test:vitest && pnpm test:broken-links",
+    "test": "pnpm test:typecheck && pnpm lint && pnpm test:vitest && pnpm test:broken-links",
     "test:vitest": "vitest run",
     "test:watch": "vitest",
     "test:broken-links": "lychee --config .lychee.toml \"src/**/*.tsx\" \"src/**/*.ts\"",
+    "test:typecheck": "tsc --noEmit --pretty -p tsconfig.json",
     "generate": "pnpm codegen-hasura-api",
     "codegen": "DOTENV_CONFIG_PATH=./.env.local graphql-codegen -r dotenv/config --config graphql.config.yaml --errors-only",
     "codegen-graphite": "graphql-codegen --config graphite.graphql.config.yaml --errors-only",
@@ -22,8 +23,7 @@
     "e2e:tests": "pnpm playwright test --config=playwright.config.ts -x",
     "e2e": "pnpm e2e:tests --project=main",
     "e2e:local": "pnpm e2e:tests --project=local",
-    "e2e:onboarding": "pnpm e2e:tests --project=onboarding",
-    "type-check": "tsc --noEmit --pretty -p tsconfig.json"
+    "e2e:onboarding": "pnpm e2e:tests --project=onboarding"
   },
   "dependencies": {
     "@apollo/client": "^3.14.0",

--- a/dashboard/src/features/orgs/projects/database/dataGrid/components/BaseTableForm/BaseTableForm.test.tsx
+++ b/dashboard/src/features/orgs/projects/database/dataGrid/components/BaseTableForm/BaseTableForm.test.tsx
@@ -324,7 +324,6 @@ describe('BaseTableForm', () => {
 
   it('should not display identity column picker when numeric type is selected', async () => {
     render(<TestTableFormWrapper />);
-    const user = new TestUserEvent();
 
     expect(screen.queryByLabelText('Identity')).not.toBeInTheDocument();
 

--- a/dashboard/src/features/orgs/projects/database/dataGrid/utils/prepareLocalRelationshipDTO/prepareLocalRelationshipDTO.test.ts
+++ b/dashboard/src/features/orgs/projects/database/dataGrid/utils/prepareLocalRelationshipDTO/prepareLocalRelationshipDTO.test.ts
@@ -18,7 +18,7 @@ describe('prepareLocalRelationshipDTO', () => {
         table: 'authors',
         source: 'default',
       },
-      relationshipType: 'object',
+      relationshipType: 'pg_create_object_relationship',
       fieldMapping: [
         {
           sourceColumn: 'author_id',
@@ -63,7 +63,7 @@ describe('prepareLocalRelationshipDTO', () => {
         table: 'books',
         source: 'default',
       },
-      relationshipType: 'array',
+      relationshipType: 'pg_create_array_relationship',
       fieldMapping: [
         {
           sourceColumn: 'id',

--- a/dashboard/src/features/orgs/projects/database/dataGrid/utils/prepareSuggestedRelationshipDTO/prepareSuggestedRelationshipDTO.test.ts
+++ b/dashboard/src/features/orgs/projects/database/dataGrid/utils/prepareSuggestedRelationshipDTO/prepareSuggestedRelationshipDTO.test.ts
@@ -1,7 +1,8 @@
 import { describe, expect, it } from 'vitest';
 import type {
   CreateLocalRelationshipArgs,
-  SuggestRelationshipsResponseRelationshipsItem,
+  SuggestedArrayRelationship,
+  SuggestedObjectRelationship,
 } from '@/utils/hasura-api/generated/schemas';
 import prepareSuggestedRelationshipDTO from './prepareSuggestedRelationshipDTO';
 
@@ -10,7 +11,7 @@ const source = 'default';
 
 describe('prepareSuggestedRelationshipDTO', () => {
   it('should create a valid object relationship DTO with manual configuration', () => {
-    const arrayRelSuggestion: SuggestRelationshipsResponseRelationshipsItem = {
+    const arrayRelSuggestion: SuggestedArrayRelationship = {
       type: 'array',
       from: {
         table: {
@@ -58,7 +59,7 @@ describe('prepareSuggestedRelationshipDTO', () => {
   });
 
   it('should create a valid object relationship DTO from a suggested relationship', () => {
-    const objectRelSuggestion: SuggestRelationshipsResponseRelationshipsItem = {
+    const objectRelSuggestion: SuggestedObjectRelationship = {
       type: 'object',
       from: {
         table: {


### PR DESCRIPTION
### Summary

This PR adds TypeScript type checking as the first step in the test pipeline for the dashboard package.

**Changes:**
- Modified the  script in  to run  before linting and testing
- Ensures TypeScript compilation errors are caught early in the development workflow
- Aligns the dashboard testing pipeline with other packages in the monorepo (e.g., nhost-js)

**Benefits:**
- Prevents TypeScript errors from reaching CI/CD without being caught
- Enforces type safety as a first-class concern in the development process  
- Improves developer experience by catching type issues before running expensive tests
- Follows industry best practices for TypeScript projects

### Checklist

- [x] No breaking changes
- [ ] Tests pass (pending CI)
- [ ] New features have new tests (N/A)
- [ ] Documentation is updated (if applicable)
- [x] Title of the PR is in the correct format