### PR TITLE
feat(codegen): implement support for application/x-www-form-urlencoded

### DIFF
--- a/tools/codegen/processor/intermediate_test.go
+++ b/tools/codegen/processor/intermediate_test.go
@@ -3,6 +3,7 @@ package processor_test
 import (
 	"bytes"
 	"errors"
+	"flag"
 	"fmt"
 	"os"
 	"testing"
@@ -13,6 +14,9 @@ import (
 	v3 "github.com/pb33f/libopenapi/datamodel/high/v3"
 	"github.com/stretchr/testify/assert"
 )
+
+//nolint:gochecknoglobals
+var flagUpdate = flag.Bool("update", false, "update expected output files with current output")
 
 func getModel(filepath string) (*libopenapi.DocumentModel[v3.Document], error) {
 	// Read OpenAPI file
@@ -54,6 +58,9 @@ func TestInterMediateRepresentationRender(t *testing.T) {
 		{
 			name: "content.yaml",
 		},
+		{
+			name: "form-url-encoded.yaml",
+		},
 	}
 
 	for _, tc := range cases {
@@ -77,18 +84,21 @@ func TestInterMediateRepresentationRender(t *testing.T) {
 
 			output := buf.String()
 
-			// f, err := os.OpenFile(
-			// 	"testdata/"+tc.name+".ts",
-			// 	os.O_CREATE|os.O_WRONLY|os.O_TRUNC,
-			// 	0o644,
-			// )
-			// if err != nil {
-			// 	t.Fatalf("failed to open output file: %v", err)
-			// }
-			// defer f.Close()
-			// if _, err := f.WriteString(output); err != nil {
-			// 	t.Fatalf("failed to write output file: %v", err)
-			// }
+			if *flagUpdate {
+				f, err := os.OpenFile(
+					"testdata/"+tc.name+".ts",
+					os.O_CREATE|os.O_WRONLY|os.O_TRUNC,
+					0o644,
+				)
+				if err != nil {
+					t.Fatalf("failed to open output file: %v", err)
+				}
+				defer f.Close()
+
+				if _, err := f.WriteString(output); err != nil {
+					t.Fatalf("failed to write output file: %v", err)
+				}
+			}
 
 			b, err := os.ReadFile("testdata/" + tc.name + ".ts")
 			if err != nil {

--- a/tools/codegen/processor/methods.go
+++ b/tools/codegen/processor/methods.go
@@ -15,6 +15,7 @@ const (
 	minStatusForError           = 300
 	mediaApplicationJSON        = "application/json"
 	mediaApplicationOctetStream = "application/octet-stream"
+	mediaFormURLEncoded         = "application/x-www-form-urlencoded"
 )
 
 type Method struct {
@@ -131,6 +132,16 @@ func (m *Method) RequestJSON() Type { //nolint:ireturn
 func (m *Method) RequestFormData() Type { //nolint:ireturn
 	for m, t := range m.Bodies {
 		if m == "multipart/form-data" {
+			return t
+		}
+	}
+
+	return nil
+}
+
+func (m *Method) RequestFormURLEncoded() Type { //nolint:ireturn
+	for m, t := range m.Bodies {
+		if m == mediaFormURLEncoded {
 			return t
 		}
 	}

--- a/tools/codegen/processor/testdata/form-url-encoded.yaml
+++ b/tools/codegen/processor/testdata/form-url-encoded.yaml
@@ -1,0 +1,57 @@
+openapi: "3.0.0"
+
+paths:
+  /oauth2/revoke:
+    post:
+      summary: OAuth2 Token Revocation (RFC 7009)
+      description: Revoke an access token or refresh token.
+      operationId: oauth2Revoke
+      tags:
+        - session
+      requestBody:
+        required: true
+        content:
+          application/x-www-form-urlencoded:
+            schema:
+              $ref: "#/components/schemas/OAuth2RevokeRequest"
+      responses:
+        "200":
+          description: Token successfully revoked (or was already invalid)
+        default:
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/OAuth2ErrorResponse"
+          description: OAuth2 error response
+
+components:
+  schemas:
+    OAuth2RevokeRequest:
+      type: object
+      properties:
+        token:
+          type: string
+        token_type_hint:
+          type: string
+          enum: [access_token, refresh_token]
+          nullable: true
+        client_id:
+          type: string
+          nullable: true
+        client_secret:
+          type: string
+          nullable: true
+      required:
+        - token
+
+    OAuth2ErrorResponse:
+      type: object
+      properties:
+        error:
+          type: string
+          description: OAuth2 error code
+        error_description:
+          type: string
+          description: Human-readable error description
+      required:
+        - error

--- a/tools/codegen/processor/testdata/form-url-encoded.yaml.ts
+++ b/tools/codegen/processor/testdata/form-url-encoded.yaml.ts
@@ -1,0 +1,140 @@
+/**
+ * This file is auto-generated. Do not edit manually.
+ */
+
+import type { ChainFunction, FetchResponse } from "../fetch";
+import { createEnhancedFetch, FetchError } from "../fetch";
+
+/**
+ * 
+ */
+export type OAuth2RevokeRequestToken_type_hint = "access_token" | "refresh_token";
+
+
+/**
+ * 
+ @property token (`string`) - 
+ @property token_type_hint? (`OAuth2RevokeRequestToken_type_hint`) - 
+ @property client_id? (`string`) - 
+ @property client_secret? (`string`) - */
+export interface OAuth2RevokeRequest {
+  /**
+   * 
+   */
+  token: string,
+  /**
+   * 
+   */
+  token_type_hint?: OAuth2RevokeRequestToken_type_hint,
+  /**
+   * 
+   */
+  client_id?: string,
+  /**
+   * 
+   */
+  client_secret?: string,
+};
+
+
+/**
+ * 
+ @property error (`string`) - OAuth2 error code
+ @property error_description? (`string`) - Human-readable error description*/
+export interface OAuth2ErrorResponse {
+  /**
+   * OAuth2 error code
+   */
+  error: string,
+  /**
+   * Human-readable error description
+   */
+  error_description?: string,
+};
+
+
+
+export interface Client {
+  baseURL: string;
+
+  /** Add a middleware function to the fetch chain
+   * @param chainFunction - The middleware function to add
+   */
+  pushChainFunction(chainFunction: ChainFunction): void;
+    /**
+     Summary: OAuth2 Token Revocation (RFC 7009)
+     Revoke an access token or refresh token.
+
+     This method may return different T based on the response code:
+     - 200: void
+     */
+  oauth2Revoke(
+    body: OAuth2RevokeRequest,
+    options?: RequestInit,
+  ): Promise<FetchResponse<void>>;
+};
+
+
+export const createAPIClient = (
+  baseURL: string,
+  chainFunctions: ChainFunction[] = [],
+): Client => {
+  let fetch = createEnhancedFetch(chainFunctions);
+
+  const pushChainFunction = (chainFunction: ChainFunction) => {
+    chainFunctions.push(chainFunction);
+    fetch = createEnhancedFetch(chainFunctions);
+  };
+    const  oauth2Revoke = async (
+    body: OAuth2RevokeRequest,
+    options?: RequestInit,
+  ): Promise<FetchResponse<void>> => {
+    const url = `${ baseURL }/oauth2/revoke`;
+    const params = new URLSearchParams();
+    if (body["token"] !== undefined) {
+      params.append("token", String(body["token"]));
+    }
+    if (body["token_type_hint"] !== undefined) {
+      params.append("token_type_hint", String(body["token_type_hint"]));
+    }
+    if (body["client_id"] !== undefined) {
+      params.append("client_id", String(body["client_id"]));
+    }
+    if (body["client_secret"] !== undefined) {
+      params.append("client_secret", String(body["client_secret"]));
+    }
+
+    const res = await fetch(url, {
+      ...options,
+      method: "POST",
+      headers: {
+        "Content-Type": "application/x-www-form-urlencoded",
+        ...options?.headers,
+      },
+      body: params.toString(),
+    });
+
+    if (res.status >= 300) {
+      const responseBody = [412].includes(res.status) ? null : await res.text();
+      const payload: unknown = responseBody ? JSON.parse(responseBody) : {};
+      throw new FetchError(payload, res.status, res.headers);
+    }
+    
+    const payload: undefined = undefined;
+    
+
+    return {
+      body: payload,
+      status: res.status,
+      headers: res.headers,
+    } as FetchResponse<void>;
+
+  };
+
+
+  return {
+    baseURL,
+    pushChainFunction,
+      oauth2Revoke,
+  };
+};

--- a/tools/codegen/processor/typescript/templates/client.tmpl
+++ b/tools/codegen/processor/typescript/templates/client.tmpl
@@ -214,6 +214,31 @@ export const createAPIClient = (
       method: "{{ .Method }}",
       body: formData,
     });
+  {{- else if .RequestFormURLEncoded }}
+    const params = new URLSearchParams();
+    {{- range .RequestFormURLEncoded.Properties }}
+    {{- if eq .Type.Kind "array" }}
+    if (body["{{ .Name }}"] !== undefined) {
+      body["{{ .Name }}"].forEach((value) => {
+        params.append("{{ .Name }}", String(value));
+      });
+    }
+    {{- else }}
+    if (body["{{ .Name }}"] !== undefined) {
+      params.append("{{ .Name }}", String(body["{{ .Name }}"]));
+    }
+    {{- end }}
+    {{- end }}
+
+    const res = await fetch(url, {
+      ...options,
+      method: "{{ .Method }}",
+      headers: {
+        "Content-Type": "application/x-www-form-urlencoded",
+        ...options?.headers,
+      },
+      body: params.toString(),
+    });
   {{- else if not .RequestHasBody }}
     const res = await fetch(url, {
       ...options,


### PR DESCRIPTION
This PR implements support for `application/x-www-form-urlencoded` content type in the TypeScript code generator.

## Changes
- **Backend (Go)**: Added `RequestFormURLEncoded()` method to detect form-encoded request bodies
- **Template**: Extended client template to handle URL-encoded form data using `URLSearchParams`
- **Tests**: Added comprehensive test coverage with OAuth2 token revocation example
- **Test Infrastructure**: Improved test setup with `-update` flag for easier test data management

## Implementation Details
- Form data is serialized using the standard `URLSearchParams` API
- Proper Content-Type header (`application/x-www-form-urlencoded`) is set automatically
- Array values are handled correctly with multiple `append()` calls
- All field types are converted to strings as required by the URL-encoded format

## OAuth2 Use Case
This enhancement specifically enables OAuth2 token revocation endpoints (RFC 7009) and other OAuth2 flows that require form-encoded payloads instead of JSON.