### PR TITLE
fix(observability): do not alert on NoData as it can raise false alerts

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -36,6 +36,7 @@ Where `PKG` is:
 - `nhost-js`: For changes to the Nhost JavaScript SDK
 - `nixops`: For changes to the NixOps
 - `storage`: For changes to the Nhost Storage service
+- 'observability': For changes to the Nhost Observability managed service
 
 Where `SUMMARY` is a short description of what the PR does.
 

--- a/.github/actions/validate-pr-title/action.yaml
+++ b/.github/actions/validate-pr-title/action.yaml
@@ -17,7 +17,7 @@ runs:
 
         # Define valid types and packages
         VALID_TYPES="feat|fix|chore"
-        VALID_PKGS="auth|ci|cli|codegen|dashboard|deps|docs|examples|internal\/lib|nhost-js|nixops|storage"
+        VALID_PKGS="auth|ci|cli|codegen|dashboard|deps|docs|examples|internal\/lib|nhost-js|nixops|storage|observability"
 
         # Check if title matches the pattern TYPE(PKG): SUMMARY
         if [[ ! "$PR_TITLE" =~ ^(${VALID_TYPES})\((${VALID_PKGS})\):\ .+ ]]; then
@@ -32,7 +32,7 @@ runs:
           echo ""
           echo "Valid PKGs:"
           echo "  - auth, ci, cli, codegen, dashboard, deps, docs, examples,"
-          echo "  - nhost-js, nixops, storage"
+          echo "  - nhost-js, nixops, storage, observability, internal/lib"
           echo ""
           echo "Example: feat(cli): add new command for database migrations"
           exit 1

--- a/observability/grafana/rules_nhost.yaml
+++ b/observability/grafana/rules_nhost.yaml
@@ -51,7 +51,7 @@ groups:
                 maxDataPoints: 43200
                 refId: B
                 type: threshold
-          noDataState: Alerting
+          noDataState: OK
           execErrState: Alerting
           for: 15m
           annotations:
@@ -123,7 +123,7 @@ groups:
                 maxDataPoints: 43200
                 refId: B
                 type: threshold
-          noDataState: Alerting
+          noDataState: OK
           execErrState: Alerting
           for: 15m
           annotations:
@@ -195,7 +195,7 @@ groups:
                 maxDataPoints: 43200
                 refId: B
                 type: threshold
-          noDataState: Alerting
+          noDataState: OK
           execErrState: Alerting
           for: 15m
           annotations:
@@ -342,7 +342,7 @@ groups:
                 maxDataPoints: 43200
                 refId: B
                 type: threshold
-          noDataState: Alerting
+          noDataState: OK
           execErrState: Alerting
           for: 15m
           annotations:


### PR DESCRIPTION
## Summary

This PR fixes false alerting issues in Grafana observability rules by changing the noDataState from Alerting to OK for multiple alert rules.

## Changes Made

- Updated 4 alert rules in observability/grafana/rules_nhost.yaml to set noDataState: OK instead of noDataState: Alerting
- Added observability as a valid package prefix in PR title validation
- Updated PR template to document the new observability package scope

## Rationale

When monitoring systems have no data available (e.g., during maintenance windows, service restarts, or data collection gaps), setting noDataState: Alerting can trigger false positive alerts. By changing this to OK, we prevent unnecessary alert noise while still maintaining proper alerting when actual execution errors occur (execErrState: Alerting remains unchanged).