### PR TITLE
fix(ci): minor fixes to CI

### DIFF
--- a/.github/workflows/wf_docker_push_image.yaml
+++ b/.github/workflows/wf_docker_push_image.yaml
@@ -67,8 +67,7 @@ jobs:
           for ARCH in "x86_64" "aarch64"; do
             skopeo copy --insecure-policy \
               dir:/home/runner/artifacts/${{ inputs.NAME }}-docker-image-$ARCH-$VERSION \
-              docker-daemon:$CONTAINER_NAME:$VERSION-$ARCH
-            docker push $CONTAINER_NAME:$VERSION-$ARCH
+              docker://$CONTAINER_NAME:$VERSION-$ARCH
           done
 
           docker manifest create \

--- a/.github/workflows/wf_docker_push_image_ecr.yaml
+++ b/.github/workflows/wf_docker_push_image_ecr.yaml
@@ -62,7 +62,7 @@ jobs:
       - name: "Inspect artifacts"
         run: find ~/artifacts
 
-      - name: "Push docker image to docker hub"
+      - name: "Push docker image to ECR"
         run: |
           export NAME=${{ inputs.NAME }}
           export VERSION=${{ steps.vars.outputs.VERSION }}
@@ -72,8 +72,7 @@ jobs:
           for ARCH in "x86_64" "aarch64"; do
             skopeo copy --insecure-policy \
               dir:/home/runner/artifacts/${{ inputs.NAME }}-docker-image-$ARCH-$VERSION \
-              docker-daemon:$CONTAINER_NAME:$VERSION-$ARCH
-            docker push $CONTAINER_NAME:$VERSION-$ARCH
+              docker://$CONTAINER_NAME:$VERSION-$ARCH
           done
 
           docker manifest create \

--- a/services/storage/Makefile
+++ b/services/storage/Makefile
@@ -40,14 +40,12 @@ build-docker-image-clamav:  ## Build docker container for clamav
 		.\#packages.aarch64-linux.clamav-docker-image \
 		--print-build-logs
 	nix develop \#skopeo -c \
-		skopeo copy --insecure-policy dir:./result docker-daemon:clamav:$(VERSION)-aarch64
+		skopeo copy --insecure-policy dir:./result docker://nhost/clamav:$(VERSION)-aarch64
 	nix build $(docker-build-options) --show-trace \
 		.\#packages.x86_64-linux.clamav-docker-image \
 		--print-build-logs
 	nix develop \#skopeo -c \
-		skopeo copy --insecure-policy dir:./result docker-daemon:clamav:$(VERSION)-x86_64
-	docker push nhost/clamav:$(VERSION)-aarch64
-	docker push nhost/clamav:$(VERSION)-x86_64
+		skopeo copy --insecure-policy dir:./result docker://nhost/clamav:$(VERSION)-x86_64
 	docker manifest create \
 	  nhost/clamav:$(VERSION) \
 	    --amend nhost/clamav:$(VERSION)-aarch64 \


### PR DESCRIPTION
## Summary

This PR optimizes the Docker image pushing process by streamlining the skopeo copy operations. Instead of copying images to the local Docker daemon first and then pushing them separately, the changes enable direct copying from directories to remote registries, reducing intermediate steps and improving efficiency.

## Key Changes

- **GitHub Workflows**: Modified  and  to use direct skopeo copy to remote registries
- **Storage Makefile**: Updated  to streamline the ClamAV image build process with direct registry pushing
- **Process Simplification**: Eliminated intermediate docker daemon steps, reducing the two-step process (copy to daemon + push) to a single direct copy operation

## Benefits

- Reduced build time by eliminating intermediate steps
- Lower disk space usage (no temporary images in local daemon)
- Cleaner and more maintainable CI pipeline
- Consistent approach across all image push workflows