### PR TITLE
fix(docs): removed unnecessary js to force sections open

### DIFF
--- a/docs/astro.config.mjs
+++ b/docs/astro.config.mjs
@@ -346,7 +346,7 @@ export default defineConfig({
                 },
                 {
                   label: 'Workflows',
-                  collapsed: true,
+                  collapsed: false,
                   items: [
                     { slug: 'products/auth/workflows/email-password' },
                     { slug: 'products/auth/workflows/passwordless-email' },
@@ -361,7 +361,7 @@ export default defineConfig({
                 },
                 {
                   label: 'Security',
-                  collapsed: true,
+                  collapsed: false,
                   items: [
                     { slug: 'products/auth/elevated-permissions' },
                     { slug: 'products/auth/bot-protection' },
@@ -402,7 +402,7 @@ export default defineConfig({
                 },
                 {
                   label: 'Platform',
-                  collapsed: true,
+                  collapsed: false,
                   items: [
                     { slug: 'products/storage/cdn' },
                     { slug: 'products/storage/antivirus' },
@@ -513,7 +513,7 @@ export default defineConfig({
                 },
                 {
                   label: 'Development',
-                  collapsed: true,
+                  collapsed: false,
                   items: [
                     { slug: 'platform/cli' },
                     { slug: 'platform/cli/local-development' },
@@ -537,7 +537,7 @@ export default defineConfig({
                 },
                 {
                   label: 'Self-Hosting',
-                  collapsed: true,
+                  collapsed: false,
                   items: [
                     { slug: 'platform/self-hosting' },
                     { slug: 'platform/self-hosting/community' },
@@ -647,7 +647,7 @@ export default defineConfig({
                 },
                 {
                   label: 'Deprecated Libraries',
-                  collapsed: true,
+                  collapsed: false,
                   autogenerate: { directory: 'reference/deprecated' },
                 },
               ],

--- a/docs/src/components/Header.astro
+++ b/docs/src/components/Header.astro
@@ -552,25 +552,6 @@ const currentSection = navLinks.find((link) => {
 </nav>
 
 <script>
-    // Force all top-level sidebar sections to be always open
-    function forceOpenSidebarSections() {
-        const sidebar = document.querySelector('.sidebar-content');
-        if (sidebar) {
-            // Open all top-level details elements
-            sidebar.querySelectorAll('ul.top-level > li > details').forEach(details => {
-                details.setAttribute('open', '');
-            });
-        }
-    }
-
-    // Run on initial load
-    forceOpenSidebarSections();
-
-    // Re-run after Astro view transitions
-    document.addEventListener('astro:after-swap', () => {
-        forceOpenSidebarSections();
-    });
-
     // Mobile navigation toggle
     const mobileNavToggle = document.getElementById('mobile-nav-toggle');
     const mobileNav = document.getElementById('mobile-nav');


### PR DESCRIPTION
## Summary

This PR fixes a documentation sidebar navigation issue by removing unnecessary JavaScript code that was forcing sidebar sections to be always open, which was causing the sidebar to lose its position state during navigation.

## Changes

- **Removed JavaScript sidebar forcing logic** (Header.astro): Eliminated the forceOpenSidebarSections() function and its event listeners that were programmatically opening all sidebar sections
- **Updated sidebar configuration** (astro.config.mjs): Changed 6 sidebar sections from collapsed: true to collapsed: false to maintain the expanded state through configuration instead of JavaScript manipulation

## Impact

- Fixes sidebar navigation state persistence issues
- Improves user experience by maintaining proper navigation context
- Simplifies codebase by removing unnecessary JavaScript intervention in favor of declarative configuration