### PR TITLE
fix(dashboard): invalid permissions SDL composition in remote schemas if using local dashboard

### DIFF
--- a/dashboard/src/features/orgs/projects/remote-schemas/utils/composePermissionSDL.ts
+++ b/dashboard/src/features/orgs/projects/remote-schemas/utils/composePermissionSDL.ts
@@ -56,13 +56,12 @@ function printTypeSDL(
       }
 
       let fieldStr = f.name;
-      let valueStr = '';
 
       if (!typeName.startsWith('enum')) {
         if (f.args && !isEmptyValue(f.args)) {
           fieldStr = `${fieldStr}(`;
           Object.values(f.args).forEach((arg: GraphQLInputField) => {
-            valueStr = `${arg.name} : ${arg.type.toString()}`;
+            let valueStr = `${arg.name} : ${arg.type.toString()}`;
 
             if (arg.defaultValue !== undefined) {
               const defaultValue = stringifyGraphQLValue({
@@ -92,11 +91,7 @@ function printTypeSDL(
         }
       }
 
-      if (typeName.startsWith('input')) {
-        result = `${result}\n      ${valueStr}`;
-      } else {
-        result = `${result}\n      ${fieldStr}`;
-      }
+      result = `${result}\n      ${fieldStr}`;
     });
   }
 


### PR DESCRIPTION
### Summary

This fix resolves an issue in the remote schema permission SDL composition logic where the generated SDL was invalid when using input types. The previous implementation incorrectly handled the scope of the `valueStr` variable, causing it to be used outside its intended scope for input types.

### Key Changes

- Fixed variable scope issue in `printTypeSDL` function by moving `valueStr` declaration inside the argument processing loop
- Removed the conditional logic that was incorrectly appending `valueStr` for input types instead of the properly formatted `fieldStr`
- This ensures that all type definitions (including input types) are consistently formatted in the generated SDL

### Testing

The fix has been tested with local dashboard instances using remote schemas with input types to verify SDL generation is now valid.

### Checklist

- [X] No breaking changes
- [X] Tests pass
- [X] New features have new tests
- [X] Documentation is updated (if applicable)  
- [X] Title of the PR is in the correct format (see below)