### PR TITLE
chore(cli): bump nhost/dashboard to 2.52.0

### DIFF
--- a/cli/cmd/dev/cloud.go
+++ b/cli/cmd/dev/cloud.go
@@ -56,7 +56,7 @@ func CommandCloud() *cli.Command {
 			&cli.StringFlag{ //nolint:exhaustruct
 				Name:    flagDashboardVersion,
 				Usage:   "Dashboard version to use",
-				Value:   "nhost/dashboard:2.50.0",
+				Value:   "nhost/dashboard:2.52.0",
 				Sources: cli.EnvVars("NHOST_DASHBOARD_VERSION"),
 			},
 			&cli.StringFlag{ //nolint:exhaustruct

--- a/cli/cmd/dev/up.go
+++ b/cli/cmd/dev/up.go
@@ -111,7 +111,7 @@ func CommandUp() *cli.Command { //nolint:funlen
 			&cli.StringFlag{ //nolint:exhaustruct
 				Name:    flagDashboardVersion,
 				Usage:   "Dashboard version to use",
-				Value:   "nhost/dashboard:2.50.0",
+				Value:   "nhost/dashboard:2.52.0",
 				Sources: cli.EnvVars("NHOST_DASHBOARD_VERSION"),
 			},
 			&cli.StringFlag{ //nolint:exhaustruct

--- a/docs/src/content/docs/reference/cli/commands.mdx
+++ b/docs/src/content/docs/reference/cli/commands.mdx
@@ -254,7 +254,7 @@ Start local development environment
 
 **--ca-certificates**="": Mounts and everrides path to CA certificates in the containers [$NHOST_CA_CERTIFICATES]
 
-**--dashboard-version**="": Dashboard version to use (default: "nhost/dashboard:2.50.0") [$NHOST_DASHBOARD_VERSION]
+**--dashboard-version**="": Dashboard version to use (default: "nhost/dashboard:2.52.0") [$NHOST_DASHBOARD_VERSION]
 
 **--disable-tls**: Disable TLS [$NHOST_DISABLE_TLS]
 
@@ -284,7 +284,7 @@ Start local development environment connected to an Nhost Cloud project (BETA)
 
 **--ca-certificates**="": Mounts and everrides path to CA certificates in the containers [$NHOST_CA_CERTIFICATES]
 
-**--dashboard-version**="": Dashboard version to use (default: "nhost/dashboard:2.50.0") [$NHOST_DASHBOARD_VERSION]
+**--dashboard-version**="": Dashboard version to use (default: "nhost/dashboard:2.52.0") [$NHOST_DASHBOARD_VERSION]
 
 **--disable-tls**: Disable TLS [$NHOST_DISABLE_TLS]
 


### PR DESCRIPTION
This PR bumps the Nhost Dashboard Docker image to version 2.52.0.