### PR TITLE
fix(dashboard): avoid refetching too aggressively

### DIFF
--- a/dashboard/src/features/orgs/projects/database/dataGrid/components/DataBrowserGrid/DataGridQueryParamsProvider/DataGridQueryParamsProvider.tsx
+++ b/dashboard/src/features/orgs/projects/database/dataGrid/components/DataBrowserGrid/DataGridQueryParamsProvider/DataGridQueryParamsProvider.tsx
@@ -78,6 +78,7 @@ function DataGridQueryParamsProvider({ children }: PropsWithChildren) {
     const filtersForTheTable = getDataGridFilters(tablePath);
     _setAppliedFilters(filtersForTheTable);
     setSortBy([]);
+    setCurrentOffset(0);
   }, [tablePath]);
 
   isFiltersLoadedFromStorage.current = compareLoadedFiltersToStorage(

--- a/dashboard/src/pages/_app.tsx
+++ b/dashboard/src/pages/_app.tsx
@@ -38,7 +38,7 @@ const clientSideEmotionCache = createEmotionCache();
 const queryClient = new QueryClient({
   defaultOptions: {
     queries: {
-      staleTime: 30_000,
+      staleTime: 5_000,
     },
   },
 });

--- a/dashboard/src/pages/_app.tsx
+++ b/dashboard/src/pages/_app.tsx
@@ -35,7 +35,13 @@ import { RecoilRoot } from 'recoil';
 
 // Client-side cache, shared for the whole session of the user in the browser.
 const clientSideEmotionCache = createEmotionCache();
-const queryClient = new QueryClient();
+const queryClient = new QueryClient({
+  defaultOptions: {
+    queries: {
+      staleTime: 30_000,
+    },
+  },
+});
 
 export type NextPageWithLayout = NextPage & {
   getLayout?: (page: ReactElement) => ReactElement;


### PR DESCRIPTION
This PR addresses aggressive refetching behavior in the database data grid by implementing three key optimizations:

## Changes Made

### 1. Add Global Query Stale Time (_app.tsx)
- Set default staleTime: 5_000 (5 seconds) for all React Query queries
- Prevents unnecessary refetches when data is still fresh
- Improves overall application performance and reduces server load

### 2. Reset Pagination Offset on Table Navigation (DataGridQueryParamsProvider.tsx)
- Added setCurrentOffset(0) when switching between tables
- Ensures users start at the first page when navigating to different tables
- Fixes UX issue where users could land on empty pages with out-of-range offsets

## Impact
- Performance: Reduced unnecessary network requests through intelligent caching
- UX: Fixed pagination issues when navigating between tables  

These changes work together to create a smoother, more efficient data browsing experience in the dashboard.