### PR TITLE
fix(ci): minor speed improvements related to nix/caching

### DIFF
--- a/.github/actions/cache-nix/action.yml
+++ b/.github/actions/cache-nix/action.yml
@@ -11,5 +11,116 @@ runs:
     - name: "Cache build"
       shell: bash
       run: |
-        nix store sign --key-file <(echo "${{ inputs.NIX_CACHE_PRIV_KEY }}") --all
-        nix copy --to 's3://nhost-nix-cache?region=eu-central-1' --substitute-on-destination --all
+        S3_BUCKET="nhost-nix-cache"
+        S3_REGION="eu-central-1"
+
+        elapsed() {
+          local start=$1
+          echo "$(( $(date +%s) - start ))s"
+        }
+
+        upload_to_s3() {
+          set -euo pipefail
+          local store_path="$1"
+          local t0=$(date +%s)
+          local store_hash
+          store_hash=$(basename "$store_path" | cut -d- -f1)
+
+          # Get path metadata
+          local info
+          info=$(nix path-info --json "$store_path")
+          local nar_hash_sri
+          nar_hash_sri=$(echo "$info" | jq -r ".[\"$store_path\"].narHash")
+          local nar_hash
+          nar_hash=$(nix hash convert --to nix32 "$nar_hash_sri")
+          local nar_size
+          nar_size=$(echo "$info" | jq -r ".[\"$store_path\"].narSize")
+          local refs
+          refs=$(echo "$info" | jq -r "[.[\"$store_path\"].references[] | split(\"/\")[-1]] | join(\" \")")
+          local sigs
+          sigs=$(echo "$info" | jq -r ".[\"$store_path\"].signatures[]")
+
+          # Create compressed NAR
+          local tmp_nar
+          tmp_nar=$(mktemp)
+          local t1=$(date +%s)
+          nix nar pack "$store_path" | zstd -q > "$tmp_nar"
+          local file_size
+          file_size=$(stat -c%s "$tmp_nar")
+          local file_hash
+          file_hash=$(nix-hash --type sha256 --base32 --flat "$tmp_nar")
+          local t2=$(date +%s)
+
+          # Upload NAR
+          aws s3 cp "$tmp_nar" "s3://${S3_BUCKET}/nar/${file_hash}.nar.zst" \
+            --region "$S3_REGION" --quiet
+          rm "$tmp_nar"
+          local t3=$(date +%s)
+
+          # Build narinfo
+          local narinfo
+          narinfo="StorePath: ${store_path}
+        URL: nar/${file_hash}.nar.zst
+        Compression: zstd
+        FileHash: sha256:${file_hash}
+        FileSize: ${file_size}
+        NarHash: sha256:${nar_hash}
+        NarSize: ${nar_size}
+        References: ${refs}"
+
+          while IFS= read -r sig; do
+            [ -n "$sig" ] && narinfo="${narinfo}
+        Sig: ${sig}"
+          done <<< "$sigs"
+
+          # Upload narinfo
+          echo "$narinfo" | aws s3 cp - "s3://${S3_BUCKET}/${store_hash}.narinfo" \
+            --region "$S3_REGION" --quiet
+
+          echo "Uploaded $(basename "$store_path") (nar_size=${nar_size} file_size=${file_size} compress=$(( t2 - t1 ))s upload=$(( t3 - t2 ))s total=$(( t3 - t0 ))s)"
+        }
+        export -f upload_to_s3 elapsed
+        export S3_BUCKET S3_REGION
+
+        STEP_START=$(date +%s)
+
+        # Find locally-built paths (unsigned, non-drv)
+        T=$(date +%s)
+        mapfile -t LOCAL_PATHS < <(
+          nix path-info --all --json \
+            | jq -r 'to_entries[] | select(.key | endswith(".drv") | not) | select(.value.signatures | length == 0) | .key'
+        )
+        echo "[discover] Found ${#LOCAL_PATHS[@]} locally-built paths in $(elapsed $T)"
+
+        if [ ${#LOCAL_PATHS[@]} -eq 0 ]; then
+          echo "No locally-built paths to cache"
+          exit 0
+        fi
+
+        # Sign them
+        T=$(date +%s)
+        printf '%s\n' "${LOCAL_PATHS[@]}" \
+          | xargs nix store sign --key-file <(echo "${{ inputs.NIX_CACHE_PRIV_KEY }}")
+        echo "[sign] Signed ${#LOCAL_PATHS[@]} paths in $(elapsed $T)"
+
+        # Check which paths are missing from S3 (in parallel)
+        T=$(date +%s)
+        mapfile -t MISSING_PATHS < <(
+          printf '%s\n' "${LOCAL_PATHS[@]}" \
+            | xargs -P 16 -I{} bash -c \
+              'aws s3api head-object --bucket "$S3_BUCKET" --region "$S3_REGION" --key "$(basename "$1" | cut -d- -f1).narinfo" >/dev/null 2>&1 || echo "$1"' _ {}
+        )
+        echo "[check] Found ${#MISSING_PATHS[@]}/${#LOCAL_PATHS[@]} paths missing from cache in $(elapsed $T)"
+
+        if [ ${#MISSING_PATHS[@]} -eq 0 ]; then
+          echo "All paths already cached"
+          exit 0
+        fi
+
+        # Upload missing paths
+        T=$(date +%s)
+        printf '%s\n' "${MISSING_PATHS[@]}" \
+          | xargs -P 4 -I{} bash -c 'upload_to_s3 "$@"' _ {}
+        echo "[upload] Uploaded ${#MISSING_PATHS[@]} paths in $(elapsed $T)"
+
+        echo "[total] Cache step completed in $(elapsed $STEP_START)"

--- a/.github/actions/setup-nix/action.yml
+++ b/.github/actions/setup-nix/action.yml
@@ -29,24 +29,4 @@ runs:
           keep-env-derivations = true
           keep-outputs = true
 
-    - name: Restore and save Nix store
-      uses: nix-community/cache-nix-action@v6
-      with:
-        primary-key: nix-${{ inputs.NAME }}-${{ runner.os }}-${{ runner.arch }}-${{ hashFiles('**/*.nix', '**/flake.lock') }}
-        restore-prefixes-first-match: nix-${{ inputs.NAME }}-${{ runner.os }}-${{ runner.arch }}-
-        gc-max-store-size-linux: 2G
-        purge: true
-        purge-prefixes: nix-${{ inputs.NAME }}-
-        purge-created: 0
-        purge-last-accessed: 0
-        purge-primary-key: never
-
-    # - name: "Verify if nixops is pre-built"
-    #   id: verify-nixops-build
-    #   run: |
-    #     export drvPath=$(make build-nixops-dry-run)
-    #     echo "Derivation path: $drvPath"
-    #     nix path-info --store s3://nhost-nix-cache\?region=eu-central-1 $drvPath \
-    #       || (echo "Wait until nixops is already built and cached and run again" && exit 1)
-    #   if: ${{ inputs.NAME != 'nixops' }}
 

--- a/.github/workflows/gen_schedule_update_deps.yaml
+++ b/.github/workflows/gen_schedule_update_deps.yaml
@@ -33,12 +33,6 @@ jobs:
           substituters = https://cache.nixos.org/?priority=40 s3://nhost-nix-cache?region=eu-central-1&priority=50
           trusted-public-keys = cache.nixos.org-1:6NCHdD59X431o0gWypbMrAURkbJ16ZPMQFGspcDShjY= ${{ secrets.NIX_CACHE_PUB_KEY }}
 
-    - name: Cache nix store
-      uses: actions/cache@v5
-      with:
-        path: /nix
-        key: nix-update-deps-${{ hashFiles('flakes.nix', 'flake.lock') }}
-
     - name: Update nix flakes
       run: nix flake update
 
@@ -69,12 +63,11 @@ jobs:
           dependencies
         draft: false
 
-    - name: "Cache nix store on s3"
-      run: |
-        echo ${{ secrets.NIX_CACHE_PRIV_KEY }} > cache-priv-key.pem
-        nix build .\#devShells.x86_64-linux.default
-        nix store sign --key-file cache-priv-key.pem --all
-        nix copy --to s3://nhost-nix-cache\?region=eu-central-1 .\#devShells.x86_64-linux.default
+    - name: "Build dev shell"
+      run: nix build .\#devShells.x86_64-linux.default
 
-    - run: rm cache-priv-key.pem
+    - name: "Cache nix store on s3"
+      uses: ./.github/actions/cache-nix
+      with:
+        NIX_CACHE_PRIV_KEY: ${{ secrets.NIX_CACHE_PRIV_KEY }}
       if: always()

--- a/.github/workflows/wf_build_artifacts.yaml
+++ b/.github/workflows/wf_build_artifacts.yaml
@@ -72,6 +72,15 @@ jobs:
         NIX_CACHE_PUB_KEY: ${{ secrets.NIX_CACHE_PUB_KEY }}
         GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
+    - name: "Verify if we need to build"
+      id: verify-build
+      run: |
+        export drvPath=$(make build-dry-run)
+        nix path-info --store s3://nhost-nix-cache\?region=eu-central-1 $drvPath \
+          && export BUILD_NEEDED=no \
+          || export BUILD_NEEDED=yes
+        echo BUILD_NEEDED=$BUILD_NEEDED >> $GITHUB_OUTPUT
+
     - name: Compute common env vars
       id: vars
       run: |
@@ -111,4 +120,4 @@ jobs:
       uses: ./.github/actions/cache-nix
       with:
         NIX_CACHE_PRIV_KEY: ${{ secrets.NIX_CACHE_PRIV_KEY }}
-      if: always()
+      if: ${{ always() && steps.verify-build.outputs.BUILD_NEEDED == 'yes' }}

--- a/.github/workflows/wf_check.yaml
+++ b/.github/workflows/wf_check.yaml
@@ -92,4 +92,4 @@ jobs:
       uses: ./.github/actions/cache-nix
       with:
         NIX_CACHE_PRIV_KEY: ${{ secrets.NIX_CACHE_PRIV_KEY }}
-      if: always()
+      if: ${{ always() && steps.verify-build.outputs.BUILD_NEEDED == 'yes' }}


### PR DESCRIPTION
### **PR Type**
Enhancement


___

### **Description**
- Introduce composite actions for Nix setup and caching

- Migrate workflows to use `setup-nix` and `cache-nix`

- Update `pr-agent` action to v0.30 and runner


___

### Diagram Walkthrough


```mermaid
flowchart LR
  setup["Composite `setup-nix` action"]
  cache["Composite `cache-nix` action"]
  workflows["GitHub workflows"]
  pragent_old["Codium-ai/pr-agent@v0.26"]
  pragent_new["Codium-ai/pr-agent@v0.30"]

  setup --> workflows
  workflows --> cache
  pragent_old -- "upgraded to" --> pragent_new
```



<details> <summary><h3> File Walkthrough</h3></summary>

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Enhancement</strong></td><td><details><summary>2 files</summary><table>
<tr>
  <td><strong>action.yml</strong><dd><code>Add composite action for Nix caching</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/nhost/nhost/pull/3955/files#diff-6f9d544e5069b5f9d2c56a5079c3da7e24a08b08f513e7e1775ad10393f5ad37">+15/-0</a>&nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>action.yml</strong><dd><code>Add composite action for Nix setup</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/nhost/nhost/pull/3955/files#diff-d6d03b00722cea2a21415f2e41951abebd36b521b485d7e4fc9fbb4a3c0195dc">+51/-0</a>&nbsp; &nbsp; </td>

</tr>
</table></details></td></tr><tr><td><strong>Configuration changes</strong></td><td><details><summary>10 files</summary><table>
<tr>
  <td><strong>ci_create_release.yaml</strong><dd><code>Use `setup-nix` and `cache-nix` in release CI</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/nhost/nhost/pull/3955/files#diff-9f32bd5671fcb04c5f1b35ea33677c4704302536e0c4ff9e06b514dc9b3d4f0c">+5/-23</a>&nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>ci_update_changelog.yaml</strong><dd><code>Use composite Nix actions in changelog CI</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/nhost/nhost/pull/3955/files#diff-399add8ac39ae1cd7ae2f4f8ceb89290f6f43e25b7b2c499da61dd68a5cf2f16">+5/-23</a>&nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>cli_release.yaml</strong><dd><code>Integrate Nix composite actions in CLI release</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/nhost/nhost/pull/3955/files#diff-59930599cb486b2671a1411c1b55bf31c89b69725d5923922dd75f4e1ed5b522">+9/-27</a>&nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>cli_test_new_project.yaml</strong><dd><code>Use Nix composite actions in CLI test workflow</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/nhost/nhost/pull/3955/files#diff-3f78314dee618c9c0bd144f18ee3c49fe9f06b14acbfcf57d1bd0d8e7c11f639">+9/-28</a>&nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>gen_ai_review.yaml</strong><dd><code>Update runner and `pr-agent` to v0.30</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/nhost/nhost/pull/3955/files#diff-d1e4c772e0acb5ce4891df2dd94ba58ffaf6393e8f75493ec7e10cbce1c4992c">+5/-6</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>wf_build_artifacts.yaml</strong><dd><code>Use Nix composite actions in build artifacts</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/nhost/nhost/pull/3955/files#diff-63d6f3e2e5894df4d88cf2c82b3d0c90e7b0b7c8ca9da25a3d46f35f15270fb0">+9/-36</a>&nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>wf_check.yaml</strong><dd><code>Use Nix composite actions in check workflow</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/nhost/nhost/pull/3955/files#diff-c2ecea6736037ba6304681d744d612d44d7681788d2fbc58ce223cf52ecefa43">+9/-36</a>&nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>wf_dashboard_e2e_staging.yaml</strong><dd><code>Use Nix composite actions in e2e staging</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/nhost/nhost/pull/3955/files#diff-a7fa29d56c482bdb946a35ffa66002731a16f69b2278e5f10244051fd9ff0e3a">+9/-27</a>&nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>wf_deploy_vercel.yaml</strong><dd><code>Use Nix composite actions in Vercel deploy</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/nhost/nhost/pull/3955/files#diff-2cefabe2c777ef34c091ee0f8d44ece60e4121814fa8cc38fe05d929fea197bc">+5/-23</a>&nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>wf_release_npm.yaml</strong><dd><code>Use Nix composite actions in npm release</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/nhost/nhost/pull/3955/files#diff-a7f381f9d0b9662aafc6b0db6f7bc72c9354c723fcebd4762c341534ed1f6bf4">+5/-23</a>&nbsp; &nbsp; </td>

</tr>
</table></details></td></tr></tr></tbody></table>

</details>

___

<!-- nhost-reviewer:start -->
### **PR Type**
Configuration

___

### **Description**
- Rewrites the `cache-nix` composite action to build proper narinfo files, sign only locally-built paths, check S3 for existing entries before uploading, and upload NARs in parallel with zstd compression
- Removes the `nix-community/cache-nix-action@v6` GitHub Actions cache layer from `setup-nix`, relying solely on the S3 binary cache as a Nix substituter
- Adds a `verify-build` step to `wf_build_artifacts` and conditionalizes the cache step on `BUILD_NEEDED` in both `wf_build_artifacts` and `wf_check` to skip redundant cache uploads
- Migrates `gen_schedule_update_deps` to use the `cache-nix` composite action instead of inline sign+copy commands

___

### Diagram Walkthrough

```mermaid
flowchart TD
  subgraph "Nix Setup"
    A["setup-nix action"] -->|"configures S3 substituter"| B["Nix Store"]
  end

  subgraph "Build Phase"
    B --> C{"verify-build:\nderivation in S3?"}
    C -->|"yes"| D["Skip build/check"]
    C -->|"no"| E["Run build/check"]
  end

  subgraph "Cache Phase (cache-nix action)"
    E --> F["Discover unsigned\nlocal paths"]
    F --> G["Sign paths"]
    G --> H["Check S3 for\nexisting narinfo"]
    H --> I["Upload missing\nNARs + narinfo"]
  end
```

<details> <summary><h3> File Walkthrough</h3></summary>

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody>
<tr><td><strong>Composite actions</strong></td><td><details><summary>2 files</summary><table>
<tr>
  <td><strong>action.yml</strong> (cache-nix)<dd><code>Rewrite S3 cache upload: discover locally-built paths, sign, check S3, upload missing NARs+narinfo in parallel with zstd</code></dd></td>
  <td><a href="https://github.com/nhost/nhost/pull/3955/files#diff-6f9d544e5069b5f9d2c56a5079c3da7e24a08b08f513e7e1775ad10393f5ad37">+112/-2</a></td>
</tr>
<tr>
  <td><strong>action.yml</strong> (setup-nix)<dd><code>Remove nix-community/cache-nix-action@v6 GHA cache layer and commented-out code</code></dd></td>
  <td><a href="https://github.com/nhost/nhost/pull/3955/files#diff-d6d03b00722cea2a21415f2e41951abebd36b521b485d7e4fc9fbb4a3c0195dc">+0/-20</a></td>
</tr>
</table></details></td></tr>
<tr><td><strong>Workflow changes</strong></td><td><details><summary>3 files</summary><table>
<tr>
  <td><strong>gen_schedule_update_deps.yaml</strong><dd><code>Replace inline sign+copy with cache-nix action, separate build step</code></dd></td>
  <td><a href="https://github.com/nhost/nhost/pull/3955/files#diff-ae003e22c1e5cbf186e1749d77dec35965e521d2583ba8cf45fcb1c8f300e177">+6/-13</a></td>
</tr>
<tr>
  <td><strong>wf_build_artifacts.yaml</strong><dd><code>Add verify-build step, conditionalize cache on BUILD_NEEDED</code></dd></td>
  <td><a href="https://github.com/nhost/nhost/pull/3955/files#diff-63d6f3e2e5894df4d88cf2c82b3d0c90e7b0b7c8ca9da25a3d46f35f15270fb0">+10/-1</a></td>
</tr>
<tr>
  <td><strong>wf_check.yaml</strong><dd><code>Conditionalize cache step on BUILD_NEEDED</code></dd></td>
  <td><a href="https://github.com/nhost/nhost/pull/3955/files#diff-c2ecea6736037ba6304681d744d612d44d7681788d2fbc58ce223cf52ecefa43">+1/-1</a></td>
</tr>
</table></details></td></tr>
</tbody></table>

</details>

___

<!-- nhost-reviewer:end -->