### PR TITLE
chore(docs): increate OG font size

### DIFF
--- a/docs/src/utils/og-image.ts
+++ b/docs/src/utils/og-image.ts
@@ -28,11 +28,11 @@ export async function generateOgImage(
 ): Promise<Buffer> {
   // Adapt font size for long titles
   const titleLength = title.length;
-  let titleFontSize = 52;
+  let titleFontSize = 58;
   if (titleLength > 60) {
-    titleFontSize = 36;
+    titleFontSize = 40;
   } else if (titleLength > 40) {
-    titleFontSize = 44;
+    titleFontSize = 48;
   }
 
   const displayDescription = description ? truncate(description, 140) : '';
@@ -57,8 +57,8 @@ export async function generateOgImage(
             type: 'img',
             props: {
               src: logoDataUri,
-              width: 140,
-              height: 48,
+              width: 180,
+              height: 62,
               style: { objectFit: 'contain' },
             },
           },
@@ -78,7 +78,7 @@ export async function generateOgImage(
                       props: {
                         style: {
                           color: '#0066ff',
-                          fontSize: '20px',
+                          fontSize: '28px',
                           fontWeight: 600,
                           letterSpacing: '0.05em',
                         },
@@ -105,7 +105,7 @@ export async function generateOgImage(
                       props: {
                         style: {
                           color: '#9ca3af',
-                          fontSize: '22px',
+                          fontSize: '28px',
                           fontWeight: 400,
                           lineHeight: 1.4,
                           maxWidth: '900px',


### PR DESCRIPTION
<!-- nhost-reviewer:start -->
### **PR Type**
Enhancement

___

### **Description**
- Increase font sizes across the OG image generator for better readability on social media platforms (title, breadcrumb, and description text)
- Scale up the Nhost logo dimensions in OG images from 140x48 to 180x62 for improved brand visibility

___

<details> <summary><h3> File Walkthrough</h3></summary>

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody>
<tr><td><strong>OG image generation</strong></td><td><details><summary>1 file</summary><table>
<tr>
  <td><strong>og-image.ts</strong><dd><code>Bump title font sizes (52→58, 44→48, 36→40), breadcrumb font (20→28), description font (22→28), and logo dimensions (140x48→180x62)</code></dd></td>
  <td><a href="https://github.com/nhost/nhost/pull/XXX/files#diff-cd93cdcf53cff80d39f487bd18febc15e07c2b8f50df26366b53124afeea7f68">+7/-7</a></td>
</tr>
</table></details></td></tr>
</tbody></table>

</details>

___

<!-- nhost-reviewer:end -->
