### PR TITLE
chore(cli): fix release to update homebrew correctly

### DIFF
--- a/.github/workflows/cli_wf_release.yaml
+++ b/.github/workflows/cli_wf_release.yaml
@@ -121,7 +121,7 @@ jobs:
           formula-name: nhost
           homebrew-tap: nhost/homebrew-tap
           version: ${{ steps.vars.outputs.VERSION }}
-          assets-dir: upload
+          assets-dir: cli/upload
           github-token: ${{ secrets.GH_PAT }}
 
       - name: "Store Nix cache"


### PR DESCRIPTION
<!-- nhost-reviewer:start -->
### **PR Type**
Bug fix

___

### **Description**
- Fix the `assets-dir` path for the Homebrew formula update step in the CLI release workflow. The composite action runs from the repo root (not the `cli/` working directory), so the path must be `cli/upload` instead of `upload`.

___

<details> <summary><h3> File Walkthrough</h3></summary>

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody>
<tr><td><strong>CI/CD configuration</strong></td><td><details><summary>1 file</summary><table>
<tr>
  <td><strong>cli_wf_release.yaml</strong><dd><code>Fix assets-dir path from "upload" to "cli/upload" for the update-homebrew-formula action</code></dd></td>
  <td><a href="https://github.com/nhost/nhost/pull/3981/files#diff-e288b96eae0779953d2781c05420f388fd18510e7b109bd6f1fa2e673c7eaa47">+1/-1</a></td>
</tr>
</table></details></td></tr>
</tbody></table>

</details>

___

<!-- nhost-reviewer:end -->