### PR TITLE
feat(dashboard): delete buckets

### DIFF
--- a/dashboard/next.config.js
+++ b/dashboard/next.config.js
@@ -69,12 +69,6 @@ module.exports = withBundleAnalyzer({
           '/orgs/:orgSlug/projects/:appSubdomain/database/browser/default',
         permanent: true,
       },
-      {
-        source: '/orgs/:orgSlug/projects/:appSubdomain/storage',
-        destination:
-          '/orgs/:orgSlug/projects/:appSubdomain/storage/bucket/default',
-        permanent: true,
-      },
     ];
   },
 });

--- a/dashboard/src/features/orgs/projects/database/dataGrid/components/BaseTableForm/BaseTableForm.test.tsx
+++ b/dashboard/src/features/orgs/projects/database/dataGrid/components/BaseTableForm/BaseTableForm.test.tsx
@@ -289,14 +289,16 @@ describe('BaseTableForm', () => {
 
   it('should display identity column picker when bigint is selected', async () => {
     render(<TestTableFormWrapper />);
-    const user = new TestUserEvent();
 
     expect(screen.queryByLabelText('Identity')).not.toBeInTheDocument();
 
     await TestUserEvent.fireClickEvent(
       screen.getByPlaceholderText('Select type'),
     );
-    await user.type(screen.getByPlaceholderText('Select type'), 'int');
+    await TestUserEvent.fireTypeEvent(
+      screen.getByPlaceholderText('Select type'),
+      'int',
+    );
     await TestUserEvent.fireClickEvent(
       screen.getByRole('option', { name: /^bigint.*int8/ }),
     );

--- a/dashboard/src/features/orgs/projects/storage/components/BucketActions/BucketActions.test.tsx
+++ b/dashboard/src/features/orgs/projects/storage/components/BucketActions/BucketActions.test.tsx
@@ -6,12 +6,26 @@ describe('BucketActions', () => {
   it('should call onEdit when Edit Bucket is clicked', async () => {
     const user = new TestUserEvent();
     const onEdit = vi.fn();
+    const onDelete = vi.fn();
 
-    render(<BucketActions onEdit={onEdit} />);
+    render(<BucketActions onEdit={onEdit} onDelete={onDelete} />);
 
     await user.click(screen.getByRole('button'));
     await user.click(screen.getByText('Edit Bucket'));
 
     expect(onEdit).toHaveBeenCalledOnce();
+  });
+
+  it('should call onDelete when Delete Bucket is clicked', async () => {
+    const user = new TestUserEvent();
+    const onEdit = vi.fn();
+    const onDelete = vi.fn();
+
+    render(<BucketActions onEdit={onEdit} onDelete={onDelete} />);
+
+    await user.click(screen.getByRole('button'));
+    await user.click(screen.getByText('Delete Bucket'));
+
+    expect(onDelete).toHaveBeenCalledOnce();
   });
 });

--- a/dashboard/src/features/orgs/projects/storage/components/BucketActions/BucketActions.tsx
+++ b/dashboard/src/features/orgs/projects/storage/components/BucketActions/BucketActions.tsx
@@ -1,17 +1,22 @@
-import { Ellipsis, SquarePen } from 'lucide-react';
+import { Ellipsis, SquarePen, Trash2 } from 'lucide-react';
 import { Button } from '@/components/ui/v3/button';
 import {
   DropdownMenu,
   DropdownMenuContent,
   DropdownMenuItem,
+  DropdownMenuSeparator,
   DropdownMenuTrigger,
 } from '@/components/ui/v3/dropdown-menu';
 
 interface BucketActionsProps {
   onEdit: () => void;
+  onDelete: () => void;
 }
 
-export default function BucketActions({ onEdit }: BucketActionsProps) {
+export default function BucketActions({
+  onEdit,
+  onDelete,
+}: BucketActionsProps) {
   return (
     <DropdownMenu>
       <DropdownMenuTrigger asChild>
@@ -31,6 +36,14 @@ export default function BucketActions({ onEdit }: BucketActionsProps) {
         >
           <SquarePen className="h-4 w-4" />
           <span>Edit Bucket</span>
+        </DropdownMenuItem>
+        <DropdownMenuSeparator className="my-0" />
+        <DropdownMenuItem
+          className="!text-destructive flex h-9 cursor-pointer items-center gap-2 rounded-none text-sm+ focus:text-destructive"
+          onClick={onDelete}
+        >
+          <Trash2 className="h-4 w-4" />
+          <span>Delete Bucket</span>
         </DropdownMenuItem>
       </DropdownMenuContent>
     </DropdownMenu>

--- a/dashboard/src/features/orgs/projects/storage/components/DeleteBucketDialog/DeleteBucketDialog.test.tsx
+++ b/dashboard/src/features/orgs/projects/storage/components/DeleteBucketDialog/DeleteBucketDialog.test.tsx
@@ -1,0 +1,119 @@
+import { useState } from 'react';
+import { vi } from 'vitest';
+import { render, screen, TestUserEvent, waitFor } from '@/tests/testUtils';
+import DeleteBucketDialog from './DeleteBucketDialog';
+
+function Wrapper({ onDelete = vi.fn() }: { onDelete?: () => Promise<void> }) {
+  const [open, setOpen] = useState(true);
+  return (
+    <DeleteBucketDialog
+      bucketId="avatars"
+      open={open}
+      onOpenChange={setOpen}
+      onDelete={onDelete}
+    />
+  );
+}
+
+describe('DeleteBucketDialog', () => {
+  it('should have the Delete button disabled when the checkbox is unchecked', () => {
+    render(<Wrapper />);
+
+    expect(screen.getByRole('button', { name: 'Delete' })).toBeDisabled();
+  });
+
+  it('should enable the Delete button after checking the confirmation checkbox', async () => {
+    const user = new TestUserEvent();
+    render(<Wrapper />);
+
+    await user.click(screen.getByRole('checkbox'));
+
+    expect(screen.getByRole('button', { name: 'Delete' })).toBeEnabled();
+  });
+
+  it('should disable the Delete button again after unchecking the checkbox', async () => {
+    const user = new TestUserEvent();
+    render(<Wrapper />);
+
+    await user.click(screen.getByRole('checkbox'));
+    await user.click(screen.getByRole('checkbox'));
+
+    expect(screen.getByRole('button', { name: 'Delete' })).toBeDisabled();
+  });
+
+  it('should reset the checkbox when the dialog is closed via Cancel', async () => {
+    const user = new TestUserEvent();
+
+    function ReopenableWrapper() {
+      const [open, setOpen] = useState(true);
+      return (
+        <>
+          <button type="button" onClick={() => setOpen(true)}>
+            Reopen
+          </button>
+          <DeleteBucketDialog
+            bucketId="avatars"
+            open={open}
+            onOpenChange={setOpen}
+            onDelete={vi.fn()}
+          />
+        </>
+      );
+    }
+
+    render(<ReopenableWrapper />);
+
+    await user.click(screen.getByRole('checkbox'));
+    expect(screen.getByRole('button', { name: 'Delete' })).toBeEnabled();
+
+    await user.click(screen.getByRole('button', { name: 'Cancel' }));
+
+    await user.click(screen.getByRole('button', { name: 'Reopen' }));
+
+    await waitFor(() => {
+      expect(screen.getByRole('checkbox')).not.toBeChecked();
+      expect(screen.getByRole('button', { name: 'Delete' })).toBeDisabled();
+    });
+  });
+
+  it('should call onDelete when Delete button is clicked', async () => {
+    const user = new TestUserEvent();
+    const onDelete = vi.fn().mockResolvedValue(undefined);
+
+    render(<Wrapper onDelete={onDelete} />);
+
+    await user.click(screen.getByRole('checkbox'));
+    await user.click(screen.getByRole('button', { name: 'Delete' }));
+
+    await waitFor(() => {
+      expect(onDelete).toHaveBeenCalledTimes(1);
+    });
+  });
+
+  it('should disable both buttons and show spinner during deletion', async () => {
+    const user = new TestUserEvent();
+    let resolveDelete: () => void;
+    const onDelete = vi.fn(
+      () =>
+        new Promise<void>((resolve) => {
+          resolveDelete = resolve;
+        }),
+    );
+
+    render(<Wrapper onDelete={onDelete} />);
+
+    await user.click(screen.getByRole('checkbox'));
+    await user.click(screen.getByRole('button', { name: 'Delete' }));
+
+    await waitFor(() => {
+      expect(screen.getByRole('button', { name: 'Cancel' })).toBeDisabled();
+    });
+    expect(screen.getByRole('button', { name: 'Delete' })).toBeDisabled();
+
+    resolveDelete!();
+
+    await waitFor(() => {
+      expect(screen.getByRole('button', { name: 'Cancel' })).toBeEnabled();
+    });
+  });
+});

--- a/dashboard/src/features/orgs/projects/storage/components/DeleteBucketDialog/DeleteBucketDialog.tsx
+++ b/dashboard/src/features/orgs/projects/storage/components/DeleteBucketDialog/DeleteBucketDialog.tsx
@@ -1,0 +1,110 @@
+import { useState } from 'react';
+import {
+  AlertDialog,
+  AlertDialogAction,
+  AlertDialogCancel,
+  AlertDialogContent,
+  AlertDialogDescription,
+  AlertDialogFooter,
+  AlertDialogHeader,
+  AlertDialogTitle,
+} from '@/components/ui/v3/alert-dialog';
+import { ButtonWithLoading, buttonVariants } from '@/components/ui/v3/button';
+import { Checkbox } from '@/components/ui/v3/checkbox';
+import { Separator } from '@/components/ui/v3/separator';
+
+interface DeleteBucketDialogProps {
+  bucketId: string;
+  open: boolean;
+  onOpenChange: (open: boolean) => void;
+  onDelete: () => Promise<void>;
+}
+
+export default function DeleteBucketDialog({
+  bucketId,
+  open,
+  onOpenChange,
+  onDelete,
+}: DeleteBucketDialogProps) {
+  const [confirmed, setConfirmed] = useState(false);
+  const [deleting, setDeleting] = useState(false);
+
+  function handleOpenChange(nextOpen: boolean) {
+    if (!nextOpen) {
+      setConfirmed(false);
+    }
+    onOpenChange(nextOpen);
+  }
+
+  async function handleDelete(e: React.MouseEvent) {
+    e.preventDefault();
+    setDeleting(true);
+
+    try {
+      await onDelete();
+    } finally {
+      setDeleting(false);
+      setConfirmed(false);
+    }
+  }
+
+  return (
+    <AlertDialog open={open} onOpenChange={handleOpenChange}>
+      <AlertDialogContent className="flex w-[32rem] max-w-[32rem] flex-col gap-6 p-6 text-left text-foreground">
+        <AlertDialogHeader>
+          <AlertDialogTitle className="truncate">
+            Delete Bucket
+          </AlertDialogTitle>
+          <AlertDialogDescription>
+            <span className="block pb-4">
+              Bucket:{' '}
+              <span className="rounded-md bg-accent px-1 py-0.5 font-mono">
+                {bucketId}
+              </span>
+            </span>
+            <span className="block">
+              Are you sure you want to delete this bucket?
+            </span>
+            <span className="block">
+              <span className="font-bold text-destructive">
+                All files will be permanently deleted.
+              </span>
+            </span>
+          </AlertDialogDescription>
+        </AlertDialogHeader>
+
+        <div className="flex flex-col gap-2">
+          <Separator />
+          <div className="flex items-center gap-3">
+            <Checkbox
+              id="delete-bucket-confirm"
+              checked={confirmed}
+              onCheckedChange={(checked) => setConfirmed(Boolean(checked))}
+            />
+            <label
+              htmlFor="delete-bucket-confirm"
+              className="font-medium text-sm leading-none peer-disabled:cursor-not-allowed peer-disabled:opacity-70"
+            >
+              I understand this will permanently delete all files in this bucket
+            </label>
+          </div>
+          <Separator />
+        </div>
+
+        <AlertDialogFooter>
+          <AlertDialogCancel disabled={deleting}>Cancel</AlertDialogCancel>
+          <AlertDialogAction asChild>
+            <ButtonWithLoading
+              onClick={handleDelete}
+              className={buttonVariants({ variant: 'destructive' })}
+              disabled={deleting || !confirmed}
+              loading={deleting}
+            >
+              Delete
+            </ButtonWithLoading>
+          </AlertDialogAction>
+        </AlertDialogFooter>
+      </AlertDialogContent>
+    </AlertDialog>
+  );
+}

--- a/dashboard/src/features/orgs/projects/storage/components/DeleteBucketDialog/index.ts
+++ b/dashboard/src/features/orgs/projects/storage/components/DeleteBucketDialog/index.ts
@@ -1,0 +1,1 @@
+export { default as DeleteBucketDialog } from './DeleteBucketDialog';

--- a/dashboard/src/features/orgs/projects/storage/components/StorageLayout/StorageLayout.tsx
+++ b/dashboard/src/features/orgs/projects/storage/components/StorageLayout/StorageLayout.tsx
@@ -1,0 +1,37 @@
+import type { PropsWithChildren } from 'react';
+import { LoadingScreen } from '@/components/presentational/LoadingScreen';
+import { generateAppServiceUrl } from '@/features/orgs/projects/common/utils/generateAppServiceUrl';
+import { useProject } from '@/features/orgs/projects/hooks/useProject';
+import { StorageSidebar } from '@/features/orgs/projects/storage/components/StorageSidebar';
+import { NhostApolloProvider } from '@/providers/Apollo';
+import { getHasuraAdminSecret } from '@/utils/env';
+
+export default function StorageLayout({ children }: PropsWithChildren) {
+  const { project, loading } = useProject();
+
+  if (!project || loading) {
+    return <LoadingScreen />;
+  }
+
+  return (
+    <NhostApolloProvider
+      graphqlUrl={generateAppServiceUrl(
+        project.subdomain,
+        project.region,
+        'graphql',
+      )}
+      fetchPolicy="cache-first"
+      globalHeaders={{
+        'x-hasura-admin-secret':
+          process.env.NEXT_PUBLIC_ENV === 'dev'
+            ? getHasuraAdminSecret()
+            : project.config!.hasura.adminSecret,
+      }}
+    >
+      <StorageSidebar />
+      <div className="box flex w-full flex-auto flex-col overflow-x-hidden">
+        {children}
+      </div>
+    </NhostApolloProvider>
+  );
+}

--- a/dashboard/src/features/orgs/projects/storage/components/StorageLayout/index.ts
+++ b/dashboard/src/features/orgs/projects/storage/components/StorageLayout/index.ts
@@ -1,0 +1,1 @@
+export { default as StorageLayout } from './StorageLayout';

--- a/dashboard/src/features/orgs/projects/storage/components/StorageSidebar/StorageSidebar.test.tsx
+++ b/dashboard/src/features/orgs/projects/storage/components/StorageSidebar/StorageSidebar.test.tsx
@@ -1,18 +1,26 @@
 import { setupServer } from 'msw/node';
 import { vi } from 'vitest';
+import { mockMatchMediaValue } from '@/tests/mocks';
 import tokenQuery from '@/tests/msw/mocks/rest/tokenQuery';
 import {
   createGraphqlMockResolver,
   render,
   screen,
+  TestUserEvent,
   waitFor,
 } from '@/tests/testUtils';
 import StorageSidebar from './StorageSidebar';
+
+Object.defineProperty(window, 'matchMedia', {
+  writable: true,
+  value: vi.fn().mockImplementation(mockMatchMediaValue),
+});
 
 const mocks = vi.hoisted(() => ({
   useRouter: vi.fn(),
   useIsPlatform: vi.fn(),
   useProject: vi.fn(),
+  useAppClient: vi.fn(),
 }));
 
 vi.mock('next/router', () => ({
@@ -25,6 +33,10 @@ vi.mock('@/features/orgs/projects/common/hooks/useIsPlatform', () => ({
 
 vi.mock('@/features/orgs/projects/hooks/useProject', () => ({
   useProject: mocks.useProject,
+}));
+
+vi.mock('@/features/orgs/projects/hooks/useAppClient', () => ({
+  useAppClient: mocks.useAppClient,
 }));
 
 const getUseRouterObject = (bucketId?: string) => ({
@@ -92,12 +104,18 @@ describe('StorageSidebar', () => {
     mocks.useProject.mockReturnValue({
       project: { config: { hasura: { adminSecret: 'secret' } } },
     });
+    mocks.useAppClient.mockReturnValue({
+      storage: {
+        deleteOrphanedFiles: vi.fn().mockResolvedValue(undefined),
+      },
+    });
   });
 
   afterEach(() => {
     mocks.useRouter.mockRestore();
     mocks.useIsPlatform.mockRestore();
     mocks.useProject.mockRestore();
+    mocks.useAppClient.mockRestore();
     vi.restoreAllMocks();
   });
 
@@ -197,6 +215,167 @@ describe('StorageSidebar', () => {
         'href',
         '/orgs/xyz/projects/test-project/storage/bucket/avatars',
       );
+    });
+  });
+
+  it('should open confirmation dialog when Delete Bucket is clicked', async () => {
+    const user = new TestUserEvent({ pointerEventsCheck: 0 });
+    mocks.useRouter.mockReturnValue(getUseRouterObject('default'));
+    const resolver = createGraphqlMockResolver('getBuckets', 'query');
+    server.use(resolver.handler);
+
+    render(<StorageSidebar />);
+
+    resolver.resolve({ buckets: mockBuckets });
+
+    await waitFor(() => {
+      expect(screen.getByText('default')).toBeInTheDocument();
+    });
+
+    const actionButtons = screen.getAllByRole('button', { name: '' });
+    const ellipsisButton = actionButtons.find((btn) =>
+      btn.querySelector('.lucide-ellipsis'),
+    );
+    await user.click(ellipsisButton!);
+    await user.click(screen.getByText('Delete Bucket'));
+
+    await waitFor(() => {
+      expect(
+        screen.getByText(/Are you sure you want to delete/),
+      ).toBeInTheDocument();
+      expect(
+        screen.getByText('default', { selector: 'span.font-mono' }),
+      ).toBeInTheDocument();
+    });
+  });
+
+  it('should call delete mutation and navigate away when confirming deletion of current bucket', async () => {
+    const user = new TestUserEvent({ pointerEventsCheck: 0 });
+    const routerObj = getUseRouterObject('avatars');
+    mocks.useRouter.mockReturnValue(routerObj);
+
+    const bucketsResolver = createGraphqlMockResolver('getBuckets', 'query');
+    const deleteResolver = createGraphqlMockResolver(
+      'deleteBucket',
+      'mutation',
+    );
+    server.use(bucketsResolver.handler, deleteResolver.handler);
+
+    render(<StorageSidebar />);
+
+    bucketsResolver.resolve({ buckets: mockBuckets });
+
+    await waitFor(() => {
+      expect(screen.getByText('avatars')).toBeInTheDocument();
+    });
+
+    const avatarsItem = screen.getByText('avatars').closest('li');
+    const ellipsisButton = avatarsItem!.querySelector('button[data-state]');
+    await user.click(ellipsisButton!);
+    await user.click(screen.getByText('Delete Bucket'));
+
+    await waitFor(() => {
+      expect(
+        screen.getByText(/Are you sure you want to delete/),
+      ).toBeInTheDocument();
+    });
+
+    await user.click(screen.getByRole('checkbox'));
+    await user.click(screen.getByRole('button', { name: 'Delete' }));
+
+    deleteResolver.resolve({ deleteBucket: { id: 'avatars' } });
+
+    await waitFor(() => {
+      expect(routerObj.push).toHaveBeenCalledWith(
+        '/orgs/xyz/projects/test-project/storage',
+      );
+    });
+  });
+
+  it('should call deleteOrphanedFiles on the storage client when deleting a bucket', async () => {
+    const user = new TestUserEvent({ pointerEventsCheck: 0 });
+    const routerObj = getUseRouterObject('default');
+    mocks.useRouter.mockReturnValue(routerObj);
+
+    const deleteOrphanedFiles = vi.fn().mockResolvedValue(undefined);
+    mocks.useAppClient.mockReturnValue({
+      storage: { deleteOrphanedFiles },
+    });
+
+    const bucketsResolver = createGraphqlMockResolver('getBuckets', 'query');
+    const deleteResolver = createGraphqlMockResolver(
+      'deleteBucket',
+      'mutation',
+    );
+    server.use(bucketsResolver.handler, deleteResolver.handler);
+
+    render(<StorageSidebar />);
+
+    bucketsResolver.resolve({ buckets: mockBuckets });
+
+    await waitFor(() => {
+      expect(screen.getByText('avatars')).toBeInTheDocument();
+    });
+
+    const avatarsItem = screen.getByText('avatars').closest('li');
+    const ellipsisButton = avatarsItem!.querySelector('button[data-state]');
+    await user.click(ellipsisButton!);
+    await user.click(screen.getByText('Delete Bucket'));
+
+    await waitFor(() => {
+      expect(
+        screen.getByText(/Are you sure you want to delete/),
+      ).toBeInTheDocument();
+    });
+
+    await user.click(screen.getByRole('checkbox'));
+    await user.click(screen.getByRole('button', { name: 'Delete' }));
+
+    deleteResolver.resolve({ deleteBucket: { id: 'avatars' } });
+
+    await waitFor(() => {
+      expect(deleteOrphanedFiles).toHaveBeenCalledOnce();
+    });
+  });
+
+  it('should not navigate away when deleting a bucket that is not currently viewed', async () => {
+    const user = new TestUserEvent({ pointerEventsCheck: 0 });
+    const routerObj = getUseRouterObject('default');
+    mocks.useRouter.mockReturnValue(routerObj);
+
+    const bucketsResolver = createGraphqlMockResolver('getBuckets', 'query');
+    const deleteResolver = createGraphqlMockResolver(
+      'deleteBucket',
+      'mutation',
+    );
+    server.use(bucketsResolver.handler, deleteResolver.handler);
+
+    render(<StorageSidebar />);
+
+    bucketsResolver.resolve({ buckets: mockBuckets });
+
+    await waitFor(() => {
+      expect(screen.getByText('avatars')).toBeInTheDocument();
+    });
+
+    const avatarsItem = screen.getByText('avatars').closest('li');
+    const ellipsisButton = avatarsItem!.querySelector('button[data-state]');
+    await user.click(ellipsisButton!);
+    await user.click(screen.getByText('Delete Bucket'));
+
+    await waitFor(() => {
+      expect(
+        screen.getByText(/Are you sure you want to delete/),
+      ).toBeInTheDocument();
+    });
+
+    await user.click(screen.getByRole('checkbox'));
+    await user.click(screen.getByRole('button', { name: 'Delete' }));
+
+    deleteResolver.resolve({ deleteBucket: { id: 'avatars' } });
+
+    await waitFor(() => {
+      expect(routerObj.push).not.toHaveBeenCalled();
     });
   });
 });

--- a/dashboard/src/features/orgs/projects/storage/components/StorageSidebar/StorageSidebar.tsx
+++ b/dashboard/src/features/orgs/projects/storage/components/StorageSidebar/StorageSidebar.tsx
@@ -2,6 +2,7 @@ import { useApolloClient } from '@apollo/client';
 import { Archive, Plus } from 'lucide-react';
 import NextLink from 'next/link';
 import { useRouter } from 'next/router';
+import { useState } from 'react';
 import { useDialog } from '@/components/common/DialogProvider';
 import { FeatureSidebar } from '@/components/layout/FeatureSidebar';
 import { Button } from '@/components/ui/v3/button';
@@ -10,9 +11,13 @@ import { useIsPlatform } from '@/features/orgs/projects/common/hooks/useIsPlatfo
 import { useProject } from '@/features/orgs/projects/hooks/useProject';
 import { BucketActions } from '@/features/orgs/projects/storage/components/BucketActions';
 import { CreateBucketForm } from '@/features/orgs/projects/storage/components/CreateBucketForm';
+import { DeleteBucketDialog } from '@/features/orgs/projects/storage/components/DeleteBucketDialog';
 import { EditBucketForm } from '@/features/orgs/projects/storage/components/EditBucketForm';
 import { useBuckets } from '@/features/orgs/projects/storage/hooks/useBuckets';
+import { useDeleteOrphanedFiles } from '@/features/orgs/projects/storage/hooks/useDeleteOrphanedFiles';
+import { execPromiseWithErrorToast } from '@/features/orgs/utils/execPromiseWithErrorToast';
 import { cn, isNotEmptyValue } from '@/lib/utils';
+import { useDeleteBucketMutation } from '@/utils/__generated__/graphql';
 
 interface StorageSidebarContentProps {
   onSidebarItemClick?: VoidFunction;
@@ -34,6 +39,10 @@ function StorageSidebarContent({
   const apolloClient = useApolloClient();
   const { openDrawer, closeDrawerWithDirtyGuard } = useDialog();
   const { buckets, loading, error } = useBuckets();
+  const [deleteBucket] = useDeleteBucketMutation({ client: apolloClient });
+  const [bucketToDelete, setBucketToDelete] = useState<string | null>(null);
+
+  const deleteOrphanedFiles = useDeleteOrphanedFiles();
 
   function openCreateBucketDrawer() {
     openDrawer({
@@ -60,6 +69,34 @@ function StorageSidebarContent({
         />
       ),
     });
+  }
+
+  async function handleDeleteBucket() {
+    if (!bucketToDelete) {
+      return;
+    }
+
+    await execPromiseWithErrorToast(
+      async () => {
+        await deleteBucket({
+          variables: { id: bucketToDelete },
+          refetchQueries: ['getBuckets'],
+        });
+        await deleteOrphanedFiles();
+        if (bucketSlug === bucketToDelete) {
+          await router.push(
+            `/orgs/${orgSlug}/projects/${appSubdomain}/storage`,
+          );
+        }
+      },
+      {
+        loadingMessage: 'Deleting bucket...',
+        successMessage: 'Bucket has been deleted successfully.',
+        errorMessage: 'Failed to delete bucket.',
+      },
+    );
+
+    setBucketToDelete(null);
   }
 
   if (loading) {
@@ -123,6 +160,7 @@ function StorageSidebarContent({
                       </NextLink>
                       <BucketActions
                         onEdit={() => openEditBucketDrawer(bucket.id)}
+                        onDelete={() => setBucketToDelete(bucket.id)}
                       />
                     </div>
                   </Button>
@@ -132,6 +170,18 @@ function StorageSidebarContent({
           </ul>
         )}
       </nav>
+      {bucketToDelete && (
+        <DeleteBucketDialog
+          bucketId={bucketToDelete}
+          open={!!bucketToDelete}
+          onOpenChange={(open) => {
+            if (!open) {
+              setBucketToDelete(null);
+            }
+          }}
+          onDelete={handleDeleteBucket}
+        />
+      )}
     </div>
   );
 }

--- a/dashboard/src/features/orgs/projects/storage/dataGrid/components/FilesDataGrid/FilesDataGrid.tsx
+++ b/dashboard/src/features/orgs/projects/storage/dataGrid/components/FilesDataGrid/FilesDataGrid.tsx
@@ -246,7 +246,6 @@ export default function FilesDataGrid({
 
       return;
     }
-
     if (file.size > bucket.maxUploadFileSize) {
       // biome-ignore lint/style/noParameterAssign: reset file input's value
       event.target.value = '';

--- a/dashboard/src/features/orgs/projects/storage/hooks/useDeleteOrphanedFiles/index.ts
+++ b/dashboard/src/features/orgs/projects/storage/hooks/useDeleteOrphanedFiles/index.ts
@@ -1,0 +1,1 @@
+export { default as useDeleteOrphanedFiles } from './useDeleteOrphanedFiles';

--- a/dashboard/src/features/orgs/projects/storage/hooks/useDeleteOrphanedFiles/useDeleteOrphanedFiles.ts
+++ b/dashboard/src/features/orgs/projects/storage/hooks/useDeleteOrphanedFiles/useDeleteOrphanedFiles.ts
@@ -1,0 +1,22 @@
+import { useCallback } from 'react';
+import { useAppClient } from '@/features/orgs/projects/hooks/useAppClient';
+import { useProject } from '@/features/orgs/projects/hooks/useProject';
+
+function useDeleteOrphanedFiles() {
+  const appClient = useAppClient();
+  const { project } = useProject();
+
+  const deleteOrphanedFiles = useCallback(
+    async () =>
+      await appClient.storage.deleteOrphanedFiles({
+        headers: {
+          'x-hasura-admin-secret': project!.config!.hasura.adminSecret,
+        },
+      }),
+    [appClient, project?.config?.hasura.adminSecret],
+  );
+
+  return deleteOrphanedFiles;
+}
+
+export default useDeleteOrphanedFiles;

--- a/dashboard/src/pages/orgs/[orgSlug]/projects/[appSubdomain]/storage/bucket/[...bucketId].tsx
+++ b/dashboard/src/pages/orgs/[orgSlug]/projects/[appSubdomain]/storage/bucket/[...bucketId].tsx
@@ -1,45 +1,16 @@
 import type { ReactElement } from 'react';
-import { LoadingScreen } from '@/components/presentational/LoadingScreen';
 import { RetryableErrorBoundary } from '@/components/presentational/RetryableErrorBoundary';
 import { OrgLayout } from '@/features/orgs/layout/OrgLayout';
-import { generateAppServiceUrl } from '@/features/orgs/projects/common/utils/generateAppServiceUrl';
-import { useProject } from '@/features/orgs/projects/hooks/useProject';
 import { Bucket } from '@/features/orgs/projects/storage/components/Bucket';
-import { StorageSidebar } from '@/features/orgs/projects/storage/components/StorageSidebar';
-import { NhostApolloProvider } from '@/providers/Apollo';
-import { getHasuraAdminSecret } from '@/utils/env';
+import { StorageLayout } from '@/features/orgs/projects/storage/components/StorageLayout';
 
 export default function StoragePage() {
-  const { project, loading } = useProject();
-
-  if (!project || loading) {
-    return <LoadingScreen />;
-  }
-
   return (
-    <NhostApolloProvider
-      graphqlUrl={generateAppServiceUrl(
-        project.subdomain,
-        project.region,
-        'graphql',
-      )}
-      fetchPolicy="cache-first"
-      globalHeaders={{
-        'x-hasura-admin-secret':
-          process.env.NEXT_PUBLIC_ENV === 'dev'
-            ? getHasuraAdminSecret()
-            : project.config!.hasura.adminSecret,
-      }}
-    >
-      <StorageSidebar />
-      <div className="box flex w-full flex-auto flex-col overflow-x-hidden">
-        <div className="h-full max-w-full pb-25 xs+:pb-[56.5px]">
-          <RetryableErrorBoundary>
-            <Bucket />
-          </RetryableErrorBoundary>
-        </div>
-      </div>
-    </NhostApolloProvider>
+    <div className="h-full max-w-full pb-25 xs+:pb-[56.5px]">
+      <RetryableErrorBoundary>
+        <Bucket />
+      </RetryableErrorBoundary>
+    </div>
   );
 }
 
@@ -50,7 +21,7 @@ StoragePage.getLayout = function getLayout(page: ReactElement) {
         className: 'flex h-full',
       }}
     >
-      {page}
+      <StorageLayout>{page}</StorageLayout>
     </OrgLayout>
   );
 };

--- a/dashboard/src/pages/orgs/[orgSlug]/projects/[appSubdomain]/storage/index.tsx
+++ b/dashboard/src/pages/orgs/[orgSlug]/projects/[appSubdomain]/storage/index.tsx
@@ -1,0 +1,32 @@
+import { FolderOpen } from 'lucide-react';
+import type { ReactElement } from 'react';
+import { OrgLayout } from '@/features/orgs/layout/OrgLayout';
+import { StorageLayout } from '@/features/orgs/projects/storage/components/StorageLayout';
+
+export default function StorageIndexPage() {
+  return (
+    <div className="grid w-full place-content-center gap-2 px-4 py-16 text-center">
+      <div className="mx-auto">
+        <FolderOpen className="h-12 w-12 text-muted-foreground" />
+      </div>
+      <h1 className="!leading-6 font-inter-var font-medium text-[1.125rem]">
+        Storage
+      </h1>
+      <p className="text-muted-foreground">
+        Select a bucket from the sidebar to browse its files
+      </p>
+    </div>
+  );
+}
+
+StorageIndexPage.getLayout = function getLayout(page: ReactElement) {
+  return (
+    <OrgLayout
+      mainContainerProps={{
+        className: 'flex h-full',
+      }}
+    >
+      <StorageLayout>{page}</StorageLayout>
+    </OrgLayout>
+  );
+};

--- a/dashboard/src/tests/testUtils.tsx
+++ b/dashboard/src/tests/testUtils.tsx
@@ -210,8 +210,8 @@ export const mockPointerEvent = () => {
 export class TestUserEvent {
   private user: UserEvent;
 
-  constructor() {
-    this.user = userEvent.setup();
+  constructor(options?: Options) {
+    this.user = userEvent.setup(options);
   }
 
   async click(element: Element) {

--- a/dashboard/src/utils/getProjectFeaturePagePath/getProjectFeaturePagePath.test.ts
+++ b/dashboard/src/utils/getProjectFeaturePagePath/getProjectFeaturePagePath.test.ts
@@ -52,3 +52,11 @@ test('should truncate at the first dynamic segment for remote schemas', () => {
     ),
   ).toBe('/graphql/remote-schemas');
 });
+
+test('should return /storage when on a bucket detail page', () => {
+  expect(
+    getProjectFeaturePagePath(
+      '/orgs/[orgSlug]/projects/[appSubdomain]/storage/bucket/[bucketId]',
+    ),
+  ).toBe('/storage');
+});

--- a/dashboard/src/utils/getProjectFeaturePagePath/getProjectFeaturePagePath.ts
+++ b/dashboard/src/utils/getProjectFeaturePagePath/getProjectFeaturePagePath.ts
@@ -1,4 +1,14 @@
 /**
+ * Maps computed feature paths that are not valid navigable pages to their
+ * actual parent page. This is needed when a dynamic route's direct parent
+ * segment is not a list page (e.g. `/storage/bucket` has no index, only
+ * `/storage` does).
+ */
+const featurePathOverrides: Record<string, string> = {
+  '/storage/bucket': '/storage',
+};
+
+/**
  * Extracts the dashboard feature page's path from a Next.js route pathname,
  * stripping any dynamic segments after `[appSubdomain]`.
  *
@@ -14,5 +24,9 @@ export default function getProjectFeaturePagePath(pathname: string): string {
     return afterProject;
   }
 
-  return afterProject.substring(0, afterProject.lastIndexOf('/', firstDynamic));
+  const computed = afterProject.substring(
+    0,
+    afterProject.lastIndexOf('/', firstDynamic),
+  );
+  return featurePathOverrides[computed] ?? computed;
 }


### PR DESCRIPTION
### Checklist

- [ ] No breaking changes
- [ ] Tests pass
- [ ] New features have new tests
- [ ] Documentation is updated (if applicable)
- [ ] Title of the PR is in the correct format (see below)

<!-- nhost-reviewer:start -->
### **PR Type**
Enhancement

___

### **Description**
- Adds per-bucket storage pages with a new `StorageSidebar` listing all buckets, replacing the previous single-page storage view
- Introduces CRUD operations for buckets: create, edit (via drawer forms), and delete (with confirmation dialog)
- Extracts a reusable `FeatureSidebar` component from duplicated sidebar logic across DataBrowser, Events, AI, and Remote Schemas sidebars
- Adds a new `FormSwitch` form component for react-hook-form switch fields
- Refactors file queries (`useFiles`, `useFilesAggregate`) to accept a `bucketId` filter via a shared `buildFilesWhereClause` utility
- Rewrites `useBuckets` hook to sort the default bucket first and moves it from `dataGrid/hooks` to `storage/hooks`

___

### Diagram Walkthrough

```mermaid
flowchart LR
  subgraph Pages
    SI["storage/index.tsx"] --> SL["StorageLayout"]
    SB["storage/bucket/[bucketId].tsx"] --> SL
  end
  SL --> SS["StorageSidebar"]
  SL --> BC["Bucket Component"]
  SS --> UB["useBuckets"]
  SS --> CBF["CreateBucketForm"]
  SS --> EBF["EditBucketForm"]
  SS --> DBD["DeleteBucketDialog"]
  CBF --> BBF["BaseBucketForm"]
  EBF --> BBF
  BC --> FDG["FilesDataGrid"]
  FDG --> UF["useFiles"]
  FDG --> UFA["useFilesAggregate"]
  UF --> BWC["buildFilesWhereClause"]
  UFA --> BWC
  subgraph Shared
    FS["FeatureSidebar"]
  end
  SS --> FS
  AIS["AISidebar"] --> FS
  DBS["DataBrowserSidebar"] --> FS
  CTS["CronTriggersSidebar"] --> FS
  ETS["EventTriggersSidebar"] --> FS
  RSB["RemoteSchemaSidebar"] --> FS
```

<details> <summary><h3> File Walkthrough</h3></summary>

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody>
<tr><td><strong>Shared components</strong></td><td><details><summary>4 files</summary><table>
<tr>
  <td><strong>FeatureSidebar.tsx</strong><dd><code>New reusable sidebar shell extracted from duplicated logic in 5 sidebars</code></dd></td>
  <td><a href="https://github.com/nhost/nhost/pull/3987/files#diff-9b384b3d0989ba281ef7ecf7c64d5fe7e12dd4e2c55a01eb579ec8958c3ab463">+115/-0</a></td>
</tr>
<tr>
  <td><strong>index.ts</strong> (FeatureSidebar)<dd><code>Barrel export for FeatureSidebar</code></dd></td>
  <td><a href="https://github.com/nhost/nhost/pull/3987/files#diff-272033a2207e0539abaf3c10c62fdb2764a8dcf73388979036d659cbbacc797b">+1/-0</a></td>
</tr>
<tr>
  <td><strong>FormSwitch.tsx</strong><dd><code>New form switch component wrapping react-hook-form with shadcn Switch</code></dd></td>
  <td><a href="https://github.com/nhost/nhost/pull/3987/files#diff-6168e8a05826059a9c14d1d669ab48e1bc8af7cf4b7bac812312a64c4e44c1d3">+98/-0</a></td>
</tr>
<tr>
  <td><strong>index.ts</strong> (FormSwitch)<dd><code>Barrel export for FormSwitch</code></dd></td>
  <td><a href="https://github.com/nhost/nhost/pull/3987/files#diff-af2ecac37ae674e0392168234cae2cb36081ac9e588e4ea1796085acfe242359">+1/-0</a></td>
</tr>
</table></details></td></tr>

<tr><td><strong>Storage feature</strong></td><td><details><summary>19 files</summary><table>
<tr>
  <td><strong>StorageLayout.tsx</strong><dd><code>Refactored from storage.tsx page into a layout with sidebar + children slot</code></dd></td>
  <td><a href="https://github.com/nhost/nhost/pull/3987/files#diff-604d0f2bba4f794febfe1f63b7f53cfb5baacb62231353f70093aec1f2fad7e8">+6/-13</a></td>
</tr>
<tr>
  <td><strong>StorageSidebar.tsx</strong><dd><code>New sidebar listing buckets with create/edit/delete actions</code></dd></td>
  <td><a href="https://github.com/nhost/nhost/pull/3987/files#diff-37d98e387a489aa3f46c40acb7a30d6fcef16270620bd27d4e1e50fa16d425c9">+194/-0</a></td>
</tr>
<tr>
  <td><strong>StorageSidebar.test.tsx</strong><dd><code>Tests for sidebar: loading, list, selection, delete flow</code></dd></td>
  <td><a href="https://github.com/nhost/nhost/pull/3987/files#diff-89c8a414de3e1d893432347211f4b3a066ca6100dcea22c4d23fd6e9dd764ed1">+324/-0</a></td>
</tr>
<tr>
  <td><strong>Bucket.tsx</strong><dd><code>Per-bucket page component fetching bucket data and rendering FilesDataGrid</code></dd></td>
  <td><a href="https://github.com/nhost/nhost/pull/3987/files#diff-6a9a914e8fda4b412cbd70dcfc0562096afc1bdc0436425048d08a9008bb0a8c">+49/-0</a></td>
</tr>
<tr>
  <td><strong>Bucket.test.tsx</strong><dd><code>Tests for Bucket component: loading, found, not found states</code></dd></td>
  <td><a href="https://github.com/nhost/nhost/pull/3987/files#diff-10d193969cb5e8a453894ddb14e090479e452c785491ce17ef252fd1304acbf8">+123/-0</a></td>
</tr>
<tr>
  <td><strong>BaseBucketForm.tsx</strong><dd><code>Shared bucket form with name, sizes, cache, presigned URLs fields</code></dd></td>
  <td><a href="https://github.com/nhost/nhost/pull/3987/files#diff-5d7fb0d1c9829e4764ccb06ea6ab51c4178784baed04d6e09a8838f492a0c71a">+131/-0</a></td>
</tr>
<tr>
  <td><strong>BaseBucketForm.test.tsx</strong><dd><code>Tests for form rendering and validation</code></dd></td>
  <td><a href="https://github.com/nhost/nhost/pull/3987/files#diff-529061911ba73ea4d3583a31ae36a66e4e61e9eec5674ba975e3956784685824">+98/-0</a></td>
</tr>
<tr>
  <td><strong>bucketFormSchema.ts</strong><dd><code>Zod schema with cross-field validation for bucket form</code></dd></td>
  <td><a href="https://github.com/nhost/nhost/pull/3987/files#diff-7898c648907d52026cdfae0ae55f167a0ee76adb152c53afb970f411028d3e33">+26/-0</a></td>
</tr>
<tr>
  <td><strong>CreateBucketForm.tsx</strong><dd><code>Create bucket form using insertBucket mutation with navigation</code></dd></td>
  <td><a href="https://github.com/nhost/nhost/pull/3987/files#diff-adf7c0eb28cfd17a3cce99aed1e3cdf9ab45166c1791d12348278d20ef17f9b2">+72/-0</a></td>
</tr>
<tr>
  <td><strong>EditBucketForm.tsx</strong><dd><code>Edit bucket form with updateBucket mutation and rename handling</code></dd></td>
  <td><a href="https://github.com/nhost/nhost/pull/3987/files#diff-b272659a74bc92f572bb1ae7744390fa989f9c6358ff0cbf510da096f4555725">+119/-0</a></td>
</tr>
<tr>
  <td><strong>DeleteBucketDialog.tsx</strong><dd><code>Confirmation dialog with checkbox guard for destructive delete</code></dd></td>
  <td><a href="https://github.com/nhost/nhost/pull/3987/files#diff-005bbc0c7c0b0eef6b9dc4e5f6626adfb733e14a0b4fe584fea835a524b2f85b">+108/-0</a></td>
</tr>
<tr>
  <td><strong>BucketActions.tsx</strong><dd><code>Dropdown menu with Edit and Delete actions for a bucket item</code></dd></td>
  <td><a href="https://github.com/nhost/nhost/pull/3987/files#diff-876e11a67a9654908edd8c99f295734f0e2387844ee90354481c9645c02cc573">+51/-0</a></td>
</tr>
<tr>
  <td><strong>BucketActions.test.tsx</strong><dd><code>Tests for dropdown action callbacks</code></dd></td>
  <td><a href="https://github.com/nhost/nhost/pull/3987/files#diff-bb9398739dcabafaf3be81a9257308c03bc68f5b9c5a6b60a22f788167b95e8e">+32/-0</a></td>
</tr>
<tr>
  <td><strong>useBuckets.ts</strong><dd><code>Rewritten hook sorting default bucket first with useMemo</code></dd></td>
  <td><a href="https://github.com/nhost/nhost/pull/3987/files#diff-7a8b36d67a413d77f2144ce1838618ac6f997910419e0405a06d018f89dd6f97">+23/-0</a></td>
</tr>
<tr>
  <td><strong>useBuckets.test.tsx</strong><dd><code>Tests for default-first sorting and empty state</code></dd></td>
  <td><a href="https://github.com/nhost/nhost/pull/3987/files#diff-856a6acdb8356f315f6cb779671ff51541426e85de89ff6d37eb995f4ed6eb72">+106/-0</a></td>
</tr>
<tr>
  <td><strong>buildFilesWhereClause.ts</strong><dd><code>Shared utility building GraphQL where clause with bucket + search filters</code></dd></td>
  <td><a href="https://github.com/nhost/nhost/pull/3987/files#diff-4df62f3a3307cb5d724180a68e86a353788cb909a0a0c90777216f7254f326b1">+27/-0</a></td>
</tr>
<tr>
  <td><strong>buildFilesWhereClause.test.ts</strong><dd><code>Tests for where clause building with various filter combos</code></dd></td>
  <td><a href="https://github.com/nhost/nhost/pull/3987/files#diff-a035fcbad484c8a202d0a8274b383231aabee7547b351d69ef4476620c028037">+66/-0</a></td>
</tr>
<tr>
  <td><strong>FilesDataGrid.tsx</strong><dd><code>Accepts bucket prop instead of using useBuckets internally</code></dd></td>
  <td><a href="https://github.com/nhost/nhost/pull/3987/files#diff-18c8df727e1a4fc6a94d03bd4a3a7a8cb3ad44d754803c4c7988c1c00a4b7caf">+17/-14</a></td>
</tr>
<tr>
  <td><strong>useFiles.ts / useFilesAggregate.ts</strong><dd><code>Accept bucketId and delegate to buildFilesWhereClause</code></dd></td>
  <td><a href="https://github.com/nhost/nhost/pull/3987/files#diff-ed71bc1eff3e4515937f01dec41686108466c8272d974628483103ea4dd0b1ed">+9/-10</a>, <a href="https://github.com/nhost/nhost/pull/3987/files#diff-f6535d7353cf98e6fdb8acbd06c091bd2769758f053f7ca314505c41267a74ce">+9/-13</a></td>
</tr>
</table></details></td></tr>

<tr><td><strong>Sidebar refactors (FeatureSidebar adoption)</strong></td><td><details><summary>5 files</summary><table>
<tr>
  <td><strong>AISidebar.tsx</strong><dd><code>Replaced inline sidebar logic with FeatureSidebar wrapper</code></dd></td>
  <td><a href="https://github.com/nhost/nhost/pull/3987/files#diff-2f2161c7ecd92c30bc3a637955f8739ed65d02d36ddf201a018905fa4f10b711">+13/-92</a></td>
</tr>
<tr>
  <td><strong>DataBrowserSidebar.tsx</strong><dd><code>Replaced inline sidebar logic with FeatureSidebar wrapper</code></dd></td>
  <td><a href="https://github.com/nhost/nhost/pull/3987/files#diff-3a9ff7af4a31fbf7e501a77399b2b35306d9e635b021c93f1bc13fc4e225219c">+7/-80</a></td>
</tr>
<tr>
  <td><strong>CronTriggersBrowserSidebar.tsx</strong><dd><code>Replaced inline sidebar logic with FeatureSidebar wrapper</code></dd></td>
  <td><a href="https://github.com/nhost/nhost/pull/3987/files#diff-1c520bd194f7dcc33c167914ee3b0601f5f10c8cc59bf1424f3f929039741d6c">+5/-76</a></td>
</tr>
<tr>
  <td><strong>EventTriggersBrowserSidebar.tsx</strong><dd><code>Replaced inline sidebar logic with FeatureSidebar wrapper</code></dd></td>
  <td><a href="https://github.com/nhost/nhost/pull/3987/files#diff-dbe0e39e093864f4ebad0e7e5abe16fdb1ac3ddf40afea36f818b45b0f5b83c0">+5/-76</a></td>
</tr>
<tr>
  <td><strong>RemoteSchemaBrowserSidebar.tsx</strong><dd><code>Replaced inline sidebar logic with FeatureSidebar wrapper</code></dd></td>
  <td><a href="https://github.com/nhost/nhost/pull/3987/files#diff-599c9195f2ed2560128675d88a938d38c599ab75a2fd06d6b86dbdc176605641">+17/-86</a></td>
</tr>
</table></details></td></tr>

<tr><td><strong>GraphQL queries/mutations</strong></td><td><details><summary>5 files</summary><table>
<tr>
  <td><strong>getBuckets.graphql</strong><dd><code>Extended fields and added order_by clause</code></dd></td>
  <td><a href="https://github.com/nhost/nhost/pull/3987/files#diff-5304f9cacd113e5ebe63f2a64291c1e00099f377a86e0d1db80da81dc5ac4f1d">+5/-1</a></td>
</tr>
<tr>
  <td><strong>getBucket.graphql</strong><dd><code>New query to fetch a single bucket by ID</code></dd></td>
  <td><a href="https://github.com/nhost/nhost/pull/3987/files#diff-9cfce656e1986725ef0d7b7bfb87fc5463ebeb8695a8964a60f2bc601eab4a07">+12/-0</a></td>
</tr>
<tr>
  <td><strong>insertBucket.graphql</strong><dd><code>New mutation to create a bucket</code></dd></td>
  <td><a href="https://github.com/nhost/nhost/pull/3987/files#diff-22e2a13d9e46e9887ce48197d7cc4ad2ebfe2569d9a33039397b7be3ab7ba39d">+5/-0</a></td>
</tr>
<tr>
  <td><strong>updateBucket.graphql</strong><dd><code>New mutation to update a bucket</code></dd></td>
  <td><a href="https://github.com/nhost/nhost/pull/3987/files#diff-338d0446db567b3fd19d75c1ae23469a4c04e131bc33491d9313438f3ae1bca4">+5/-0</a></td>
</tr>
<tr>
  <td><strong>deleteBucket.graphql</strong><dd><code>New mutation to delete a bucket</code></dd></td>
  <td><a href="https://github.com/nhost/nhost/pull/3987/files#diff-bec3f6644642d31b0d03185818d317ad506919a330d958e65a4b4e4117e378e9">+5/-0</a></td>
</tr>
</table></details></td></tr>

<tr><td><strong>Page wiring</strong></td><td><details><summary>15 files</summary><table>
<tr>
  <td><strong>storage/index.tsx</strong><dd><code>New storage index page with placeholder prompting bucket selection</code></dd></td>
  <td><a href="https://github.com/nhost/nhost/pull/3987/files#diff-c84e438c7819cf9f796a55793f8d0c37d68af3dcbfdfc8d9bbf7c2809e210a6d">+32/-0</a></td>
</tr>
<tr>
  <td><strong>storage/bucket/[bucketId].tsx</strong><dd><code>New dynamic page rendering a single bucket's files</code></dd></td>
  <td><a href="https://github.com/nhost/nhost/pull/3987/files#diff-bc9acfa57096c747fee7ca7f159042330493780f0f626d047c344319d0286caa">+27/-0</a></td>
</tr>
<tr>
  <td><strong>PausedProjectContent.tsx</strong><dd><code>Added bucket detail page to paused-project block list</code></dd></td>
  <td><a href="https://github.com/nhost/nhost/pull/3987/files#diff-a03f06f837ef91f9118bc2bfdee6bbd8002ad2db000413195fe0209c1ff98e17">+1/-0</a></td>
</tr>
<tr>
  <td><strong>AI pages (3 files)</strong><dd><code>Removed className prop from AISidebar usage</code></dd></td>
  <td><a href="https://github.com/nhost/nhost/pull/3987/files#diff-7899d8d55f092651c722e063ffbab70ebfc9bbd845e349f3d4c88942fc723ecc">+1/-1</a>, <a href="https://github.com/nhost/nhost/pull/3987/files#diff-23be5f3d94bedf6332a72e290abd05516ee515793e097178323d6e42e27b0172">+1/-1</a>, <a href="https://github.com/nhost/nhost/pull/3987/files#diff-67ed2c588a335e53f8e4dc5b8af947c218f7a2fd35a239a3ab548606d6d90dbd">+1/-1</a></td>
</tr>
<tr>
  <td><strong>Database pages (3 files)</strong><dd><code>Removed className prop from DataBrowserSidebar usage</code></dd></td>
  <td><a href="https://github.com/nhost/nhost/pull/3987/files#diff-2b5b3759fb22a0b1311133eb1abec464416844df26c6a3a1b2af6913d09956fe">+1/-1</a>, <a href="https://github.com/nhost/nhost/pull/3987/files#diff-3092dd85115f09fb62be31613345bc4d21a1872908c4ffbff5b0c71757207e7d">+1/-1</a>, <a href="https://github.com/nhost/nhost/pull/3987/files#diff-c78898595d9fb7949a3cb7a3cee3aa5d481500a66fef64c496ef52e3e287826b">+1/-1</a></td>
</tr>
<tr>
  <td><strong>Cron trigger pages (2 files)</strong><dd><code>Removed className prop from CronTriggersBrowserSidebar usage</code></dd></td>
  <td><a href="https://github.com/nhost/nhost/pull/3987/files#diff-788715d61fabdf33f7bec0899ef0a5401acbce3b1c45a36f9fc4303a95f7c546">+1/-1</a>, <a href="https://github.com/nhost/nhost/pull/3987/files#diff-e6e48daa9b8d575ffb01de020e836a9069c32bb728d3f23b8f8a1e57ebd9b855">+1/-1</a></td>
</tr>
<tr>
  <td><strong>Event trigger pages (2 files)</strong><dd><code>Removed className prop from EventTriggersBrowserSidebar usage</code></dd></td>
  <td><a href="https://github.com/nhost/nhost/pull/3987/files#diff-43617dc0ccbae99489ff26209070557aafdfda4bc446b58db475886d8a07c698">+1/-1</a>, <a href="https://github.com/nhost/nhost/pull/3987/files#diff-d321f37ddebd90100b17e9fdd9c513f389654bfe3b2e76308d58f15805799ad8">+1/-1</a></td>
</tr>
<tr>
  <td><strong>Remote schema pages (2 files)</strong><dd><code>Removed className prop from RemoteSchemaBrowserSidebar usage</code></dd></td>
  <td><a href="https://github.com/nhost/nhost/pull/3987/files#diff-278b7c7ef101d5cadb6bb3608c11eb419bc6b3911ccea24c0d07d1c28d3f31cf">+1/-1</a>, <a href="https://github.com/nhost/nhost/pull/3987/files#diff-f5f04976c8916740e11083cacec897d96c20b4d4d661b3cadc43561644231d23">+1/-1</a></td>
</tr>
</table></details></td></tr>

<tr><td><strong>Generated / deleted</strong></td><td><details><summary>3 files</summary><table>
<tr>
  <td><strong>graphql.ts</strong><dd><code>Generated types for new bucket queries/mutations</code></dd></td>
  <td><a href="https://github.com/nhost/nhost/pull/3987/files#diff-fbd5db84b560b1c91675004448c6c7fa0dcbfb28b9eb05d53b03e6cb7b83ebac">+180/-2</a></td>
</tr>
<tr>
  <td><strong>useBuckets.ts (deleted)</strong><dd><code>Old useBuckets hook removed in favor of new version</code></dd></td>
  <td><a href="https://github.com/nhost/nhost/pull/3987/files#diff-09ca73d7ac93bdba15a6d04f3a9f0e7b32de967374f20b65ae13b842f4a69967">+0/-19</a></td>
</tr>
<tr>
  <td><strong>useBuckets/index.ts (moved)</strong><dd><code>Barrel export moved from dataGrid/hooks to storage/hooks</code></dd></td>
  <td><a href="https://github.com/nhost/nhost/pull/3987/files#diff-8b974fba088d04604d2073c703e1c38ce3de4e9e115727377f029251c12c5abc">+0/-0</a></td>
</tr>
</table></details></td></tr>

<tr><td><strong>Index/barrel exports</strong></td><td><details><summary>8 files</summary><table>
<tr>
  <td><strong>Various index.ts files</strong><dd><code>Barrel exports for StorageLayout, StorageSidebar, Bucket, BaseBucketForm, BucketActions, CreateBucketForm, EditBucketForm, DeleteBucketDialog</code></dd></td>
  <td>+1/-0 each</td>
</tr>
</table></details></td></tr>
</tbody></table>

</details>

___

<!-- nhost-reviewer:end -->
