### PR TITLE
fix(docs): style fix, anchor icon overlapping heading text

### DIFF
--- a/docs/src/styles/custom.css
+++ b/docs/src/styles/custom.css
@@ -539,6 +539,26 @@ html:not([class~="dark"]) .welcome-get-started {
   line-height: 1.4 !important;
 }
 
+/* Match heading wrapper font-size to the heading overrides above.
+   Starlight's anchor link icon uses `em` units resolved against the wrapper's
+   font-size, while the heading padding resolves against the heading's font-size.
+   Without this, the icon is sized too large and overlaps the heading text. */
+.sl-markdown-content .sl-heading-wrapper.level-h2 {
+  font-size: 1.25rem !important;
+}
+.sl-markdown-content .sl-heading-wrapper.level-h3 {
+  font-size: 1rem !important;
+}
+.sl-markdown-content .sl-heading-wrapper.level-h4 {
+  font-size: 0.875rem !important;
+}
+
+/* Anchor icon sizing */
+.sl-markdown-content .sl-heading-wrapper {
+  --sl-anchor-icon-size: 1em;
+  --sl-anchor-icon-gap: 0.3em;
+}
+
 /* Paragraphs - better spacing (only direct children, not inside cards) */
 .sl-markdown-content > p {
   margin-bottom: 1.25rem !important;


### PR DESCRIPTION
Before:
<img width="211" height="182" alt="Screenshot 2026-03-10 at 16 30 59" src="https://github.com/user-attachments/assets/696e49ae-125a-4c79-bcb2-bfb74006b09f" />

After:
<img width="178" height="130" alt="Screenshot 2026-03-10 at 17 29 15" src="https://github.com/user-attachments/assets/43099063-d9b4-4d4a-9fa2-7acad1a1d944" />

### Checklist

- [X] No breaking changes
- [X] Tests pass
- [X] New features have new tests
- [X] Documentation is updated (if applicable)
- [X] Title of the PR is in the correct format (see below)
