### PR TITLE
fix(storage): cleanup multipart form correctly when replacing files

### DIFF
--- a/services/storage/controller/replace_file.go
+++ b/services/storage/controller/replace_file.go
@@ -5,6 +5,7 @@ import (
 	"encoding/json"
 	"fmt"
 	"log/slog"
+	"mime/multipart"
 
 	oapimw "github.com/nhost/nhost/internal/lib/oapi/middleware"
 	"github.com/nhost/nhost/services/storage/api"
@@ -23,7 +24,9 @@ type ReplaceFileResponse struct {
 	Error *ErrorResponse `json:"error,omitempty"`
 }
 
-func replaceFileParseRequest(request api.ReplaceFileRequestObject) (fileData, *APIError) {
+func replaceFileParseRequest(
+	request api.ReplaceFileRequestObject,
+) (fileData, *multipart.Form, *APIError) {
 	res := fileData{
 		ID:       request.Id,
 		Name:     "",
@@ -33,15 +36,15 @@ func replaceFileParseRequest(request api.ReplaceFileRequestObject) (fileData, *A
 
 	form, err := request.Body.ReadForm(maxFormMemory)
 	if err != nil {
-		return fileData{}, InternalServerError(
+		return fileData{}, nil, InternalServerError(
 			fmt.Errorf("problem reading multipart form: %w", err),
 		)
 	}
-	defer form.RemoveAll() //nolint:errcheck
 
 	file := form.File["file"]
 	if len(file) != 1 {
-		return fileData{}, ErrMultipartFileWrong
+		form.RemoveAll() //nolint:errcheck
+		return fileData{}, nil, ErrMultipartFileWrong
 	}
 
 	res.header = file[0]
@@ -50,19 +53,21 @@ func replaceFileParseRequest(request api.ReplaceFileRequestObject) (fileData, *A
 	metadata, ok := form.Value["metadata"]
 	if ok {
 		if len(metadata) != len(file) {
-			return fileData{}, ErrMetadataLength
+			form.RemoveAll() //nolint:errcheck
+			return fileData{}, nil, ErrMetadataLength
 		}
 
 		var d replaceFileMetadata
 		if err := json.Unmarshal([]byte(metadata[0]), &d); err != nil {
-			return fileData{}, WrongMetadataFormatError(err)
+			form.RemoveAll() //nolint:errcheck
+			return fileData{}, nil, WrongMetadataFormatError(err)
 		}
 
 		res.Name = d.Name
 		res.Metadata = d.Metadata
 	}
 
-	return res, nil
+	return res, form, nil
 }
 
 func (ctrl *Controller) ReplaceFile( //nolint:funlen,ireturn
@@ -72,11 +77,12 @@ func (ctrl *Controller) ReplaceFile( //nolint:funlen,ireturn
 	logger := oapimw.LoggerFromContext(ctx)
 	sessionHeaders := middleware.SessionHeadersFromContext(ctx)
 
-	file, apiErr := replaceFileParseRequest(request)
+	file, form, apiErr := replaceFileParseRequest(request)
 	if apiErr != nil {
 		logger.ErrorContext(ctx, "problem parsing request", slog.String("error", apiErr.Error()))
 		return apiErr, nil
 	}
+	defer form.RemoveAll() //nolint:errcheck
 
 	originalMetadata, bucketMetadata, apiErr := ctrl.getFileMetadata(
 		ctx, request.Id, false, sessionHeaders,

--- a/services/storage/controller/replace_file_test.go
+++ b/services/storage/controller/replace_file_test.go
@@ -57,10 +57,16 @@ func TestReplaceFile(t *testing.T) {
 	t.Parallel()
 
 	cases := []struct {
-		name string
+		name     string
+		contents string
 	}{
 		{
-			name: "successful",
+			name:     "successful",
+			contents: "some content",
+		},
+		{
+			name:     "successful with large file exceeding maxFormMemory",
+			contents: strings.Repeat("x", 1<<20+1),
 		},
 	}
 
@@ -73,7 +79,7 @@ func TestReplaceFile(t *testing.T) {
 			)
 
 			file := fakeFile{
-				contents:    "some content",
+				contents:    tc.contents,
 				contentType: "",
 				md: fakeFileMetadata{
 					Name: "a_file.txt",
@@ -114,7 +120,7 @@ func TestReplaceFile(t *testing.T) {
 				controller.BucketMetadata{
 					ID:                   "blah",
 					MinUploadFile:        0,
-					MaxUploadFile:        100,
+					MaxUploadFile:        2 << 20,
 					PresignedURLsEnabled: true,
 					DownloadExpiration:   30,
 					CreatedAt:            "2021-12-15T13:26:52.082485+00:00",
@@ -190,7 +196,7 @@ func TestReplaceFile(t *testing.T) {
 			assert(t, api.ReplaceFile200JSONResponse{
 				Id:               file.md.ID,
 				Name:             "a_file.txt",
-				Size:             12,
+				Size:             int64(len(tc.contents)),
 				BucketId:         "blah",
 				Etag:             "some-etag",
 				CreatedAt:        time.Time{}, // ignored


### PR DESCRIPTION
<!-- nhost-reviewer:start -->
### **PR Type**
Bug fix

___

### **Description**
- Fix premature cleanup of multipart form temporary files in `replaceFileParseRequest` that could cause file read failures for uploads exceeding the 1MB memory threshold.
- Move `form.RemoveAll()` from the parse function to the caller (`ReplaceFile`), aligning with the existing pattern in `UploadFile`.

___

<details> <summary><h3> File Walkthrough</h3></summary>

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody>
<tr><td><strong>Core logic</strong></td><td><details><summary>1 files</summary><table>
<tr>
  <td><strong>replace_file.go</strong><dd><code>Return multipart.Form from parse function and defer cleanup in caller to prevent use-after-free of temp files</code></dd></td>
  <td><a href="https://github.com/nhost/nhost/pull/4002/files#diff-84e7fa8c5de42c6235a27fec3b91dac72adf8328c9e6b4fd5a94ea6998346af4">+14/-8</a></td>
</tr>
</table></details></td></tr>
</tbody></table>

</details>

___

<!-- nhost-reviewer:end -->
