### PR TITLE
fix(dashboard): filter by project name in the header's projects combobox

### DIFF
--- a/dashboard/src/components/layout/Header/ProjectsComboBox.tsx
+++ b/dashboard/src/components/layout/Header/ProjectsComboBox.tsx
@@ -96,6 +96,7 @@ export default function ProjectsComboBox() {
                   <CommandItem
                     key={option.value}
                     value={option.value}
+                    keywords={[option.label]}
                     onSelect={() => handleProjectSelect(option)}
                   >
                     <Check


### PR DESCRIPTION
<!-- nhost-reviewer:start -->
### **PR Type**
Bug fix

___

### **Description**
- Add `keywords` prop to `CommandItem` in the projects combobox so that typing in the search input filters projects by their display name, not just by subdomain.

___

<details> <summary><h3> File Walkthrough</h3></summary>

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody>
<tr><td><strong>Dashboard UI</strong></td><td><details><summary>1 file</summary><table>
<tr>
  <td><strong>ProjectsComboBox.tsx</strong><dd><code>Add keywords={[option.label]} so Command filters by project name</code></dd></td>
  <td><a href="https://github.com/nhost/nhost/pull/4010/files#diff-3cce1319c40c935cc1ff9487f6bf9dff402d1da5087fa93be4a8c699eb5f3313">+1/-0</a></td>
</tr>
</table></details></td></tr>
</tbody></table>

</details>

___

<!-- nhost-reviewer:end -->