### PR TITLE
fix(ci): prevent potential command injection in PR title validation

### DIFF
--- a/.github/actions/validate-pr-title/action.yaml
+++ b/.github/actions/validate-pr-title/action.yaml
@@ -10,9 +10,9 @@ runs:
   steps:
     - name: "Validate PR title format"
       shell: bash
+      env:
+        PR_TITLE: ${{ inputs.pr_title }}
       run: |
-        PR_TITLE="${{ inputs.pr_title }}"
-
         echo "Validating PR title: $PR_TITLE"
 
         # Define valid types and packages


### PR DESCRIPTION
Shouldn't be an issue as all jobs are protected by this gate:

https://github.com/nhost/nhost/blob/main/.github/workflows/cli_checks.yaml#L40-L49

But better to address in case the gate is removed by mistake or a new job forgets it.

Many thanks to @abhayclasher for finding and reporting this issue.