### PR TITLE
fix(cli): conditionally enable storage URL based on port exposure

### DIFF
--- a/cli/dockercompose/storage.go
+++ b/cli/dockercompose/storage.go
@@ -30,7 +30,7 @@ func storage( //nolint:funlen
 		cfg,
 		"http://graphql:8080/v1",
 		"postgres://nhost_storage_admin@postgres:5432/local?sslmode=disable",
-		URL(subdomain, "storage", httpPort, useTLS),
+		URL(subdomain, "storage", httpPort, useTLS && exposePort == 0),
 		"http://minio:9000",
 		"",
 		"nhost",


### PR DESCRIPTION
## Description

Fixes #4028

Fix the storage service URL configuration to only use TLS when the storage port is actually exposed. Previously, the TLS flag was applied unconditionally, which could cause connection issues when the port was not exposed (`exposePort == 0`).

The change adds a condition to the `useTLS` parameter: TLS is now only enabled when both `useTLS` is true AND `exposePort` is not 0 (i.e., the port is being exposed).

## Changes

- Modified `cli/dockercompose/storage.go` to conditionally apply TLS based on port exposure status

## Checklist

- [x] No breaking changes
- [x] Tests pass
- [x] New features have new tests (N/A - bug fix)
- [x] Documentation is updated (N/A - internal configuration fix)