### PR TITLE
fix(dashboard): keep column order from older configuration

### DIFF
--- a/dashboard/src/features/orgs/projects/common/components/DataGridFiltersPopover/useGetDataColumns.ts
+++ b/dashboard/src/features/orgs/projects/common/components/DataGridFiltersPopover/useGetDataColumns.ts
@@ -1,5 +1,5 @@
 import type { UnknownDataGridRow } from '@/features/orgs/projects/storage/dataGrid/components/DataGrid';
-import { SELECTION_COLUMN_ID } from '@/features/orgs/projects/storage/dataGrid/components/DataGrid/useDataGrid';
+import { SELECTION_COLUMN_ID } from '@/features/orgs/projects/storage/dataGrid/components/DataGrid';
 import { useDataGridConfig } from '@/features/orgs/projects/storage/dataGrid/components/DataGridConfigProvider';
 
 export function useGetDataColumns<

--- a/dashboard/src/features/orgs/projects/common/components/DataGridTableViewConfigurationPopover/ColumnCustomizer.tsx
+++ b/dashboard/src/features/orgs/projects/common/components/DataGridTableViewConfigurationPopover/ColumnCustomizer.tsx
@@ -3,7 +3,7 @@ import type { Column } from '@tanstack/react-table';
 import { DragAndDropList } from '@/components/common/DragAndDropList';
 import { useTablePath } from '@/features/orgs/projects/database/common/hooks/useTablePath';
 import type { UnknownDataGridRow } from '@/features/orgs/projects/storage/dataGrid/components/DataGrid';
-import { SELECTION_COLUMN_ID } from '@/features/orgs/projects/storage/dataGrid/components/DataGrid/useDataGrid';
+import { SELECTION_COLUMN_ID } from '@/features/orgs/projects/storage/dataGrid/components/DataGrid';
 import { useDataGridConfig } from '@/features/orgs/projects/storage/dataGrid/components/DataGridConfigProvider';
 import { saveColumnOrder } from '@/features/orgs/projects/storage/dataGrid/utils/PersistentDataTableConfigurationStorage';
 import { isEmptyValue } from '@/lib/utils';

--- a/dashboard/src/features/orgs/projects/common/components/DataGridTableViewConfigurationPopover/ShowHideAllColumnsButtons.tsx
+++ b/dashboard/src/features/orgs/projects/common/components/DataGridTableViewConfigurationPopover/ShowHideAllColumnsButtons.tsx
@@ -2,7 +2,7 @@ import type { VisibilityState } from '@tanstack/react-table';
 import { Button } from '@/components/ui/v3/button';
 import { ButtonGroup } from '@/components/ui/v3/button-group';
 import { useTablePath } from '@/features/orgs/projects/database/common/hooks/useTablePath';
-import { SELECTION_COLUMN_ID } from '@/features/orgs/projects/storage/dataGrid/components/DataGrid/useDataGrid';
+import { SELECTION_COLUMN_ID } from '@/features/orgs/projects/storage/dataGrid/components/DataGrid';
 import { useDataGridConfig } from '@/features/orgs/projects/storage/dataGrid/components/DataGridConfigProvider';
 import {
   saveColumnOrder,

--- a/dashboard/src/features/orgs/projects/database/dataGrid/components/BaseTableForm/BaseTableForm.test.tsx
+++ b/dashboard/src/features/orgs/projects/database/dataGrid/components/BaseTableForm/BaseTableForm.test.tsx
@@ -269,14 +269,16 @@ describe('BaseTableForm', () => {
 
   it('should display identity column picker when integer is selected', async () => {
     render(<TestTableFormWrapper />);
-    const user = new TestUserEvent();
 
     expect(screen.queryByLabelText('Identity')).not.toBeInTheDocument();
 
     await TestUserEvent.fireClickEvent(
       screen.getByPlaceholderText('Select type'),
     );
-    await user.type(screen.getByPlaceholderText('Select type'), 'int');
+    await TestUserEvent.fireTypeEvent(
+      screen.getByPlaceholderText('Select type'),
+      'int',
+    );
     await TestUserEvent.fireClickEvent(
       screen.getByRole('option', { name: /^integer.*int4/ }),
     );

--- a/dashboard/src/features/orgs/projects/database/dataGrid/components/DataBrowserGrid/DataBrowserGridContainer.test.tsx
+++ b/dashboard/src/features/orgs/projects/database/dataGrid/components/DataBrowserGrid/DataBrowserGridContainer.test.tsx
@@ -1,0 +1,134 @@
+import { setupServer } from 'msw/node';
+import { vi } from 'vitest';
+import { COLUMN_CONFIGURATION_STORAGE_KEY } from '@/features/orgs/projects/storage/dataGrid/utils/PersistentDataTableConfigurationStorage';
+import { getProjectQuery } from '@/tests/msw/mocks/graphql/getProjectQuery';
+import hasuraMetadataQuery from '@/tests/msw/mocks/rest/hasuraMetadataQuery';
+import tableQuery from '@/tests/msw/mocks/rest/tableQuery';
+import tokenQuery from '@/tests/msw/mocks/rest/tokenQuery';
+import {
+  localStorageMock,
+  queryClient,
+  render,
+  screen,
+  setInitialStore,
+  waitFor,
+} from '@/tests/testUtils';
+import DataBrowserGridContainer from './DataBrowserGridContainer';
+import { DataGridQueryParamsProvider } from './DataGridQueryParamsProvider';
+
+const mocks = vi.hoisted(() => ({
+  useRouter: vi.fn(),
+}));
+
+vi.mock('next/router', () => ({
+  useRouter: mocks.useRouter,
+}));
+
+const server = setupServer(
+  tokenQuery,
+  tableQuery,
+  hasuraMetadataQuery,
+  getProjectQuery,
+);
+
+function createRouterValue(tableSlug: string) {
+  return {
+    query: {
+      orgSlug: 'xyz',
+      appSubdomain: 'test-project',
+      dataSourceSlug: 'default',
+      schemaSlug: 'public',
+      tableSlug,
+    },
+    pathname:
+      '/orgs/[orgSlug]/projects/[appSubdomain]/database/browser/[dataSourceSlug]/[schemaSlug]/tables/[tableSlug]',
+    route:
+      '/orgs/[orgSlug]/projects/[appSubdomain]/database/browser/[dataSourceSlug]/[schemaSlug]/tables/[tableSlug]',
+    asPath: `/orgs/xyz/projects/test-project/database/browser/default/public/tables/${tableSlug}`,
+    basePath: '',
+    isLocaleDomain: false,
+    isReady: true,
+    isPreview: false,
+    isFallback: false,
+    push: vi.fn(),
+    replace: vi.fn(),
+    reload: vi.fn(),
+    back: vi.fn(),
+    forward: vi.fn(),
+    prefetch: vi.fn(),
+    beforePopState: vi.fn(),
+    events: { on: vi.fn(), off: vi.fn(), emit: vi.fn() },
+  };
+}
+
+describe('DataBrowserGridContainer', () => {
+  beforeAll(() => {
+    global.localStorage = localStorageMock();
+    window.HTMLElement.prototype.scrollTo = vi.fn();
+    server.listen();
+  });
+
+  beforeEach(() => {
+    localStorage.clear();
+    queryClient.clear();
+  });
+
+  afterAll(() => {
+    server.close();
+  });
+
+  it('should load the correct column visibility for each table when switching', async () => {
+    // Both "authors" and "town" tables have a shared "name" column.
+    // "authors" has "name" visible, "town" has "name" hidden.
+    // Switching tables should update the grid to reflect the stored config.
+    const authorsTablePath = 'default.public.authors';
+    const townTablePath = 'default.public.town';
+
+    setInitialStore({
+      [COLUMN_CONFIGURATION_STORAGE_KEY]: JSON.stringify({
+        [authorsTablePath]: {
+          columnVisibility: { name: true },
+          columnOrder: [],
+        },
+        [townTablePath]: {
+          columnVisibility: { name: false },
+          columnOrder: [],
+        },
+      }),
+    });
+
+    mocks.useRouter.mockReturnValue(createRouterValue('authors'));
+
+    const { rerender } = render(
+      <DataGridQueryParamsProvider>
+        <DataBrowserGridContainer />
+      </DataGridQueryParamsProvider>,
+    );
+
+    await waitFor(() => {
+      expect(screen.getByRole('table')).toBeInTheDocument();
+    });
+
+    expect(
+      screen.getByRole('columnheader', { name: /name/i }),
+    ).toBeInTheDocument();
+
+    mocks.useRouter.mockReturnValue(createRouterValue('town'));
+
+    rerender(
+      <DataGridQueryParamsProvider>
+        <DataBrowserGridContainer />
+      </DataGridQueryParamsProvider>,
+    );
+
+    await waitFor(() => {
+      expect(screen.getByRole('table')).toBeInTheDocument();
+    });
+
+    await waitFor(() => {
+      expect(
+        screen.queryByRole('columnheader', { name: /name/i }),
+      ).not.toBeInTheDocument();
+    });
+  });
+});

--- a/dashboard/src/features/orgs/projects/database/dataGrid/components/DataBrowserGrid/DataBrowserGridContainer.tsx
+++ b/dashboard/src/features/orgs/projects/database/dataGrid/components/DataBrowserGrid/DataBrowserGridContainer.tsx
@@ -1,0 +1,10 @@
+import { useRouter } from 'next/router';
+import type { DataBrowserGridProps } from './DataBrowserGrid';
+import DataBrowserGrid from './DataBrowserGrid';
+
+export default function DataBrowserGridContainer(props: DataBrowserGridProps) {
+  const { query } = useRouter();
+  const { tableSlug } = query;
+
+  return <DataBrowserGrid key={tableSlug as string} {...props} />;
+}

--- a/dashboard/src/features/orgs/projects/database/dataGrid/components/DataBrowserGrid/index.ts
+++ b/dashboard/src/features/orgs/projects/database/dataGrid/components/DataBrowserGrid/index.ts
@@ -1,2 +1,3 @@
 export * from './DataBrowserGrid';
 export { default as DataBrowserGrid } from './DataBrowserGrid';
+export { default as DataBrowserGridContainer } from './DataBrowserGridContainer';

--- a/dashboard/src/features/orgs/projects/storage/dataGrid/components/DataGrid/DataGrid.tsx
+++ b/dashboard/src/features/orgs/projects/storage/dataGrid/components/DataGrid/DataGrid.tsx
@@ -119,33 +119,29 @@ function DataGrid<TColumnData extends UnknownDataGridRow>(
           />
         )}
         {columns.length > 0 && allColumnsHidden && <AllColumnsHiddenMessage />}
-        {columns.length > 0 &&
-          !allColumnsHidden &&
-          dataGridProps.tableInitialized && (
-            <div
-              ref={mergeRefs([ref, tableRef])}
-              className={cn(
-                'box overflow-x-auto bg-background',
-                { 'h-[calc(100%-1px)]': !loading }, // need to set height like this to remove vertical scrollbar
-                className,
-              )}
-            >
-              <DataGridFrame>
-                <div className="relative h-full">
-                  <DataGridHeader {...headerProps} />
-                  <DataGridBody
-                    isRowDisabled={isRowDisabled}
-                    emptyStateMessage={emptyStateMessage}
-                    loading={loading}
-                  />
-                </div>
-              </DataGridFrame>
-            </div>
-          )}
-
-        {(loading || !dataGridProps.tableInitialized) && (
-          <Spinner className="my-4" />
+        {columns.length > 0 && !allColumnsHidden && (
+          <div
+            ref={mergeRefs([ref, tableRef])}
+            className={cn(
+              'box overflow-x-auto bg-background',
+              { 'h-[calc(100%-1px)]': !loading }, // need to set height like this to remove vertical scrollbar
+              className,
+            )}
+          >
+            <DataGridFrame>
+              <div className="relative h-full">
+                <DataGridHeader {...headerProps} />
+                <DataGridBody
+                  isRowDisabled={isRowDisabled}
+                  emptyStateMessage={emptyStateMessage}
+                  loading={loading}
+                />
+              </div>
+            </DataGridFrame>
+          </div>
         )}
+
+        {loading && <Spinner className="my-4" />}
       </DataTableDesignProvider>
     </DataGridConfigProvider>
   );

--- a/dashboard/src/features/orgs/projects/storage/dataGrid/components/DataGrid/constants.ts
+++ b/dashboard/src/features/orgs/projects/storage/dataGrid/components/DataGrid/constants.ts
@@ -1,0 +1,1 @@
+export const SELECTION_COLUMN_ID = 'selection-column';

--- a/dashboard/src/features/orgs/projects/storage/dataGrid/components/DataGrid/index.ts
+++ b/dashboard/src/features/orgs/projects/storage/dataGrid/components/DataGrid/index.ts
@@ -1,3 +1,4 @@
+export * from './constants';
 export * from './DataGrid';
 export { default as DataGrid } from './DataGrid';
 export * from './types';

--- a/dashboard/src/features/orgs/projects/storage/dataGrid/components/DataGrid/useDataGrid.test.tsx
+++ b/dashboard/src/features/orgs/projects/storage/dataGrid/components/DataGrid/useDataGrid.test.tsx
@@ -5,10 +5,11 @@ import useDataGrid from './useDataGrid';
 const mocks = vi.hoisted(() => ({
   getColumnVisibility: vi.fn(),
   getColumnOrder: vi.fn(),
+  useTablePath: vi.fn(() => 'test-table-path'),
 }));
 
 vi.mock('@/features/orgs/projects/database/common/hooks/useTablePath', () => ({
-  useTablePath: vi.fn(() => 'test-table-path'),
+  useTablePath: mocks.useTablePath,
 }));
 
 vi.mock(
@@ -27,21 +28,6 @@ vi.mock(
 );
 
 describe('useDataGrid', () => {
-  it('should initialize tableInitialized as false and then true', async () => {
-    const { result } = renderHook(() =>
-      useDataGrid({
-        columns: [],
-        data: [],
-      }),
-    );
-
-    expect(result.current.tableInitialized).toBe(false);
-
-    await waitFor(() => expect(result.current.tableInitialized).toBe(true), {
-      timeout: 1000,
-    });
-  });
-
   it('should call PersistenDataTableConfigurationStorage to load configuration', async () => {
     renderHook(() =>
       useDataGrid({

--- a/dashboard/src/features/orgs/projects/storage/dataGrid/components/DataGrid/useDataGrid.tsx
+++ b/dashboard/src/features/orgs/projects/storage/dataGrid/components/DataGrid/useDataGrid.tsx
@@ -11,7 +11,7 @@ import {
   useReactTable,
 } from '@tanstack/react-table';
 import type { ReactNode, RefObject } from 'react';
-import { useEffect, useMemo, useState } from 'react';
+import { useMemo } from 'react';
 import { Checkbox } from '@/components/ui/v3/checkbox';
 import { useTablePath } from '@/features/orgs/projects/database/common/hooks/useTablePath';
 import {
@@ -19,9 +19,12 @@ import {
   getColumnOrder,
   getColumnVisibility,
 } from '@/features/orgs/projects/storage/dataGrid/utils/PersistentDataTableConfigurationStorage';
+import { SELECTION_COLUMN_ID } from './constants';
 import type { UnknownDataGridRow } from './types';
 
-export const SELECTION_COLUMN_ID = 'selection-column';
+if (typeof window !== 'undefined') {
+  convertToV8IfNeeded();
+}
 
 export interface UseDataGridBaseOptions<
   T extends UnknownDataGridRow = UnknownDataGridRow,
@@ -69,9 +72,7 @@ export type UseDataGridReturn<
   Omit<
     UseDataGridBaseOptions<T>,
     'enableRowSelection' | 'onSortingChange' | 'sorting'
-  > & {
-    tableInitialized: boolean;
-  };
+  >;
 
 export default function useDataGrid<T extends UnknownDataGridRow>({
   data,
@@ -85,7 +86,6 @@ export default function useDataGrid<T extends UnknownDataGridRow>({
   ...options
 }: UseDataGridOptions<T>): UseDataGridReturn<T> {
   const tablePath = useTablePath();
-  const [tableInitialized, setTableInitialized] = useState(false);
 
   const defaultColumn: Partial<ColumnDef<T>> = useMemo(
     () => ({
@@ -163,24 +163,8 @@ export default function useDataGrid<T extends UnknownDataGridRow>({
     ...options,
   });
 
-  useEffect(() => {
-    convertToV8IfNeeded();
-    setTableInitialized(false);
-    const columnVisibilityForTable = getColumnVisibility(tablePath);
-    reactTable.setColumnVisibility(columnVisibilityForTable);
-
-    const columnOrderForTable = getColumnOrder(tablePath);
-    reactTable.setColumnOrder(columnOrderForTable);
-    const st = setTimeout(() => {
-      setTableInitialized(true);
-    }, 250);
-
-    return () => clearTimeout(st);
-  }, [tablePath, reactTable]);
-
   return {
     ...reactTable,
-    tableInitialized,
     allowSort,
     allowResize,
     allowSelection,

--- a/dashboard/src/features/orgs/projects/storage/dataGrid/components/DataGridCell/DataGridCell.tsx
+++ b/dashboard/src/features/orgs/projects/storage/dataGrid/components/DataGridCell/DataGridCell.tsx
@@ -20,7 +20,7 @@ import type {
   DataBrowserGridCellProps,
 } from '@/features/orgs/projects/database/dataGrid/types/dataBrowser';
 import type { UnknownDataGridRow } from '@/features/orgs/projects/storage/dataGrid/components/DataGrid';
-import { SELECTION_COLUMN_ID } from '@/features/orgs/projects/storage/dataGrid/components/DataGrid/useDataGrid';
+import { SELECTION_COLUMN_ID } from '@/features/orgs/projects/storage/dataGrid/components/DataGrid';
 import { cn, isNotEmptyValue } from '@/lib/utils';
 import { copy } from '@/utils/copy';
 import { triggerToast } from '@/utils/toast';

--- a/dashboard/src/features/orgs/projects/storage/dataGrid/components/DataGridHeader/DataGridHeader.tsx
+++ b/dashboard/src/features/orgs/projects/storage/dataGrid/components/DataGridHeader/DataGridHeader.tsx
@@ -1,7 +1,7 @@
 import type { Header } from '@tanstack/react-table';
 import type { DetailedHTMLProps, HTMLProps } from 'react';
 import type { UnknownDataGridRow } from '@/features/orgs/projects/storage/dataGrid/components/DataGrid';
-import { SELECTION_COLUMN_ID } from '@/features/orgs/projects/storage/dataGrid/components/DataGrid/useDataGrid';
+import { SELECTION_COLUMN_ID } from '@/features/orgs/projects/storage/dataGrid/components/DataGrid';
 import { useDataGridConfig } from '@/features/orgs/projects/storage/dataGrid/components/DataGridConfigProvider';
 import { DataGridHeaderButton } from '@/features/orgs/projects/storage/dataGrid/components/DataGridHeaderButton';
 import { cn } from '@/lib/utils';

--- a/dashboard/src/features/orgs/projects/storage/dataGrid/components/DataGridHeaderButton/DataGridHeaderButton.tsx
+++ b/dashboard/src/features/orgs/projects/storage/dataGrid/components/DataGridHeaderButton/DataGridHeaderButton.tsx
@@ -2,7 +2,7 @@ import { flexRender, type Header } from '@tanstack/react-table';
 import { ArrowDown, ArrowUp } from 'lucide-react';
 import { Button } from '@/components/ui/v3/button';
 import type { UnknownDataGridRow } from '@/features/orgs/projects/storage/dataGrid/components/DataGrid';
-import { SELECTION_COLUMN_ID } from '@/features/orgs/projects/storage/dataGrid/components/DataGrid/useDataGrid';
+import { SELECTION_COLUMN_ID } from '@/features/orgs/projects/storage/dataGrid/components/DataGrid';
 import { useDataGridConfig } from '@/features/orgs/projects/storage/dataGrid/components/DataGridConfigProvider';
 import { cn } from '@/lib/utils';
 

--- a/dashboard/src/features/orgs/projects/storage/dataGrid/utils/PersistentDataTableConfigurationStorage.test.ts
+++ b/dashboard/src/features/orgs/projects/storage/dataGrid/utils/PersistentDataTableConfigurationStorage.test.ts
@@ -11,8 +11,6 @@ import {
 
 describe('PersistentDataTableConfigurationStorage', () => {
   const TABLE_PATH = 'default.public.myTable';
-  const CONFIG_HAS_BEEN_CONVERTED_TO_V8_KEY = 'nhost_has_been_converted_to_v8';
-
   beforeAll(() => {
     global.localStorage = localStorageMock();
   });
@@ -130,30 +128,142 @@ describe('PersistentDataTableConfigurationStorage', () => {
 
     expect(moviesConfig).toStrictEqual({ director: false, rating: false });
     expect(booksConfig).toStrictEqual({ isbn: false });
-    expect(localStorage.getItem(CONFIG_HAS_BEEN_CONVERTED_TO_V8_KEY)).toBe(
-      'true',
-    );
   });
 
-  it('should not convert if already converted', () => {
+  it('should convert columnOrder even when there are no hiddenColumns', () => {
     const MOVIES_TABLE = 'default.public.movies';
-    const initialStore = {
+
+    setInitialStore({
+      [COLUMN_CONFIGURATION_STORAGE_KEY]: JSON.stringify({
+        [MOVIES_TABLE]: {
+          hiddenColumns: [],
+          columnOrder: ['title', 'year', 'director'],
+        },
+      }),
+    });
+
+    convertToV8IfNeeded();
+
+    const columnOrder = getColumnOrder(MOVIES_TABLE);
+    expect(columnOrder).toStrictEqual([
+      'selection-column',
+      'title',
+      'year',
+      'director',
+    ]);
+  });
+
+  it('should convert both hiddenColumns and columnOrder independently', () => {
+    const MOVIES_TABLE = 'default.public.movies';
+
+    setInitialStore({
+      [COLUMN_CONFIGURATION_STORAGE_KEY]: JSON.stringify({
+        [MOVIES_TABLE]: {
+          hiddenColumns: ['director'],
+          columnOrder: ['title', 'year', 'director'],
+        },
+      }),
+    });
+
+    convertToV8IfNeeded();
+
+    const columnVisibility = getColumnVisibility(MOVIES_TABLE);
+    const columnOrder = getColumnOrder(MOVIES_TABLE);
+
+    expect(columnVisibility).toStrictEqual({ director: false });
+    expect(columnOrder).toStrictEqual([
+      'selection-column',
+      'title',
+      'year',
+      'director',
+    ]);
+  });
+
+  it('should be idempotent — calling convertToV8IfNeeded twice should not duplicate selection-column', () => {
+    const MOVIES_TABLE = 'default.public.movies';
+
+    setInitialStore({
+      [COLUMN_CONFIGURATION_STORAGE_KEY]: JSON.stringify({
+        [MOVIES_TABLE]: {
+          hiddenColumns: ['director'],
+          columnOrder: ['title', 'year', 'director'],
+        },
+      }),
+    });
+
+    convertToV8IfNeeded();
+    convertToV8IfNeeded();
+
+    const columnOrder = getColumnOrder(MOVIES_TABLE);
+    expect(columnOrder).toStrictEqual([
+      'selection-column',
+      'title',
+      'year',
+      'director',
+    ]);
+
+    const columnVisibility = getColumnVisibility(MOVIES_TABLE);
+    expect(columnVisibility).toStrictEqual({ director: false });
+  });
+
+  it('should only convert old-format entries when mixed with v8 entries', () => {
+    const MOVIES_TABLE = 'default.public.movies';
+    const BOOKS_TABLE = 'default.public.books';
+
+    setInitialStore({
       [COLUMN_CONFIGURATION_STORAGE_KEY]: JSON.stringify({
         [MOVIES_TABLE]: {
           hiddenColumns: ['director'],
           columnOrder: ['title', 'director'],
         },
+        [BOOKS_TABLE]: {
+          columnVisibility: { isbn: false },
+          columnOrder: ['selection-column', 'title', 'isbn'],
+        },
       }),
-      [CONFIG_HAS_BEEN_CONVERTED_TO_V8_KEY]: 'true',
-    };
-    setInitialStore(initialStore);
+    });
 
     convertToV8IfNeeded();
 
-    const storedData = JSON.parse(
-      localStorage.getItem(COLUMN_CONFIGURATION_STORAGE_KEY) || '{}',
-    );
-    expect(storedData[MOVIES_TABLE]).toHaveProperty('hiddenColumns');
-    expect(storedData[MOVIES_TABLE]).not.toHaveProperty('columnVisibility');
+    expect(getColumnVisibility(MOVIES_TABLE)).toStrictEqual({
+      director: false,
+    });
+    expect(getColumnOrder(MOVIES_TABLE)).toStrictEqual([
+      'selection-column',
+      'title',
+      'director',
+    ]);
+
+    expect(getColumnVisibility(BOOKS_TABLE)).toStrictEqual({ isbn: false });
+    expect(getColumnOrder(BOOKS_TABLE)).toStrictEqual([
+      'selection-column',
+      'title',
+      'isbn',
+    ]);
+  });
+
+  it('should not convert if data is already in v8 format', () => {
+    const MOVIES_TABLE = 'default.public.movies';
+
+    setInitialStore({
+      [COLUMN_CONFIGURATION_STORAGE_KEY]: JSON.stringify({
+        [MOVIES_TABLE]: {
+          columnVisibility: { director: false },
+          columnOrder: ['selection-column', 'title', 'director'],
+        },
+      }),
+    });
+
+    convertToV8IfNeeded();
+
+    const columnVisibility = getColumnVisibility(MOVIES_TABLE);
+    const columnOrder = getColumnOrder(MOVIES_TABLE);
+
+    expect(columnVisibility).toStrictEqual({ director: false });
+    expect(columnOrder).toStrictEqual([
+      'selection-column',
+      'title',
+      'director',
+    ]);
   });
 });

--- a/dashboard/src/features/orgs/projects/storage/dataGrid/utils/PersistentDataTableConfigurationStorage.ts
+++ b/dashboard/src/features/orgs/projects/storage/dataGrid/utils/PersistentDataTableConfigurationStorage.ts
@@ -1,6 +1,6 @@
 import type { ColumnOrderState, VisibilityState } from '@tanstack/react-table';
 import type { RowDensity } from '@/features/orgs/projects/common/types/dataTableConfigurationTypes';
-import { SELECTION_COLUMN_ID } from '@/features/orgs/projects/storage/dataGrid/components/DataGrid/useDataGrid';
+import { SELECTION_COLUMN_ID } from '@/features/orgs/projects/storage/dataGrid/components/DataGrid/constants';
 import { isEmptyValue, isNotEmptyValue } from '@/lib/utils';
 
 export const COLUMN_CONFIGURATION_STORAGE_KEY =
@@ -8,8 +8,6 @@ export const COLUMN_CONFIGURATION_STORAGE_KEY =
 
 const DATA_TABLE_CONFIGURATION_STORAGE_KEY =
   'nhost_data_table_configuration_storage';
-
-const CONFIG_HAS_BEEN_CONVERTED_TO_V8_KEY = 'nhost_has_been_converted_to_v8';
 
 type ColumnConfiguration = {
   columnVisibility: VisibilityState;
@@ -20,6 +18,12 @@ type OldColumnConfiguration = {
   hiddenColumns: string[];
   columnOrder: string[];
 };
+
+function isOldFormat(
+  config: ColumnConfiguration | OldColumnConfiguration,
+): config is OldColumnConfiguration {
+  return 'hiddenColumns' in config;
+}
 
 type DataTableViewConfiguration = {
   rowDensity: RowDensity;
@@ -123,47 +127,48 @@ export function saveRowDensity(rowDensity: RowDensity) {
   );
 }
 export function convertToV8IfNeeded() {
-  const isConfigNotConvertedToV8 =
-    localStorage.getItem(CONFIG_HAS_BEEN_CONVERTED_TO_V8_KEY) !== 'true';
-
   const allStoredData = getAllStoredData();
-  if (isConfigNotConvertedToV8 && isNotEmptyValue(allStoredData)) {
-    const convertedData = {
-      ...allStoredData,
-    };
 
-    Object.keys(allStoredData).forEach((key) => {
-      const tableConfiguration = allStoredData[
-        key
-      ] as unknown as OldColumnConfiguration;
+  const needsConversion = Object.values(allStoredData).some((config) =>
+    isOldFormat(config as ColumnConfiguration | OldColumnConfiguration),
+  );
 
-      const { hiddenColumns = [] } = tableConfiguration;
-      if (isNotEmptyValue(hiddenColumns)) {
-        const columnVisibility = hiddenColumns.reduce<VisibilityState>(
+  if (!needsConversion) {
+    return;
+  }
+
+  const convertedData = { ...allStoredData };
+
+  for (const key of Object.keys(allStoredData)) {
+    const entry = allStoredData[key] as unknown as
+      | ColumnConfiguration
+      | OldColumnConfiguration;
+
+    if (!isOldFormat(entry)) {
+      continue;
+    }
+
+    const tableConfiguration = entry;
+
+    const columnVisibility = isNotEmptyValue(tableConfiguration.hiddenColumns)
+      ? tableConfiguration.hiddenColumns.reduce<VisibilityState>(
           (vs, col) => ({
             ...vs,
             [col]: false,
           }),
           {},
-        );
+        )
+      : (convertedData[key].columnVisibility ?? {});
 
-        const columnOrder = isNotEmptyValue(tableConfiguration.columnOrder)
-          ? [SELECTION_COLUMN_ID, ...(tableConfiguration.columnOrder ?? [])]
-          : [];
+    const columnOrder = isNotEmptyValue(tableConfiguration.columnOrder)
+      ? [SELECTION_COLUMN_ID, ...tableConfiguration.columnOrder]
+      : (convertedData[key].columnOrder ?? []);
 
-        const v8TableConfig: ColumnConfiguration = {
-          columnVisibility,
-          columnOrder,
-        };
-        convertedData[key] = v8TableConfig;
-      }
-    });
-
-    localStorage.setItem(
-      COLUMN_CONFIGURATION_STORAGE_KEY,
-      JSON.stringify(convertedData),
-    );
-
-    localStorage.setItem(CONFIG_HAS_BEEN_CONVERTED_TO_V8_KEY, 'true');
+    convertedData[key] = { columnVisibility, columnOrder };
   }
+
+  localStorage.setItem(
+    COLUMN_CONFIGURATION_STORAGE_KEY,
+    JSON.stringify(convertedData),
+  );
 }

--- a/dashboard/src/pages/orgs/[orgSlug]/projects/[appSubdomain]/database/browser/[dataSourceSlug]/[schemaSlug]/tables/[tableSlug].tsx
+++ b/dashboard/src/pages/orgs/[orgSlug]/projects/[appSubdomain]/database/browser/[dataSourceSlug]/[schemaSlug]/tables/[tableSlug].tsx
@@ -3,7 +3,7 @@ import { LoadingScreen } from '@/components/presentational/LoadingScreen';
 import { RetryableErrorBoundary } from '@/components/presentational/RetryableErrorBoundary';
 import { OrgLayout } from '@/features/orgs/layout/OrgLayout';
 import { useIsPlatform } from '@/features/orgs/projects/common/hooks/useIsPlatform';
-import { DataBrowserGrid } from '@/features/orgs/projects/database/dataGrid/components/DataBrowserGrid';
+import { DataBrowserGridContainer } from '@/features/orgs/projects/database/dataGrid/components/DataBrowserGrid';
 import { DataGridQueryParamsProvider } from '@/features/orgs/projects/database/dataGrid/components/DataBrowserGrid/DataGridQueryParamsProvider';
 import { DataBrowserSidebar } from '@/features/orgs/projects/database/dataGrid/components/DataBrowserSidebar';
 import { useProject } from '@/features/orgs/projects/hooks/useProject';
@@ -19,7 +19,7 @@ export default function DataBrowserTableDetailsPage() {
   return (
     <RetryableErrorBoundary>
       <DataGridQueryParamsProvider>
-        <DataBrowserGrid />
+        <DataBrowserGridContainer />
       </DataGridQueryParamsProvider>
     </RetryableErrorBoundary>
   );


### PR DESCRIPTION
### Checklist

- [ ] No breaking changes
- [ ] Tests pass
- [ ] New features have new tests
- [ ] Documentation is updated (if applicable)
- [ ] Title of the PR is in the correct format (see below)

<!-- nhost-reviewer:start -->
### **PR Type**
Bug fix

___

### **Description**
- Fix column order/visibility not resetting when switching between database tables by introducing a `DataBrowserGridContainer` that uses React `key` to force remount on table change
- Remove the imperative `useEffect`-based column configuration (with the 250ms `tableInitialized` delay hack) in favor of declarative `initialState` on `useReactTable`
- Improve the `convertToV8IfNeeded` migration to detect old format from data shape instead of relying on a separate localStorage flag, and move it to module-level execution
- Move `SELECTION_COLUMN_ID` to its own `constants.ts` and re-export from the barrel index

___

### Diagram Walkthrough

```mermaid
flowchart LR
  A["tableSlug page"] --> B["DataBrowserGridContainer"]
  B -- "key={tableSlug}" --> C["DataBrowserGrid"]
  C --> D["useDataGrid"]
  D -- "initialState" --> E["useReactTable"]
  D -- "module-level" --> F["convertToV8IfNeeded()"]
  F --> G["PersistentDataTableConfigurationStorage"]
  G --> H["localStorage"]
```

<details> <summary><h3> File Walkthrough</h3></summary>

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody>
<tr><td><strong>Core logic</strong></td><td><details><summary>5 files</summary><table>
<tr>
  <td><strong>DataBrowserGridContainer.tsx</strong><dd><code>New wrapper that keys DataBrowserGrid on tableSlug to force remount on table switch</code></dd></td>
  <td><a href="https://github.com/nhost/nhost/pull/XXX/files#diff-f236631af26f6d62989bfeb4e0b12096b0e538389b95be20a040959d54bbe2b9">+10/-0</a></td>
</tr>
<tr>
  <td><strong>useDataGrid.tsx</strong><dd><code>Remove imperative useEffect for column config; use initialState instead; call convertToV8IfNeeded at module level</code></dd></td>
  <td><a href="https://github.com/nhost/nhost/pull/XXX/files#diff-b7d1d5dc3797f8720bda954c5710c045752d5129e3daf8a2692a6e9b9139b8be">+6/-22</a></td>
</tr>
<tr>
  <td><strong>PersistentDataTableConfigurationStorage.ts</strong><dd><code>Rewrite convertToV8IfNeeded to detect old format from data shape; remove external flag</code></dd></td>
  <td><a href="https://github.com/nhost/nhost/pull/XXX/files#diff-5f1241ff3b661652cb3be8a82c7f272107119d9810bc9d41809ad7344c001882">+44/-39</a></td>
</tr>
<tr>
  <td><strong>DataGrid.tsx</strong><dd><code>Remove tableInitialized guard; simplify spinner condition to loading-only</code></dd></td>
  <td><a href="https://github.com/nhost/nhost/pull/XXX/files#diff-3bc6476aed14d8e4f26134fa452d22c41b6d3ecb0989871a8a99230a82496474">+22/-26</a></td>
</tr>
<tr>
  <td><strong>constants.ts</strong><dd><code>Extract SELECTION_COLUMN_ID to standalone constants file</code></dd></td>
  <td><a href="https://github.com/nhost/nhost/pull/XXX/files#diff-dae1f2b629ec0dde9ad9ac1ffe1de9d9416168603f911d01e6eab64258a6c37c">+1/-0</a></td>
</tr>
</table></details></td></tr>
<tr><td><strong>Import updates</strong></td><td><details><summary>7 files</summary><table>
<tr>
  <td><strong>useGetDataColumns.ts</strong><dd><code>Update SELECTION_COLUMN_ID import to barrel index</code></dd></td>
  <td><a href="https://github.com/nhost/nhost/pull/XXX/files#diff-48a5c0cd5ffa47d053be3a5b8834cbebef335528dfc40097a70c1d3c618a07bf">+1/-1</a></td>
</tr>
<tr>
  <td><strong>ColumnCustomizer.tsx</strong><dd><code>Update SELECTION_COLUMN_ID import to barrel index</code></dd></td>
  <td><a href="https://github.com/nhost/nhost/pull/XXX/files#diff-57753d0ed5a0ccf9fab15135216ebcea64cc2894f19647679328041f525952d8">+1/-1</a></td>
</tr>
<tr>
  <td><strong>ShowHideAllColumnsButtons.tsx</strong><dd><code>Update SELECTION_COLUMN_ID import to barrel index</code></dd></td>
  <td><a href="https://github.com/nhost/nhost/pull/XXX/files#diff-d1942614c3b91d3afb95e4ae7ec23c29a36ba376828d0fd41bcc6db73e52cf1f">+1/-1</a></td>
</tr>
<tr>
  <td><strong>DataGridCell.tsx</strong><dd><code>Update SELECTION_COLUMN_ID import to barrel index</code></dd></td>
  <td><a href="https://github.com/nhost/nhost/pull/XXX/files#diff-0049e6acaddf9f9b60fe43a1fbb2657564bd019e690d0361aae39f44a03adaa2">+1/-1</a></td>
</tr>
<tr>
  <td><strong>DataGridHeader.tsx</strong><dd><code>Update SELECTION_COLUMN_ID import to barrel index</code></dd></td>
  <td><a href="https://github.com/nhost/nhost/pull/XXX/files#diff-3f5f16ea95a730255a07806c96b55fd4946c92eebcb869cdf83ad92bfe034b4c">+1/-1</a></td>
</tr>
<tr>
  <td><strong>DataGridHeaderButton.tsx</strong><dd><code>Update SELECTION_COLUMN_ID import to barrel index</code></dd></td>
  <td><a href="https://github.com/nhost/nhost/pull/XXX/files#diff-4e9624559165361950af94e0775337d6937c300e4184106f08975e9b324c3010">+1/-1</a></td>
</tr>
<tr>
  <td><strong>[tableSlug].tsx</strong><dd><code>Switch from DataBrowserGrid to DataBrowserGridContainer</code></dd></td>
  <td><a href="https://github.com/nhost/nhost/pull/XXX/files#diff-2b5b3759fb22a0b1311133eb1abec464416844df26c6a3a1b2af6913d09956fe">+2/-2</a></td>
</tr>
</table></details></td></tr>
<tr><td><strong>Barrel exports</strong></td><td><details><summary>2 files</summary><table>
<tr>
  <td><strong>DataGrid/index.ts</strong><dd><code>Re-export constants from new constants.ts</code></dd></td>
  <td><a href="https://github.com/nhost/nhost/pull/XXX/files#diff-a0d89da49afb2886716411cc2e56f464af21477a89865ba3d73fc7547e619cdc">+1/-0</a></td>
</tr>
<tr>
  <td><strong>DataBrowserGrid/index.ts</strong><dd><code>Export new DataBrowserGridContainer</code></dd></td>
  <td><a href="https://github.com/nhost/nhost/pull/XXX/files#diff-1f75de1891a92bfe5d57473743e885ddd6c0d5213c588799a63555cfbd255636">+1/-0</a></td>
</tr>
</table></details></td></tr>
<tr><td><strong>Tests</strong></td><td><details><summary>3 files</summary><table>
<tr>
  <td><strong>DataBrowserGridContainer.test.tsx</strong><dd><code>New integration test verifying column visibility resets correctly when switching tables</code></dd></td>
  <td><a href="https://github.com/nhost/nhost/pull/XXX/files#diff-8cd17f11c60d18cbceadedabc585c6f0cfaa79f4ac3595b00d2f57266ee60f1f">+134/-0</a></td>
</tr>
<tr>
  <td><strong>PersistentDataTableConfigurationStorage.test.ts</strong><dd><code>Rewrite v8 migration tests: add idempotency, mixed-format, and columnOrder-only cases</code></dd></td>
  <td><a href="https://github.com/nhost/nhost/pull/XXX/files#diff-5301ba52de2933617d24b3f78c1e782a20195d3db120aa877e1c80883300f9dd">+125/-15</a></td>
</tr>
<tr>
  <td><strong>useDataGrid.test.tsx</strong><dd><code>Remove tableInitialized test; hoist useTablePath mock</code></dd></td>
  <td><a href="https://github.com/nhost/nhost/pull/XXX/files#diff-6cb8e5006656807772d884f1eaeafef5263a64c1f65820c6ae397fcef74fa124">+2/-16</a></td>
</tr>
</table></details></td></tr>
<tr><td><strong>Test utilities</strong></td><td><details><summary>1 file</summary><table>
<tr>
  <td><strong>BaseTableForm.test.tsx</strong><dd><code>Replace deprecated TestUserEvent instance usage with static fireTypeEvent</code></dd></td>
  <td><a href="https://github.com/nhost/nhost/pull/XXX/files#diff-76c87617e7921fd6eb4bf7bb18f98a702dbc95e7b6d9342a9c1befa88c7f8fb6">+4/-2</a></td>
</tr>
</table></details></td></tr>
</tbody></table>

</details>

___

<!-- nhost-reviewer:end -->
