### PR TITLE
ci: add final status check gate workflow

### DIFF
--- a/.github/workflows/ci_final_status_check.yaml
+++ b/.github/workflows/ci_final_status_check.yaml
@@ -14,7 +14,7 @@ permissions:
 jobs:
   final-status:
     name: "ci: final status check"
-    runs-on: ubuntu-latest
+    runs-on: blacksmith-2vcpu-ubuntu-2404
     timeout-minutes: 60
     steps:
       - name: Wait for all checks and verify status


### PR DESCRIPTION
## Summary

- Adds a new `ci: final status check` workflow that **always runs on every PR** (no path filter)
- Polls the GitHub Checks API for all monitored check workflows, waits for them to complete, and reports a single pass/fail status
- Enables configuring branch protection to require just this one check, solving the monorepo problem where path-filtered checks don't all run on every PR

## How it works

1. Triggers on every `pull_request_target` (opened, synchronize, reopened)
2. Waits 60s for other workflows to start
3. Polls check runs every 30s, filtering to the 12 known check workflows
4. After all checks complete, waits an additional 2min settle window for late starters
5. Reports **failure** if any check failed/cancelled/timed out, **success** if all passed/skipped
6. Times out after 45min as a safety net

## Branch protection setup

After merging, configure branch protection to require only:
- `ci: final status check`

This single required check will transitively enforce all 12 project check workflows.

## Test plan

- [ ] Verify the workflow triggers on a test PR
- [ ] Verify it correctly detects and waits for path-filtered check workflows
- [ ] Verify it passes when all triggered checks pass
- [ ] Verify it fails when any triggered check fails
- [ ] Verify the settle window handles late-starting workflows
- [ ] Configure branch protection rule after validation

https://claude.ai/code/session_01Q1M9aPGQChyqFttBJhSsot