### PR TITLE
release(packages/stripe-graphql-js): 1.3.1

### DIFF
--- a/packages/stripe-graphql-js/CHANGELOG.md
+++ b/packages/stripe-graphql-js/CHANGELOG.md
@@ -1,3 +1,34 @@
+## [@nhost/stripe-graphql-js@1.3.1] - 2026-06-29
+
+### 🐛 Bug Fixes
+
+- *(deps)* Update lodash due to vulnerability (#4108)
+- *(deps)* Update vite due to CVE (#4122)
+- *(docs)* Downgrade to vite7 due to incompatibilities (#4134)
+- *(deps)* Bump up uuid, Astro and xmldom due to CVEs (#4187)
+- *(deps)* Fix postcss XSS advisory (GHSA-qx2v-qp2m-jg93) (#4197)
+- *(ci)* Make build and check work on NixOS (#4234)
+- *(deps)* Fix fast-uri advisory (GHSA-v39h-62p7-jpjc) (#4265)
+- *(deps)* Fix ws advisory (GHSA-58qx-3vcg-4xpx) (#4307)
+- *(deps)* Bump up shellquote due to CVE (#4499)
+
+
+### ⚙️ Miscellaneous Tasks
+
+- *(ci)* Added a small wrapper around govulncheck to allow filtering some CVEs (#4112)
+- *(nixops)* Drop nix-filter input in favor of pkgs.lib.fileset (#4377)
+- *(nixops)* Scope pinned toolchain overlays (#4506)
+
+
+### Chore
+
+- *(deps)* Update various npm packages due to cves (#4073)
+- *(deps)* Update deps due to cve (#4091)
+- *(deps)* Update pnpm to v11 (#4275)
+- *(deps)* Update various packages due to CVEs (#4328)
+- *(deps)* Update vulnerable dependencies (#4338)
+- *(deps)* Update vulnerable dependencies (#4530)
+
 ## [@nhost/stripe-graphql-js@1.3.0] - 2026-03-26
 
 ### 🚀 Features


### PR DESCRIPTION
Automated release preparation for packages/stripe-graphql-js version 1.3.1.

Version references in dependent files (CLI sources, docs, etc.) are bumped in a follow-up PR after the release publishes — see `wf_bump_refs.yaml`.