### PR TITLE
fix(auth): select primary verified email from GitHub OAuth

### DIFF
--- a/services/auth/go/providers/github.go
+++ b/services/auth/go/providers/github.go
@@ -47,10 +47,39 @@ type gitHubUser struct {
 	AvatarURL string `json:"avatar_url"`
 }
 
-type gitHubEmail []struct {
+type gitHubEmailEntry struct {
 	Email    string `json:"email"`
 	Verified bool   `json:"verified"`
 	Primary  bool   `json:"primary"`
+}
+
+type gitHubEmail []gitHubEmailEntry
+
+// selectEmail picks the best email from a GitHub user's email list.
+// Priority: primary+verified > first verified > first email.
+func selectEmail(emails gitHubEmail) gitHubEmailEntry {
+	selected := emails[0]
+	primarySeen := false
+
+	for _, e := range emails {
+		if e.Primary && e.Verified {
+			return e
+		}
+
+		if e.Primary {
+			primarySeen = true
+		}
+
+		if e.Verified && !selected.Verified {
+			selected = e
+		}
+
+		if selected.Verified && primarySeen {
+			break
+		}
+	}
+
+	return selected
 }
 
 func (g *Github) GetProfile(
@@ -84,23 +113,7 @@ func (g *Github) GetProfile(
 		return oidc.Profile{}, errors.New("GitHub user has no email addresses") //nolint:err113
 	}
 
-	// Select the primary verified email. Fall back to first verified,
-	// then first email if none are verified.
-	selected := emails[0]
-	for _, e := range emails {
-		if e.Primary && e.Verified {
-			selected = e
-			break
-		}
-	}
-	if !selected.Primary {
-		for _, e := range emails {
-			if e.Verified {
-				selected = e
-				break
-			}
-		}
-	}
+	selected := selectEmail(emails)
 
 	return oidc.Profile{
 		ProviderUserID: strconv.Itoa(user.ID),

--- a/services/auth/go/providers/github_internal_test.go
+++ b/services/auth/go/providers/github_internal_test.go
@@ -1,0 +1,79 @@
+package providers
+
+import (
+	"testing"
+)
+
+func TestSelectEmail(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name          string
+		emails        gitHubEmail
+		expectedEmail string
+		expectedVer   bool
+	}{
+		{
+			name: "single primary and verified",
+			emails: gitHubEmail{
+				{Email: "a@test.com", Verified: true, Primary: true},
+			},
+			expectedEmail: "a@test.com",
+			expectedVer:   true,
+		},
+		{
+			name: "primary verified among multiple",
+			emails: gitHubEmail{
+				{Email: "a@test.com", Verified: true, Primary: false},
+				{Email: "b@test.com", Verified: true, Primary: true},
+				{Email: "c@test.com", Verified: false, Primary: false},
+			},
+			expectedEmail: "b@test.com",
+			expectedVer:   true,
+		},
+		{
+			name: "no primary verified falls back to first verified",
+			emails: gitHubEmail{
+				{Email: "a@test.com", Verified: false, Primary: false},
+				{Email: "b@test.com", Verified: true, Primary: false},
+				{Email: "c@test.com", Verified: true, Primary: false},
+			},
+			expectedEmail: "b@test.com",
+			expectedVer:   true,
+		},
+		{
+			name: "no verified falls back to first email",
+			emails: gitHubEmail{
+				{Email: "a@test.com", Verified: false, Primary: false},
+				{Email: "b@test.com", Verified: false, Primary: true},
+			},
+			expectedEmail: "a@test.com",
+			expectedVer:   false,
+		},
+		{
+			name: "primary unverified with verified alternative",
+			emails: gitHubEmail{
+				{Email: "a@test.com", Verified: false, Primary: true},
+				{Email: "b@test.com", Verified: true, Primary: false},
+			},
+			expectedEmail: "b@test.com",
+			expectedVer:   true,
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+
+			got := selectEmail(tc.emails)
+
+			if got.Email != tc.expectedEmail {
+				t.Errorf("email: got %q, want %q", got.Email, tc.expectedEmail)
+			}
+
+			if got.Verified != tc.expectedVer {
+				t.Errorf("verified: got %v, want %v", got.Verified, tc.expectedVer)
+			}
+		})
+	}
+}


### PR DESCRIPTION
## Summary

The GitHub OAuth provider calls `/user/emails` to get the user's email addresses, but blindly uses `emails[0]` — the first entry in the array. GitHub's API does not guarantee ordering, so users can end up with a non-primary (or even unverified) email stored in their Nhost account.

This PR:
- Adds the `Primary` field to the `gitHubEmail` struct (previously not parsed from the API response)
- Selects the primary + verified email first
- Falls back to first verified email, then first email overall

## Context

This is a follow-up to [hasura-auth#658](https://github.com/nhost/hasura-auth/pull/658), which added the `/user/emails` API call but took `emails[0]` without filtering. The automated reviewer [flagged this](https://github.com/nhost/hasura-auth/pull/658) at the time, but it was merged without addressing the comment.

GitHub API reference: https://docs.github.com/en/rest/users/emails#list-email-addresses-for-the-authenticated-user

The response includes `email`, `verified`, `primary`, and `visibility` fields per entry. Only `primary` was missing from the struct.

## Test plan

- [ ] Sign in with a GitHub account that has multiple email addresses where the primary email is not first in the API response
- [ ] Verify the primary verified email is stored in `auth.users.email`
- [ ] Sign in with a GitHub account that has no primary email set — verify fallback to first verified email

<!-- nhost-reviewer:start -->
### **PR Type**
Bug fix

___

### **Description**
- Fix GitHub OAuth email selection to prefer the user's primary verified email instead of blindly using the first email in the API response
- Add `Primary` field to `gitHubEmail` struct to parse the `primary` flag from GitHub's `/user/emails` endpoint
- Implement a three-tier fallback: primary+verified → first verified → first email

___

<details> <summary><h3> File Walkthrough</h3></summary>

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody>
<tr><td><strong>Core logic</strong></td><td><details><summary>1 file</summary><table>
<tr>
  <td><strong>github.go</strong><dd><code>Add Primary field to gitHubEmail struct and implement email selection logic with fallback chain</code></dd></td>
  <td><a href="https://github.com/nhost/nhost/pull/4085/files#diff-5f724740af1a1095b598582f9abc277f0531ec3c644b46c490fb04eddac6b1f7">+21/-2</a></td>
</tr>
</table></details></td></tr>
</tbody></table>

</details>

___

<!-- nhost-reviewer:end -->