### PR TITLE
fix(postgres): update outdated extensions dynamically

### DIFF
--- a/services/postgres/CHANGELOG.md
+++ b/services/postgres/CHANGELOG.md
@@ -1,5 +1,9 @@
 ## CHANGELOG
 
+### main
+
+- Update extensions script to dynamically update all outdated extensions instead of only timescaledb
+
 ### {16.13,17.9,18.3}-20260320-1
 
 - Updated postgres to 16.13, 17.9 and 18.3

--- a/services/postgres/postgres/nhost.d/XXXX-update-extensions.sql
+++ b/services/postgres/postgres/nhost.d/XXXX-update-extensions.sql
@@ -1,1 +1,19 @@
-ALTER EXTENSION timescaledb UPDATE;
+DO $$
+DECLARE
+    ext record;
+BEGIN
+    FOR ext IN
+        SELECT e.extname
+        FROM pg_extension e
+        JOIN pg_available_extensions ae ON e.extname = ae.name
+        WHERE e.extversion <> ae.default_version
+    LOOP
+        BEGIN
+            RAISE NOTICE 'Updating extension %', ext.extname;
+            EXECUTE format('ALTER EXTENSION %I UPDATE', ext.extname);
+        EXCEPTION WHEN OTHERS THEN
+            RAISE WARNING 'Failed to update extension %: %', ext.extname, SQLERRM;
+        END;
+    END LOOP;
+END;
+$$;


### PR DESCRIPTION
<!-- nhost-reviewer:start -->
### **PR Type**
Enhancement

___

### **Description**
- Replace the hardcoded `ALTER EXTENSION timescaledb UPDATE` with a dynamic PL/pgSQL block that discovers and updates all outdated extensions automatically
- The new script queries `pg_extension` joined with `pg_available_extensions` to find extensions where the installed version differs from the default version, then iterates and updates each one
- Per-extension exception handling ensures that a failure to update one extension does not prevent others from being updated

___

<details> <summary><h3> File Walkthrough</h3></summary>

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody>
<tr><td><strong>Core logic</strong></td><td><details><summary>1 file</summary><table>
<tr>
  <td><strong>4088X-update-extensions.sql</strong><dd><code>Replace single timescaledb update with dynamic loop updating all outdated extensions</code></dd></td>
  <td><a href="https://github.com/nhost/nhost/pull/4088/files#diff-cf17402e8736f76ffbd09365230b958e352bfe736a08de688facb4452569c539">+19/-1</a></td>
</tr>
</table></details></td></tr>
<tr><td><strong>Documentation</strong></td><td><details><summary>1 file</summary><table>
<tr>
  <td><strong>CHANGELOG.md</strong><dd><code>Add changelog entry for the dynamic extension update change</code></dd></td>
  <td><a href="https://github.com/nhost/nhost/pull/4088/files#diff-4678b7ea1e6e228936ae1b983ca5c060f4b942223f89bd476d7b09b47ba50d30">+4/-0</a></td>
</tr>
</table></details></td></tr>
</tbody></table>

</details>

___

<!-- nhost-reviewer:end -->