### PR TITLE
chore(ci): fix concurrency groups

### DIFF
--- a/.github/workflows/auth_checks.yaml
+++ b/.github/workflows/auth_checks.yaml
@@ -25,8 +25,8 @@ on:
   merge_group:
 
 concurrency:
-  group: ${{ github.workflow }}-${{ github.event_name == 'pull_request' && format('pr-{0}', github.event.pull_request.number) || format('push-{0}', github.sha) }}
-  cancel-in-progress: ${{ github.event_name == 'pull_request' }}
+  group: ${{ github.workflow }}-${{ startsWith(github.event_name, 'pull_request') && format('pr-{0}', github.event.pull_request.number) || format('push-{0}', github.sha) }}
+  cancel-in-progress: ${{ startsWith(github.event_name, 'pull_request') }}
 
 jobs:
   detect-changes:

--- a/.github/workflows/ci_final_status_check.yaml
+++ b/.github/workflows/ci_final_status_check.yaml
@@ -6,7 +6,7 @@ on:
   merge_group:
 
 concurrency:
-  group: ${{ github.workflow }}-${{ github.event_name == 'pull_request' && format('pr-{0}', github.event.pull_request.number) || format('mg-{0}', github.event.merge_group.head_sha) }}
+  group: ${{ github.workflow }}-${{ startsWith(github.event_name, 'pull_request') && format('pr-{0}', github.event.pull_request.number) || format('mg-{0}', github.event.merge_group.head_sha) }}
   cancel-in-progress: true
 
 permissions:

--- a/.github/workflows/cli_checks.yaml
+++ b/.github/workflows/cli_checks.yaml
@@ -31,8 +31,8 @@ on:
   merge_group:
 
 concurrency:
-  group: ${{ github.workflow }}-${{ github.event_name == 'pull_request' && format('pr-{0}', github.event.pull_request.number) || format('push-{0}', github.sha) }}
-  cancel-in-progress: ${{ github.event_name == 'pull_request' }}
+  group: ${{ github.workflow }}-${{ startsWith(github.event_name, 'pull_request') && format('pr-{0}', github.event.pull_request.number) || format('push-{0}', github.sha) }}
+  cancel-in-progress: ${{ startsWith(github.event_name, 'pull_request') }}
 
 jobs:
   detect-changes:

--- a/.github/workflows/codegen_checks.yaml
+++ b/.github/workflows/codegen_checks.yaml
@@ -23,8 +23,8 @@ on:
   merge_group:
 
 concurrency:
-  group: ${{ github.workflow }}-${{ github.event_name == 'pull_request' && format('pr-{0}', github.event.pull_request.number) || format('push-{0}', github.sha) }}
-  cancel-in-progress: ${{ github.event_name == 'pull_request' }}
+  group: ${{ github.workflow }}-${{ startsWith(github.event_name, 'pull_request') && format('pr-{0}', github.event.pull_request.number) || format('push-{0}', github.sha) }}
+  cancel-in-progress: ${{ startsWith(github.event_name, 'pull_request') }}
 
 jobs:
   detect-changes:

--- a/.github/workflows/dashboard_checks.yaml
+++ b/.github/workflows/dashboard_checks.yaml
@@ -31,8 +31,8 @@ on:
   merge_group:
 
 concurrency:
-  group: ${{ github.workflow }}-${{ github.event_name == 'pull_request' && format('pr-{0}', github.event.pull_request.number) || format('push-{0}', github.sha) }}
-  cancel-in-progress: ${{ github.event_name == 'pull_request' }}
+  group: ${{ github.workflow }}-${{ startsWith(github.event_name, 'pull_request') && format('pr-{0}', github.event.pull_request.number) || format('push-{0}', github.sha) }}
+  cancel-in-progress: ${{ startsWith(github.event_name, 'pull_request') }}
 
 jobs:
   detect-changes:

--- a/.github/workflows/docs_checks.yaml
+++ b/.github/workflows/docs_checks.yaml
@@ -36,8 +36,8 @@ on:
   merge_group:
 
 concurrency:
-  group: ${{ github.workflow }}-${{ github.event_name == 'pull_request' && format('pr-{0}', github.event.pull_request.number) || format('push-{0}', github.sha) }}
-  cancel-in-progress: ${{ github.event_name == 'pull_request' }}
+  group: ${{ github.workflow }}-${{ startsWith(github.event_name, 'pull_request') && format('pr-{0}', github.event.pull_request.number) || format('push-{0}', github.sha) }}
+  cancel-in-progress: ${{ startsWith(github.event_name, 'pull_request') }}
 
 jobs:
   detect-changes:

--- a/.github/workflows/examples_demos_checks.yaml
+++ b/.github/workflows/examples_demos_checks.yaml
@@ -39,8 +39,8 @@ on:
   merge_group:
 
 concurrency:
-  group: ${{ github.workflow }}-${{ github.event_name == 'pull_request' && format('pr-{0}', github.event.pull_request.number) || format('push-{0}', github.sha) }}
-  cancel-in-progress: ${{ github.event_name == 'pull_request' }}
+  group: ${{ github.workflow }}-${{ startsWith(github.event_name, 'pull_request') && format('pr-{0}', github.event.pull_request.number) || format('push-{0}', github.sha) }}
+  cancel-in-progress: ${{ startsWith(github.event_name, 'pull_request') }}
 
 jobs:
   detect-changes:

--- a/.github/workflows/examples_guides_checks.yaml
+++ b/.github/workflows/examples_guides_checks.yaml
@@ -39,8 +39,8 @@ on:
   merge_group:
 
 concurrency:
-  group: ${{ github.workflow }}-${{ github.event_name == 'pull_request' && format('pr-{0}', github.event.pull_request.number) || format('push-{0}', github.sha) }}
-  cancel-in-progress: ${{ github.event_name == 'pull_request' }}
+  group: ${{ github.workflow }}-${{ startsWith(github.event_name, 'pull_request') && format('pr-{0}', github.event.pull_request.number) || format('push-{0}', github.sha) }}
+  cancel-in-progress: ${{ startsWith(github.event_name, 'pull_request') }}
 
 jobs:
   detect-changes:

--- a/.github/workflows/examples_tutorials_checks.yaml
+++ b/.github/workflows/examples_tutorials_checks.yaml
@@ -39,8 +39,8 @@ on:
   merge_group:
 
 concurrency:
-  group: ${{ github.workflow }}-${{ github.event_name == 'pull_request' && format('pr-{0}', github.event.pull_request.number) || format('push-{0}', github.sha) }}
-  cancel-in-progress: ${{ github.event_name == 'pull_request' }}
+  group: ${{ github.workflow }}-${{ startsWith(github.event_name, 'pull_request') && format('pr-{0}', github.event.pull_request.number) || format('push-{0}', github.sha) }}
+  cancel-in-progress: ${{ startsWith(github.event_name, 'pull_request') }}
 
 jobs:
   detect-changes:

--- a/.github/workflows/nhost-js_checks.yaml
+++ b/.github/workflows/nhost-js_checks.yaml
@@ -40,8 +40,8 @@ on:
   merge_group:
 
 concurrency:
-  group: ${{ github.workflow }}-${{ github.event_name == 'pull_request' && format('pr-{0}', github.event.pull_request.number) || format('push-{0}', github.sha) }}
-  cancel-in-progress: ${{ github.event_name == 'pull_request' }}
+  group: ${{ github.workflow }}-${{ startsWith(github.event_name, 'pull_request') && format('pr-{0}', github.event.pull_request.number) || format('push-{0}', github.sha) }}
+  cancel-in-progress: ${{ startsWith(github.event_name, 'pull_request') }}
 
 jobs:
   detect-changes:

--- a/.github/workflows/nixops_checks.yaml
+++ b/.github/workflows/nixops_checks.yaml
@@ -14,8 +14,8 @@ on:
   merge_group:
 
 concurrency:
-  group: ${{ github.workflow }}-${{ github.event_name == 'pull_request' && format('pr-{0}', github.event.pull_request.number) || format('push-{0}', github.sha) }}
-  cancel-in-progress: ${{ github.event_name == 'pull_request' }}
+  group: ${{ github.workflow }}-${{ startsWith(github.event_name, 'pull_request') && format('pr-{0}', github.event.pull_request.number) || format('push-{0}', github.sha) }}
+  cancel-in-progress: ${{ startsWith(github.event_name, 'pull_request') }}
 
 jobs:
   detect-changes:

--- a/.github/workflows/postgres_checks.yaml
+++ b/.github/workflows/postgres_checks.yaml
@@ -18,8 +18,8 @@ on:
   merge_group:
 
 concurrency:
-  group: ${{ github.workflow }}-${{ github.event_name == 'pull_request' && format('pr-{0}', github.event.pull_request.number) || format('push-{0}', github.sha) }}
-  cancel-in-progress: ${{ github.event_name == 'pull_request' }}
+  group: ${{ github.workflow }}-${{ startsWith(github.event_name, 'pull_request') && format('pr-{0}', github.event.pull_request.number) || format('push-{0}', github.sha) }}
+  cancel-in-progress: ${{ startsWith(github.event_name, 'pull_request') }}
 
 jobs:
   detect-changes:

--- a/.github/workflows/storage_checks.yaml
+++ b/.github/workflows/storage_checks.yaml
@@ -25,8 +25,8 @@ on:
   merge_group:
 
 concurrency:
-  group: ${{ github.workflow }}-${{ github.event_name == 'pull_request' && format('pr-{0}', github.event.pull_request.number) || format('push-{0}', github.sha) }}
-  cancel-in-progress: ${{ github.event_name == 'pull_request' }}
+  group: ${{ github.workflow }}-${{ startsWith(github.event_name, 'pull_request') && format('pr-{0}', github.event.pull_request.number) || format('push-{0}', github.sha) }}
+  cancel-in-progress: ${{ startsWith(github.event_name, 'pull_request') }}
 
 jobs:
   detect-changes:

--- a/.github/workflows/stripe-graphql-js_checks.yaml
+++ b/.github/workflows/stripe-graphql-js_checks.yaml
@@ -45,8 +45,8 @@ on:
       - "packages/stripe-graphql-js/**"
 
 concurrency:
-  group: ${{ github.workflow }}-${{ github.event_name == 'pull_request' && format('pr-{0}', github.event.pull_request.number) || format('push-{0}', github.sha) }}
-  cancel-in-progress: ${{ github.event_name == 'pull_request' }}
+  group: ${{ github.workflow }}-${{ startsWith(github.event_name, 'pull_request') && format('pr-{0}', github.event.pull_request.number) || format('push-{0}', github.sha) }}
+  cancel-in-progress: ${{ startsWith(github.event_name, 'pull_request') }}
 
 jobs:
   check-permissions:


### PR DESCRIPTION
<!-- nhost-reviewer:start -->
### **PR Type**
Bug fix

___

### **Description**
- Fixed concurrency group expressions in all CI check workflows to use `startsWith(github.event_name, 'pull_request')` instead of `github.event_name == 'pull_request'`, so that `pull_request_target` events are correctly matched for concurrency grouping and cancellation.

___

<details> <summary><h3> File Walkthrough</h3></summary>

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody>
<tr><td><strong>CI workflow concurrency fixes</strong></td><td><details><summary>14 files</summary><table>
<tr>
  <td><strong>auth_checks.yaml</strong><dd><code>Use startsWith for event_name matching in concurrency group</code></dd></td>
  <td><a href="https://github.com/nhost/nhost/pull/4095/files#diff-e008be4c75d4fd5b9c11517b9507be917f4b28efe68d72a4657b042f2601d8db">+2/-2</a></td>
</tr>
<tr>
  <td><strong>ci_final_status_check.yaml</strong><dd><code>Use startsWith for event_name matching in concurrency group</code></dd></td>
  <td><a href="https://github.com/nhost/nhost/pull/4095/files#diff-707c849e95e5d82212b01dc4f99b7fbc87d26ae2a6a8793ebbd79015fc6a0b72">+1/-1</a></td>
</tr>
<tr>
  <td><strong>cli_checks.yaml</strong><dd><code>Use startsWith for event_name matching in concurrency group</code></dd></td>
  <td><a href="https://github.com/nhost/nhost/pull/4095/files#diff-85e94af94a1e00a42e4095f4d62c5c016af01ba3314b74395cbe21bc1dc0b6bf">+2/-2</a></td>
</tr>
<tr>
  <td><strong>codegen_checks.yaml</strong><dd><code>Use startsWith for event_name matching in concurrency group</code></dd></td>
  <td><a href="https://github.com/nhost/nhost/pull/4095/files#diff-a0832a0d24c56aeff885d0163d2d0a54af9dd042dfbbe0fd5eba7c9997de7089">+2/-2</a></td>
</tr>
<tr>
  <td><strong>dashboard_checks.yaml</strong><dd><code>Use startsWith for event_name matching in concurrency group</code></dd></td>
  <td><a href="https://github.com/nhost/nhost/pull/4095/files#diff-a8a8acdeffa4fff6d4fabd436cc1c2c377cda640d5028bd3dfcec5ef5df6e33f">+2/-2</a></td>
</tr>
<tr>
  <td><strong>docs_checks.yaml</strong><dd><code>Use startsWith for event_name matching in concurrency group</code></dd></td>
  <td><a href="https://github.com/nhost/nhost/pull/4095/files#diff-d11d903fdbfbe578bebef818b8a40eec3c1d413342e6feca475028af3ef69857">+2/-2</a></td>
</tr>
<tr>
  <td><strong>examples_demos_checks.yaml</strong><dd><code>Use startsWith for event_name matching in concurrency group</code></dd></td>
  <td><a href="https://github.com/nhost/nhost/pull/4095/files#diff-48c5a14a5d1da9f35b409ecc95fae8f3a319f97bffbf0020efcb8c360347dc02">+2/-2</a></td>
</tr>
<tr>
  <td><strong>examples_guides_checks.yaml</strong><dd><code>Use startsWith for event_name matching in concurrency group</code></dd></td>
  <td><a href="https://github.com/nhost/nhost/pull/4095/files#diff-56c96ece925a38bd3e84d3fff001760c68d40744013d2b3458ad445a686a0c36">+2/-2</a></td>
</tr>
<tr>
  <td><strong>examples_tutorials_checks.yaml</strong><dd><code>Use startsWith for event_name matching in concurrency group</code></dd></td>
  <td><a href="https://github.com/nhost/nhost/pull/4095/files#diff-745712dc409289d30fe4caa74de567df9cc9fac97750ae5566f93a51e48bf539">+2/-2</a></td>
</tr>
<tr>
  <td><strong>nhost-js_checks.yaml</strong><dd><code>Use startsWith for event_name matching in concurrency group</code></dd></td>
  <td><a href="https://github.com/nhost/nhost/pull/4095/files#diff-4d839ed910ed156389855fb82fc583c1bafccef3691c01ba5170bf4dc4fcc19c">+2/-2</a></td>
</tr>
<tr>
  <td><strong>nixops_checks.yaml</strong><dd><code>Use startsWith for event_name matching in concurrency group</code></dd></td>
  <td><a href="https://github.com/nhost/nhost/pull/4095/files#diff-5201e3151155366e6bb8b672a9fb68b52ae38b8c20c5f09c44953c040892226f">+2/-2</a></td>
</tr>
<tr>
  <td><strong>postgres_checks.yaml</strong><dd><code>Use startsWith for event_name matching in concurrency group</code></dd></td>
  <td><a href="https://github.com/nhost/nhost/pull/4095/files#diff-96f56006ce1231f9e7b97209f14a5b8ae8497c05cb3bb3602849a7133507f81b">+2/-2</a></td>
</tr>
<tr>
  <td><strong>storage_checks.yaml</strong><dd><code>Use startsWith for event_name matching in concurrency group</code></dd></td>
  <td><a href="https://github.com/nhost/nhost/pull/4095/files#diff-c4c7991f3cae655b5afbc8632eac8749c49bc2375821bc61690adac14aba1c1e">+2/-2</a></td>
</tr>
<tr>
  <td><strong>stripe-graphql-js_checks.yaml</strong><dd><code>Use startsWith for event_name matching in concurrency group</code></dd></td>
  <td><a href="https://github.com/nhost/nhost/pull/4095/files#diff-bdacf1b64bef6766a7dc346095bee3b482dfd21c8db50ce5b6e703d69bdef350">+2/-2</a></td>
</tr>
</table></details></td></tr>
</tbody></table>

</details>

___

<!-- nhost-reviewer:end -->