### PR TITLE
fix(dashboard): Allow editing primary keys

### DIFF
--- a/dashboard/src/features/orgs/projects/storage/dataGrid/components/DataGridCell/DataGridCell.tsx
+++ b/dashboard/src/features/orgs/projects/storage/dataGrid/components/DataGridCell/DataGridCell.tsx
@@ -73,8 +73,7 @@ function DataGridCellContent<
     column: { id, columnDef },
     row,
   } = cell;
-  const { onCellEdit, isNullable, isPrimary, type, isEditable } =
-    columnDef.meta || {};
+  const { onCellEdit, isNullable, type, isEditable } = columnDef.meta || {};
   const { openAlertDialog } = useDialog();
 
   const {
@@ -111,12 +110,6 @@ function DataGridCellContent<
   } = useDataGridCell();
 
   function activateInput() {
-    if (isPrimary) {
-      openTooltip("Primary keys can't be edited.");
-
-      return;
-    }
-
     editCell();
 
     if (type === 'boolean') {
@@ -127,7 +120,7 @@ function DataGridCellContent<
   }
 
   async function handleClick(event: MouseEvent<HTMLDivElement>) {
-    if (!isEditable || isEditing || isPrimary) {
+    if (!isEditable || isEditing) {
       return;
     }
 
@@ -228,12 +221,6 @@ function DataGridCellContent<
   }
 
   function resetCell() {
-    if (isPrimary) {
-      openTooltip('Primary keys are non-nullable.');
-
-      return;
-    }
-
     if (!isNullable) {
       openTooltip(
         <span>

--- a/dashboard/src/features/orgs/projects/storage/dataGrid/components/FilesDataGrid/FilesDataGrid.tsx
+++ b/dashboard/src/features/orgs/projects/storage/dataGrid/components/FilesDataGrid/FilesDataGrid.tsx
@@ -63,9 +63,6 @@ const columns: ColumnDef<StoredFile>[] = [
       <DataGridTextCell {...(props as CellContext<StoredFile, string>)} />
     ),
     size: 318,
-    meta: {
-      isPrimary: true,
-    },
   },
   {
     header: 'name',


### PR DESCRIPTION
### Checklist

- [ ] No breaking changes
- [ ] Tests pass
- [ ] New features have new tests
- [ ] Documentation is updated (if applicable)
- [ ] Title of the PR is in the correct format (see below)

<!-- nhost-reviewer:start -->
### **PR Type**
Bug fix

___

### **Description**
- Removed redundant `isPrimary` guards from the storage DataGridCell that prevented editing and resetting primary key columns, allowing them to be edited when `isEditable` is set.
- The `isEditable` flag already controls whether a cell can be edited; the additional `isPrimary` checks were an unnecessary secondary gate.

___

<details> <summary><h3> File Walkthrough</h3></summary>

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody>
<tr><td><strong>Storage data grid</strong></td><td><details><summary>1 file</summary><table>
<tr>
  <td><strong>DataGridCell.tsx</strong><dd><code>Remove isPrimary guards from activateInput, handleClick, and resetCell to allow editing primary key cells</code></dd></td>
  <td><a href="https://github.com/nhost/nhost/pull/4103/files#diff-0049e6acaddf9f9b60fe43a1fbb2657564bd019e690d0361aae39f44a03adaa2">+2/-15</a></td>
</tr>
</table></details></td></tr>
</tbody></table>

</details>

___

<!-- nhost-reviewer:end -->

