### PR TITLE
release(services/mcp): 0.2.0

### DIFF
--- a/services/mcp/CHANGELOG.md
+++ b/services/mcp/CHANGELOG.md
@@ -1,0 +1,20 @@
+## [mcp@0.2.0] - 2026-06-29
+
+### 🚀 Features
+
+- *(mcp)* Detect browser requests and serve configurable HTML page (#4104)
+
+
+### 🐛 Bug Fixes
+
+- *(ci)* Make build and check work on NixOS (#4234)
+- *(internal/lib)* Consolidate / improve middleware into shared internal/lib/oapi (#4513)
+
+
+### ⚙️ Miscellaneous Tasks
+
+- *(nixops)* Bump go due to cves (#4124)
+- *(ci)* Minor changes to go linter to reduce noise (#4329)
+- *(ci)* Follow-up skill improvements (#4332)
+- *(nixops)* Drop nix-filter input in favor of pkgs.lib.fileset (#4377)
+


### PR DESCRIPTION
Automated release preparation for services/mcp version 0.2.0.

Version references in dependent files (CLI sources, docs, etc.) are bumped in a follow-up PR after the release publishes — see `wf_bump_refs.yaml`.