### PR TITLE
fix(dashboard): allow updating arrays in database

### DIFF
--- a/dashboard/src/features/orgs/projects/database/dataGrid/components/BaseRecordForm/BaseRecordForm.tsx
+++ b/dashboard/src/features/orgs/projects/database/dataGrid/components/BaseRecordForm/BaseRecordForm.tsx
@@ -126,6 +126,7 @@ export default function BaseRecordForm({
               gridColumn?.type === 'date' && value instanceof Date
                 ? value.toUTCString()
                 : value,
+            specificType: gridColumn?.specificType,
           },
         };
       }, {});

--- a/dashboard/src/features/orgs/projects/database/dataGrid/hooks/useCreateRecordMutation/createRecord.test.ts
+++ b/dashboard/src/features/orgs/projects/database/dataGrid/hooks/useCreateRecordMutation/createRecord.test.ts
@@ -1,0 +1,132 @@
+import { HttpResponse, http } from 'msw';
+import { setupServer } from 'msw/node';
+import { afterAll, afterEach, beforeAll, describe, expect, test } from 'vitest';
+import createRecord from './createRecord';
+
+const defaultOptions = {
+  dataSource: 'default',
+  appUrl: 'http://localhost:1337',
+  adminSecret: 'test-admin-secret',
+  schema: 'public',
+  table: 'users',
+};
+
+let capturedBody: unknown = null;
+
+const server = setupServer(
+  http.post('http://localhost:1337/v2/query', async ({ request }) => {
+    capturedBody = await request.json();
+    return HttpResponse.json([{ result_type: 'CommandOk', result: null }]);
+  }),
+);
+
+beforeAll(() => server.listen());
+afterEach(() => {
+  server.resetHandlers();
+  capturedBody = null;
+});
+afterAll(() => server.close());
+
+type CapturedRequest = { args: Array<{ args: { sql: string } }> };
+
+describe('createRecord', () => {
+  test('inserts scalar values as SQL literals', async () => {
+    await createRecord({
+      ...defaultOptions,
+      columnValues: {
+        name: { value: 'Alice' },
+      },
+    });
+
+    const sql = (capturedBody as CapturedRequest).args[0].args.sql;
+    expect(sql).toMatch(/INSERT INTO/);
+    expect(sql).toContain('Alice');
+    expect(sql).not.toContain('ARRAY[');
+  });
+
+  test('inserts array values using ARRAY[...] syntax', async () => {
+    await createRecord({
+      ...defaultOptions,
+      columnValues: {
+        tags: { value: '["a","b","c"]', specificType: 'text[]' },
+      },
+    });
+
+    const sql = (capturedBody as CapturedRequest).args[0].args.sql;
+    expect(sql).toContain('ARRAY[');
+    expect(sql).toContain("'a'");
+    expect(sql).toContain("'b'");
+    expect(sql).toContain("'c'");
+    // must not be inserted as a plain string literal like '[...]'
+    expect(sql).not.toMatch(/'(\[.*\])'/);
+  });
+
+  test('inserts integer array values using ARRAY[...] syntax', async () => {
+    await createRecord({
+      ...defaultOptions,
+      columnValues: {
+        scores: { value: '[1,2,3]', specificType: 'integer[]' },
+      },
+    });
+
+    const sql = (capturedBody as CapturedRequest).args[0].args.sql;
+    expect(sql).toContain('ARRAY[');
+    expect(sql).not.toMatch(/'(\[.*\])'/);
+  });
+
+  test('uses DEFAULT when value is absent and column has a default', async () => {
+    await createRecord({
+      ...defaultOptions,
+      columnValues: {
+        id: { value: undefined, fallbackValue: 'DEFAULT' },
+      },
+    });
+
+    const sql = (capturedBody as CapturedRequest).args[0].args.sql;
+    expect(sql).toContain('DEFAULT');
+  });
+
+  test('uses NULL when value is absent and column is nullable', async () => {
+    await createRecord({
+      ...defaultOptions,
+      columnValues: {
+        bio: { value: null, fallbackValue: 'NULL' },
+      },
+    });
+
+    const sql = (capturedBody as CapturedRequest).args[0].args.sql;
+    expect(sql).toContain('NULL');
+  });
+
+  test('throws a descriptive error when an array column value is not valid JSON', async () => {
+    await expect(
+      createRecord({
+        ...defaultOptions,
+        columnValues: {
+          tags: { value: '{a,b}', specificType: 'text[]' },
+        },
+      }),
+    ).rejects.toThrow('Invalid array value for column "tags"');
+  });
+
+  test('throws a normalized error when the server returns an error', async () => {
+    server.use(
+      http.post('http://localhost:1337/v2/query', () =>
+        HttpResponse.json(
+          {
+            error: 'column "name" of relation "users" does not exist',
+            code: '42703',
+          },
+          { status: 400 },
+        ),
+      ),
+    );
+
+    await expect(
+      createRecord({
+        ...defaultOptions,
+        columnValues: { name: { value: 'Alice' } },
+      }),
+    ).rejects.toThrow();
+  });
+});

--- a/dashboard/src/features/orgs/projects/database/dataGrid/hooks/useCreateRecordMutation/createRecord.ts
+++ b/dashboard/src/features/orgs/projects/database/dataGrid/hooks/useCreateRecordMutation/createRecord.ts
@@ -34,10 +34,20 @@ export default async function createRecord<TData extends object = {}>({
 
   const values = columnIds
     .map((columnId) => {
-      const { value, fallbackValue } = columnValues[columnId];
+      const { value, fallbackValue, specificType } = columnValues[columnId];
 
       if (!value && fallbackValue) {
         return fallbackValue;
+      }
+
+      if (specificType?.endsWith('[]')) {
+        try {
+          return format('ARRAY[%L]', JSON.parse(value as string));
+        } catch {
+          throw new Error(
+            `Invalid array value for column "${columnId}". Use JSON array format, e.g. [1, 2, 3].`,
+          );
+        }
       }
 
       return format('%L', value);

--- a/dashboard/src/features/orgs/projects/database/dataGrid/hooks/useUpdateRecordMutation/updateRecord.test.ts
+++ b/dashboard/src/features/orgs/projects/database/dataGrid/hooks/useUpdateRecordMutation/updateRecord.test.ts
@@ -1,0 +1,189 @@
+import { HttpResponse, http } from 'msw';
+import { setupServer } from 'msw/node';
+import type { DataBrowserGridRow } from '@/features/orgs/projects/database/dataGrid/types/dataBrowser';
+import updateRecord from './updateRecord';
+
+const defaultOptions = {
+  dataSource: 'default',
+  appUrl: 'http://localhost:1337',
+  adminSecret: 'test-admin-secret',
+  schema: 'public',
+  table: 'users',
+};
+
+type RowCell = {
+  id: string;
+  isPrimary?: boolean;
+  specificType: string;
+  value: unknown;
+};
+
+function makeRow(cells: RowCell[]): DataBrowserGridRow {
+  const original = Object.fromEntries(cells.map((c) => [c.id, c.value]));
+  return {
+    original,
+    getAllCells: () =>
+      cells.map((c) => ({
+        column: {
+          id: c.id,
+          columnDef: {
+            meta: {
+              id: c.id,
+              isPrimary: c.isPrimary ?? false,
+              specificType: c.specificType,
+            },
+          },
+        },
+      })),
+  } as unknown as DataBrowserGridRow;
+}
+
+let capturedBody: unknown = null;
+
+const server = setupServer(
+  http.post('http://localhost:1337/v2/query', async ({ request }) => {
+    capturedBody = await request.json();
+    return HttpResponse.json([
+      { result_type: 'CommandOk', result: null },
+      {
+        result_type: 'TuplesOk',
+        result: [['data'], ['{"id":1,"name":"Alice"}']],
+      },
+    ]);
+  }),
+);
+
+beforeAll(() => server.listen());
+afterEach(() => {
+  server.resetHandlers();
+  capturedBody = null;
+});
+afterAll(() => server.close());
+
+type CapturedRequest = { args: Array<{ args: { sql: string } }> };
+
+describe('updateRecord', () => {
+  test('updates a scalar column using SQL literal syntax', async () => {
+    const row = makeRow([
+      { id: 'id', isPrimary: true, specificType: 'integer', value: 1 },
+      { id: 'name', specificType: 'text', value: 'Alice' },
+    ]);
+
+    await updateRecord({
+      ...defaultOptions,
+      row,
+      columnsToUpdate: { name: { value: 'Bob' } },
+    });
+
+    const sql = (capturedBody as CapturedRequest).args[0].args.sql;
+    expect(sql).toMatch(/UPDATE/);
+    expect(sql).toContain('Bob');
+    expect(sql).not.toContain('ARRAY[');
+  });
+
+  test('updates an array column using ARRAY[...] syntax', async () => {
+    const row = makeRow([
+      { id: 'id', isPrimary: true, specificType: 'integer', value: 1 },
+      { id: 'tags', specificType: 'text[]', value: ['a', 'b'] },
+    ]);
+
+    await updateRecord({
+      ...defaultOptions,
+      row,
+      columnsToUpdate: { tags: { value: '["x","y"]' } },
+    });
+
+    const sql = (capturedBody as CapturedRequest).args[0].args.sql;
+    expect(sql).toContain('ARRAY[');
+    expect(sql).toContain("'x'");
+    expect(sql).toContain("'y'");
+    expect(sql).not.toMatch(/tags = '(\[.*\])'/);
+  });
+
+  test('sets a column to NULL when reset is true', async () => {
+    const row = makeRow([
+      { id: 'id', isPrimary: true, specificType: 'integer', value: 1 },
+      { id: 'bio', specificType: 'text', value: 'hello' },
+    ]);
+
+    await updateRecord({
+      ...defaultOptions,
+      row,
+      columnsToUpdate: { bio: { value: null, reset: true } },
+    });
+
+    const sql = (capturedBody as CapturedRequest).args[0].args.sql;
+    expect(sql).toContain('bio = NULL');
+  });
+
+  test('builds the WHERE clause from primary key columns', async () => {
+    const row = makeRow([
+      { id: 'id', isPrimary: true, specificType: 'integer', value: 42 },
+      { id: 'name', specificType: 'text', value: 'Alice' },
+    ]);
+
+    await updateRecord({
+      ...defaultOptions,
+      row,
+      columnsToUpdate: { name: { value: 'Bob' } },
+    });
+
+    const sql = (capturedBody as CapturedRequest).args[0].args.sql;
+    expect(sql).toMatch(/WHERE/);
+    expect(sql).toContain('42');
+  });
+
+  test('throws when no primary key column is present', async () => {
+    const row = makeRow([{ id: 'name', specificType: 'text', value: 'Alice' }]);
+
+    await expect(
+      updateRecord({
+        ...defaultOptions,
+        row,
+        columnsToUpdate: { name: { value: 'Bob' } },
+      }),
+    ).rejects.toThrow('No primary keys found for row.');
+  });
+
+  test('throws a descriptive error when an array column value is not valid JSON', async () => {
+    const row = makeRow([
+      { id: 'id', isPrimary: true, specificType: 'integer', value: 1 },
+      { id: 'tags', specificType: 'text[]', value: ['a'] },
+    ]);
+
+    await expect(
+      updateRecord({
+        ...defaultOptions,
+        row,
+        columnsToUpdate: { tags: { value: '{a,b}' } },
+      }),
+    ).rejects.toThrow('Invalid array value for column "tags"');
+  });
+
+  test('throws a normalized error when the server returns an error', async () => {
+    server.use(
+      http.post('http://localhost:1337/v2/query', () =>
+        HttpResponse.json(
+          {
+            error: 'relation "public.users" does not exist',
+            code: '42P01',
+          },
+          { status: 400 },
+        ),
+      ),
+    );
+
+    const row = makeRow([
+      { id: 'id', isPrimary: true, specificType: 'integer', value: 1 },
+      { id: 'name', specificType: 'text', value: 'Alice' },
+    ]);
+
+    await expect(
+      updateRecord({
+        ...defaultOptions,
+        row,
+        columnsToUpdate: { name: { value: 'Bob' } },
+      }),
+    ).rejects.toThrow();
+  });
+});

--- a/dashboard/src/features/orgs/projects/database/dataGrid/hooks/useUpdateRecordMutation/updateRecord.ts
+++ b/dashboard/src/features/orgs/projects/database/dataGrid/hooks/useUpdateRecordMutation/updateRecord.ts
@@ -6,6 +6,7 @@ import {
 import type {
   AffectedRowsResult,
   ColumnUpdateOptions,
+  DataBrowserColumnMetadata,
   DataBrowserGridRow,
   MutationOrQueryBaseOptions,
   QueryError,
@@ -40,9 +41,10 @@ export default async function updateRecord<
   row,
   columnsToUpdate,
 }: UpdateRecordOptions & UpdateRecordVariables<TData>) {
-  const primaryKeys = row
-    .getAllCells()
-    .filter(({ column }) => column.columnDef.meta?.isPrimary);
+  const allCells = row.getAllCells();
+  const primaryKeys = allCells.filter(
+    ({ column }) => column.columnDef.meta?.isPrimary,
+  );
 
   if (primaryKeys.length === 0) {
     throw new Error('No primary keys found for row.');
@@ -70,6 +72,20 @@ export default async function updateRecord<
         return format('%I = NULL', key);
       }
 
+      const col = allCells.find(
+        ({ column }) =>
+          (column.columnDef.meta as DataBrowserColumnMetadata)?.id === key,
+      )!.column.columnDef.meta as DataBrowserColumnMetadata;
+
+      if (col.specificType.endsWith('[]')) {
+        try {
+          return format('%I = ARRAY[%L]', key, JSON.parse(value));
+        } catch {
+          throw new Error(
+            `Invalid array value for column "${key}". Use JSON array format, e.g. [1, 2, 3].`,
+          );
+        }
+      }
       return format('%I = %L', key, value);
     })
     .join(', ');

--- a/dashboard/src/features/orgs/projects/database/dataGrid/types/dataBrowser/dataBrowser.ts
+++ b/dashboard/src/features/orgs/projects/database/dataGrid/types/dataBrowser/dataBrowser.ts
@@ -271,6 +271,11 @@ export interface ColumnInsertOptions {
    * Fallback value if the column value is `undefined`.
    */
   fallbackValue?: 'NULL' | 'DEFAULT';
+  /**
+   * PostgreSQL specific type of the column (e.g. `text`, `integer[]`).
+   * Used to determine special SQL formatting such as ARRAY[...] literals.
+   */
+  specificType?: string;
 }
 
 /**


### PR DESCRIPTION
<!-- nhost-reviewer:start -->
### **PR Type**
Bug fix

___

### **Description**
- Fix database data browser to correctly insert and update PostgreSQL array columns (e.g. `text[]`, `integer[]`) using `ARRAY[...]` SQL syntax instead of inserting the raw JSON string as a literal.
- Pass `specificType` from column metadata through the create record form so `createRecord` can detect array columns.
- In `updateRecord`, look up the column's `specificType` from the row's cell metadata to detect array columns and format the SQL accordingly.
- Add comprehensive test suites for both `createRecord` and `updateRecord` covering scalar values, array values, NULL/DEFAULT fallbacks, error handling, and invalid input validation.

___

### Diagram Walkthrough

```mermaid
flowchart LR
  A["BaseRecordForm"] -->|"passes specificType"| B["CreateRecordForm"]
  B -->|"columnValues with specificType"| C["createRecord()"]
  C -->|"ARRAY[...] for [] types"| D["Hasura v2/query"]

  E["DataGridCell"] -->|"columnsToUpdate"| F["updateRecord()"]
  F -->|"looks up specificType from row cells"| F
  F -->|"ARRAY[...] for [] types"| D
```

<details> <summary><h3> File Walkthrough</h3></summary>

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody>
<tr><td><strong>Core logic</strong></td><td><details><summary>3 files</summary><table>
<tr>
  <td><strong>createRecord.ts</strong><dd><code>Add array column detection: format values as ARRAY[...] when specificType ends with []</code></dd></td>
  <td><a href="https://github.com/nhost/nhost/pull/XXX/files#diff-764ca6f10d0bfeb3abcdbac4630a30c3daa75f39b89b196b8eb95473b1332e22">+11/-1</a></td>
</tr>
<tr>
  <td><strong>updateRecord.ts</strong><dd><code>Look up specificType from row cell metadata and format array columns as ARRAY[...] in UPDATE SET clause</code></dd></td>
  <td><a href="https://github.com/nhost/nhost/pull/XXX/files#diff-d55f2716d5999af410e357f4d7ee06afaa93f6b185bbeffecbe2917c16a5e3f0">+19/-3</a></td>
</tr>
<tr>
  <td><strong>BaseRecordForm.tsx</strong><dd><code>Pass specificType from grid column metadata into ColumnInsertOptions</code></dd></td>
  <td><a href="https://github.com/nhost/nhost/pull/XXX/files#diff-b6bf356211ea3f56b05941761c63104cbfdea0588e986413ec33f9afff58bcdd">+1/-0</a></td>
</tr>
</table></details></td></tr>
<tr><td><strong>Types</strong></td><td><details><summary>1 file</summary><table>
<tr>
  <td><strong>dataBrowser.ts</strong><dd><code>Add optional specificType field to ColumnInsertOptions interface</code></dd></td>
  <td><a href="https://github.com/nhost/nhost/pull/XXX/files#diff-33c6810dbd7e2910c86a15009467a348f064380b0e1dd787ef320b4e7543403b">+5/-0</a></td>
</tr>
</table></details></td></tr>
<tr><td><strong>Tests</strong></td><td><details><summary>2 files</summary><table>
<tr>
  <td><strong>createRecord.test.ts</strong><dd><code>Test suite for createRecord: scalar inserts, array inserts, DEFAULT/NULL fallbacks, invalid JSON, server errors</code></dd></td>
  <td><a href="https://github.com/nhost/nhost/pull/XXX/files#diff-997d4ee7c853bddafe373fa991cc330ec479b2757f37f4b6556051d5e56df5ca">+132/-0</a></td>
</tr>
<tr>
  <td><strong>updateRecord.test.ts</strong><dd><code>Test suite for updateRecord: scalar updates, array updates, NULL reset, WHERE clause, missing PK, invalid JSON, server errors</code></dd></td>
  <td><a href="https://github.com/nhost/nhost/pull/XXX/files#diff-e3d275736970f64c5408b98667076120f76ba75d4bcf9c85113859b74ec43837">+192/-0</a></td>
</tr>
</table></details></td></tr>
</tbody></table>

</details>

___

<!-- nhost-reviewer:end -->
