### PR TITLE
fix(dashboard): disable Publish toggle for non-publishable port types in Run service form

### DIFF
--- a/dashboard/src/features/orgs/projects/services/components/ServiceForm/components/PortsFormSection/PortsFormSection.tsx
+++ b/dashboard/src/features/orgs/projects/services/components/ServiceForm/components/PortsFormSection/PortsFormSection.tsx
@@ -12,7 +12,10 @@ import { Text } from '@/components/ui/v2/Text';
 import { Tooltip } from '@/components/ui/v2/Tooltip';
 import { useProject } from '@/features/orgs/projects/hooks/useProject';
 import { InfoCard } from '@/features/orgs/projects/overview/components/InfoCard';
-import { PortTypes } from '@/features/orgs/projects/services/components/ServiceForm/components/PortsFormSection/PortsFormSectionTypes';
+import {
+  isPublishablePortType,
+  type PortTypes,
+} from '@/features/orgs/projects/services/components/ServiceForm/components/PortsFormSection/PortsFormSectionTypes';
 import type { ServiceFormValues } from '@/features/orgs/projects/services/components/ServiceForm/ServiceFormTypes';
 import { isNotEmptyValue } from '@/lib/utils';
 import type { ConfigRunServicePort } from '@/utils/__generated__/graphql';
@@ -35,14 +38,17 @@ export default function PortsFormSection() {
 
   const formValues = useWatch<ServiceFormValues & { subdomain: string }>();
 
-  const onChangePortType = (value: string | undefined, index: number) =>
+  const onChangePortType = (value: string | undefined, index: number) => {
     setValue(`ports.${index}.type`, value as PortTypes);
+    if (!isPublishablePortType(value)) {
+      setValue(`ports.${index}.publish`, false);
+    }
+  };
 
   const showURL = (index: number) =>
     isNotEmptyValue(formValues.subdomain) &&
     isNotEmptyValue(project) &&
-    (formValues.ports?.[index]?.type === PortTypes.HTTP ||
-      formValues.ports?.[index]?.type === PortTypes.GRPC) &&
+    isPublishablePortType(formValues.ports?.[index]?.type) &&
     formValues.ports?.[index]?.publish;
 
   return (
@@ -119,7 +125,9 @@ export default function PortsFormSection() {
 
               <ControlledSwitch
                 {...register(`ports.${index}.publish`)}
-                disabled={false} // TODO turn off and disable if the port is not http
+                disabled={
+                  !isPublishablePortType(formValues.ports?.at?.(index)?.type)
+                }
                 label={
                   <Text variant="subtitle1" component="span">
                     Publish

--- a/dashboard/src/features/orgs/projects/services/components/ServiceForm/components/PortsFormSection/PortsFormSectionTypes.ts
+++ b/dashboard/src/features/orgs/projects/services/components/ServiceForm/components/PortsFormSection/PortsFormSectionTypes.ts
@@ -4,3 +4,7 @@ export enum PortTypes {
   UDP = 'udp',
   GRPC = 'grpc',
 }
+
+export function isPublishablePortType(type: PortTypes | string | undefined) {
+  return type === PortTypes.HTTP || type === PortTypes.GRPC;
+}


### PR DESCRIPTION
### Checklist

- [X] No breaking changes
- [X] Tests pass
- [X] New features have new tests
- [X] Documentation is updated (if applicable)
- [X] Title of the PR is in the correct format (see below)

<!-- nhost-reviewer:start -->
### **PR Type**
Bug fix

___

### **Description**
- Add `isPublishablePortType` helper that returns `true` for HTTP and GRPC port types
- Disable the Publish toggle when the port type is not publishable (TCP, UDP)
- Auto-reset `publish` to `false` when the user switches to a non-publishable port type
- Refactor the `showURL` logic to use the new helper instead of inline comparisons

___

<details> <summary><h3> File Walkthrough</h3></summary>

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody>
<tr><td><strong>Ports form logic</strong></td><td><details><summary>2 files</summary><table>
<tr>
  <td><strong>PortsFormSectionTypes.ts</strong><dd><code>Add isPublishablePortType helper function for HTTP/GRPC check</code></dd></td>
  <td><a href="https://github.com/nhost/nhost/pull/4116/files#diff-76ee341cb357f613e378223a41a9004560f3433eb0b6e52fffa35d74403b4527">+4/-0</a></td>
</tr>
<tr>
  <td><strong>PortsFormSection.tsx</strong><dd><code>Disable Publish switch for non-publishable ports, reset on type change, refactor showURL</code></dd></td>
  <td><a href="https://github.com/nhost/nhost/pull/4116/files#diff-75c4254c31fe6addb187b5d122dd1fa171c1a8875c0152a6c1b2a05257c61d4c">+13/-5</a></td>
</tr>
</table></details></td></tr>
</tbody></table>

</details>

___

<!-- nhost-reviewer:end -->