### PR TITLE
fix(auth): limit returned rows to the most recent in case users have multiple linked accounts

### DIFF
--- a/services/auth/go/sql/query.sql
+++ b/services/auth/go/sql/query.sql
@@ -423,6 +423,7 @@ WITH old_token AS (
   WHERE user_id = @user_id AND provider_id = @provider_id
   ORDER BY updated_at DESC
   LIMIT 1
+  FOR UPDATE
 )
 UPDATE auth.user_providers
 SET access_token = ''

--- a/services/auth/go/sql/query.sql.go
+++ b/services/auth/go/sql/query.sql.go
@@ -394,6 +394,7 @@ WITH old_token AS (
   WHERE user_id = $1 AND provider_id = $2
   ORDER BY updated_at DESC
   LIMIT 1
+  FOR UPDATE
 )
 UPDATE auth.user_providers
 SET access_token = ''


### PR DESCRIPTION
<!-- nhost-reviewer:start -->
### **PR Type**
Bug fix

___

### **Description**
- Fix `GetProviderSession` SQL query to handle users with multiple linked accounts for the same provider by selecting only the most recently updated row
- Add `FOR UPDATE` row-level locking to prevent race conditions during the read-and-clear operation
- Target the UPDATE by primary key (`id`) instead of the composite `(user_id, provider_id)` to ensure exactly one row is modified

___

<details> <summary><h3> File Walkthrough</h3></summary>

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody>
<tr><td><strong>SQL queries</strong></td><td><details><summary>1 file</summary><table>
<tr>
  <td><strong>query.sql</strong><dd><code>Scope GetProviderSession CTE to single row with ORDER BY/LIMIT/FOR UPDATE, update by id</code></dd></td>
  <td><a href="https://github.com/nhost/nhost/pull/4118/files#diff-97f747248104c1546792d48460adc342691cf9541b0f0970a773c5835668d41a">+5/-2</a></td>
</tr>
</table></details></td></tr>
<tr><td><strong>Generated code</strong></td><td><details><summary>1 file</summary><table>
<tr>
  <td><strong>query.sql.go</strong><dd><code>Regenerated by sqlc to reflect query.sql changes</code></dd></td>
  <td><a href="https://github.com/nhost/nhost/pull/4118/files#diff-a9f5d32f2fd6726736782eda230adec7603a35dbbbecc7537551bf35f5b35a17">+5/-2</a></td>
</tr>
</table></details></td></tr>
</tbody></table>

</details>

___

<!-- nhost-reviewer:end -->