### PR TITLE
feat(dashboard): Storage maintenance

### DIFF
--- a/dashboard/src/features/orgs/projects/storage/components/StorageMaintenanceButton/StorageMaintenanceButton.test.tsx
+++ b/dashboard/src/features/orgs/projects/storage/components/StorageMaintenanceButton/StorageMaintenanceButton.test.tsx
@@ -1,0 +1,188 @@
+import { HttpResponse, http } from 'msw';
+import { setupServer } from 'msw/node';
+import { vi } from 'vitest';
+import { mockMatchMediaValue } from '@/tests/mocks';
+import tokenQuery from '@/tests/msw/mocks/rest/tokenQuery';
+import { render, screen, TestUserEvent, waitFor } from '@/tests/testUtils';
+import StorageMaintenanceButton from './StorageMaintenanceButton';
+
+Object.defineProperty(window, 'matchMedia', {
+  writable: true,
+  value: vi.fn().mockImplementation(mockMatchMediaValue),
+});
+
+const STORAGE_BASE = 'https://local.storage.local.nhost.run/v1';
+
+const mocks = vi.hoisted(() => ({
+  useProject: vi.fn(),
+  useIsPlatform: vi.fn(),
+}));
+
+vi.mock('@/features/orgs/projects/hooks/useProject', () => ({
+  useProject: mocks.useProject,
+}));
+
+vi.mock('@/features/orgs/projects/common/hooks/useIsPlatform', () => ({
+  useIsPlatform: mocks.useIsPlatform,
+}));
+
+const server = setupServer(tokenQuery);
+
+describe('StorageMaintenanceButton', () => {
+  const user = new TestUserEvent();
+
+  beforeAll(() => {
+    server.listen();
+  });
+
+  beforeEach(() => {
+    server.resetHandlers();
+    mocks.useIsPlatform.mockReturnValue(false);
+    mocks.useProject.mockReturnValue({
+      project: {
+        id: 'test-project',
+        config: { hasura: { adminSecret: 'secret' } },
+      },
+    });
+  });
+
+  afterEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  afterAll(() => {
+    server.close();
+  });
+
+  describe('singular/plural copy', () => {
+    it('should use singular "file" and "entry" when counts are 1', async () => {
+      server.use(
+        http.post(`${STORAGE_BASE}/ops/list-orphans`, () =>
+          HttpResponse.json({ files: [{ id: 'orphan-1' }] }),
+        ),
+        http.post(`${STORAGE_BASE}/ops/list-broken-metadata`, () =>
+          HttpResponse.json({ metadata: [{ id: 'broken-1' }] }),
+        ),
+      );
+
+      render(<StorageMaintenanceButton />);
+      await user.click(screen.getByRole('button'));
+
+      await waitFor(() => {
+        expect(screen.getByText('1 orphaned file found.')).toBeInTheDocument();
+        expect(
+          screen.getByText('1 broken metadata entry found.'),
+        ).toBeInTheDocument();
+      });
+    });
+
+    it('should use plural "files" and "entries" when counts are > 1', async () => {
+      server.use(
+        http.post(`${STORAGE_BASE}/ops/list-orphans`, () =>
+          HttpResponse.json({
+            files: [{ id: 'o-1' }, { id: 'o-2' }, { id: 'o-3' }],
+          }),
+        ),
+        http.post(`${STORAGE_BASE}/ops/list-broken-metadata`, () =>
+          HttpResponse.json({
+            metadata: [{ id: 'b-1' }, { id: 'b-2' }],
+          }),
+        ),
+      );
+
+      render(<StorageMaintenanceButton />);
+      await user.click(screen.getByRole('button'));
+
+      await waitFor(() => {
+        expect(screen.getByText('3 orphaned files found.')).toBeInTheDocument();
+        expect(
+          screen.getByText('2 broken metadata entries found.'),
+        ).toBeInTheDocument();
+      });
+    });
+  });
+
+  describe('delete actions', () => {
+    it('should call deleteOrphans then refetch both lists', async () => {
+      const callOrder: string[] = [];
+
+      server.use(
+        http.post(`${STORAGE_BASE}/ops/list-orphans`, () => {
+          callOrder.push('list-orphans');
+          return HttpResponse.json({ files: [{ id: 'o-1' }] });
+        }),
+        http.post(`${STORAGE_BASE}/ops/list-broken-metadata`, () => {
+          callOrder.push('list-broken-metadata');
+          return HttpResponse.json({ metadata: [] });
+        }),
+        http.post(`${STORAGE_BASE}/ops/delete-orphans`, () => {
+          callOrder.push('delete-orphans');
+          return HttpResponse.json({ files: [] });
+        }),
+      );
+
+      render(<StorageMaintenanceButton />);
+      await user.click(screen.getByRole('button'));
+
+      await waitFor(() => {
+        expect(screen.getByText('1 orphaned file found.')).toBeInTheDocument();
+      });
+
+      callOrder.length = 0;
+
+      const deleteButton = screen.getByRole('button', { name: 'Delete' });
+      await user.click(deleteButton);
+
+      await waitFor(() => {
+        expect(callOrder).toContain('delete-orphans');
+        expect(callOrder).toContain('list-orphans');
+        expect(callOrder).toContain('list-broken-metadata');
+        expect(callOrder.indexOf('delete-orphans')).toBeLessThan(
+          callOrder.indexOf('list-orphans'),
+        );
+      });
+    });
+
+    it('should call deleteBroken then refetch both lists', async () => {
+      const callOrder: string[] = [];
+
+      server.use(
+        http.post(`${STORAGE_BASE}/ops/list-orphans`, () => {
+          callOrder.push('list-orphans');
+          return HttpResponse.json({ files: [] });
+        }),
+        http.post(`${STORAGE_BASE}/ops/list-broken-metadata`, () => {
+          callOrder.push('list-broken-metadata');
+          return HttpResponse.json({ metadata: [{ id: 'b-1' }] });
+        }),
+        http.post(`${STORAGE_BASE}/ops/delete-broken-metadata`, () => {
+          callOrder.push('delete-broken-metadata');
+          return HttpResponse.json({ metadata: [] });
+        }),
+      );
+
+      render(<StorageMaintenanceButton />);
+      await user.click(screen.getByRole('button'));
+
+      await waitFor(() => {
+        expect(
+          screen.getByText('1 broken metadata entry found.'),
+        ).toBeInTheDocument();
+      });
+
+      callOrder.length = 0;
+
+      const deleteButton = screen.getByRole('button', { name: 'Delete' });
+      await user.click(deleteButton);
+
+      await waitFor(() => {
+        expect(callOrder).toContain('delete-broken-metadata');
+        expect(callOrder).toContain('list-orphans');
+        expect(callOrder).toContain('list-broken-metadata');
+        expect(callOrder.indexOf('delete-broken-metadata')).toBeLessThan(
+          callOrder.indexOf('list-orphans'),
+        );
+      });
+    });
+  });
+});

--- a/dashboard/src/features/orgs/projects/storage/components/StorageMaintenanceButton/StorageMaintenanceButton.tsx
+++ b/dashboard/src/features/orgs/projects/storage/components/StorageMaintenanceButton/StorageMaintenanceButton.tsx
@@ -1,0 +1,103 @@
+import { Wrench } from 'lucide-react';
+import { Button } from '@/components/ui/v3/button';
+import {
+  Popover,
+  PopoverContent,
+  PopoverTrigger,
+} from '@/components/ui/v3/popover';
+import { useStorageMaintenance } from '@/features/orgs/projects/storage/hooks/useStorageMaintenance';
+import { execPromiseWithErrorToast } from '@/features/orgs/utils/execPromiseWithErrorToast';
+
+export default function StorageMaintenanceButton() {
+  const {
+    orphanCount,
+    brokenMetadataCount,
+    refetch,
+    deleteOrphans,
+    deleteBroken,
+  } = useStorageMaintenance();
+
+  const totalIssues = orphanCount + brokenMetadataCount;
+
+  function handleDeleteOrphans() {
+    execPromiseWithErrorToast(
+      async () => {
+        await deleteOrphans();
+        await refetch();
+      },
+      {
+        loadingMessage: 'Deleting orphaned files...',
+        successMessage: 'Orphaned files deleted successfully.',
+        errorMessage: 'Failed to delete orphaned files.',
+      },
+    );
+  }
+
+  function handleDeleteBroken() {
+    execPromiseWithErrorToast(
+      async () => {
+        await deleteBroken();
+        await refetch();
+      },
+      {
+        loadingMessage: 'Deleting broken metadata...',
+        successMessage: 'Broken metadata deleted successfully.',
+        errorMessage: 'Failed to delete broken metadata.',
+      },
+    );
+  }
+
+  return (
+    <Popover>
+      <PopoverTrigger asChild>
+        <Button variant="outline" size="icon" className="relative">
+          <Wrench />
+          {totalIssues > 0 && (
+            <span className="absolute right-[6px] bottom-[8px] w-[0.625rem] rounded-full bg-primary-text p-0 text-[0.625rem] text-paper leading-none">
+              !
+            </span>
+          )}
+        </Button>
+      </PopoverTrigger>
+      <PopoverContent align="end" className="flex w-80 flex-col gap-4 p-4">
+        <p className="font-medium text-sm">Storage Maintenance</p>
+        <div className="flex flex-col gap-3">
+          <div className="flex items-center justify-between">
+            <p className="text-muted-foreground text-sm">
+              {orphanCount > 0
+                ? `${orphanCount} orphaned ${orphanCount === 1 ? 'file' : 'files'} found.`
+                : 'No orphaned files.'}
+            </p>
+            {orphanCount > 0 && (
+              <Button
+                variant="destructive"
+                size="sm"
+                className="h-7 text-xs"
+                onClick={handleDeleteOrphans}
+              >
+                Delete
+              </Button>
+            )}
+          </div>
+          <div className="flex items-center justify-between">
+            <p className="text-muted-foreground text-sm">
+              {brokenMetadataCount > 0
+                ? `${brokenMetadataCount} broken metadata ${brokenMetadataCount === 1 ? 'entry' : 'entries'} found.`
+                : 'No broken metadata.'}
+            </p>
+            {brokenMetadataCount > 0 && (
+              <Button
+                variant="destructive"
+                size="sm"
+                className="h-7 text-xs"
+                onClick={handleDeleteBroken}
+              >
+                Delete
+              </Button>
+            )}
+          </div>
+        </div>
+      </PopoverContent>
+    </Popover>
+  );
+}

--- a/dashboard/src/features/orgs/projects/storage/components/StorageMaintenanceButton/index.ts
+++ b/dashboard/src/features/orgs/projects/storage/components/StorageMaintenanceButton/index.ts
@@ -1,0 +1,1 @@
+export { default as StorageMaintenanceButton } from './StorageMaintenanceButton';

--- a/dashboard/src/features/orgs/projects/storage/dataGrid/components/FilesDataGridControls/FilesDataGridControls.tsx
+++ b/dashboard/src/features/orgs/projects/storage/dataGrid/components/FilesDataGridControls/FilesDataGridControls.tsx
@@ -8,6 +8,7 @@ import { DataGridFiltersPopover } from '@/features/orgs/projects/common/componen
 import { DataGridTableViewConfigurationPopover } from '@/features/orgs/projects/common/components/DataGridTableViewConfigurationPopover';
 import { useAppClient } from '@/features/orgs/projects/hooks/useAppClient';
 import { useProject } from '@/features/orgs/projects/hooks/useProject';
+import { StorageMaintenanceButton } from '@/features/orgs/projects/storage/components/StorageMaintenanceButton';
 import { useDataGridConfig } from '@/features/orgs/projects/storage/dataGrid/components/DataGridConfigProvider';
 import type { DataGridPaginationProps } from '@/features/orgs/projects/storage/dataGrid/components/DataGridPagination';
 import { DataGridPagination } from '@/features/orgs/projects/storage/dataGrid/components/DataGridPagination';
@@ -157,6 +158,7 @@ export default function FilesDataGridControls({
               storageKey={storageKey}
               isFetching={isFetching}
             />
+            <StorageMaintenanceButton />
             <DataGridTableViewConfigurationPopover />
             <FileUploadButton
               className={twMerge(

--- a/dashboard/src/features/orgs/projects/storage/hooks/useStorageMaintenance/index.ts
+++ b/dashboard/src/features/orgs/projects/storage/hooks/useStorageMaintenance/index.ts
@@ -1,0 +1,1 @@
+export { default as useStorageMaintenance } from './useStorageMaintenance';

--- a/dashboard/src/features/orgs/projects/storage/hooks/useStorageMaintenance/useStorageMaintenance.test.tsx
+++ b/dashboard/src/features/orgs/projects/storage/hooks/useStorageMaintenance/useStorageMaintenance.test.tsx
@@ -1,0 +1,128 @@
+import { QueryClientProvider } from '@tanstack/react-query';
+import { HttpResponse, http } from 'msw';
+import { setupServer } from 'msw/node';
+import type { PropsWithChildren } from 'react';
+import { vi } from 'vitest';
+import tokenQuery from '@/tests/msw/mocks/rest/tokenQuery';
+import { queryClient, renderHook, waitFor } from '@/tests/testUtils';
+import useStorageMaintenance from './useStorageMaintenance';
+
+const STORAGE_BASE = 'https://local.storage.local.nhost.run/v1';
+
+const mocks = vi.hoisted(() => ({
+  useProject: vi.fn(),
+  useIsPlatform: vi.fn(),
+}));
+
+vi.mock('@/features/orgs/projects/hooks/useProject', () => ({
+  useProject: mocks.useProject,
+}));
+
+vi.mock('@/features/orgs/projects/common/hooks/useIsPlatform', () => ({
+  useIsPlatform: mocks.useIsPlatform,
+}));
+
+const server = setupServer(tokenQuery);
+
+function wrapper({ children }: PropsWithChildren) {
+  return (
+    <QueryClientProvider client={queryClient}>{children}</QueryClientProvider>
+  );
+}
+
+describe('useStorageMaintenance', () => {
+  beforeAll(() => {
+    server.listen();
+  });
+
+  beforeEach(() => {
+    server.resetHandlers();
+    queryClient.clear();
+    mocks.useIsPlatform.mockReturnValue(false);
+  });
+
+  afterEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  afterAll(() => {
+    server.close();
+  });
+
+  it('should not fetch when adminSecret is falsy', async () => {
+    const listOrphansSpy = vi.fn();
+    const listBrokenSpy = vi.fn();
+
+    server.use(
+      http.post(`${STORAGE_BASE}/ops/list-orphans`, () => {
+        listOrphansSpy();
+        return HttpResponse.json({ files: [] });
+      }),
+      http.post(`${STORAGE_BASE}/ops/list-broken-metadata`, () => {
+        listBrokenSpy();
+        return HttpResponse.json({ metadata: [] });
+      }),
+    );
+
+    mocks.useProject.mockReturnValue({
+      project: {
+        id: 'test-project',
+        config: { hasura: { adminSecret: '' } },
+      },
+    });
+
+    const { result } = renderHook(() => useStorageMaintenance(), { wrapper });
+
+    await waitFor(() => {
+      expect(result.current.orphanCount).toBe(0);
+      expect(result.current.brokenMetadataCount).toBe(0);
+    });
+
+    expect(listOrphansSpy).not.toHaveBeenCalled();
+    expect(listBrokenSpy).not.toHaveBeenCalled();
+  });
+
+  it('should pass x-hasura-admin-secret header to delete endpoints', async () => {
+    const capturedHeaders: Record<string, string | null> = {};
+
+    server.use(
+      http.post(`${STORAGE_BASE}/ops/list-orphans`, () =>
+        HttpResponse.json({ files: [{ id: 'o-1' }] }),
+      ),
+      http.post(`${STORAGE_BASE}/ops/list-broken-metadata`, () =>
+        HttpResponse.json({ metadata: [{ id: 'b-1' }] }),
+      ),
+      http.post(`${STORAGE_BASE}/ops/delete-orphans`, ({ request }) => {
+        capturedHeaders.deleteOrphans = request.headers.get(
+          'x-hasura-admin-secret',
+        );
+        return HttpResponse.json({ files: [] });
+      }),
+      http.post(`${STORAGE_BASE}/ops/delete-broken-metadata`, ({ request }) => {
+        capturedHeaders.deleteBroken = request.headers.get(
+          'x-hasura-admin-secret',
+        );
+        return HttpResponse.json({ metadata: [] });
+      }),
+    );
+
+    mocks.useProject.mockReturnValue({
+      project: {
+        id: 'test-project',
+        config: { hasura: { adminSecret: 'my-secret-123' } },
+      },
+    });
+
+    const { result } = renderHook(() => useStorageMaintenance(), { wrapper });
+
+    await waitFor(() => {
+      expect(result.current.orphanCount).toBe(1);
+    });
+
+    await result.current.deleteOrphans();
+    await result.current.deleteBroken();
+
+    expect(capturedHeaders.deleteOrphans).toBe('my-secret-123');
+    expect(capturedHeaders.deleteBroken).toBe('my-secret-123');
+  });
+});

--- a/dashboard/src/features/orgs/projects/storage/hooks/useStorageMaintenance/useStorageMaintenance.ts
+++ b/dashboard/src/features/orgs/projects/storage/hooks/useStorageMaintenance/useStorageMaintenance.ts
@@ -1,0 +1,51 @@
+import { useQuery } from '@tanstack/react-query';
+import { useCallback } from 'react';
+import { useAppClient } from '@/features/orgs/projects/hooks/useAppClient';
+import { useProject } from '@/features/orgs/projects/hooks/useProject';
+
+export default function useStorageMaintenance() {
+  const appClient = useAppClient();
+  const { project } = useProject();
+
+  const adminSecret = project?.config?.hasura.adminSecret;
+  const headers = { 'x-hasura-admin-secret': adminSecret ?? '' };
+
+  const {
+    data: orphansData,
+    isLoading: orphansLoading,
+    refetch: refetchOrphans,
+  } = useQuery({
+    queryKey: ['storage-orphans', project?.id],
+    queryFn: () => appClient.storage.listOrphanedFiles({ headers }),
+    enabled: !!adminSecret,
+  });
+
+  const {
+    data: brokenData,
+    isLoading: brokenLoading,
+    refetch: refetchBroken,
+  } = useQuery({
+    queryKey: ['storage-broken-metadata', project?.id],
+    queryFn: () => appClient.storage.listBrokenMetadata({ headers }),
+    enabled: !!adminSecret,
+  });
+
+  const refetch = useCallback(async () => {
+    await Promise.all([refetchOrphans(), refetchBroken()]);
+  }, [refetchOrphans, refetchBroken]);
+
+  const deleteOrphans = () =>
+    appClient.storage.deleteOrphanedFiles({ headers });
+
+  const deleteBroken = () =>
+    appClient.storage.deleteBrokenMetadata({ headers });
+
+  return {
+    orphanCount: orphansData?.body.files?.length ?? 0,
+    brokenMetadataCount: brokenData?.body.metadata?.length ?? 0,
+    isLoading: orphansLoading || brokenLoading,
+    refetch,
+    deleteOrphans,
+    deleteBroken,
+  };
+}


### PR DESCRIPTION
<!-- nhost-reviewer:start -->
### **PR Type**
Enhancement

___

### **Description**
- Decouples `DataGridFiltersPopover` and `DataGridQueryParamsProvider` from the database-specific `useTablePath` hook by accepting a generic `storageKey` prop, making them reusable across database and storage pages.
- Simplifies pagination state by deriving `currentOffset` directly from the URL `page` query param instead of mirroring it in component state, removing the dual-state problem and `setCurrentOffset` from the public API.
- Moves `DataGridQueryParamsProvider` ownership into `DataBrowserGridContainer` and `Bucket` (with a `key` prop for automatic reset on navigation), replacing the old `useEffect`-based sync logic.
- Adds a shared `usePageBoundsRedirect` hook that redirects to the last valid page when the current page is out of bounds after a data change.
- Replaces the storage files search-string input with the existing `DataGridFiltersPopover`, wiring `FilesDataGrid` into the shared `DataGridQueryParamsProvider` context and introducing `filtersToFilesWhere` to translate `DataGridFilter[]` into Hasura `Files_Bool_Exp`.
- Adds `StorageMaintenanceButton` and `useStorageMaintenance`: a popover UI for detecting and deleting orphaned files and broken metadata entries, with full MSW-backed tests.

___

### Diagram Walkthrough

```mermaid
flowchart LR
  subgraph DB["Database browser"]
    DBGC["DataBrowserGridContainer\n(key=tablePath)"]
    DQPP["DataGridQueryParamsProvider\n(storageKey=tablePath)"]
    DBG["DataBrowserGrid"]
    DBGCTRL["DataBrowserGridControls"]
    DGFP["DataGridFiltersPopover\n(storageKey=tablePath)"]
    PBRD1["usePageBoundsRedirect"]
  end

  subgraph Storage["Storage browser"]
    Bucket["Bucket\n(key=bucketId)"]
    DQPP2["DataGridQueryParamsProvider\n(storageKey=storage:bucketId)"]
    FDG["FilesDataGrid"]
    FDGCTRL["FilesDataGridControls"]
    DGFP2["DataGridFiltersPopover\n(storageKey=storage:bucketId)"]
    FTW["filtersToFilesWhere"]
    SMB["StorageMaintenanceButton"]
    PBRD2["usePageBoundsRedirect"]
  end

  DBGC --> DQPP --> DBG --> DBGCTRL --> DGFP
  DBG --> PBRD1
  Bucket --> DQPP2 --> FDG --> FDGCTRL --> DGFP2
  FDGCTRL --> SMB
  FDG --> FTW
  FDG --> PBRD2
```

<details> <summary><h3> File Walkthrough</h3></summary>

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody>
<tr><td><strong>Shared filter/pagination infrastructure</strong></td><td><details><summary>6 files</summary><table>
<tr>
  <td><strong>DataGridFiltersProvider.tsx</strong><dd><code>Accepts storageKey prop; removes useTablePath dependency; exposes storageKey in context</code></dd></td>
  <td><a href="https://github.com/nhost/nhost/pull/4126/files#diff-e238db2c1a27ebf89f0d86ae63cfd0de38bb5895cc9d9fb5eb15e7eb88d35b2f">+15/-7</a></td>
</tr>
<tr>
  <td><strong>DataGridFiltersPopover.tsx</strong><dd><code>Accepts storageKey and isFetching props; passes both into children</code></dd></td>
  <td><a href="https://github.com/nhost/nhost/pull/4126/files#diff-aece9c2a5c87b4636a2293b959eb2cf4090908d3ab833fbd02f76730f7312d39">+19/-5</a></td>
</tr>
<tr>
  <td><strong>DataGridFilterActions.tsx</strong><dd><code>Accepts isFetching prop instead of computing it internally via useIsFetching</code></dd></td>
  <td><a href="https://github.com/nhost/nhost/pull/4126/files#diff-a757ce03ed5f1747eb8765cc195e0e20a4881895355e27278e9bab1c2afab398">+7/-25</a></td>
</tr>
<tr>
  <td><strong>DataGridFilterValue.tsx</strong><dd><code>Removes setCurrentOffset call on Enter key</code></dd></td>
  <td><a href="https://github.com/nhost/nhost/pull/4126/files#diff-f95663c0e7d70ffedff0e8b8baf0b237c4509cf0c65a0928bdf7143dea1e04ea">+1/-2</a></td>
</tr>
<tr>
  <td><strong>useGetDataColumns.ts</strong><dd><code>Filters out columns where getCanFilter() is false</code></dd></td>
  <td><a href="https://github.com/nhost/nhost/pull/4126/files#diff-48a5c0cd5ffa47d053be3a5b8834cbebef335528dfc40097a70c1d3c618a07bf">+1/-1</a></td>
</tr>
<tr>
  <td><strong>usePageBoundsRedirect.ts</strong><dd><code>New hook: redirects to last valid page when currentOffset exceeds numberOfPages</code></dd></td>
  <td><a href="https://github.com/nhost/nhost/pull/4126/files#diff-99ed29adcfbadf99b53c1d4361ea4959d49858b5fd969c3ea3615313b0e6ee3f">+18/-0</a></td>
</tr>
</table></details></td></tr>

<tr><td><strong>DataGridQueryParamsProvider refactor</strong></td><td><details><summary>2 files</summary><table>
<tr>
  <td><strong>DataGridQueryParamsProvider.tsx</strong><dd><code>Accepts storageKey prop; derives currentOffset from URL directly; removes setCurrentOffset, isFiltersLoadedFromStorage, and table-path sync effects</code></dd></td>
  <td><a href="https://github.com/nhost/nhost/pull/4126/files#diff-2493d07cc18a56e6ebcda46ae5ece5b0fb5b330cfdd128568ac15a3b38c67031">+12/-42</a></td>
</tr>
<tr>
  <td><strong>PersistentDataGridFilterStorage.ts</strong><dd><code>Renames tablePath parameter to storageKey</code></dd></td>
  <td><a href="https://github.com/nhost/nhost/pull/4126/files#diff-a759a39c36ba2bac7ee37bfa344b66221a6a3ae4a25e301c6ec36f516c28d1dd">+4/-4</a></td>
</tr>
</table></details></td></tr>

<tr><td><strong>Database browser integration</strong></td><td><details><summary>4 files</summary><table>
<tr>
  <td><strong>DataBrowserGridContainer.tsx</strong><dd><code>Owns DataGridQueryParamsProvider with key=tablePath for automatic reset on table navigation</code></dd></td>
  <td><a href="https://github.com/nhost/nhost/pull/4126/files#diff-f236631af26f6d62989bfeb4e0b12096b0e538389b95be20a040959d54bbe2b9">+9/-6</a></td>
</tr>
<tr>
  <td><strong>DataBrowserGrid.tsx</strong><dd><code>Removes setCurrentOffset usages; uses usePageBoundsRedirect; drops isFiltersLoadedFromStorage guard</code></dd></td>
  <td><a href="https://github.com/nhost/nhost/pull/4126/files#diff-5910fd8730fbe65c60aa5f54031989a7868e944d5958f69535e5684b72ca1396">+6/-34</a></td>
</tr>
<tr>
  <td><strong>DataBrowserGridControls.tsx</strong><dd><code>Computes isFetching from useIsFetching; passes storageKey and isFetching to DataGridFiltersPopover</code></dd></td>
  <td><a href="https://github.com/nhost/nhost/pull/4126/files#diff-640ce3e15c8d5f35d8bbe74792c59493afe5bc69873d2a40f81233da2b02661c">+19/-2</a></td>
</tr>
<tr>
  <td><strong>[tableSlug].tsx</strong><dd><code>Removes DataGridQueryParamsProvider wrapper (now inside DataBrowserGridContainer)</code></dd></td>
  <td><a href="https://github.com/nhost/nhost/pull/4126/files#diff-2b5b3759fb22a0b1311133eb1abec464416844df26c6a3a1b2af6913d09956fe">+1/-4</a></td>
</tr>
</table></details></td></tr>

<tr><td><strong>Storage browser integration</strong></td><td><details><summary>6 files</summary><table>
<tr>
  <td><strong>Bucket.tsx</strong><dd><code>Wraps FilesDataGrid with DataGridQueryParamsProvider keyed on bucket id</code></dd></td>
  <td><a href="https://github.com/nhost/nhost/pull/4126/files#diff-6a9a914e8fda4b412cbd70dcfc0562096afc1bdc0436425048d08a9008bb0a8c">+9/-1</a></td>
</tr>
<tr>
  <td><strong>FilesDataGrid.tsx</strong><dd><code>Replaces local search state with DataGridQueryParamsProvider context; uses filtersToFilesWhere; uses usePageBoundsRedirect</code></dd></td>
  <td><a href="https://github.com/nhost/nhost/pull/4126/files#diff-18c8df727e1a4fc6a94d03bd4a3a7a8cb3ad44d754803c4c7988c1c00a4b7caf">+33/-61</a></td>
</tr>
<tr>
  <td><strong>FilesDataGridControls.tsx</strong><dd><code>Replaces text search input with DataGridFiltersPopover and StorageMaintenanceButton</code></dd></td>
  <td><a href="https://github.com/nhost/nhost/pull/4126/files#diff-b85b40168e9c149331a68cb1a0cbec570c75233fa34385945e094b8f4c032974">+12/-14</a></td>
</tr>
<tr>
  <td><strong>filtersToFilesWhere.ts</strong><dd><code>New utility: converts DataGridFilter[] + bucketId to a Hasura Files_Bool_Exp</code></dd></td>
  <td><a href="https://github.com/nhost/nhost/pull/4126/files#diff-32c37861b6aba0ebfecb965fa984b1db3e38a88adcd9e3058c5d366c7f99473e">+85/-0</a></td>
</tr>
<tr>
  <td><strong>useFiles.ts</strong><dd><code>Accepts where: Files_Bool_Exp directly instead of searchString + bucketId</code></dd></td>
  <td><a href="https://github.com/nhost/nhost/pull/4126/files#diff-ed71bc1eff3e4515937f01dec41686108466c8272d974628483103ea4dd0b1ed">+4/-11</a></td>
</tr>
<tr>
  <td><strong>useFilesAggregate.ts</strong><dd><code>Accepts where: Files_Bool_Exp directly instead of searchString + bucketId</code></dd></td>
  <td><a href="https://github.com/nhost/nhost/pull/4126/files#diff-f6535d7353cf98e6fdb8acbd06c091bd2769758f053f7ca314505c41267a74ce">+7/-12</a></td>
</tr>
</table></details></td></tr>

<tr><td><strong>Storage maintenance feature</strong></td><td><details><summary>3 files</summary><table>
<tr>
  <td><strong>StorageMaintenanceButton.tsx</strong><dd><code>New component: popover with counts and delete actions for orphaned files and broken metadata</code></dd></td>
  <td><a href="https://github.com/nhost/nhost/pull/4126/files#diff-e8fea9baabf55d2ad9d0412720b237184741938762506ab4c2820904cea40ede">+103/-0</a></td>
</tr>
<tr>
  <td><strong>useStorageMaintenance.ts</strong><dd><code>New hook: fetches orphaned files and broken metadata counts; exposes delete mutations</code></dd></td>
  <td><a href="https://github.com/nhost/nhost/pull/4126/files#diff-6ff6e67f83a0af26687e20f7545c42d50b4dd1e7698735d24289f71ddb8fc776">+51/-0</a></td>
</tr>
</table></details></td></tr>

<tr><td><strong>Tests</strong></td><td><details><summary>4 files</summary><table>
<tr>
  <td><strong>DataBrowserGridContainer.test.tsx</strong><dd><code>Removes manual DataGridQueryParamsProvider wrapper (now internal to container)</code></dd></td>
  <td><a href="https://github.com/nhost/nhost/pull/4126/files#diff-8cd17f11c60d18cbceadedabc585c6f0cfaa79f4ac3595b00d2f57266ee60f1f">+2/-11</a></td>
</tr>
<tr>
  <td><strong>FilesDataGrid.test.tsx</strong><dd><code>New integration tests: verifies where clause construction and empty state messages</code></dd></td>
  <td><a href="https://github.com/nhost/nhost/pull/4126/files#diff-bbe7b3a22eaa001990eb210919d0dcc332b8e7c618c87df3ea8b8467e855b131">+156/-0</a></td>
</tr>
<tr>
  <td><strong>filtersToFilesWhere.test.ts</strong><dd><code>New unit tests: covers all operators, IS/IS NOT null checks, IN/NOT IN splitting</code></dd></td>
  <td><a href="https://github.com/nhost/nhost/pull/4126/files#diff-fbc81cfaa03ecc678ddf67049d220382b27fa57473944e4fb264160e9551b341">+183/-0</a></td>
</tr>
<tr>
  <td><strong>StorageMaintenanceButton.test.tsx</strong><dd><code>New component tests: singular/plural copy, delete-then-refetch order assertions</code></dd></td>
  <td><a href="https://github.com/nhost/nhost/pull/4126/files#diff-9c2e2d1e0679022b01aec240177c74ad9f526291bef814f36597ce3814cdf14a">+188/-0</a></td>
</tr>
<tr>
  <td><strong>useStorageMaintenance.test.tsx</strong><dd><code>New hook tests: disabled when adminSecret is falsy; admin secret passed in delete headers</code></dd></td>
  <td><a href="https://github.com/nhost/nhost/pull/4126/files#diff-e986655fe9b05c0259a4df262a63805230fcbaebfbee9c7ddf59b8a934f73b27">+128/-0</a></td>
</tr>
</table></details></td></tr>

</tbody></table>

</details>

___

<!-- nhost-reviewer:end -->