### PR TITLE
fix(storage): forward session headers on /ops/list-broken-metadata

### DIFF
--- a/services/storage/controller/list_broken_metadata.go
+++ b/services/storage/controller/list_broken_metadata.go
@@ -15,8 +15,8 @@ type ListBrokenMetadataResponse struct {
 }
 
 func (ctrl *Controller) listBrokenMetadata(ctx context.Context) ([]FileSummary, *APIError) {
-	headers := middleware.SessionHeadersFromContext(ctx)
-	filesInHasura, apiErr := ctrl.metadataStorage.ListFiles(ctx, headers)
+	sessionHeaders := middleware.SessionHeadersFromContext(ctx)
+	filesInHasura, apiErr := ctrl.metadataStorage.ListFiles(ctx, sessionHeaders)
 	if apiErr != nil {
 		return nil, apiErr
 	}

--- a/services/storage/controller/list_broken_metadata.go
+++ b/services/storage/controller/list_broken_metadata.go
@@ -7,6 +7,7 @@ import (
 
 	oapimw "github.com/nhost/nhost/internal/lib/oapi/middleware"
 	"github.com/nhost/nhost/services/storage/api"
+	"github.com/nhost/nhost/services/storage/middleware"
 )
 
 type ListBrokenMetadataResponse struct {
@@ -14,7 +15,8 @@ type ListBrokenMetadataResponse struct {
 }
 
 func (ctrl *Controller) listBrokenMetadata(ctx context.Context) ([]FileSummary, *APIError) {
-	filesInHasura, apiErr := ctrl.metadataStorage.ListFiles(ctx, nil)
+	headers := middleware.SessionHeadersFromContext(ctx)
+	filesInHasura, apiErr := ctrl.metadataStorage.ListFiles(ctx, headers)
 	if apiErr != nil {
 		return nil, apiErr
 	}

--- a/services/storage/controller/list_broken_metadata.go
+++ b/services/storage/controller/list_broken_metadata.go
@@ -16,6 +16,7 @@ type ListBrokenMetadataResponse struct {
 
 func (ctrl *Controller) listBrokenMetadata(ctx context.Context) ([]FileSummary, *APIError) {
 	sessionHeaders := middleware.SessionHeadersFromContext(ctx)
+
 	filesInHasura, apiErr := ctrl.metadataStorage.ListFiles(ctx, sessionHeaders)
 	if apiErr != nil {
 		return nil, apiErr


### PR DESCRIPTION
<!-- nhost-reviewer:start -->
### **PR Type**
Bug fix

___

### **Description**
- Forward session headers (e.g. `X-Hasura-*`, `Authorization`) when calling `ListFiles` in the `listBrokenMetadata` handler, matching the pattern used by all other storage controller methods.
- Previously, `nil` headers were passed, which meant the Hasura GraphQL call lacked the caller's session context, potentially causing authorization failures or returning incorrect results.

___

<details> <summary><h3> File Walkthrough</h3></summary>

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody>
<tr><td><strong>Core logic</strong></td><td><details><summary>1 file</summary><table>
<tr>
  <td><strong>list_broken_metadata.go</strong><dd><code>Extract session headers from context and pass to ListFiles instead of nil</code></dd></td>
  <td><a href="https://github.com/nhost/nhost/pull/4131/files#diff-ff3707ec8c59e0ef0fc2b6bc9f51b2610dae9f867ffb9773b369bda5efd29a46">+3/-1</a></td>
</tr>
</table></details></td></tr>
</tbody></table>

</details>

___

<!-- nhost-reviewer:end -->