### PR TITLE
fix(storage): Pass session headers to DeleteFileByID

### DIFF
--- a/services/storage/controller/delete_broken_metadata.go
+++ b/services/storage/controller/delete_broken_metadata.go
@@ -6,6 +6,7 @@ import (
 
 	oapimw "github.com/nhost/nhost/internal/lib/oapi/middleware"
 	"github.com/nhost/nhost/services/storage/api"
+	"github.com/nhost/nhost/services/storage/middleware"
 )
 
 func (ctrl *Controller) deleteBrokenMetadata(
@@ -16,8 +17,10 @@ func (ctrl *Controller) deleteBrokenMetadata(
 		return nil, apiErr
 	}
 
+	sessionHeaders := middleware.SessionHeadersFromContext(ctx)
+
 	for _, m := range missing {
-		if apiErr := ctrl.metadataStorage.DeleteFileByID(ctx, m.ID, nil); apiErr != nil {
+		if apiErr := ctrl.metadataStorage.DeleteFileByID(ctx, m.ID, sessionHeaders); apiErr != nil {
 			return nil, apiErr
 		}
 	}


### PR DESCRIPTION
<!-- nhost-reviewer:start -->
### **PR Type**
Bug fix

___

### **Description**
- Pass session headers to `DeleteFileByID` when deleting broken metadata, fixing a regression where auth/authorization context was dropped during the cleanup operation.

___

<details> <summary><h3> File Walkthrough</h3></summary>

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody>
<tr><td><strong>Bug fix</strong></td><td><details><summary>1 file</summary><table>
<tr>
  <td><strong>delete_broken_metadata.go</strong><dd><code>Extract session headers from context and forward them to DeleteFileByID instead of passing nil</code></dd></td>
  <td><a href="https://github.com/nhost/nhost/pull/4144/files#diff-f7ce24e6a6280c12dde105cbf92158e27a8829b9998d297b52580f13dcebfc6f">+4/-1</a></td>
</tr>
</table></details></td></tr>
</tbody></table>

</details>

___

<!-- nhost-reviewer:end -->