### PR TITLE
fix(dashboard): Conditionally fill in address in onboarding test

### DIFF
--- a/dashboard/e2e/onboarding/onboarding.test.ts
+++ b/dashboard/e2e/onboarding/onboarding.test.ts
@@ -47,19 +47,25 @@ test('user should be able to finish onboarding', async () => {
     .getByPlaceholder('Full name on card')
     .fill('EndyTo EndyTest');
   await stripeFrame.locator('#billingCountry').scrollIntoViewIfNeeded();
-  // Need to comment out for testing outside US START
-  // await stripeFrame.getByPlaceholder('Address', { exact: true }).click();
-  // stripeFrame.locator('span:has-text("Enter address manually")');
-  // await stripeFrame.getByText('Enter address manually').click();
-  // await stripeFrame
-  //   .getByPlaceholder('Address line 1', { exact: true })
-  //   .fill('123 Main Street');
-  // await stripeFrame
-  //   .getByPlaceholder('City', { exact: true })
-  //   .fill('Springfield');
-  // await stripeFrame.getByPlaceholder('ZIP', { exact: true }).fill('62701');
-  // await stripeFrame.locator('#enableStripePass').click({ force: true });
-  // Need to comment out for testing outside US END
+
+  const manualAddressLink = stripeFrame.getByText('Enter address manually');
+  if (await manualAddressLink.isVisible()) {
+    await stripeFrame.getByPlaceholder('Address', { exact: true }).click();
+    await manualAddressLink.click();
+    await stripeFrame
+      .getByPlaceholder('Address line 1', { exact: true })
+      .fill('123 Main Street');
+    await stripeFrame
+      .getByPlaceholder('City', { exact: true })
+      .fill('Springfield');
+    await stripeFrame.getByPlaceholder('ZIP', { exact: true }).fill('62701');
+  }
+
+  const stripePassToggle = stripeFrame.locator('#enableStripePass');
+  if (await stripePassToggle.isChecked()) {
+    await stripePassToggle.click({ force: true });
+  }
+
   stripeFrame
     .getByTestId('hosted-payment-submit-button')
     .scrollIntoViewIfNeeded();
@@ -167,19 +173,25 @@ test('should be able to upgrade an organization', async () => {
     .getByPlaceholder('Full name on card')
     .fill('EndyTo EndyTest');
   await stripeFrame.locator('#billingCountry').scrollIntoViewIfNeeded();
-  // Need to comment out for testing outside US START
-  // await stripeFrame.getByPlaceholder('Address', { exact: true }).click();
-  // stripeFrame.locator('span:has-text("Enter address manually")');
-  // await stripeFrame.getByText('Enter address manually').click();
-  // await stripeFrame
-  //   .getByPlaceholder('Address line 1', { exact: true })
-  //   .fill('123 Main Street');
-  // await stripeFrame
-  //   .getByPlaceholder('City', { exact: true })
-  //   .fill('Springfield');
-  // await stripeFrame.getByPlaceholder('ZIP', { exact: true }).fill('62701');
-  // await stripeFrame.locator('#enableStripePass').click({ force: true });
-  // Need to comment out for testing outside US END
+
+  const manualAddressLink = stripeFrame.getByText('Enter address manually');
+  if (await manualAddressLink.isVisible()) {
+    await stripeFrame.getByPlaceholder('Address', { exact: true }).click();
+    await manualAddressLink.click();
+    await stripeFrame
+      .getByPlaceholder('Address line 1', { exact: true })
+      .fill('123 Main Street');
+    await stripeFrame
+      .getByPlaceholder('City', { exact: true })
+      .fill('Springfield');
+    await stripeFrame.getByPlaceholder('ZIP', { exact: true }).fill('62701');
+  }
+
+  const stripePassToggle = stripeFrame.locator('#enableStripePass');
+  if (await stripePassToggle.isChecked()) {
+    await stripePassToggle.click({ force: true });
+  }
+
   stripeFrame
     .getByTestId('hosted-payment-submit-button')
     .scrollIntoViewIfNeeded();


### PR DESCRIPTION
### Checklist

- [ ] No breaking changes
- [ ] Tests pass
- [ ] New features have new tests
- [ ] Documentation is updated (if applicable)
- [ ] Title of the PR is in the correct format (see below)

<!-- nhost-reviewer:start -->
### **PR Type**
Tests

___

### **Description**
- Replace hardcoded commented-out Stripe address block with a conditional that only fills the address form when the "Enter address manually" link is visible (handles both US and non-US test environments).
- Replace unconditional `#enableStripePass` click with a conditional that only clicks the toggle when it is currently checked, preventing unintended re-enabling of Stripe Pass.
- Apply both fixes consistently across the two onboarding test cases (`finish onboarding` and `upgrade an organization`).

___

<details> <summary><h3> File Walkthrough</h3></summary>

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody>
<tr><td><strong>E2E Tests</strong></td><td><details><summary>1 file</summary><table>
<tr>
  <td><strong>onboarding.test.ts</strong><dd><code>Replace commented-out Stripe address/pass blocks with environment-conditional logic</code></dd></td>
  <td><a href="https://github.com/nhost/nhost/pull/4147/files#diff-0263bde085f69167e7c84795fad78dd54c9ab50f534677ef60ccd2c31998d522">+38/-26</a></td>
</tr>
</table></details></td></tr>
</tbody></table>

</details>

___

<!-- nhost-reviewer:end -->