### PR TITLE
release(dashboard): 2.60.0

### DIFF
--- a/.github/workflows/cli_wf_test_new_project.yaml
+++ b/.github/workflows/cli_wf_test_new_project.yaml
@@ -80,7 +80,6 @@ jobs:
         run: |
           export NHOST_CLI_AUTH_URL="https://mytpiiwxeyrvlqrxuknp.auth.eu-central-1.nhost.run/v1"
           export NHOST_CLI_GRAPHQL_URL="https://mytpiiwxeyrvlqrxuknp.graphql.eu-central-1.nhost.run/v1"
-          export NHOST_CONFIGSERVER_IMAGE=cli:0.0.0-dev
 
           unzip /home/runner/artifacts/cli-artifact-x86_64-0.0.0-dev/result.zip
 
@@ -88,6 +87,16 @@ jobs:
           cd new-project
           /home/runner/_work/nhost/nhost/cli/result/bin/cli login --pat ${{ secrets.NHOST_PAT }}
           /home/runner/_work/nhost/nhost/cli/result/bin/cli init
+
+      # Skipped on `release/dashboard` PRs because the release PR bumps the
+      # `nhost/dashboard:<tag>` ref in `cli/cmd/dev/` to a version that isn't
+      # published until the PR merges, which makes `cli up` fail to pull it.
+      - name: "Start the project"
+        if: ${{ !startsWith(github.head_ref, 'release/dashboard') }}
+        run: |
+          export NHOST_CONFIGSERVER_IMAGE=cli:0.0.0-dev
+
+          cd new-project
           /home/runner/_work/nhost/nhost/cli/result/bin/cli up --down-on-error
           /home/runner/_work/nhost/nhost/cli/result/bin/cli down --volumes
 

--- a/cli/cmd/dev/cloud.go
+++ b/cli/cmd/dev/cloud.go
@@ -56,7 +56,7 @@ func CommandCloud() *cli.Command {
 			&cli.StringFlag{ //nolint:exhaustruct
 				Name:    flagDashboardVersion,
 				Usage:   "Dashboard version to use",
-				Value:   "nhost/dashboard:2.59.0",
+				Value:   "nhost/dashboard:2.60.0",
 				Sources: cli.EnvVars("NHOST_DASHBOARD_VERSION"),
 			},
 			&cli.StringFlag{ //nolint:exhaustruct

--- a/cli/cmd/dev/up.go
+++ b/cli/cmd/dev/up.go
@@ -112,7 +112,7 @@ func CommandUp() *cli.Command { //nolint:funlen
 			&cli.StringFlag{ //nolint:exhaustruct
 				Name:    flagDashboardVersion,
 				Usage:   "Dashboard version to use",
-				Value:   "nhost/dashboard:2.59.0",
+				Value:   "nhost/dashboard:2.60.0",
 				Sources: cli.EnvVars("NHOST_DASHBOARD_VERSION"),
 			},
 			&cli.StringFlag{ //nolint:exhaustruct

--- a/dashboard/CHANGELOG.md
+++ b/dashboard/CHANGELOG.md
@@ -1,3 +1,24 @@
+## [@nhost/dashboard@2.60.0] - 2026-04-20
+
+### 🚀 Features
+
+- *(dashboard)* Delete buckets (#3987)
+- *(dashboard)* Add filters to storage page (#4125)
+- *(dashboard)* Storage maintenance (#4126)
+- *(dashboard)* Add permission handling to storage (#4049)
+- *(auth)* Allow disabling auto-signup (#4168)
+
+
+### 🐛 Bug Fixes
+
+- *(dashboard)* Combine View and Materialized View database sidebar filters, and improve filter bar UX (#4152)
+- *(dashboard)* Show the correct preview (#4157)
+
+
+### ⚙️ Miscellaneous Tasks
+
+- *(ci)* Bump version references as part of the changelog (#4169)
+
 ## [@nhost/dashboard@2.59.0] - 2026-04-14
 
 ### 🚀 Features

--- a/docs/src/content/docs/reference/cli/commands.mdx
+++ b/docs/src/content/docs/reference/cli/commands.mdx
@@ -254,7 +254,7 @@ Start local development environment
 
 **--ca-certificates**="": Mounts and everrides path to CA certificates in the containers [$NHOST_CA_CERTIFICATES]
 
-**--dashboard-version**="": Dashboard version to use (default: "nhost/dashboard:2.59.0") [$NHOST_DASHBOARD_VERSION]
+**--dashboard-version**="": Dashboard version to use (default: "nhost/dashboard:2.60.0") [$NHOST_DASHBOARD_VERSION]
 
 **--disable-tls**: Disable TLS [$NHOST_DISABLE_TLS]
 
@@ -286,7 +286,7 @@ Start local development environment connected to an Nhost Cloud project (BETA)
 
 **--ca-certificates**="": Mounts and everrides path to CA certificates in the containers [$NHOST_CA_CERTIFICATES]
 
-**--dashboard-version**="": Dashboard version to use (default: "nhost/dashboard:2.59.0") [$NHOST_DASHBOARD_VERSION]
+**--dashboard-version**="": Dashboard version to use (default: "nhost/dashboard:2.60.0") [$NHOST_DASHBOARD_VERSION]
 
 **--disable-tls**: Disable TLS [$NHOST_DISABLE_TLS]
 


### PR DESCRIPTION
Automated release preparation for dashboard version 2.60.0

Changes:
- Updated CHANGELOG.md
- Bumped version references (`make changelog-bump-refs`) in dependent files