### PR TITLE
feat(storage): do not require SELECT permissions to upload

### DIFF
--- a/services/storage/metadata/client_gen.go
+++ b/services/storage/metadata/client_gen.go
@@ -190,15 +190,15 @@ func (t *BucketMetadataFragment) GetCacheControl() *string {
 	return t.CacheControl
 }
 
-type InsertFile_InsertFile struct {
-	ID string "json:\"id\" graphql:\"id\""
+type InsertFile_InsertFiles struct {
+	AffectedRows int64 "json:\"affected_rows\" graphql:\"affected_rows\""
 }
 
-func (t *InsertFile_InsertFile) GetID() string {
+func (t *InsertFile_InsertFiles) GetAffectedRows() int64 {
 	if t == nil {
-		t = &InsertFile_InsertFile{}
+		t = &InsertFile_InsertFiles{}
 	}
-	return t.ID
+	return t.AffectedRows
 }
 
 type DeleteFile_DeleteFile struct {
@@ -257,14 +257,14 @@ func (t *ListFilesSummary) GetFiles() []*FileMetadataSummaryFragment {
 }
 
 type InsertFile struct {
-	InsertFile *InsertFile_InsertFile "json:\"insertFile,omitempty\" graphql:\"insertFile\""
+	InsertFiles *InsertFile_InsertFiles "json:\"insertFiles,omitempty\" graphql:\"insertFiles\""
 }
 
-func (t *InsertFile) GetInsertFile() *InsertFile_InsertFile {
+func (t *InsertFile) GetInsertFiles() *InsertFile_InsertFiles {
 	if t == nil {
 		t = &InsertFile{}
 	}
-	return t.InsertFile
+	return t.InsertFiles
 }
 
 type UpdateFile struct {
@@ -400,8 +400,8 @@ func (c *Client) ListFilesSummary(ctx context.Context, interceptors ...clientv2.
 }
 
 const InsertFileDocument = `mutation InsertFile ($object: files_insert_input!) {
-	insertFile(object: $object) {
-		id
+	insertFiles(objects: [$object]) {
+		affected_rows
 	}
 }
 `

--- a/services/storage/metadata/hasura.go
+++ b/services/storage/metadata/hasura.go
@@ -146,7 +146,7 @@ func (h *Hasura) InitializeFile(
 	}
 
 	if resp.InsertFiles == nil || resp.InsertFiles.AffectedRows != 1 {
-		return controller.ForbiddenError(nil, "file was not inserted")
+		return controller.ForbiddenError(errors.New("file was not inserted"), "file was not inserted")
 	}
 
 	return nil

--- a/services/storage/metadata/hasura.go
+++ b/services/storage/metadata/hasura.go
@@ -129,7 +129,7 @@ func (h *Hasura) InitializeFile(
 	fileID, name string, size int64, bucketID, mimeType string,
 	headers http.Header,
 ) *controller.APIError {
-	_, err := h.cl.InsertFile(
+	resp, err := h.cl.InsertFile(
 		ctx,
 		FilesInsertInput{ //nolint:exhaustruct
 			BucketID: new(bucketID),
@@ -143,6 +143,10 @@ func (h *Hasura) InitializeFile(
 	if err != nil {
 		aerr := parseGraphqlError(err)
 		return aerr.ExtendError("problem initializing file metadata")
+	}
+
+	if resp.InsertFiles == nil || resp.InsertFiles.AffectedRows != 1 {
+		return controller.ForbiddenError(nil, "file was not inserted")
 	}
 
 	return nil

--- a/services/storage/metadata/hasura.go
+++ b/services/storage/metadata/hasura.go
@@ -11,6 +11,8 @@ import (
 	"github.com/nhost/nhost/services/storage/controller"
 )
 
+var errFileNotInserted = errors.New("file was not inserted")
+
 func parseGraphqlError(err error) *controller.APIError {
 	var ghErr *clientv2.ErrorResponse
 	if errors.As(err, &ghErr) {
@@ -146,7 +148,10 @@ func (h *Hasura) InitializeFile(
 	}
 
 	if resp.InsertFiles == nil || resp.InsertFiles.AffectedRows != 1 {
-		return controller.ForbiddenError(errors.New("file was not inserted"), "file was not inserted")
+		return controller.ForbiddenError(
+			errFileNotInserted,
+			"file was not inserted",
+		)
 	}
 
 	return nil

--- a/services/storage/metadata/hasura_test.go
+++ b/services/storage/metadata/hasura_test.go
@@ -133,7 +133,7 @@ func TestInitializeFile(t *testing.T) {
 			headers:            getAuthHeader(),
 			expectedStatusCode: 400,
 			expectedPublicResponse: &controller.ErrorResponse{
-				Message: `{"networkErrors":null,"graphqlErrors":[{"message":"invalid input syntax for type uuid: \"asdsad\"","extensions":{"code":"data-exception","path":"$.selectionSet.insertFile.args.object"}}]}`,
+				Message: `{"networkErrors":null,"graphqlErrors":[{"message":"invalid input syntax for type uuid: \"asdsad\"","extensions":{"code":"data-exception","path":"$.selectionSet.insertFiles.args.objects[0]"}}]}`,
 			},
 		},
 		{

--- a/services/storage/metadata/metadata.graphql
+++ b/services/storage/metadata/metadata.graphql
@@ -49,8 +49,8 @@ query ListFilesSummary {
 }
 
 mutation InsertFile($object: files_insert_input!) {
-  insertFile(object: $object) {
-    id
+  insertFiles(objects: [$object]) {
+    affected_rows
   }
 }
 


### PR DESCRIPTION
<!-- nhost-reviewer:start -->
### **PR Type**
Bug fix

___

### **Description**
- Switch the `InsertFile` GraphQL mutation from `insertFile` (single-object insert returning the row) to `insertFiles` (batch insert returning `affected_rows`), removing the need for SELECT permissions on the `files` table during uploads.
- Add a post-insert check verifying that exactly one row was affected, returning a 403 Forbidden error if the insert was silently rejected by Hasura permissions.

___

<details> <summary><h3> File Walkthrough</h3></summary>

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody>
<tr><td><strong>GraphQL schema</strong></td><td><details><summary>1 file</summary><table>
<tr>
  <td><strong>metadata.graphql</strong><dd><code>Change InsertFile mutation from insertFile(object:) to insertFiles(objects:) returning affected_rows</code></dd></td>
  <td><a href="https://github.com/nhost/nhost/pull/XXX/files#diff-48fd87e3ea93c1ce38ab8f6188fbe4b973b01a8277cd8857745e6dc45598afae">+2/-2</a></td>
</tr>
</table></details></td></tr>
<tr><td><strong>Core logic</strong></td><td><details><summary>1 file</summary><table>
<tr>
  <td><strong>hasura.go</strong><dd><code>Check affected_rows after insert and return ForbiddenError if file was not inserted</code></dd></td>
  <td><a href="https://github.com/nhost/nhost/pull/XXX/files#diff-45e2c6beb3e51113bd070766f64603dfd15fd2975b97082db548e4cb7458e12a">+5/-1</a></td>
</tr>
</table></details></td></tr>
<tr><td><strong>Generated code</strong></td><td><details><summary>1 file</summary><table>
<tr>
  <td><strong>client_gen.go</strong><dd><code>Regenerated client types: InsertFile now returns InsertFile_InsertFiles with AffectedRows</code></dd></td>
  <td><a href="https://github.com/nhost/nhost/pull/XXX/files#diff-ee9d0b70f550f2037608ce79c97cbed1e1238802d46219e19ba52aca347ebaf9">+10/-10</a></td>
</tr>
</table></details></td></tr>
</tbody></table>

</details>

___

<!-- nhost-reviewer:end -->