### PR TITLE
chore(functions): build improvements

### DIFF
--- a/.github/workflows/functions_wf_release.yaml
+++ b/.github/workflows/functions_wf_release.yaml
@@ -58,21 +58,3 @@ jobs:
     secrets:
       DOCKER_USERNAME: ${{ secrets.DOCKER_USERNAME }}
       DOCKER_PASSWORD: ${{ secrets.DOCKER_PASSWORD }}
-
-  push-docker-ecr:
-    strategy:
-      matrix:
-        node: ["20", "22"]
-      fail-fast: true
-    uses: ./.github/workflows/wf_docker_push_image_ecr.yaml
-    needs:
-      - build_artifacts
-    with:
-      NAME: functions
-      PATH: services/functions
-      VERSION: ${{ inputs.VERSION }}
-      ENV: "NODE_VERSION=${{ matrix.node }}"
-      ARTIFACT_SUFFIX: "-node${{ matrix.node }}"
-    secrets:
-      AWS_ACCOUNT_ID: ${{ secrets.AWS_ACCOUNT_ID }}
-      CONTAINER_REGISTRY: ${{ secrets.AWS_ACCOUNT_ID }}.dkr.ecr.eu-central-1.amazonaws.com

--- a/services/functions/Makefile
+++ b/services/functions/Makefile
@@ -4,8 +4,8 @@ include $(ROOT_DIR)/build/makefiles/general.makefile
 NODE_VERSION?=22
 DOCKER_DEV_ENV_PATH=build/dev/docker
 
-# Prepend Node version to VERSION if not already present
-ifeq (,$(findstring $(NODE_VERSION),$(VERSION)))
+# Prepend Node version to VERSION if not already prefixed
+ifneq ($(NODE_VERSION)-,$(firstword $(subst -, ,$(VERSION)))-)
 VERSION:=$(NODE_VERSION)-$(VERSION)
 endif
 

--- a/services/functions/Makefile
+++ b/services/functions/Makefile
@@ -4,6 +4,11 @@ include $(ROOT_DIR)/build/makefiles/general.makefile
 NODE_VERSION?=22
 DOCKER_DEV_ENV_PATH=build/dev/docker
 
+# Prepend Node version to VERSION if not already present
+ifeq (,$(findstring $(NODE_VERSION),$(VERSION)))
+VERSION:=$(NODE_VERSION)-$(VERSION)
+endif
+
 
 .PHONY: build-docker-image
 build-docker-image:  ## Build docker container for native architecture

--- a/services/functions/Makefile
+++ b/services/functions/Makefile
@@ -16,7 +16,7 @@ build-docker-image:  ## Build docker container for native architecture
 		.\#packages.$(ARCH)-linux.$(NAME)-node$(NODE_VERSION)-docker-image \
 		--print-build-logs
 	nix develop \#skopeo -c \
-		skopeo copy --insecure-policy dir:./result docker-daemon:$(NAME)-node$(NODE_VERSION):$(VERSION)
+		skopeo copy --insecure-policy dir:./result docker-daemon:$(NAME):$(VERSION)
 
 
 .PHONY: _dev-env-build

--- a/services/functions/build/dev/docker/docker-compose.yaml
+++ b/services/functions/build/dev/docker/docker-compose.yaml
@@ -1,6 +1,6 @@
 services:
   functions-node20:
-    image: functions-node20:0.0.0-dev
+    image: functions:20-0.0.0-dev
     container_name: functions-node20
     ports:
       - "3001:3000"
@@ -16,7 +16,7 @@ services:
     restart: unless-stopped
 
   functions-node22:
-    image: functions-node22:0.0.0-dev
+    image: functions:22-0.0.0-dev
     container_name: functions-node22
     ports:
       - "3002:3000"
@@ -32,7 +32,7 @@ services:
     restart: unless-stopped
 
   functions-npm:
-    image: functions-node22:0.0.0-dev
+    image: functions:22-0.0.0-dev
     container_name: functions-npm
     ports:
       - "3003:3000"
@@ -48,7 +48,7 @@ services:
     restart: unless-stopped
 
   functions-yarn:
-    image: functions-node22:0.0.0-dev
+    image: functions:22-0.0.0-dev
     container_name: functions-yarn
     ports:
       - "3004:3000"

--- a/services/functions/server.js
+++ b/services/functions/server.js
@@ -45,7 +45,7 @@ function getRuntime() {
 function discoverFunctions(functionsPath) {
   return glob.sync('**/*.@(js|ts)', {
     cwd: functionsPath,
-    ignore: ['**/node_modules/**', '**/_*/**', '**/_*', '**/.wrapper-*'],
+    ignore: ['**/node_modules/**', '**/_*/**', '**/_*'],
   });
 }
 
@@ -66,12 +66,14 @@ function generateWrapper(relativeFunctionPath) {
 
 async function buildFunction(functionsPath, file) {
   const safeName = fileToSafeName(file);
-  const funcDir = path.dirname(path.join(functionsPath, file));
-  const funcBasename = path.basename(file);
 
-  // Write wrapper in the same directory as the function for correct require() resolution
-  const wrapperPath = path.join(funcDir, `.wrapper-${safeName}.js`);
-  const wrapperContent = generateWrapper(`./${funcBasename}`);
+  // Write wrapper under BUILD_DIR to avoid polluting the user's functions directory.
+  // Use the absolute path to the function so require() resolution still works.
+  const wrapperDir = path.join(BUILD_DIR, 'wrappers');
+  fs.mkdirSync(wrapperDir, { recursive: true });
+  const wrapperPath = path.join(wrapperDir, `.wrapper-${safeName}.js`);
+  const absoluteFuncPath = path.join(functionsPath, file);
+  const wrapperContent = generateWrapper(absoluteFuncPath);
   fs.writeFileSync(wrapperPath, wrapperContent);
 
   const distDir = path.join(BUILD_DIR, 'dist', safeName);


### PR DESCRIPTION
<!-- nhost-reviewer:start -->
### **PR Type**
Refactoring

___

### **Description**
- Removed ECR image push from the functions release workflow, keeping only Docker Hub publishing.
- Changed Docker image naming from `functions-node{N}:{VERSION}` to `functions:{N}-{VERSION}`, embedding the Node version in the tag instead of the image name.
- Moved esbuild wrapper files from the user's functions directory to `BUILD_DIR` (`/tmp/nhost-build/wrappers/`) to avoid polluting the source tree, and switched to absolute paths for function resolution.
- Removed the `.wrapper-*` glob ignore pattern from function discovery since wrappers are no longer written alongside user code.

___

### Diagram Walkthrough

```mermaid
flowchart LR
  A["Makefile"] -->|"prepends NODE_VERSION to tag"| B["Docker image\nfunctions:{N}-{VERSION}"]
  C["server.js"] -->|"writes wrappers to BUILD_DIR"| D["/tmp/nhost-build/wrappers/"]
  D -->|"absolute path require"| E["esbuild bundle"]
  F["release workflow"] -->|"removed ECR push"| G["Docker Hub only"]
```

<details> <summary><h3> File Walkthrough</h3></summary>

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody>
<tr><td><strong>CI / Release</strong></td><td><details><summary>1 file</summary><table>
<tr>
  <td><strong>functions_wf_release.yaml</strong><dd><code>Remove push-docker-ecr job and its matrix strategy</code></dd></td>
  <td><a href="https://github.com/nhost/nhost/pull/4158/files#diff-9b12bc6d333475a91c890b4d1301af485b5dfe0e398cf1617114c22eb722aa01">+0/-18</a></td>
</tr>
</table></details></td></tr>
<tr><td><strong>Build system</strong></td><td><details><summary>2 files</summary><table>
<tr>
  <td><strong>Makefile</strong><dd><code>Prepend NODE_VERSION to VERSION tag; use unified image name</code></dd></td>
  <td><a href="https://github.com/nhost/nhost/pull/4158/files#diff-7d44ca57821eecb9dc499f1f4c70e0738a1e17d1b19aec6602b4086ac4cbe77b">+6/-1</a></td>
</tr>
<tr>
  <td><strong>docker-compose.yaml</strong><dd><code>Update image references to new naming scheme</code></dd></td>
  <td><a href="https://github.com/nhost/nhost/pull/4158/files#diff-b6cfbb3f44eb65d4174b999ae1e9596899a36281d83a7974149e8a9e6e2e1af5">+4/-4</a></td>
</tr>
</table></details></td></tr>
<tr><td><strong>Core logic</strong></td><td><details><summary>1 file</summary><table>
<tr>
  <td><strong>server.js</strong><dd><code>Move wrappers to BUILD_DIR; use absolute paths; drop .wrapper-* ignore</code></dd></td>
  <td><a href="https://github.com/nhost/nhost/pull/4158/files#diff-3e3fa54db1b505851f46932547f48ebe3c042fd140996fef7afeeaefbb5850e7">+8/-6</a></td>
</tr>
</table></details></td></tr>
</tbody></table>

</details>

___

<!-- nhost-reviewer:end -->