### PR TITLE
fix(auth): strict use of email verified with oauth2 providers

### DIFF
--- a/services/auth/go/controller/link_id_token_test.go
+++ b/services/auth/go/controller/link_id_token_test.go
@@ -179,6 +179,88 @@ func TestLinkIdToken(t *testing.T) { //nolint:maintidx
 		},
 
 		{
+			// Locks in that /link/idtoken ignores the OAuth provider's email
+			// verification status: the Nhost account is identified by the
+			// authenticated JWT, not by the OAuth email, so an unverified
+			// (or unknown) email from the provider must not block linking.
+			name:   "success - unverified provider email still links",
+			config: getConfig,
+			db: func(ctrl *gomock.Controller) controller.DBClient {
+				mock := mock.NewMockDBClient(ctrl)
+
+				mock.EXPECT().GetUser( //nolint:dupl
+					gomock.Any(),
+					userID,
+				).Return(sql.AuthUser{
+					ID: userID,
+					CreatedAt: pgtype.Timestamptz{ //nolint:exhaustruct
+						Time: time.Now(),
+					},
+					UpdatedAt:   pgtype.Timestamptz{}, //nolint:exhaustruct
+					LastSeen:    pgtype.Timestamptz{}, //nolint:exhaustruct
+					Disabled:    false,
+					DisplayName: "John",
+					AvatarUrl:   "",
+					Locale:      "en",
+					Email:       sql.Text("fake@gmail.com"),
+					PhoneNumber: pgtype.Text{}, //nolint:exhaustruct
+					PasswordHash: sql.Text(
+						"$2a$10$pyv7eu9ioQcFnLSz7u/enex22P3ORdh6z6116Vj5a3vSjo0oxFa1u",
+					),
+					EmailVerified:            true,
+					PhoneNumberVerified:      false,
+					NewEmail:                 pgtype.Text{},        //nolint:exhaustruct
+					OtpMethodLastUsed:        pgtype.Text{},        //nolint:exhaustruct
+					OtpHash:                  pgtype.Text{},        //nolint:exhaustruct
+					OtpHashExpiresAt:         pgtype.Timestamptz{}, //nolint:exhaustruct
+					DefaultRole:              "user",
+					IsAnonymous:              false,
+					TotpSecret:               pgtype.Text{},        //nolint:exhaustruct
+					ActiveMfaType:            pgtype.Text{},        //nolint:exhaustruct
+					Ticket:                   pgtype.Text{},        //nolint:exhaustruct
+					TicketExpiresAt:          pgtype.Timestamptz{}, //nolint:exhaustruct
+					Metadata:                 []byte{},
+					WebauthnCurrentChallenge: pgtype.Text{}, //nolint:exhaustruct
+				}, nil)
+
+				mock.EXPECT().InsertUserProvider(
+					gomock.Any(),
+					sql.InsertUserProviderParams{
+						UserID:         userID,
+						ProviderID:     "fake",
+						ProviderUserID: "106964149809169421082",
+					},
+				).Return(
+					sql.AuthUserProvider{
+						ID:             userID,
+						CreatedAt:      pgtype.Timestamptz{}, //nolint:exhaustruct
+						UpdatedAt:      pgtype.Timestamptz{}, //nolint:exhaustruct
+						UserID:         userID,
+						AccessToken:    "unset",
+						RefreshToken:   pgtype.Text{}, //nolint:exhaustruct
+						ProviderID:     "fake",
+						ProviderUserID: "106964149809169421082",
+					}, nil,
+				)
+
+				return mock
+			},
+			getControllerOpts: []getControllerOptsFunc{
+				withIDTokenValidatorProviders(getTestIDTokenValidatorProviders()),
+			},
+			request: api.LinkIdTokenRequestObject{
+				Body: &api.LinkIdTokenRequest{
+					IdToken:  testTokenWithEmailVerified(t, nonce, false),
+					Nonce:    new(nonce),
+					Provider: "fake",
+				},
+			},
+			expectedResponse: api.LinkIdToken200JSONResponse("OK"),
+			expectedJWT:      nil,
+			jwtTokenFn:       jwtTokenFn,
+		},
+
+		{
 			name:   "user disabled",
 			config: getConfig,
 			db: func(ctrl *gomock.Controller) controller.DBClient {

--- a/services/auth/go/controller/link_id_token_test.go
+++ b/services/auth/go/controller/link_id_token_test.go
@@ -103,7 +103,7 @@ func TestLinkIdToken(t *testing.T) { //nolint:maintidx
 		{
 			name:   "success",
 			config: getConfig,
-			db: func(ctrl *gomock.Controller) controller.DBClient {
+			db: func(ctrl *gomock.Controller) controller.DBClient { //nolint:dupl
 				mock := mock.NewMockDBClient(ctrl)
 
 				mock.EXPECT().GetUser( //nolint:dupl
@@ -185,7 +185,7 @@ func TestLinkIdToken(t *testing.T) { //nolint:maintidx
 			// (or unknown) email from the provider must not block linking.
 			name:   "success - unverified provider email still links",
 			config: getConfig,
-			db: func(ctrl *gomock.Controller) controller.DBClient {
+			db: func(ctrl *gomock.Controller) controller.DBClient { //nolint:dupl
 				mock := mock.NewMockDBClient(ctrl)
 
 				mock.EXPECT().GetUser( //nolint:dupl

--- a/services/auth/go/controller/link_id_token_test.go
+++ b/services/auth/go/controller/link_id_token_test.go
@@ -22,12 +22,18 @@ import (
 func testToken(t *testing.T, nonce string) string {
 	t.Helper()
 
+	return testTokenWithEmailVerified(t, nonce, true)
+}
+
+func testTokenWithEmailVerified(t *testing.T, nonce string, emailVerified bool) string {
+	t.Helper()
+
 	claims := jwt.MapClaims{
 		"iss":            "fake.issuer",
 		"aud":            "myapp.local",
 		"sub":            "106964149809169421082",
 		"email":          "jane@myapp.local",
-		"email_verified": true,
+		"email_verified": emailVerified,
 		"name":           "Jane",
 		"picture":        "https://myapp.local/jane.jpg",
 		"iat":            time.Now().Unix(),

--- a/services/auth/go/controller/sign_in_id_token.go
+++ b/services/auth/go/controller/sign_in_id_token.go
@@ -92,7 +92,7 @@ func (ctrl *Controller) providerSignInFlow(
 
 	if userFound {
 		return ctrl.providerFlowSignIn(
-			ctx, user, providerFound, provider, profile.ProviderUserID, logger,
+			ctx, user, providerFound, provider, profile, logger,
 		)
 	}
 
@@ -269,17 +269,31 @@ func (ctrl *Controller) providerFlowSignIn(
 	user sql.AuthUser,
 	providerFound bool,
 	provider string,
-	providerUserID string,
+	profile oidc.Profile,
 	logger *slog.Logger,
 ) (*api.Session, *APIError) {
 	logger.InfoContext(ctx, "user found, signing in")
 
 	if !providerFound {
+		// Linking a new provider identity to an existing account requires the
+		// provider to have verified ownership of the email. Without this guard,
+		// an attacker could claim an unverified email on the OAuth provider
+		// (e.g. by changing their email to the victim's address and skipping
+		// confirmation) and take over the matching Nhost account.
+		if !profile.EmailVerified {
+			logger.WarnContext(ctx,
+				"refusing to link provider to existing account: email not verified by provider",
+				slog.String("provider", provider),
+			)
+
+			return nil, ErrUnverifiedUser
+		}
+
 		if _, apiErr := ctrl.wf.InsertUserProvider(
 			ctx,
 			user.ID,
 			provider,
-			providerUserID,
+			profile.ProviderUserID,
 			logger,
 		); apiErr != nil {
 			return nil, apiErr
@@ -317,6 +331,17 @@ func (ctrl *Controller) providerResolveUser(
 		logger.InfoContext(ctx, "user found, resolving for PKCE")
 
 		if !providerFound {
+			// See providerFlowSignIn: never link a provider identity to an
+			// existing account without verified email ownership.
+			if !profile.EmailVerified {
+				logger.WarnContext(ctx,
+					"refusing to link provider to existing account: email not verified by provider",
+					slog.String("provider", provider),
+				)
+
+				return uuid.Nil, ErrUnverifiedUser
+			}
+
 			if _, apiErr := ctrl.wf.InsertUserProvider(
 				ctx,
 				user.ID,

--- a/services/auth/go/controller/sign_in_id_token.go
+++ b/services/auth/go/controller/sign_in_id_token.go
@@ -149,7 +149,7 @@ func (ctrl *Controller) providerFlowSignUp(
 		ctx,
 		profile.Email,
 		options,
-		profile.Email != "" && !profile.EmailVerified,
+		profile.Email != "" && !profile.EmailVerified.IsVerified(),
 		ctrl.providerFlowSignupWithSession(ctx, profile, provider, options),
 		ctrl.providerFlowSignupWithoutSession(ctx, profile, provider, options),
 		"",
@@ -161,7 +161,7 @@ func (ctrl *Controller) providerFlowSignUp(
 
 	if session != nil {
 		session.User.AvatarUrl = profile.Picture
-		session.User.EmailVerified = profile.EmailVerified
+		session.User.EmailVerified = profile.EmailVerified.IsVerified()
 	}
 
 	return session, nil
@@ -198,7 +198,7 @@ func (ctrl *Controller) providerFlowSignupWithSession(
 				Email:                 email,
 				Ticket:                pgtype.Text{}, //nolint:exhaustruct
 				TicketExpiresAt:       sql.TimestampTz(time.Now()),
-				EmailVerified:         profile.EmailVerified,
+				EmailVerified:         profile.EmailVerified.IsVerified(),
 				Locale:                deptr(options.Locale),
 				DefaultRole:           deptr(options.DefaultRole),
 				Metadata:              metadata,
@@ -248,7 +248,7 @@ func (ctrl *Controller) providerFlowSignupWithoutSession(
 			Email:           email,
 			Ticket:          ticket,
 			TicketExpiresAt: ticketExpiresAt,
-			EmailVerified:   profile.EmailVerified,
+			EmailVerified:   profile.EmailVerified.IsVerified(),
 			Locale:          deptr(options.Locale),
 			DefaultRole:     deptr(options.DefaultRole),
 			Metadata:        metadata,
@@ -264,6 +264,33 @@ func (ctrl *Controller) providerFlowSignupWithoutSession(
 	}
 }
 
+// ensureProviderLinkAllowed rejects an attempt to link a new OAuth provider
+// identity to an existing Nhost account when the provider has not explicitly
+// attested that the caller owns the email address. EmailVerificationStatus
+// values of Unknown (no signal) and Unverified are both rejected; only the
+// explicit Verified status allows linking.
+//
+// Without this guard, an attacker could claim an unverified email on the
+// OAuth provider (e.g. by changing their email to the victim's address and
+// skipping confirmation) and take over the matching Nhost account.
+func (ctrl *Controller) ensureProviderLinkAllowed(
+	ctx context.Context,
+	profile oidc.Profile,
+	provider string,
+	logger *slog.Logger,
+) *APIError {
+	if profile.EmailVerified.IsVerified() {
+		return nil
+	}
+
+	logger.WarnContext(ctx,
+		"refusing to link provider to existing account: email not verified by provider",
+		slog.String("provider", provider),
+	)
+
+	return ErrUnverifiedUser
+}
+
 func (ctrl *Controller) providerFlowSignIn(
 	ctx context.Context,
 	user sql.AuthUser,
@@ -275,18 +302,8 @@ func (ctrl *Controller) providerFlowSignIn(
 	logger.InfoContext(ctx, "user found, signing in")
 
 	if !providerFound {
-		// Linking a new provider identity to an existing account requires the
-		// provider to have verified ownership of the email. Without this guard,
-		// an attacker could claim an unverified email on the OAuth provider
-		// (e.g. by changing their email to the victim's address and skipping
-		// confirmation) and take over the matching Nhost account.
-		if !profile.EmailVerified {
-			logger.WarnContext(ctx,
-				"refusing to link provider to existing account: email not verified by provider",
-				slog.String("provider", provider),
-			)
-
-			return nil, ErrUnverifiedUser
+		if apiErr := ctrl.ensureProviderLinkAllowed(ctx, profile, provider, logger); apiErr != nil {
+			return nil, apiErr
 		}
 
 		if _, apiErr := ctrl.wf.InsertUserProvider(
@@ -327,36 +344,29 @@ func (ctrl *Controller) providerResolveUser(
 		return uuid.Nil, apiError
 	}
 
-	if userFound {
-		logger.InfoContext(ctx, "user found, resolving for PKCE")
-
-		if !providerFound {
-			// See providerFlowSignIn: never link a provider identity to an
-			// existing account without verified email ownership.
-			if !profile.EmailVerified {
-				logger.WarnContext(ctx,
-					"refusing to link provider to existing account: email not verified by provider",
-					slog.String("provider", provider),
-				)
-
-				return uuid.Nil, ErrUnverifiedUser
-			}
-
-			if _, apiErr := ctrl.wf.InsertUserProvider(
-				ctx,
-				user.ID,
-				provider,
-				profile.ProviderUserID,
-				logger,
-			); apiErr != nil {
-				return uuid.Nil, apiErr
-			}
-		}
-
-		return user.ID, nil
+	if !userFound {
+		return ctrl.providerSignUpResolveOnly(ctx, provider, profile, options, logger)
 	}
 
-	return ctrl.providerSignUpResolveOnly(ctx, provider, profile, options, logger)
+	logger.InfoContext(ctx, "user found, resolving for PKCE")
+
+	if !providerFound {
+		if apiErr := ctrl.ensureProviderLinkAllowed(ctx, profile, provider, logger); apiErr != nil {
+			return uuid.Nil, apiErr
+		}
+
+		if _, apiErr := ctrl.wf.InsertUserProvider(
+			ctx,
+			user.ID,
+			provider,
+			profile.ProviderUserID,
+			logger,
+		); apiErr != nil {
+			return uuid.Nil, apiErr
+		}
+	}
+
+	return user.ID, nil
 }
 
 // providerSignUpResolveOnly creates a new user from an OAuth provider profile
@@ -376,7 +386,7 @@ func (ctrl *Controller) providerSignUpResolveOnly( //nolint:cyclop,funlen
 		return uuid.Nil, apiError
 	}
 
-	sendConfirmationEmail := profile.Email != "" && !profile.EmailVerified
+	sendConfirmationEmail := profile.Email != "" && !profile.EmailVerified.IsVerified()
 
 	// If email verification is needed or new users are disabled,
 	// use the existing sign-up-without-session flow and signal that
@@ -425,7 +435,7 @@ func (ctrl *Controller) providerSignUpResolveOnly( //nolint:cyclop,funlen
 			Email:           email,
 			Ticket:          pgtype.Text{}, //nolint:exhaustruct
 			TicketExpiresAt: sql.TimestampTz(time.Now()),
-			EmailVerified:   profile.EmailVerified,
+			EmailVerified:   profile.EmailVerified.IsVerified(),
 			Locale:          deptr(options.Locale),
 			DefaultRole:     deptr(options.DefaultRole),
 			Metadata:        metadata,

--- a/services/auth/go/controller/sign_in_id_token_test.go
+++ b/services/auth/go/controller/sign_in_id_token_test.go
@@ -785,6 +785,59 @@ func TestSignInIdToken(t *testing.T) { //nolint:maintidx
 			expectedJWT: nil,
 			jwtTokenFn:  nil,
 		},
+
+		{
+			name:   "signin - existing account - email not verified - refuses to link",
+			config: getConfig,
+			db: func(ctrl *gomock.Controller) controller.DBClient {
+				mock := mock.NewMockDBClient(ctrl)
+
+				mock.EXPECT().GetUserByProviderID(
+					gomock.Any(),
+					sql.GetUserByProviderIDParams{
+						ProviderID:     "fake",
+						ProviderUserID: "106964149809169421082",
+					},
+				).Return(sql.AuthUser{}, pgx.ErrNoRows) //nolint:exhaustruct
+
+				mock.EXPECT().GetUserByEmail(
+					gomock.Any(),
+					sql.Text("jane@myapp.local"),
+				).Return(
+					//nolint:exhaustruct
+					sql.AuthUser{
+						ID: userID,
+						CreatedAt: pgtype.Timestamptz{
+							Time: time.Now(),
+						},
+						Disabled:      false,
+						DisplayName:   "Jane",
+						Email:         sql.Text("jane@myapp.local"),
+						EmailVerified: true,
+						DefaultRole:   "user",
+					}, nil)
+
+				return mock
+			},
+			getControllerOpts: []getControllerOptsFunc{
+				withIDTokenValidatorProviders(getTestIDTokenValidatorProviders()),
+			},
+			request: api.SignInIdTokenRequestObject{
+				Body: &api.SignInIdTokenRequest{
+					IdToken:  testTokenWithEmailVerified(t, nonce, false),
+					Nonce:    new(nonce),
+					Options:  nil,
+					Provider: "fake",
+				},
+			},
+			expectedResponse: controller.ErrorResponse{
+				Error:   "unverified-user",
+				Message: "User is not verified.",
+				Status:  401,
+			},
+			expectedJWT: nil,
+			jwtTokenFn:  nil,
+		},
 	}
 
 	for _, tc := range cases {

--- a/services/auth/go/controller/sign_in_provider_callback_get_test.go
+++ b/services/auth/go/controller/sign_in_provider_callback_get_test.go
@@ -602,6 +602,56 @@ func TestSignInProviderCallback(t *testing.T) { //nolint:maintidx
 		},
 
 		{
+			name:   "signin - simple - email found - email not verified - refuses to link",
+			config: getConfig,
+			db: func(ctrl *gomock.Controller) controller.DBClient {
+				mock := mock.NewMockDBClient(ctrl)
+
+				mock.EXPECT().GetUserByProviderID(
+					gomock.Any(),
+					sql.GetUserByProviderIDParams{
+						ProviderID:     "fake",
+						ProviderUserID: "1234567890",
+					},
+				).Return(sql.AuthUser{}, pgx.ErrNoRows) //nolint:exhaustruct
+
+				mock.EXPECT().GetUserByEmail(
+					gomock.Any(),
+					sql.Text("user1@fake.com"),
+				).Return(
+					//nolint:exhaustruct
+					sql.AuthUser{
+						ID: userID,
+						CreatedAt: pgtype.Timestamptz{
+							Time: time.Now(),
+						},
+						Disabled:      false,
+						DisplayName:   "Jane",
+						Email:         sql.Text("jane@myapp.local"),
+						EmailVerified: true,
+						DefaultRole:   "user",
+					}, nil)
+
+				return mock
+			},
+			request: api.SignInProviderCallbackGetRequestObject{
+				Params: api.SignInProviderCallbackGetParams{ //nolint:exhaustruct
+					Code:  new("valid-code-unverified-email"),
+					State: getState(t, jwtGetter, nil, api.SignUpOptions{}), //nolint:exhaustruct
+				},
+				Provider: "fake",
+			},
+			expectedResponse: controller.ErrorRedirectResponse{
+				Headers: struct{ Location string }{
+					Location: `^http://localhost:3000\?error=unverified-user&errorDescription=User\+is\+not\+verified.&state=some-random-state$`, //nolint:lll
+				},
+			},
+			expectedJWT:       nil,
+			jwtTokenFn:        nil,
+			getControllerOpts: nil,
+		},
+
+		{
 			name:   "signin - user disabled",
 			config: getConfig,
 			db: func(ctrl *gomock.Controller) controller.DBClient { //nolint:dupl
@@ -1493,6 +1543,59 @@ func TestSignInProviderCallback(t *testing.T) { //nolint:maintidx
 			expectedResponse: api.SignInProviderCallbackGet302Response{
 				Headers: api.SignInProviderCallbackGet302ResponseHeaders{
 					Location: `^http://localhost:3000\?code=[\w-]+&state=some-random-state$`,
+				},
+			},
+			expectedJWT:       nil,
+			jwtTokenFn:        nil,
+			getControllerOpts: nil,
+		},
+
+		{
+			name:   "pkce - signin - email found - email not verified - refuses to link",
+			config: getConfig,
+			db: func(ctrl *gomock.Controller) controller.DBClient {
+				mock := mock.NewMockDBClient(ctrl)
+
+				mock.EXPECT().GetUserByProviderID(
+					gomock.Any(),
+					sql.GetUserByProviderIDParams{
+						ProviderID:     "fake",
+						ProviderUserID: "1234567890",
+					},
+				).Return(sql.AuthUser{}, pgx.ErrNoRows) //nolint:exhaustruct
+
+				mock.EXPECT().GetUserByEmail(
+					gomock.Any(),
+					sql.Text("user1@fake.com"),
+				).Return(
+					//nolint:exhaustruct
+					sql.AuthUser{
+						ID: userID,
+						CreatedAt: pgtype.Timestamptz{
+							Time: time.Now(),
+						},
+						Disabled:      false,
+						DisplayName:   "Jane",
+						Email:         sql.Text("jane@myapp.local"),
+						EmailVerified: true,
+						DefaultRole:   "user",
+					}, nil)
+
+				return mock
+			},
+			request: api.SignInProviderCallbackGetRequestObject{
+				Params: api.SignInProviderCallbackGetParams{ //nolint:exhaustruct
+					Code: new("valid-code-unverified-email"),
+					State: getStateWithPKCE(
+						t, jwtGetter, nil, api.SignUpOptions{}, //nolint:exhaustruct
+						ptr("E9Melhoa2OwvFrEMTJguCHaoeK1t8URWbuGJSstw-cM"),
+					),
+				},
+				Provider: "fake",
+			},
+			expectedResponse: controller.ErrorRedirectResponse{
+				Headers: struct{ Location string }{
+					Location: `^http://localhost:3000\?error=unverified-user&errorDescription=User\+is\+not\+verified.&state=some-random-state$`, //nolint:lll
 				},
 			},
 			expectedJWT:       nil,

--- a/services/auth/go/controller/sign_in_provider_callback_get_test.go
+++ b/services/auth/go/controller/sign_in_provider_callback_get_test.go
@@ -912,6 +912,100 @@ func TestSignInProviderCallback(t *testing.T) { //nolint:maintidx
 		},
 
 		{
+			// Locks in that the OAuth callback's connect branch ignores the
+			// provider's email verification status: the Nhost account is
+			// identified by the connect JWT embedded in the state, not by the
+			// OAuth email, so an unverified (or unknown) email from the
+			// provider must not block linking.
+			name:   "connect - success - unverified provider email still links",
+			config: getConfig,
+			db: func(ctrl *gomock.Controller) controller.DBClient {
+				mock := mock.NewMockDBClient(ctrl)
+
+				//nolint:exhaustruct
+				mock.EXPECT().GetUser( //nolint:dupl
+					gomock.Any(),
+					userIDConnect,
+				).Return(sql.AuthUser{
+					ID: userID,
+					CreatedAt: pgtype.Timestamptz{
+						Time: time.Now(),
+					},
+					UpdatedAt:   pgtype.Timestamptz{},
+					LastSeen:    pgtype.Timestamptz{},
+					Disabled:    false,
+					DisplayName: "John",
+					AvatarUrl:   "",
+					Locale:      "en",
+					Email:       sql.Text("fake@gmail.com"),
+					PhoneNumber: pgtype.Text{},
+					PasswordHash: sql.Text(
+						"$2a$10$pyv7eu9ioQcFnLSz7u/enex22P3ORdh6z6116Vj5a3vSjo0oxFa1u",
+					),
+					EmailVerified:            true,
+					PhoneNumberVerified:      false,
+					NewEmail:                 pgtype.Text{},
+					OtpMethodLastUsed:        pgtype.Text{},
+					OtpHash:                  pgtype.Text{},
+					OtpHashExpiresAt:         pgtype.Timestamptz{},
+					DefaultRole:              "user",
+					IsAnonymous:              false,
+					TotpSecret:               pgtype.Text{},
+					ActiveMfaType:            pgtype.Text{},
+					Ticket:                   pgtype.Text{},
+					TicketExpiresAt:          sql.TimestampTz(time.Now()),
+					Metadata:                 []byte{},
+					WebauthnCurrentChallenge: pgtype.Text{},
+				}, nil)
+
+				mock.EXPECT().InsertUserProvider(
+					gomock.Any(),
+					sql.InsertUserProviderParams{
+						UserID:         userIDConnect,
+						ProviderID:     "fake",
+						ProviderUserID: "1234567890",
+					},
+				).Return(
+					//nolint:exhaustruct
+					sql.AuthUserProvider{
+						ID:             userIDConnect,
+						CreatedAt:      pgtype.Timestamptz{},
+						UpdatedAt:      pgtype.Timestamptz{},
+						UserID:         userID,
+						AccessToken:    "unset",
+						RefreshToken:   pgtype.Text{},
+						ProviderID:     "fake",
+						ProviderUserID: "1234567890",
+					}, nil,
+				)
+
+				mock.EXPECT().UpdateProviderSession(
+					gomock.Any(),
+					gomock.Any(),
+				).Return(nil)
+
+				return mock
+			},
+			request: api.SignInProviderCallbackGetRequestObject{
+				Params: api.SignInProviderCallbackGetParams{ //nolint:exhaustruct
+					Code: new("valid-code-unverified-email"),
+					State: getState(t, jwtGetter, &jwtToken, api.SignUpOptions{ //nolint:exhaustruct
+						RedirectTo: new("http://localhost:3000/connect-success"),
+					}),
+				},
+				Provider: "fake",
+			},
+			expectedResponse: api.SignInProviderCallbackGet302Response{
+				Headers: api.SignInProviderCallbackGet302ResponseHeaders{
+					Location: `^http://localhost:3000/connect-success\?state=some-random-state$`,
+				},
+			},
+			expectedJWT:       nil,
+			jwtTokenFn:        nil,
+			getControllerOpts: nil,
+		},
+
+		{
 			name:   "connect - user disabled",
 			config: getConfig,
 			db: func(ctrl *gomock.Controller) controller.DBClient {

--- a/services/auth/go/oauth2/helpers.go
+++ b/services/auth/go/oauth2/helpers.go
@@ -39,7 +39,7 @@ func computeAtHash(accessToken string) string {
 	return base64.RawURLEncoding.EncodeToString(h[:sha256.Size/2])
 }
 
-func deptr[T any](x *T) T { //nolint:ireturn
+func deptr[T any](x *T) T { //nolint:ireturn,nolintlint
 	if x == nil {
 		return *new(T)
 	}

--- a/services/auth/go/oidc/google.go
+++ b/services/auth/go/oidc/google.go
@@ -49,9 +49,15 @@ func getProfile(token *jwt.Token) (Profile, error) {
 		return Profile{}, fmt.Errorf("failed to get email claim from token: %w", err)
 	}
 
+	emailVerifiedStatus := EmailVerificationStatusUnknown
+
 	emailVerified, err := GetClaim[bool](token, "email_verified")
 	if err != nil && !errors.Is(err, ErrClaimNotFound) {
 		return Profile{}, fmt.Errorf("failed to get email_verified claim from token: %w", err)
+	}
+
+	if err == nil {
+		emailVerifiedStatus = EmailVerificationFromBool(emailVerified)
 	}
 
 	name, err := GetClaim[string](token, "name")
@@ -67,7 +73,7 @@ func getProfile(token *jwt.Token) (Profile, error) {
 	return Profile{
 		ProviderUserID: sub,
 		Email:          email,
-		EmailVerified:  emailVerified,
+		EmailVerified:  emailVerifiedStatus,
 		Name:           name,
 		Picture:        picture,
 	}, nil

--- a/services/auth/go/oidc/idtoken.go
+++ b/services/auth/go/oidc/idtoken.go
@@ -182,10 +182,46 @@ func validateNonce(token *jwt.Token, nonce string) error {
 	return nil
 }
 
+// EmailVerificationStatus expresses whether the upstream OAuth/OIDC provider
+// has attested that the user owns the email address returned on the profile.
+//
+// The zero value is EmailVerificationStatusUnknown, which means the adapter
+// had no explicit signal from the provider. Unknown is treated as unverified
+// for security-sensitive decisions (account linking, session issuance); use
+// IsVerified to branch on it.
+//
+// Adapters MUST NOT infer verification from the presence of an email. Only
+// set Verified when the provider exposes an explicit signal (an
+// email_verified claim, a confirmed_at timestamp, or equivalent).
+type EmailVerificationStatus int
+
+const (
+	EmailVerificationStatusUnknown EmailVerificationStatus = iota
+	EmailVerificationStatusVerified
+	EmailVerificationStatusUnverified
+)
+
+// IsVerified returns true only when the provider explicitly attested that the
+// email is verified. Unknown and Unverified both return false.
+func (s EmailVerificationStatus) IsVerified() bool {
+	return s == EmailVerificationStatusVerified
+}
+
+// EmailVerificationFromBool maps a provider-supplied boolean to the matching
+// verification status. Use it when the adapter has an explicit signal and
+// just needs to translate its shape.
+func EmailVerificationFromBool(verified bool) EmailVerificationStatus {
+	if verified {
+		return EmailVerificationStatusVerified
+	}
+
+	return EmailVerificationStatusUnverified
+}
+
 type Profile struct {
 	ProviderUserID string
 	Email          string
-	EmailVerified  bool
+	EmailVerified  EmailVerificationStatus
 	Name           string
 	Picture        string
 }

--- a/services/auth/go/providers/apple.go
+++ b/services/auth/go/providers/apple.go
@@ -154,7 +154,7 @@ func (a *Apple) GetProfile(
 	return oidc.Profile{
 		ProviderUserID: sub,
 		Email:          email,
-		EmailVerified:  emailVerified,
+		EmailVerified:  oidc.EmailVerificationFromBool(emailVerified),
 		Name:           displayName,
 		Picture:        "",
 	}, nil

--- a/services/auth/go/providers/azuread.go
+++ b/services/auth/go/providers/azuread.go
@@ -65,20 +65,17 @@ func (a *AzureAD) GetProfile(
 	// Only the `email` claim represents a real external email Azure AD has
 	// associated with the account. `preferred_username` and `upn` are internal
 	// directory identifiers that can be set to arbitrary values (e.g. a custom
-	// UPN like `ceo@target-company.com`) and do not prove email ownership, so
-	// using them for account linking would enable account takeover.
+	// UPN like `ceo@target-company.com`) and do not prove email ownership.
 	//
 	// The legacy v1 `/openid/userinfo` endpoint does not expose an
-	// `email_verified` claim, so we cannot independently verify the address
-	// here. The claim is trusted because it comes from the directory record
-	// the tenant administrator configured, not from user-controlled input; in
-	// a standard enterprise tenant this is the user's work email. For stricter
-	// verification, prefer the Entra ID provider, which does return
-	// `email_verified` via Microsoft Graph's OIDC userinfo endpoint.
+	// `email_verified` claim, so there is no explicit signal to report and
+	// the status is Unknown. For stricter verification, use the Entra ID
+	// provider, which returns `email_verified` via Microsoft Graph's OIDC
+	// userinfo endpoint.
 	return oidc.Profile{
 		ProviderUserID: userProfile.OID,
 		Email:          userProfile.Email,
-		EmailVerified:  userProfile.Email != "",
+		EmailVerified:  oidc.EmailVerificationStatusUnknown,
 		Name:           userProfile.Name,
 		Picture:        "",
 	}, nil

--- a/services/auth/go/providers/azuread.go
+++ b/services/auth/go/providers/azuread.go
@@ -67,6 +67,14 @@ func (a *AzureAD) GetProfile(
 	// directory identifiers that can be set to arbitrary values (e.g. a custom
 	// UPN like `ceo@target-company.com`) and do not prove email ownership, so
 	// using them for account linking would enable account takeover.
+	//
+	// The legacy v1 `/openid/userinfo` endpoint does not expose an
+	// `email_verified` claim, so we cannot independently verify the address
+	// here. The claim is trusted because it comes from the directory record
+	// the tenant administrator configured, not from user-controlled input; in
+	// a standard enterprise tenant this is the user's work email. For stricter
+	// verification, prefer the Entra ID provider, which does return
+	// `email_verified` via Microsoft Graph's OIDC userinfo endpoint.
 	return oidc.Profile{
 		ProviderUserID: userProfile.OID,
 		Email:          userProfile.Email,

--- a/services/auth/go/providers/azuread.go
+++ b/services/auth/go/providers/azuread.go
@@ -41,11 +41,9 @@ func NewAzureadProvider(
 }
 
 type azureUser struct {
-	OID    string `json:"oid"`
-	Email  string `json:"email"`
-	Name   string `json:"name"`
-	UPN    string `json:"upn"`
-	Prefer string `json:"preferred_username"`
+	OID   string `json:"oid"`
+	Email string `json:"email"`
+	Name  string `json:"name"`
 }
 
 func (a *AzureAD) GetProfile(
@@ -64,19 +62,15 @@ func (a *AzureAD) GetProfile(
 		return oidc.Profile{}, fmt.Errorf("AzureAD API error: %w", err)
 	}
 
-	email := userProfile.Email
-	if email == "" {
-		email = userProfile.Prefer
-	}
-
-	if email == "" {
-		email = userProfile.UPN
-	}
-
+	// Only the `email` claim represents a real external email Azure AD has
+	// associated with the account. `preferred_username` and `upn` are internal
+	// directory identifiers that can be set to arbitrary values (e.g. a custom
+	// UPN like `ceo@target-company.com`) and do not prove email ownership, so
+	// using them for account linking would enable account takeover.
 	return oidc.Profile{
 		ProviderUserID: userProfile.OID,
-		Email:          email,
-		EmailVerified:  email != "",
+		Email:          userProfile.Email,
+		EmailVerified:  userProfile.Email != "",
 		Name:           userProfile.Name,
 		Picture:        "",
 	}, nil

--- a/services/auth/go/providers/azuread_internal_test.go
+++ b/services/auth/go/providers/azuread_internal_test.go
@@ -1,0 +1,51 @@
+package providers
+
+import (
+	"encoding/json"
+	"testing"
+)
+
+// TestAzureADProfileIgnoresUPNAndPreferredUsername verifies that the Azure AD
+// user profile struct no longer deserializes the `upn` or `preferred_username`
+// claims. These fields are internal directory identifiers and cannot be used
+// to prove ownership of an external email, so they must never be treated as
+// an account-linking email.
+func TestAzureADProfileIgnoresUPNAndPreferredUsername(t *testing.T) {
+	t.Parallel()
+
+	body := `{
+		"oid": "00000000-0000-0000-66f3-3332eca7ea81",
+		"name": "Jane",
+		"email": "",
+		"upn": "attacker@tenant.onmicrosoft.com",
+		"preferred_username": "ceo@target-company.com"
+	}`
+
+	var profile azureUser
+	if err := json.Unmarshal([]byte(body), &profile); err != nil {
+		t.Fatalf("unmarshal failed: %v", err)
+	}
+
+	if profile.Email != "" {
+		t.Errorf("email should be empty when the claim is empty, got %q", profile.Email)
+	}
+}
+
+func TestAzureADProfileUsesEmailOnly(t *testing.T) {
+	t.Parallel()
+
+	body := `{
+		"oid": "00000000-0000-0000-66f3-3332eca7ea81",
+		"name": "Jane",
+		"email": "jane@contoso.com"
+	}`
+
+	var profile azureUser
+	if err := json.Unmarshal([]byte(body), &profile); err != nil {
+		t.Fatalf("unmarshal failed: %v", err)
+	}
+
+	if profile.Email != "jane@contoso.com" {
+		t.Errorf("email: got %q, want %q", profile.Email, "jane@contoso.com")
+	}
+}

--- a/services/auth/go/providers/bitbucket.go
+++ b/services/auth/go/providers/bitbucket.go
@@ -99,34 +99,29 @@ func (b *Bitbucket) GetProfile(
 		return oidc.Profile{}, fmt.Errorf("Bitbucket email decode error: %w", err)
 	}
 
-	// Pick the first verified email
-	var (
-		primaryEmail  string
-		fallbackEmail string
-	)
+	// Pick the first confirmed email. Unconfirmed emails MUST NOT be used for
+	// account linking: Bitbucket lets users add any email to their account
+	// without proof of ownership until they click the confirmation link, so
+	// treating an unconfirmed address as verified would enable account
+	// takeover against an existing Nhost user with the same email.
+	var primaryEmail string
 
 	for _, e := range emailResp.Values {
 		if e.IsConfirmed {
 			primaryEmail = e.Email
 			break
-		} else if fallbackEmail == "" {
-			fallbackEmail = e.Email
 		}
 	}
 
 	if primaryEmail == "" {
-		if fallbackEmail == "" {
-			return oidc.Profile{}, ErrNoConfirmedBitbucketEmail
-		}
-
-		primaryEmail = fallbackEmail
+		return oidc.Profile{}, ErrNoConfirmedBitbucketEmail
 	}
 
 	// Step 3: Return profile
 	return oidc.Profile{
 		ProviderUserID: user.UUID,
 		Email:          primaryEmail,
-		EmailVerified:  primaryEmail != "",
+		EmailVerified:  true,
 		Name:           user.DisplayName,
 		Picture:        user.Links.Avatar.Href,
 	}, nil

--- a/services/auth/go/providers/bitbucket.go
+++ b/services/auth/go/providers/bitbucket.go
@@ -99,11 +99,10 @@ func (b *Bitbucket) GetProfile(
 		return oidc.Profile{}, fmt.Errorf("Bitbucket email decode error: %w", err)
 	}
 
-	// Pick the first confirmed email. Unconfirmed emails MUST NOT be used for
-	// account linking: Bitbucket lets users add any email to their account
-	// without proof of ownership until they click the confirmation link, so
-	// treating an unconfirmed address as verified would enable account
-	// takeover against an existing Nhost user with the same email.
+	// Pick the first confirmed email. Bitbucket lets users add any email to
+	// their account without proof of ownership until they click the
+	// confirmation link, so unconfirmed addresses must never be reported as
+	// verified.
 	var primaryEmail string
 
 	for _, e := range emailResp.Values {
@@ -117,11 +116,13 @@ func (b *Bitbucket) GetProfile(
 		return oidc.Profile{}, ErrNoConfirmedBitbucketEmail
 	}
 
-	// Step 3: Return profile
+	// Step 3: Return profile. We only reach this point after selecting a
+	// confirmed email, so the status reflects Bitbucket's explicit
+	// `is_confirmed` signal.
 	return oidc.Profile{
 		ProviderUserID: user.UUID,
 		Email:          primaryEmail,
-		EmailVerified:  true,
+		EmailVerified:  oidc.EmailVerificationStatusVerified,
 		Name:           user.DisplayName,
 		Picture:        user.Links.Avatar.Href,
 	}, nil

--- a/services/auth/go/providers/bitbucket_internal_test.go
+++ b/services/auth/go/providers/bitbucket_internal_test.go
@@ -1,0 +1,160 @@
+package providers
+
+import (
+	"context"
+	"encoding/json"
+	"errors"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+)
+
+// newBitbucketTestServer serves the two endpoints used by Bitbucket.GetProfile.
+// The caller supplies the body returned for /user/emails.
+func newBitbucketTestServer(t *testing.T, emailsBody string) *httptest.Server {
+	t.Helper()
+
+	return httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		switch {
+		case strings.HasSuffix(r.URL.Path, "/user/emails"):
+			w.Header().Set("Content-Type", "application/json")
+			_, _ = w.Write([]byte(emailsBody))
+		case strings.HasSuffix(r.URL.Path, "/user"):
+			w.Header().Set("Content-Type", "application/json")
+			_, _ = w.Write([]byte(`{
+				"uuid": "{00000000-0000-0000-0000-000000000000}",
+				"display_name": "Jane",
+				"links": {"avatar": {"href": "https://example.com/a.png"}}
+			}`))
+		default:
+			http.NotFound(w, r)
+		}
+	}))
+}
+
+// bitbucketGetProfileWithBase is a test-only variant of Bitbucket.GetProfile
+// that uses baseURL instead of the hard-coded Bitbucket API host, so we can
+// exercise the email-selection logic against an httptest server.
+//
+// This mirrors the production code exactly; it intentionally only differs in
+// the two URLs it targets.
+func bitbucketGetProfileWithBase(
+	ctx context.Context,
+	baseURL, accessToken string,
+) (string, bool, error) {
+	var user bitbucketAPIUser
+	if err := fetchOAuthProfile(ctx, baseURL+"/user", accessToken, &user); err != nil {
+		return "", false, err
+	}
+
+	req, err := http.NewRequestWithContext(
+		ctx,
+		http.MethodGet,
+		baseURL+"/user/emails",
+		nil,
+	)
+	if err != nil {
+		return "", false, err
+	}
+
+	req.Header.Set("Authorization", "Bearer "+accessToken)
+
+	resp, err := http.DefaultClient.Do(req)
+	if err != nil {
+		return "", false, err
+	}
+	defer resp.Body.Close()
+
+	var emailResp bitbucketEmailsResponse
+	if err := json.NewDecoder(resp.Body).Decode(&emailResp); err != nil {
+		return "", false, err
+	}
+
+	var primaryEmail string
+
+	for _, e := range emailResp.Values {
+		if e.IsConfirmed {
+			primaryEmail = e.Email
+			break
+		}
+	}
+
+	if primaryEmail == "" {
+		return "", false, ErrNoConfirmedBitbucketEmail
+	}
+
+	return primaryEmail, true, nil
+}
+
+func TestBitbucketRejectsUnconfirmedEmails(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name          string
+		emailsBody    string
+		expectedEmail string
+		expectedErr   error
+	}{
+		{
+			name: "picks first confirmed email",
+			emailsBody: `{
+				"values": [
+					{"email": "unconfirmed@target.io", "is_confirmed": false},
+					{"email": "jane@bitbucket.io", "is_confirmed": true}
+				]
+			}`,
+			expectedEmail: "jane@bitbucket.io",
+			expectedErr:   nil,
+		},
+		{
+			name: "rejects when only unconfirmed email present (attacker case)",
+			emailsBody: `{
+				"values": [
+					{"email": "victim@target.io", "is_confirmed": false}
+				]
+			}`,
+			expectedEmail: "",
+			expectedErr:   ErrNoConfirmedBitbucketEmail,
+		},
+		{
+			name:          "rejects empty email list",
+			emailsBody:    `{"values": []}`,
+			expectedEmail: "",
+			expectedErr:   ErrNoConfirmedBitbucketEmail,
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+
+			srv := newBitbucketTestServer(t, tc.emailsBody)
+			defer srv.Close()
+
+			email, verified, err := bitbucketGetProfileWithBase(
+				t.Context(), srv.URL, "fake-token",
+			)
+
+			if tc.expectedErr != nil {
+				if !errors.Is(err, tc.expectedErr) {
+					t.Fatalf("error: got %v, want %v", err, tc.expectedErr)
+				}
+
+				return
+			}
+
+			if err != nil {
+				t.Fatalf("unexpected error: %v", err)
+			}
+
+			if email != tc.expectedEmail {
+				t.Errorf("email: got %q, want %q", email, tc.expectedEmail)
+			}
+
+			if !verified {
+				t.Errorf("verified: got false, want true")
+			}
+		})
+	}
+}

--- a/services/auth/go/providers/bitbucket_internal_test.go
+++ b/services/auth/go/providers/bitbucket_internal_test.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"encoding/json"
 	"errors"
+	"fmt"
 	"net/http"
 	"net/http/httptest"
 	"strings"
@@ -55,20 +56,20 @@ func bitbucketGetProfileWithBase(
 		nil,
 	)
 	if err != nil {
-		return "", false, err
+		return "", false, fmt.Errorf("new request: %w", err)
 	}
 
 	req.Header.Set("Authorization", "Bearer "+accessToken)
 
 	resp, err := http.DefaultClient.Do(req)
 	if err != nil {
-		return "", false, err
+		return "", false, fmt.Errorf("do request: %w", err)
 	}
 	defer resp.Body.Close()
 
 	var emailResp bitbucketEmailsResponse
 	if err := json.NewDecoder(resp.Body).Decode(&emailResp); err != nil {
-		return "", false, err
+		return "", false, fmt.Errorf("decode response: %w", err)
 	}
 
 	var primaryEmail string

--- a/services/auth/go/providers/discord.go
+++ b/services/auth/go/providers/discord.go
@@ -38,6 +38,7 @@ type discordUserProfile struct {
 	Username      string `json:"username"`
 	Discriminator string `json:"discriminator"`
 	Email         string `json:"email"`
+	Verified      bool   `json:"verified"`
 	Locale        string `json:"locale"`
 	Avatar        string `json:"avatar"`
 }
@@ -62,7 +63,7 @@ func (d *Discord) GetProfile(
 		ProviderUserID: userProfile.ID,
 		Name:           fmt.Sprintf("%s#%s", userProfile.Username, userProfile.Discriminator),
 		Email:          userProfile.Email,
-		EmailVerified:  userProfile.Email != "",
+		EmailVerified:  userProfile.Verified,
 		Picture: fmt.Sprintf(
 			"https://cdn.discordapp.com/avatars/%s/%s.png",
 			userProfile.ID,

--- a/services/auth/go/providers/discord.go
+++ b/services/auth/go/providers/discord.go
@@ -63,7 +63,7 @@ func (d *Discord) GetProfile(
 		ProviderUserID: userProfile.ID,
 		Name:           fmt.Sprintf("%s#%s", userProfile.Username, userProfile.Discriminator),
 		Email:          userProfile.Email,
-		EmailVerified:  userProfile.Verified,
+		EmailVerified:  oidc.EmailVerificationFromBool(userProfile.Verified),
 		Picture: fmt.Sprintf(
 			"https://cdn.discordapp.com/avatars/%s/%s.png",
 			userProfile.ID,

--- a/services/auth/go/providers/discord_internal_test.go
+++ b/services/auth/go/providers/discord_internal_test.go
@@ -1,72 +1,50 @@
 package providers
 
-import (
-	"encoding/json"
-	"testing"
-)
+import "testing"
 
 func TestDiscordProfileDecoding(t *testing.T) {
 	t.Parallel()
 
-	tests := []struct {
-		name             string
-		body             string
-		expectedEmail    string
-		expectedVerified bool
-	}{
-		{
-			name: "verified account",
-			body: `{
-				"id": "80351110224678912",
-				"username": "Nelly",
-				"discriminator": "1337",
-				"email": "nelly@discord.com",
-				"verified": true,
-				"avatar": "8342729096ea3675442027381ff50dfe"
-			}`,
-			expectedEmail:    "nelly@discord.com",
-			expectedVerified: true,
+	runProfileDecodingCases(
+		t,
+		[]profileDecodingCase{
+			{
+				name: "verified account",
+				body: `{
+					"id": "80351110224678912",
+					"username": "Nelly",
+					"discriminator": "1337",
+					"email": "nelly@discord.com",
+					"verified": true,
+					"avatar": "8342729096ea3675442027381ff50dfe"
+				}`,
+				expectedEmail:    "nelly@discord.com",
+				expectedVerified: true,
+			},
+			{
+				name: "unverified account must not be marked verified",
+				body: `{
+					"id": "80351110224678912",
+					"username": "Nelly",
+					"discriminator": "1337",
+					"email": "victim@target.io",
+					"verified": false
+				}`,
+				expectedEmail:    "victim@target.io",
+				expectedVerified: false,
+			},
+			{
+				name: "missing verified field defaults to false (safe)",
+				body: `{
+					"id": "80351110224678912",
+					"username": "Nelly",
+					"email": "victim@target.io"
+				}`,
+				expectedEmail:    "victim@target.io",
+				expectedVerified: false,
+			},
 		},
-		{
-			name: "unverified account must not be marked verified",
-			body: `{
-				"id": "80351110224678912",
-				"username": "Nelly",
-				"discriminator": "1337",
-				"email": "victim@target.io",
-				"verified": false
-			}`,
-			expectedEmail:    "victim@target.io",
-			expectedVerified: false,
-		},
-		{
-			name: "missing verified field defaults to false (safe)",
-			body: `{
-				"id": "80351110224678912",
-				"username": "Nelly",
-				"email": "victim@target.io"
-			}`,
-			expectedEmail:    "victim@target.io",
-			expectedVerified: false,
-		},
-	}
-
-	for _, tc := range tests {
-		t.Run(tc.name, func(t *testing.T) {
-			t.Parallel()
-
-			var profile discordUserProfile
-			if err := json.Unmarshal([]byte(tc.body), &profile); err != nil {
-				t.Fatalf("unmarshal failed: %v", err)
-			}
-
-			if profile.Email != tc.expectedEmail {
-				t.Errorf("email: got %q, want %q", profile.Email, tc.expectedEmail)
-			}
-
-			if profile.Verified != tc.expectedVerified {
-				t.Errorf("verified: got %v, want %v", profile.Verified, tc.expectedVerified)
-			}
-		})
-	}
+		func(p discordUserProfile) string { return p.Email },
+		func(p discordUserProfile) bool { return p.Verified },
+	)
 }

--- a/services/auth/go/providers/discord_internal_test.go
+++ b/services/auth/go/providers/discord_internal_test.go
@@ -1,0 +1,72 @@
+package providers
+
+import (
+	"encoding/json"
+	"testing"
+)
+
+func TestDiscordProfileDecoding(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name             string
+		body             string
+		expectedEmail    string
+		expectedVerified bool
+	}{
+		{
+			name: "verified account",
+			body: `{
+				"id": "80351110224678912",
+				"username": "Nelly",
+				"discriminator": "1337",
+				"email": "nelly@discord.com",
+				"verified": true,
+				"avatar": "8342729096ea3675442027381ff50dfe"
+			}`,
+			expectedEmail:    "nelly@discord.com",
+			expectedVerified: true,
+		},
+		{
+			name: "unverified account must not be marked verified",
+			body: `{
+				"id": "80351110224678912",
+				"username": "Nelly",
+				"discriminator": "1337",
+				"email": "victim@target.io",
+				"verified": false
+			}`,
+			expectedEmail:    "victim@target.io",
+			expectedVerified: false,
+		},
+		{
+			name: "missing verified field defaults to false (safe)",
+			body: `{
+				"id": "80351110224678912",
+				"username": "Nelly",
+				"email": "victim@target.io"
+			}`,
+			expectedEmail:    "victim@target.io",
+			expectedVerified: false,
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+
+			var profile discordUserProfile
+			if err := json.Unmarshal([]byte(tc.body), &profile); err != nil {
+				t.Fatalf("unmarshal failed: %v", err)
+			}
+
+			if profile.Email != tc.expectedEmail {
+				t.Errorf("email: got %q, want %q", profile.Email, tc.expectedEmail)
+			}
+
+			if profile.Verified != tc.expectedVerified {
+				t.Errorf("verified: got %v, want %v", profile.Verified, tc.expectedVerified)
+			}
+		})
+	}
+}

--- a/services/auth/go/providers/entraid.go
+++ b/services/auth/go/providers/entraid.go
@@ -39,10 +39,11 @@ func NewEntraIDProvider(
 }
 
 type entraidUser struct {
-	Sub        string `json:"sub"`
-	GivenName  string `json:"givenname"`
-	FamilyName string `json:"familyname"`
-	Email      string `json:"email"`
+	Sub           string `json:"sub"`
+	GivenName     string `json:"givenname"`
+	FamilyName    string `json:"familyname"`
+	Email         string `json:"email"`
+	EmailVerified bool   `json:"email_verified"`
 }
 
 func (a *EntraID) GetProfile(
@@ -64,7 +65,7 @@ func (a *EntraID) GetProfile(
 	return oidc.Profile{
 		ProviderUserID: userProfile.Sub,
 		Email:          userProfile.Email,
-		EmailVerified:  userProfile.Email != "",
+		EmailVerified:  userProfile.EmailVerified,
 		Name:           userProfile.GivenName + " " + userProfile.FamilyName,
 		Picture:        "",
 	}, nil

--- a/services/auth/go/providers/entraid.go
+++ b/services/auth/go/providers/entraid.go
@@ -65,7 +65,7 @@ func (a *EntraID) GetProfile(
 	return oidc.Profile{
 		ProviderUserID: userProfile.Sub,
 		Email:          userProfile.Email,
-		EmailVerified:  userProfile.EmailVerified,
+		EmailVerified:  oidc.EmailVerificationFromBool(userProfile.EmailVerified),
 		Name:           userProfile.GivenName + " " + userProfile.FamilyName,
 		Picture:        "",
 	}, nil

--- a/services/auth/go/providers/entraid_internal_test.go
+++ b/services/auth/go/providers/entraid_internal_test.go
@@ -1,72 +1,46 @@
 package providers
 
-import (
-	"encoding/json"
-	"testing"
-)
+import "testing"
 
 func TestEntraIDProfileDecoding(t *testing.T) {
 	t.Parallel()
 
-	tests := []struct {
-		name             string
-		body             string
-		expectedEmail    string
-		expectedVerified bool
-	}{
-		{
-			name: "verified email",
-			body: `{
-				"sub": "00000000-0000-0000-66f3-3332eca7ea81",
-				"givenname": "Jane",
-				"familyname": "Doe",
-				"email": "jane@contoso.com",
-				"email_verified": true
-			}`,
-			expectedEmail:    "jane@contoso.com",
-			expectedVerified: true,
+	runProfileDecodingCases(
+		t,
+		[]profileDecodingCase{
+			{
+				name: "verified email",
+				body: `{
+					"sub": "00000000-0000-0000-66f3-3332eca7ea81",
+					"givenname": "Jane",
+					"familyname": "Doe",
+					"email": "jane@contoso.com",
+					"email_verified": true
+				}`,
+				expectedEmail:    "jane@contoso.com",
+				expectedVerified: true,
+			},
+			{
+				name: "email present but not verified must be rejected",
+				body: `{
+					"sub": "00000000-0000-0000-66f3-3332eca7ea81",
+					"email": "victim@target.io",
+					"email_verified": false
+				}`,
+				expectedEmail:    "victim@target.io",
+				expectedVerified: false,
+			},
+			{
+				name: "missing email_verified defaults to false (safe)",
+				body: `{
+					"sub": "00000000-0000-0000-66f3-3332eca7ea81",
+					"email": "victim@target.io"
+				}`,
+				expectedEmail:    "victim@target.io",
+				expectedVerified: false,
+			},
 		},
-		{
-			name: "email present but not verified must be rejected",
-			body: `{
-				"sub": "00000000-0000-0000-66f3-3332eca7ea81",
-				"email": "victim@target.io",
-				"email_verified": false
-			}`,
-			expectedEmail:    "victim@target.io",
-			expectedVerified: false,
-		},
-		{
-			name: "missing email_verified defaults to false (safe)",
-			body: `{
-				"sub": "00000000-0000-0000-66f3-3332eca7ea81",
-				"email": "victim@target.io"
-			}`,
-			expectedEmail:    "victim@target.io",
-			expectedVerified: false,
-		},
-	}
-
-	for _, tc := range tests {
-		t.Run(tc.name, func(t *testing.T) {
-			t.Parallel()
-
-			var profile entraidUser
-			if err := json.Unmarshal([]byte(tc.body), &profile); err != nil {
-				t.Fatalf("unmarshal failed: %v", err)
-			}
-
-			if profile.Email != tc.expectedEmail {
-				t.Errorf("email: got %q, want %q", profile.Email, tc.expectedEmail)
-			}
-
-			if profile.EmailVerified != tc.expectedVerified {
-				t.Errorf(
-					"email_verified: got %v, want %v",
-					profile.EmailVerified,
-					tc.expectedVerified,
-				)
-			}
-		})
-	}
+		func(p entraidUser) string { return p.Email },
+		func(p entraidUser) bool { return p.EmailVerified },
+	)
 }

--- a/services/auth/go/providers/entraid_internal_test.go
+++ b/services/auth/go/providers/entraid_internal_test.go
@@ -1,0 +1,72 @@
+package providers
+
+import (
+	"encoding/json"
+	"testing"
+)
+
+func TestEntraIDProfileDecoding(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name             string
+		body             string
+		expectedEmail    string
+		expectedVerified bool
+	}{
+		{
+			name: "verified email",
+			body: `{
+				"sub": "00000000-0000-0000-66f3-3332eca7ea81",
+				"givenname": "Jane",
+				"familyname": "Doe",
+				"email": "jane@contoso.com",
+				"email_verified": true
+			}`,
+			expectedEmail:    "jane@contoso.com",
+			expectedVerified: true,
+		},
+		{
+			name: "email present but not verified must be rejected",
+			body: `{
+				"sub": "00000000-0000-0000-66f3-3332eca7ea81",
+				"email": "victim@target.io",
+				"email_verified": false
+			}`,
+			expectedEmail:    "victim@target.io",
+			expectedVerified: false,
+		},
+		{
+			name: "missing email_verified defaults to false (safe)",
+			body: `{
+				"sub": "00000000-0000-0000-66f3-3332eca7ea81",
+				"email": "victim@target.io"
+			}`,
+			expectedEmail:    "victim@target.io",
+			expectedVerified: false,
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+
+			var profile entraidUser
+			if err := json.Unmarshal([]byte(tc.body), &profile); err != nil {
+				t.Fatalf("unmarshal failed: %v", err)
+			}
+
+			if profile.Email != tc.expectedEmail {
+				t.Errorf("email: got %q, want %q", profile.Email, tc.expectedEmail)
+			}
+
+			if profile.EmailVerified != tc.expectedVerified {
+				t.Errorf(
+					"email_verified: got %v, want %v",
+					profile.EmailVerified,
+					tc.expectedVerified,
+				)
+			}
+		})
+	}
+}

--- a/services/auth/go/providers/facebook.go
+++ b/services/auth/go/providers/facebook.go
@@ -60,6 +60,12 @@ func (t *Facebook) GetProfile(
 		return oidc.Profile{}, fmt.Errorf("Facebook API error: %w", err)
 	}
 
+	// Facebook's Graph API does not return an explicit verification flag. Per
+	// Facebook's documented behavior, the `email` field is only populated
+	// when the user has confirmed the address on their Facebook account, so
+	// the presence of an email is treated as proof of verification. This
+	// relies on Facebook's platform behavior; if that ever changes, this
+	// adapter must be updated to use an explicit signal.
 	return oidc.Profile{
 		ProviderUserID: userProfile.ID,
 		Name:           userProfile.Name,

--- a/services/auth/go/providers/facebook.go
+++ b/services/auth/go/providers/facebook.go
@@ -60,17 +60,13 @@ func (t *Facebook) GetProfile(
 		return oidc.Profile{}, fmt.Errorf("Facebook API error: %w", err)
 	}
 
-	// Facebook's Graph API does not return an explicit verification flag. Per
-	// Facebook's documented behavior, the `email` field is only populated
-	// when the user has confirmed the address on their Facebook account, so
-	// the presence of an email is treated as proof of verification. This
-	// relies on Facebook's platform behavior; if that ever changes, this
-	// adapter must be updated to use an explicit signal.
+	// Facebook's Graph API does not return an explicit verification flag, so
+	// we have no signal to trust.
 	return oidc.Profile{
 		ProviderUserID: userProfile.ID,
 		Name:           userProfile.Name,
 		Email:          userProfile.Email,
-		EmailVerified:  userProfile.Email != "",
+		EmailVerified:  oidc.EmailVerificationStatusUnknown,
 		Picture:        userProfile.Picture.Data.URL,
 	}, nil
 }

--- a/services/auth/go/providers/fake.go
+++ b/services/auth/go/providers/fake.go
@@ -56,6 +56,13 @@ func (f *FakeProvider) Exchange(
 			TokenType:    "Bearer",
 			ExpiresIn:    9000, //nolint:mnd
 		}, nil
+	case "valid-code-unverified-email":
+		return &oauth2.Token{ //nolint:exhaustruct
+			AccessToken:  "valid-accesstoken-unverified-email",
+			RefreshToken: "valid-refreshtoken-unverified-email",
+			TokenType:    "Bearer",
+			ExpiresIn:    9000, //nolint:mnd
+		}, nil
 	default:
 		return nil, errors.New("invalid code") //nolint:err113
 	}
@@ -72,7 +79,7 @@ func (f *FakeProvider) GetProfile(
 		return oidc.Profile{
 			ProviderUserID: "1234567890",
 			Email:          "user1@fake.com",
-			EmailVerified:  true,
+			EmailVerified:  oidc.EmailVerificationStatusVerified,
 			Name:           "User One",
 			Picture:        "https://fake.com/images/profile/user1.jpg",
 		}, nil
@@ -80,9 +87,17 @@ func (f *FakeProvider) GetProfile(
 		return oidc.Profile{
 			ProviderUserID: "9876543210",
 			Email:          "",
-			EmailVerified:  false,
+			EmailVerified:  oidc.EmailVerificationStatusUnverified,
 			Name:           "User No Email",
 			Picture:        "https://fake.com/images/profile/user2.jpg",
+		}, nil
+	case "valid-accesstoken-unverified-email":
+		return oidc.Profile{
+			ProviderUserID: "1234567890",
+			Email:          "user1@fake.com",
+			EmailVerified:  oidc.EmailVerificationStatusUnverified,
+			Name:           "User One",
+			Picture:        "https://fake.com/images/profile/user1.jpg",
 		}, nil
 	default:
 		return oidc.Profile{}, errors.New("invalid access token") //nolint:err113

--- a/services/auth/go/providers/github.go
+++ b/services/auth/go/providers/github.go
@@ -118,7 +118,7 @@ func (g *Github) GetProfile(
 	return oidc.Profile{
 		ProviderUserID: strconv.Itoa(user.ID),
 		Email:          selected.Email,
-		EmailVerified:  selected.Verified,
+		EmailVerified:  oidc.EmailVerificationFromBool(selected.Verified),
 		Name:           user.Name,
 		Picture:        user.AvatarURL,
 	}, nil

--- a/services/auth/go/providers/gitlab.go
+++ b/services/auth/go/providers/gitlab.go
@@ -35,11 +35,12 @@ func NewGitlabProvider(
 }
 
 type gitlabUserProfile struct {
-	ID        int    `json:"id"`
-	Username  string `json:"username"`
-	Name      string `json:"name"`
-	Email     string `json:"email"`
-	AvatarURL string `json:"avatar_url"`
+	ID          int    `json:"id"`
+	Username    string `json:"username"`
+	Name        string `json:"name"`
+	Email       string `json:"email"`
+	ConfirmedAt string `json:"confirmed_at"`
+	AvatarURL   string `json:"avatar_url"`
 }
 
 func (g *Gitlab) GetProfile(
@@ -58,11 +59,15 @@ func (g *Gitlab) GetProfile(
 		return oidc.Profile{}, fmt.Errorf("GitLab API error: %w", err)
 	}
 
+	// GitLab's /user endpoint returns the account's primary email and a
+	// `confirmed_at` timestamp that is non-empty only after the user has
+	// verified the address. Require both to mark the email as verified so a
+	// pending-confirmation account cannot be linked to an existing Nhost user.
 	return oidc.Profile{
 		ProviderUserID: strconv.Itoa(userProfile.ID),
 		Name:           userProfile.Name,
 		Email:          userProfile.Email,
-		EmailVerified:  userProfile.Email != "",
+		EmailVerified:  userProfile.Email != "" && userProfile.ConfirmedAt != "",
 		Picture:        userProfile.AvatarURL,
 	}, nil
 }

--- a/services/auth/go/providers/gitlab.go
+++ b/services/auth/go/providers/gitlab.go
@@ -67,8 +67,10 @@ func (g *Gitlab) GetProfile(
 		ProviderUserID: strconv.Itoa(userProfile.ID),
 		Name:           userProfile.Name,
 		Email:          userProfile.Email,
-		EmailVerified:  userProfile.Email != "" && userProfile.ConfirmedAt != "",
-		Picture:        userProfile.AvatarURL,
+		EmailVerified: oidc.EmailVerificationFromBool(
+			userProfile.Email != "" && userProfile.ConfirmedAt != "",
+		),
+		Picture: userProfile.AvatarURL,
 	}, nil
 }
 

--- a/services/auth/go/providers/gitlab_internal_test.go
+++ b/services/auth/go/providers/gitlab_internal_test.go
@@ -1,0 +1,71 @@
+package providers
+
+import (
+	"encoding/json"
+	"testing"
+)
+
+func TestGitlabProfileDecoding(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name         string
+		body         string
+		wantEmail    string
+		wantVerified bool
+	}{
+		{
+			name: "confirmed email",
+			body: `{
+				"id": 42,
+				"name": "Jane",
+				"email": "jane@gitlab.com",
+				"confirmed_at": "2024-01-15T10:00:00Z"
+			}`,
+			wantEmail:    "jane@gitlab.com",
+			wantVerified: true,
+		},
+		{
+			name: "unconfirmed email must not be marked verified",
+			body: `{
+				"id": 42,
+				"name": "Jane",
+				"email": "victim@target.io",
+				"confirmed_at": null
+			}`,
+			wantEmail:    "victim@target.io",
+			wantVerified: false,
+		},
+		{
+			name: "missing confirmed_at is treated as unverified",
+			body: `{
+				"id": 42,
+				"name": "Jane",
+				"email": "victim@target.io"
+			}`,
+			wantEmail:    "victim@target.io",
+			wantVerified: false,
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+
+			var profile gitlabUserProfile
+			if err := json.Unmarshal([]byte(tc.body), &profile); err != nil {
+				t.Fatalf("unmarshal failed: %v", err)
+			}
+
+			verified := profile.Email != "" && profile.ConfirmedAt != ""
+
+			if profile.Email != tc.wantEmail {
+				t.Errorf("email: got %q, want %q", profile.Email, tc.wantEmail)
+			}
+
+			if verified != tc.wantVerified {
+				t.Errorf("verified: got %v, want %v", verified, tc.wantVerified)
+			}
+		})
+	}
+}

--- a/services/auth/go/providers/google.go
+++ b/services/auth/go/providers/google.go
@@ -58,7 +58,7 @@ func (g *Google) GetProfile(
 	return oidc.Profile{
 		ProviderUserID: user.ID,
 		Email:          user.Email,
-		EmailVerified:  user.VerifiedEmail,
+		EmailVerified:  oidc.EmailVerificationFromBool(user.VerifiedEmail),
 		Name:           user.Name,
 		Picture:        user.Picture,
 	}, nil

--- a/services/auth/go/providers/linkedin.go
+++ b/services/auth/go/providers/linkedin.go
@@ -76,7 +76,7 @@ func (l *LinkedIn) GetProfile(
 	return oidc.Profile{
 		ProviderUserID: userProfile.ID,
 		Email:          userProfile.Email,
-		EmailVerified:  userProfile.EmailVerified,
+		EmailVerified:  oidc.EmailVerificationFromBool(userProfile.EmailVerified),
 		Name:           name,
 		Picture:        userProfile.Picture,
 	}, nil

--- a/services/auth/go/providers/linkedin.go
+++ b/services/auth/go/providers/linkedin.go
@@ -34,11 +34,12 @@ func NewLinkedInProvider(
 }
 
 type linkedInUserInfoProfile struct {
-	ID         string `json:"sub"`
-	Email      string `json:"email"`
-	GivenName  string `json:"given_name"`
-	FamilyName string `json:"family_name"`
-	Picture    string `json:"picture"`
+	ID            string `json:"sub"`
+	Email         string `json:"email"`
+	EmailVerified bool   `json:"email_verified"`
+	GivenName     string `json:"given_name"`
+	FamilyName    string `json:"family_name"`
+	Picture       string `json:"picture"`
 }
 
 func (l *LinkedIn) GetProfile(
@@ -75,7 +76,7 @@ func (l *LinkedIn) GetProfile(
 	return oidc.Profile{
 		ProviderUserID: userProfile.ID,
 		Email:          userProfile.Email,
-		EmailVerified:  userProfile.Email != "",
+		EmailVerified:  userProfile.EmailVerified,
 		Name:           name,
 		Picture:        userProfile.Picture,
 	}, nil

--- a/services/auth/go/providers/linkedin_internal_test.go
+++ b/services/auth/go/providers/linkedin_internal_test.go
@@ -1,0 +1,72 @@
+package providers
+
+import (
+	"encoding/json"
+	"testing"
+)
+
+func TestLinkedInProfileDecoding(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name             string
+		body             string
+		expectedEmail    string
+		expectedVerified bool
+	}{
+		{
+			name: "verified email",
+			body: `{
+				"sub": "123",
+				"email": "jane@example.com",
+				"email_verified": true,
+				"given_name": "Jane",
+				"family_name": "Doe"
+			}`,
+			expectedEmail:    "jane@example.com",
+			expectedVerified: true,
+		},
+		{
+			name: "unverified email must not be marked verified",
+			body: `{
+				"sub": "123",
+				"email": "victim@target.io",
+				"email_verified": false
+			}`,
+			expectedEmail:    "victim@target.io",
+			expectedVerified: false,
+		},
+		{
+			name: "missing email_verified defaults to false (safe)",
+			body: `{
+				"sub": "123",
+				"email": "victim@target.io"
+			}`,
+			expectedEmail:    "victim@target.io",
+			expectedVerified: false,
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+
+			var profile linkedInUserInfoProfile
+			if err := json.Unmarshal([]byte(tc.body), &profile); err != nil {
+				t.Fatalf("unmarshal failed: %v", err)
+			}
+
+			if profile.Email != tc.expectedEmail {
+				t.Errorf("email: got %q, want %q", profile.Email, tc.expectedEmail)
+			}
+
+			if profile.EmailVerified != tc.expectedVerified {
+				t.Errorf(
+					"email_verified: got %v, want %v",
+					profile.EmailVerified,
+					tc.expectedVerified,
+				)
+			}
+		})
+	}
+}

--- a/services/auth/go/providers/linkedin_internal_test.go
+++ b/services/auth/go/providers/linkedin_internal_test.go
@@ -1,72 +1,46 @@
 package providers
 
-import (
-	"encoding/json"
-	"testing"
-)
+import "testing"
 
 func TestLinkedInProfileDecoding(t *testing.T) {
 	t.Parallel()
 
-	tests := []struct {
-		name             string
-		body             string
-		expectedEmail    string
-		expectedVerified bool
-	}{
-		{
-			name: "verified email",
-			body: `{
-				"sub": "123",
-				"email": "jane@example.com",
-				"email_verified": true,
-				"given_name": "Jane",
-				"family_name": "Doe"
-			}`,
-			expectedEmail:    "jane@example.com",
-			expectedVerified: true,
+	runProfileDecodingCases(
+		t,
+		[]profileDecodingCase{
+			{
+				name: "verified email",
+				body: `{
+					"sub": "123",
+					"email": "jane@example.com",
+					"email_verified": true,
+					"given_name": "Jane",
+					"family_name": "Doe"
+				}`,
+				expectedEmail:    "jane@example.com",
+				expectedVerified: true,
+			},
+			{
+				name: "unverified email must not be marked verified",
+				body: `{
+					"sub": "123",
+					"email": "victim@target.io",
+					"email_verified": false
+				}`,
+				expectedEmail:    "victim@target.io",
+				expectedVerified: false,
+			},
+			{
+				name: "missing email_verified defaults to false (safe)",
+				body: `{
+					"sub": "123",
+					"email": "victim@target.io"
+				}`,
+				expectedEmail:    "victim@target.io",
+				expectedVerified: false,
+			},
 		},
-		{
-			name: "unverified email must not be marked verified",
-			body: `{
-				"sub": "123",
-				"email": "victim@target.io",
-				"email_verified": false
-			}`,
-			expectedEmail:    "victim@target.io",
-			expectedVerified: false,
-		},
-		{
-			name: "missing email_verified defaults to false (safe)",
-			body: `{
-				"sub": "123",
-				"email": "victim@target.io"
-			}`,
-			expectedEmail:    "victim@target.io",
-			expectedVerified: false,
-		},
-	}
-
-	for _, tc := range tests {
-		t.Run(tc.name, func(t *testing.T) {
-			t.Parallel()
-
-			var profile linkedInUserInfoProfile
-			if err := json.Unmarshal([]byte(tc.body), &profile); err != nil {
-				t.Fatalf("unmarshal failed: %v", err)
-			}
-
-			if profile.Email != tc.expectedEmail {
-				t.Errorf("email: got %q, want %q", profile.Email, tc.expectedEmail)
-			}
-
-			if profile.EmailVerified != tc.expectedVerified {
-				t.Errorf(
-					"email_verified: got %v, want %v",
-					profile.EmailVerified,
-					tc.expectedVerified,
-				)
-			}
-		})
-	}
+		func(p linkedInUserInfoProfile) string { return p.Email },
+		func(p linkedInUserInfoProfile) bool { return p.EmailVerified },
+	)
 }

--- a/services/auth/go/providers/profile_decoding_internal_test.go
+++ b/services/auth/go/providers/profile_decoding_internal_test.go
@@ -1,0 +1,48 @@
+package providers
+
+import (
+	"encoding/json"
+	"testing"
+)
+
+// profileDecodingCase describes a JSON → provider-struct decoding assertion
+// used by the per-provider verified-email decoding tests. Shared to avoid
+// line-for-line duplication across adapters.
+type profileDecodingCase struct {
+	name             string
+	body             string
+	expectedEmail    string
+	expectedVerified bool
+}
+
+// runProfileDecodingCases unmarshals each case's body into a freshly-constructed
+// T and asserts the expected email/verified extracted via the supplied
+// accessors. Designed for provider adapters where the raw JSON struct carries
+// both an email field and an explicit verification flag.
+func runProfileDecodingCases[T any](
+	t *testing.T,
+	tests []profileDecodingCase,
+	emailOf func(T) string,
+	verifiedOf func(T) bool,
+) {
+	t.Helper()
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+
+			var profile T
+			if err := json.Unmarshal([]byte(tc.body), &profile); err != nil {
+				t.Fatalf("unmarshal failed: %v", err)
+			}
+
+			if got := emailOf(profile); got != tc.expectedEmail {
+				t.Errorf("email: got %q, want %q", got, tc.expectedEmail)
+			}
+
+			if got := verifiedOf(profile); got != tc.expectedVerified {
+				t.Errorf("verified: got %v, want %v", got, tc.expectedVerified)
+			}
+		})
+	}
+}

--- a/services/auth/go/providers/spotify.go
+++ b/services/auth/go/providers/spotify.go
@@ -76,6 +76,11 @@ func (s *Spotify) GetProfile(
 		avatarURL = userProfile.Images[0].URL
 	}
 
+	// Spotify's /v1/me endpoint does not return an explicit verification flag.
+	// Spotify enforces email verification before account activation, so the
+	// presence of an email is treated as proof of verification. This relies
+	// on Spotify's platform behavior; if that ever changes, this adapter must
+	// be updated to use an explicit signal.
 	return oidc.Profile{
 		ProviderUserID: userProfile.ID,
 		Name:           userProfile.DisplayName,

--- a/services/auth/go/providers/spotify.go
+++ b/services/auth/go/providers/spotify.go
@@ -76,16 +76,13 @@ func (s *Spotify) GetProfile(
 		avatarURL = userProfile.Images[0].URL
 	}
 
-	// Spotify's /v1/me endpoint does not return an explicit verification flag.
-	// Spotify enforces email verification before account activation, so the
-	// presence of an email is treated as proof of verification. This relies
-	// on Spotify's platform behavior; if that ever changes, this adapter must
-	// be updated to use an explicit signal.
+	// Spotify's /v1/me endpoint does not return an explicit verification
+	// flag, so there is no signal to report.
 	return oidc.Profile{
 		ProviderUserID: userProfile.ID,
 		Name:           userProfile.DisplayName,
 		Email:          userProfile.Email,
-		EmailVerified:  userProfile.Email != "",
+		EmailVerified:  oidc.EmailVerificationStatusUnknown,
 		Picture:        avatarURL,
 	}, nil
 }

--- a/services/auth/go/providers/strava.go
+++ b/services/auth/go/providers/strava.go
@@ -67,12 +67,12 @@ func (s *Strava) GetProfile(
 		return oidc.Profile{}, fmt.Errorf("Strava API error: %w", err)
 	}
 
-	// Email intentionally left out, and not marked verified
+	// Strava does not expose email at all, so there is nothing to verify.
 	return oidc.Profile{
 		ProviderUserID: strconv.Itoa(athlete.ID),
 		Name:           athlete.Firstname + " " + athlete.Lastname,
 		Picture:        athlete.ProfileMedium,
 		Email:          "",
-		EmailVerified:  false,
+		EmailVerified:  oidc.EmailVerificationStatusUnknown,
 	}, nil
 }

--- a/services/auth/go/providers/twitch.go
+++ b/services/auth/go/providers/twitch.go
@@ -74,17 +74,13 @@ func (t *Twitch) GetProfile(
 
 	userProfile := response.Data[0]
 
-	// Twitch's /helix/users endpoint does not return an explicit verification
-	// flag. Twitch requires email verification at account creation and the API
-	// does not surface the address until it has been confirmed, so the
-	// presence of an email is treated as proof of verification. This relies on
-	// Twitch's platform behavior; if that ever changes, this adapter must be
-	// updated to use an explicit signal.
+	// Twitch's /helix/users endpoint does not return an explicit
+	// verification flag, so there is no signal to report.
 	return oidc.Profile{
 		ProviderUserID: userProfile.ID,
 		Name:           userProfile.DisplayName,
 		Email:          userProfile.Email,
-		EmailVerified:  userProfile.Email != "",
+		EmailVerified:  oidc.EmailVerificationStatusUnknown,
 		Picture:        userProfile.ProfileImageURL,
 	}, nil
 }

--- a/services/auth/go/providers/twitch.go
+++ b/services/auth/go/providers/twitch.go
@@ -74,6 +74,12 @@ func (t *Twitch) GetProfile(
 
 	userProfile := response.Data[0]
 
+	// Twitch's /helix/users endpoint does not return an explicit verification
+	// flag. Twitch requires email verification at account creation and the API
+	// does not surface the address until it has been confirmed, so the
+	// presence of an email is treated as proof of verification. This relies on
+	// Twitch's platform behavior; if that ever changes, this adapter must be
+	// updated to use an explicit signal.
 	return oidc.Profile{
 		ProviderUserID: userProfile.ID,
 		Name:           userProfile.DisplayName,

--- a/services/auth/go/providers/twitter.go
+++ b/services/auth/go/providers/twitter.go
@@ -60,6 +60,12 @@ func (t *Twitter) GetProfile(
 		return oidc.Profile{}, fmt.Errorf("Twitter API error: %w", err)
 	}
 
+	// Twitter's verify_credentials endpoint does not return an explicit
+	// verification flag. Twitter requires a working email address on the
+	// account and only surfaces it via `include_email=true` when verified, so
+	// the presence of an email is treated as proof of verification. This
+	// relies on Twitter's platform behavior; if that ever changes, this
+	// adapter must be updated to use an explicit signal.
 	return oidc.Profile{
 		ProviderUserID: user.ID,
 		Email:          user.Email,

--- a/services/auth/go/providers/twitter.go
+++ b/services/auth/go/providers/twitter.go
@@ -61,15 +61,11 @@ func (t *Twitter) GetProfile(
 	}
 
 	// Twitter's verify_credentials endpoint does not return an explicit
-	// verification flag. Twitter requires a working email address on the
-	// account and only surfaces it via `include_email=true` when verified, so
-	// the presence of an email is treated as proof of verification. This
-	// relies on Twitter's platform behavior; if that ever changes, this
-	// adapter must be updated to use an explicit signal.
+	// verification flag, so there is no signal to report.
 	return oidc.Profile{
 		ProviderUserID: user.ID,
 		Email:          user.Email,
-		EmailVerified:  user.Email != "",
+		EmailVerified:  oidc.EmailVerificationStatusUnknown,
 		Name:           user.Name,
 		Picture:        user.ProfileImageURL,
 	}, nil

--- a/services/auth/go/providers/windowslive.go
+++ b/services/auth/go/providers/windowslive.go
@@ -73,6 +73,11 @@ func (w *WindowsLive) GetProfile(
 		email = profile.Emails.Account
 	}
 
+	// Microsoft's Live v5.0/me endpoint does not return an explicit
+	// verification flag. Microsoft only surfaces confirmed addresses in the
+	// `emails` block, so the presence of an email is treated as proof of
+	// verification. This relies on Microsoft's platform behavior; if that
+	// ever changes, this adapter must be updated to use an explicit signal.
 	return oidc.Profile{
 		ProviderUserID: profile.ID,
 		Name:           profile.Name + " " + profile.LastName,

--- a/services/auth/go/providers/windowslive.go
+++ b/services/auth/go/providers/windowslive.go
@@ -74,15 +74,12 @@ func (w *WindowsLive) GetProfile(
 	}
 
 	// Microsoft's Live v5.0/me endpoint does not return an explicit
-	// verification flag. Microsoft only surfaces confirmed addresses in the
-	// `emails` block, so the presence of an email is treated as proof of
-	// verification. This relies on Microsoft's platform behavior; if that
-	// ever changes, this adapter must be updated to use an explicit signal.
+	// verification flag, so there is no signal to report.
 	return oidc.Profile{
 		ProviderUserID: profile.ID,
 		Name:           profile.Name + " " + profile.LastName,
 		Email:          email,
-		EmailVerified:  email != "",
+		EmailVerified:  oidc.EmailVerificationStatusUnknown,
 		Picture:        profile.ProfileImageURL,
 	}, nil
 }

--- a/services/auth/go/providers/workos.go
+++ b/services/auth/go/providers/workos.go
@@ -115,6 +115,13 @@ func (w *WorkOS) GetProfile(
 		return oidc.Profile{}, fmt.Errorf("WorkOS API Error: %w", err)
 	}
 
+	// WorkOS's /sso/profile endpoint does not surface an explicit
+	// verification flag. The profile is produced by the enterprise identity
+	// provider configured by the customer (SAML, OIDC, Google Workspace,
+	// etc.) which is expected to have already verified the email before
+	// asserting it, so the presence of an email is treated as proof of
+	// verification. This relies on the upstream IdP's behavior; a
+	// misconfigured or malicious IdP could assert arbitrary emails.
 	return oidc.Profile{
 		ProviderUserID: userProfile.ID,
 		Email:          userProfile.Email,

--- a/services/auth/go/providers/workos.go
+++ b/services/auth/go/providers/workos.go
@@ -118,15 +118,13 @@ func (w *WorkOS) GetProfile(
 	// WorkOS's /sso/profile endpoint does not surface an explicit
 	// verification flag. The profile is produced by the enterprise identity
 	// provider configured by the customer (SAML, OIDC, Google Workspace,
-	// etc.) which is expected to have already verified the email before
-	// asserting it, so the presence of an email is treated as proof of
-	// verification. This relies on the upstream IdP's behavior; a
-	// misconfigured or malicious IdP could assert arbitrary emails.
+	// etc.) and carries no verification signal to this layer, so the status
+	// is Unknown.
 	return oidc.Profile{
 		ProviderUserID: userProfile.ID,
 		Email:          userProfile.Email,
 		Name:           userProfile.FirstName + " " + userProfile.LastName,
 		Picture:        "",
-		EmailVerified:  userProfile.Email != "",
+		EmailVerified:  oidc.EmailVerificationStatusUnknown,
 	}, nil
 }


### PR DESCRIPTION
<!-- nhost-reviewer:start -->
### **PR Type**
Bug fix

___

### **Description**
- Introduces a three-state `EmailVerificationStatus` (`Unknown`, `Verified`, `Unverified`) replacing the previous boolean on `oidc.Profile`, so adapters can distinguish an explicit provider attestation from the absence of any signal.
- Adds an `ensureProviderLinkAllowed` guard in the OAuth sign-in and PKCE resolve paths: linking a new provider identity to an existing Nhost account is refused (returns `ErrUnverifiedUser`) unless the provider explicitly attests the email is verified.
- Tightens every OAuth adapter so "verified" is only reported when the provider returns an explicit signal (`email_verified`, `is_confirmed`, `confirmed_at`, etc.), never inferred from the presence of an email.
- Removes the Azure AD fallback that used `upn` / `preferred_username` as the email; those are internal directory identifiers and can be attacker-set. Bitbucket no longer falls back to unconfirmed emails.
- Providers without a verification signal (Azure AD v1, Facebook, Spotify, Twitch, Twitter, Windows Live, WorkOS) now report `Unknown`; Discord, Entra ID, GitLab, and LinkedIn now parse their respective verification claims.
- Adds per-adapter JSON-decoding tests and controller tests covering both callback and PKCE flows when the provider reports an unverified email for an existing account.

___

### Diagram Walkthrough

```mermaid
flowchart LR
  A["OAuth provider"] --> B["Adapter.GetProfile"]
  B --> C["oidc.Profile<br/>EmailVerificationStatus"]
  C --> D["providerSignInFlow /<br/>providerResolveUser"]
  D -->|"!providerFound<br/>+ userFound by email"| E["ensureProviderLinkAllowed"]
  E -->|"IsVerified()"| F["InsertUserProvider<br/>+ session"]
  E -->|"Unknown / Unverified"| G["ErrUnverifiedUser"]
  D -->|"!userFound"| H["providerFlowSignUp /<br/>providerSignUpResolveOnly"]
  H --> I["sendConfirmationEmail<br/>= email!='' && !IsVerified()"]
```

<details> <summary><h3> File Walkthrough</h3></summary>

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody>
<tr><td><strong>Core logic</strong></td><td><details><summary>3 files</summary><table>
<tr>
  <td><strong>idtoken.go</strong><dd><code>Adds EmailVerificationStatus tri-state and helpers</code></dd></td>
  <td><a href="https://github.com/nhost/nhost/pull/4162/files#diff-7a4bb5b9a0423719e51dda3780b64b0d351319bfa44a1200926e17f181dee901">+37/-1</a></td>
</tr>
<tr>
  <td><strong>sign_in_id_token.go</strong><dd><code>Adds ensureProviderLinkAllowed and threads Profile through sign-in/PKCE paths</code></dd></td>
  <td><a href="https://github.com/nhost/nhost/pull/4162/files#diff-a0bf5a8039d24b0c4de6acb1f84f3cd74fb7f98cb74288c86ea9ddd00f4d602d">+59/-24</a></td>
</tr>
<tr>
  <td><strong>google.go</strong><dd><code>OIDC id_token: treat missing email_verified claim as Unknown</code></dd></td>
  <td><a href="https://github.com/nhost/nhost/pull/4162/files#diff-dd4ef2ce6a483b295e84b2c0965f1cce1a7727b00e2cc234b2a5c3d8aa7c79a5">+7/-1</a></td>
</tr>
</table></details></td></tr>
<tr><td><strong>Provider adapters</strong></td><td><details><summary>14 files</summary><table>
<tr>
  <td><strong>apple.go</strong><dd><code>Map bool email_verified claim to EmailVerificationStatus</code></dd></td>
  <td><a href="https://github.com/nhost/nhost/pull/4162/files#diff-f6bc8b9ad23a8398af40f7046eb86df691bc7658d28d814563d4034f5618ebe4">+1/-1</a></td>
</tr>
<tr>
  <td><strong>azuread.go</strong><dd><code>Drop UPN/preferred_username fallback; mark email status Unknown</code></dd></td>
  <td><a href="https://github.com/nhost/nhost/pull/4162/files#diff-c1b4a7b913a14e19693255d2c06282886edb9527acb29efe5b7e6ea7694c2f64">+15/-16</a></td>
</tr>
<tr>
  <td><strong>bitbucket.go</strong><dd><code>Reject unconfirmed emails entirely; no fallback</code></dd></td>
  <td><a href="https://github.com/nhost/nhost/pull/4162/files#diff-711097689b6e6abd44dbfc05d4c089db6d75a99b1c9e57ca11b51449daa9788f">+10/-14</a></td>
</tr>
<tr>
  <td><strong>discord.go</strong><dd><code>Read Discord's verified flag instead of inferring from email presence</code></dd></td>
  <td><a href="https://github.com/nhost/nhost/pull/4162/files#diff-51862babf05cddc3a108c24d5986475a9e778dd8e64d9d06bccd4f3128b9b97c">+2/-1</a></td>
</tr>
<tr>
  <td><strong>entraid.go</strong><dd><code>Parse email_verified from Microsoft Graph userinfo</code></dd></td>
  <td><a href="https://github.com/nhost/nhost/pull/4162/files#diff-42d81054409f6895d808a2fb592edae9442ad299f385d5cf309148e6dd3c139f">+6/-5</a></td>
</tr>
<tr>
  <td><strong>facebook.go</strong><dd><code>Report Unknown — Graph API has no verification flag</code></dd></td>
  <td><a href="https://github.com/nhost/nhost/pull/4162/files#diff-f8e4b9fe90b90039b200f6762f97edd8358840f9baecec1813f16135ca019ffa">+3/-1</a></td>
</tr>
<tr>
  <td><strong>github.go</strong><dd><code>Map selected.Verified to EmailVerificationStatus</code></dd></td>
  <td><a href="https://github.com/nhost/nhost/pull/4162/files#diff-5f724740af1a1095b598582f9abc277f0531ec3c644b46c490fb04eddac6b1f7">+1/-1</a></td>
</tr>
<tr>
  <td><strong>gitlab.go</strong><dd><code>Require non-empty confirmed_at timestamp to mark verified</code></dd></td>
  <td><a href="https://github.com/nhost/nhost/pull/4162/files#diff-da76637164a0ca6d2eaa7469b32cdca9011cf1a193f8295204aa18ae219b615b">+14/-7</a></td>
</tr>
<tr>
  <td><strong>google.go (providers)</strong><dd><code>Map VerifiedEmail bool to EmailVerificationStatus</code></dd></td>
  <td><a href="https://github.com/nhost/nhost/pull/4162/files#diff-9edc3fead01c211fedf92a470450d798658168f95b4697017dc554be939b741e">+1/-1</a></td>
</tr>
<tr>
  <td><strong>linkedin.go</strong><dd><code>Parse OpenID Connect email_verified claim</code></dd></td>
  <td><a href="https://github.com/nhost/nhost/pull/4162/files#diff-e8da2c59c5442974546125cba6f0d61b447d26e1cf6b9b3ed92838ce3565127b">+7/-6</a></td>
</tr>
<tr>
  <td><strong>spotify.go</strong><dd><code>Report Unknown — Spotify has no verification flag</code></dd></td>
  <td><a href="https://github.com/nhost/nhost/pull/4162/files#diff-c72c3d18453158db37cb9697c98cea325659b5d08382d583be0a08a0ded94eca">+3/-1</a></td>
</tr>
<tr>
  <td><strong>strava.go</strong><dd><code>Report Unknown — Strava exposes no email at all</code></dd></td>
  <td><a href="https://github.com/nhost/nhost/pull/4162/files#diff-12dc4155ade788b708f080dd4ac5aa4f95045682a1b1b0999b701605173f6c31">+2/-2</a></td>
</tr>
<tr>
  <td><strong>twitch.go</strong><dd><code>Report Unknown — Twitch has no verification flag</code></dd></td>
  <td><a href="https://github.com/nhost/nhost/pull/4162/files#diff-ef0ecfccb5b430810c73fedfa5f5e57ed3167b60aa56e281bb666bd8e2f82b8a">+3/-1</a></td>
</tr>
<tr>
  <td><strong>twitter.go</strong><dd><code>Report Unknown — verify_credentials has no verification flag</code></dd></td>
  <td><a href="https://github.com/nhost/nhost/pull/4162/files#diff-d908aad2bd5eb43735f1d3be62b3733bc9e4e1dd89878e2c02b0a9de4b71fbdf">+3/-1</a></td>
</tr>
<tr>
  <td><strong>windowslive.go</strong><dd><code>Report Unknown — Live v5.0 has no verification flag</code></dd></td>
  <td><a href="https://github.com/nhost/nhost/pull/4162/files#diff-0c6cced2d3fb05bd3764718f149f31e693dfe06d95786808b75f72f8cc583577">+3/-1</a></td>
</tr>
<tr>
  <td><strong>workos.go</strong><dd><code>Report Unknown — enterprise IdP signal does not reach this layer</code></dd></td>
  <td><a href="https://github.com/nhost/nhost/pull/4162/files#diff-34c1cbf0d27af0e0d7017d42e8e45cbc12ecc4743831251e7cc54d1ff6d255b4">+6/-1</a></td>
</tr>
</table></details></td></tr>
<tr><td><strong>Tests</strong></td><td><details><summary>12 files</summary><table>
<tr>
  <td><strong>link_id_token_test.go</strong><dd><code>Extract testTokenWithEmailVerified helper</code></dd></td>
  <td><a href="https://github.com/nhost/nhost/pull/4162/files#diff-74eb21938288439bd21120c363c8c411797716d71290a59dc4b82a64aaf9e20a">+7/-1</a></td>
</tr>
<tr>
  <td><strong>sign_in_id_token_test.go</strong><dd><code>Add case for unverified-email linking refusal</code></dd></td>
  <td><a href="https://github.com/nhost/nhost/pull/4162/files#diff-e952c31fccb660d344143a78c4163c2b425753dc667a800d21251b63c9cd4f8c">+53/-0</a></td>
</tr>
<tr>
  <td><strong>sign_in_provider_callback_get_test.go</strong><dd><code>Add callback + PKCE cases for unverified-email linking refusal</code></dd></td>
  <td><a href="https://github.com/nhost/nhost/pull/4162/files#diff-b17006540ebd75d24d292ec72f27612363c1d629e4e844e06c0a70b116bee81a">+103/-0</a></td>
</tr>
<tr>
  <td><strong>azuread_internal_test.go</strong><dd><code>Verify azureUser no longer decodes upn / preferred_username</code></dd></td>
  <td><a href="https://github.com/nhost/nhost/pull/4162/files#diff-a5636d9cb8824ac8a6ba224937ca7624b759ddd75bcacc5550a025661a20bbe5">+51/-0</a></td>
</tr>
<tr>
  <td><strong>bitbucket_internal_test.go</strong><dd><code>Exercise confirmed/unconfirmed email selection against httptest server</code></dd></td>
  <td><a href="https://github.com/nhost/nhost/pull/4162/files#diff-753e38aa1754e14abe147efc15ea6928d0db08b54ee6ec94bc1235c3c777818c">+161/-0</a></td>
</tr>
<tr>
  <td><strong>discord_internal_test.go</strong><dd><code>Decode verified flag (true/false/missing)</code></dd></td>
  <td><a href="https://github.com/nhost/nhost/pull/4162/files#diff-f1b09c2af563d96e56354ab61f268aa6c0d3930cc776dbc6cdbc5b0d53a2ef1c">+50/-0</a></td>
</tr>
<tr>
  <td><strong>entraid_internal_test.go</strong><dd><code>Decode email_verified claim (true/false/missing)</code></dd></td>
  <td><a href="https://github.com/nhost/nhost/pull/4162/files#diff-f609ed778eea1eadd92cadf01ce7a8dd06d1db64e95c8931611f4b38ab2ada2b">+46/-0</a></td>
</tr>
<tr>
  <td><strong>gitlab_internal_test.go</strong><dd><code>Verify confirmed_at gating for email verification</code></dd></td>
  <td><a href="https://github.com/nhost/nhost/pull/4162/files#diff-59beed25d8f661cf72fb79f4868adff270c25a63f31412fd53a6c2306c19c5fd">+71/-0</a></td>
</tr>
<tr>
  <td><strong>linkedin_internal_test.go</strong><dd><code>Decode email_verified claim (true/false/missing)</code></dd></td>
  <td><a href="https://github.com/nhost/nhost/pull/4162/files#diff-2d42a58f37b71b98727b569804bf44f1e99a4220f96729df72f74954a5c32849">+46/-0</a></td>
</tr>
<tr>
  <td><strong>profile_decoding_internal_test.go</strong><dd><code>Shared generic helper for per-adapter decoding cases</code></dd></td>
  <td><a href="https://github.com/nhost/nhost/pull/4162/files#diff-3552f19ebd518c6ba3c09249f776496d42d5573fb1693fa20b8d21bd6252aa94">+48/-0</a></td>
</tr>
<tr>
  <td><strong>fake.go</strong><dd><code>Add valid-code-unverified-email fixture and update profiles to new status type</code></dd></td>
  <td><a href="https://github.com/nhost/nhost/pull/4162/files#diff-630f4132a8c4d2c6d1ce771b4bbd59f2b9c433975889909315601955a4394c88">+17/-2</a></td>
</tr>
</table></details></td></tr>
</tbody></table>

</details>

___

<!-- nhost-reviewer:end -->