### PR TITLE
feat(dashboard): Add JSON editor to custom check

### DIFF
--- a/dashboard/src/components/ui/v3/fancy-multi-select.tsx
+++ b/dashboard/src/components/ui/v3/fancy-multi-select.tsx
@@ -47,28 +47,34 @@ export function FancyMultiSelect({
     setSelected(value);
   }, [value]);
 
-  const handleUnselect = useCallback((option: Option) => {
-    setSelected((prev) => prev.filter((s) => s.value !== option.value));
-  }, []);
+  const handleUnselect = useCallback(
+    (option: Option) => {
+      const next = selected.filter((s) => s.value !== option.value);
+      setSelected(next);
+      onChange?.(next);
+    },
+    [selected, onChange],
+  );
 
-  const handleKeyDown = useCallback((e: KeyboardEvent<HTMLDivElement>) => {
-    const input = inputRef.current;
-    if (input) {
-      if (e.key === 'Delete' || e.key === 'Backspace') {
-        if (input.value === '') {
-          setSelected((prev) => {
-            const newSelected = [...prev];
-            newSelected.pop();
-            return newSelected;
-          });
+  const handleKeyDown = useCallback(
+    (e: KeyboardEvent<HTMLDivElement>) => {
+      const input = inputRef.current;
+      if (input) {
+        if (e.key === 'Delete' || e.key === 'Backspace') {
+          if (input.value === '') {
+            const next = selected.slice(0, -1);
+            setSelected(next);
+            onChange?.(next);
+          }
+        }
+        // This is not a default behaviour of the <input /> field
+        if (e.key === 'Escape') {
+          input.blur();
         }
       }
-      // This is not a default behaviour of the <input /> field
-      if (e.key === 'Escape') {
-        input.blur();
-      }
-    }
-  }, []);
+    },
+    [selected, onChange],
+  );
 
   function handleSelect(option: Option) {
     setInputValue('');
@@ -84,7 +90,11 @@ export function FancyMultiSelect({
         option.label.toLowerCase().includes(inputValue.toLowerCase()),
     );
 
-    if (creatable && inputValue) {
+    if (
+      creatable &&
+      inputValue &&
+      !selected.some((s) => s.value === inputValue)
+    ) {
       return [
         ...filtered,
         {

--- a/dashboard/src/features/orgs/projects/common/utils/permissions/validationSchemas/basePermissionValidationSchema.test.ts
+++ b/dashboard/src/features/orgs/projects/common/utils/permissions/validationSchemas/basePermissionValidationSchema.test.ts
@@ -2,6 +2,7 @@ import type {
   ConditionNode,
   ExistsNode,
   GroupNode,
+  InvalidNode,
   RelationshipNode,
 } from '@/features/orgs/projects/database/dataGrid/utils/permissionUtils/types';
 
@@ -103,9 +104,36 @@ describe('filterValidationSchema', () => {
       ).resolves.toBeDefined();
     });
 
-    it('rejects non-string array value', async () => {
+    it('accepts numeric scalar value', async () => {
+      const filter = group('_implicit', [
+        condition({ value: 211 as unknown as string }),
+      ]);
+      await expect(
+        filterValidationSchema.validate(filter),
+      ).resolves.toBeDefined();
+    });
+
+    it('accepts boolean scalar value', async () => {
+      const filter = group('_implicit', [
+        condition({ value: true as unknown as string }),
+      ]);
+      await expect(
+        filterValidationSchema.validate(filter),
+      ).resolves.toBeDefined();
+    });
+
+    it('accepts array of numbers as value', async () => {
       const filter = group('_implicit', [
         condition({ value: [1, 2] as unknown as string }),
+      ]);
+      await expect(
+        filterValidationSchema.validate(filter),
+      ).resolves.toBeDefined();
+    });
+
+    it('rejects array containing objects', async () => {
+      const filter = group('_implicit', [
+        condition({ value: [{ a: 1 }] as unknown as string }),
       ]);
       await expect(filterValidationSchema.validate(filter)).rejects.toThrow(
         'Please enter a valid value',
@@ -200,14 +228,14 @@ describe('filterValidationSchema', () => {
         id: 'e1',
         schema: 'public',
         table: 'users',
-        where: group('_implicit', []),
+        where: group('_implicit', [condition({ id: 'c1' })]),
       };
       const exists2: ExistsNode = {
         type: 'exists',
         id: 'e2',
         schema: 'public',
         table: 'files',
-        where: group('_implicit', []),
+        where: group('_implicit', [condition({ id: 'c2' })]),
       };
       const filter = group('_implicit', [exists1, exists2]);
       await expect(filterValidationSchema.validate(filter)).rejects.toThrow(
@@ -296,7 +324,123 @@ describe('filterValidationSchema', () => {
         /name.*appears more than once/,
       );
     });
+  });
 
+  describe('non-empty group validation', () => {
+    it('rejects empty root filter', async () => {
+      const filter = group('_implicit', []);
+      await expect(filterValidationSchema.validate(filter)).rejects.toThrow(
+        /at least one rule/,
+      );
+    });
+
+    it('rejects root containing only an empty nested group', async () => {
+      const filter = group('_implicit', [group('_and', [], 'g2')]);
+      await expect(filterValidationSchema.validate(filter)).rejects.toThrow(
+        /at least one rule/,
+      );
+    });
+
+    it('rejects exists with empty where', async () => {
+      const exists: ExistsNode = {
+        type: 'exists',
+        id: 'e1',
+        schema: 'public',
+        table: 'users',
+        where: group('_implicit', []),
+      };
+      const filter = group('_implicit', [exists]);
+      await expect(filterValidationSchema.validate(filter)).rejects.toThrow(
+        /at least one condition inside the exists block/,
+      );
+    });
+
+    it('rejects exists where that only contains an empty nested group', async () => {
+      const exists: ExistsNode = {
+        type: 'exists',
+        id: 'e1',
+        schema: 'public',
+        table: 'users',
+        where: group('_implicit', [group('_and', [], 'g2')]),
+      };
+      const filter = group('_implicit', [exists]);
+      await expect(filterValidationSchema.validate(filter)).rejects.toThrow(
+        /at least one condition inside the exists block/,
+      );
+    });
+
+    it('rejects exists with missing table', async () => {
+      const exists: ExistsNode = {
+        type: 'exists',
+        id: 'e1',
+        schema: 'public',
+        table: '',
+        where: group('_implicit', [condition()]),
+      };
+      const filter = group('_implicit', [exists]);
+      await expect(filterValidationSchema.validate(filter)).rejects.toThrow(
+        /Please select a table/,
+      );
+    });
+
+    it('rejects relationship with empty child', async () => {
+      const rel: RelationshipNode = {
+        type: 'relationship',
+        id: 'r1',
+        relationship: 'author',
+        child: group('_implicit', []),
+      };
+      const filter = group('_implicit', [rel]);
+      await expect(filterValidationSchema.validate(filter)).rejects.toThrow(
+        /at least one condition inside the relationship block/,
+      );
+    });
+
+    it('rejects relationship child that only contains an empty nested group', async () => {
+      const rel: RelationshipNode = {
+        type: 'relationship',
+        id: 'r1',
+        relationship: 'author',
+        child: group('_implicit', [group('_and', [], 'g2')]),
+      };
+      const filter = group('_implicit', [rel]);
+      await expect(filterValidationSchema.validate(filter)).rejects.toThrow(
+        /at least one condition inside the relationship block/,
+      );
+    });
+  });
+
+  describe('invalid node validation', () => {
+    it('rejects invalid node with reason "primitive"', async () => {
+      const invalid: InvalidNode = {
+        type: 'invalid',
+        id: 'i1',
+        reason: 'primitive',
+        key: 'user_id',
+        raw: 5,
+      };
+      const filter = group('_implicit', [invalid]);
+      await expect(filterValidationSchema.validate(filter)).rejects.toThrow(
+        /"user_id" has a primitive value/,
+      );
+    });
+
+    it('rejects invalid node with reason "operator"', async () => {
+      const invalid: InvalidNode = {
+        type: 'invalid',
+        id: 'i1',
+        reason: 'operator',
+        key: '_ad',
+        raw: [],
+      };
+      const filter = group('_implicit', [invalid]);
+      await expect(filterValidationSchema.validate(filter)).rejects.toThrow(
+        /"_ad" is not a valid operator/,
+      );
+    });
+  });
+
+  describe('serialization collision detection (continued)', () => {
     it('detects collision in _not group with multiple children', async () => {
       const filter = group('_not', [
         condition({ id: 'c1', column: 'status', operator: '_eq', value: 'a' }),

--- a/dashboard/src/features/orgs/projects/common/utils/permissions/validationSchemas/basePermissionValidationSchema.ts
+++ b/dashboard/src/features/orgs/projects/common/utils/permissions/validationSchemas/basePermissionValidationSchema.ts
@@ -85,17 +85,37 @@ const conditionNodeSchema = Yup.object().shape({
   column: Yup.string().nullable().required('Please select a column.'),
   operator: Yup.string().nullable().required('Please select an operator.'),
   value: Yup.mixed()
-    .test(
-      'isArray',
-      'Please enter a valid value.',
-      (value) =>
-        typeof value === 'string' ||
-        (Array.isArray(value) &&
-          value.every((item) => typeof item === 'string')),
-    )
+    .test('isArray', 'Please enter a valid value.', (value) => {
+      const isPrimitive = (item: unknown) =>
+        typeof item === 'string' ||
+        typeof item === 'number' ||
+        typeof item === 'boolean';
+      return (
+        isPrimitive(value) || (Array.isArray(value) && value.every(isPrimitive))
+      );
+    })
     .nullable()
     .required('Please enter a value.'),
 });
+
+const invalidNodeSchema = Yup.object()
+  .shape({
+    type: Yup.string(),
+    id: Yup.string(),
+    reason: Yup.string(),
+    key: Yup.string(),
+  })
+  .test('not-invalid', '', function validateInvalidNode(value) {
+    if (!value || value.type !== 'invalid') {
+      return true;
+    }
+    const { reason, key } = value as { reason: string; key: string };
+    const message =
+      reason === 'primitive'
+        ? `"${key}" has a primitive value — did you mean {"_eq": ...}?`
+        : `"${key}" is not a valid operator — did you mean "_and" or "_or"?`;
+    return this.createError({ message });
+  });
 
 // biome-ignore lint/suspicious/noExplicitAny: recursive schema requires any
 const groupNodeSchema: Yup.ObjectSchema<any> = Yup.object().shape({
@@ -114,11 +134,30 @@ const groupNodeSchema: Yup.ObjectSchema<any> = Yup.object().shape({
       if (value?.type === 'relationship') {
         return relationshipNodeSchema;
       }
+      if (value?.type === 'invalid') {
+        return invalidNodeSchema;
+      }
       return groupNodeSchema;
       // biome-ignore lint/suspicious/noExplicitAny: discriminated union requires any
     }) as any,
   ),
 });
+
+function groupHasLeaf(value: unknown): boolean {
+  if (!value) {
+    return false;
+  }
+  const group = value as GroupNode;
+  if (!Array.isArray(group.children) || group.children.length === 0) {
+    return false;
+  }
+  return group.children.some((child) => {
+    if (child.type === 'group') {
+      return groupHasLeaf(child);
+    }
+    return true;
+  });
+}
 
 // biome-ignore lint/suspicious/noExplicitAny: recursive schema requires any
 const existsNodeSchema: Yup.ObjectSchema<any> = Yup.object().shape({
@@ -126,7 +165,11 @@ const existsNodeSchema: Yup.ObjectSchema<any> = Yup.object().shape({
   id: Yup.string(),
   schema: Yup.string().required('Please select a schema.'),
   table: Yup.string().required('Please select a table.'),
-  where: groupNodeSchema,
+  where: groupNodeSchema.test(
+    'exists-where-not-empty',
+    'Please add at least one condition inside the exists block.',
+    groupHasLeaf,
+  ),
 });
 
 // biome-ignore lint/suspicious/noExplicitAny: recursive schema requires any
@@ -136,11 +179,25 @@ const relationshipNodeSchema: Yup.ObjectSchema<any> = Yup.object().shape({
   relationship: Yup.string()
     .nullable()
     .required('Please select a relationship.'),
-  child: groupNodeSchema,
+  child: groupNodeSchema.test(
+    'relationship-child-not-empty',
+    'Please add at least one condition inside the relationship block.',
+    groupHasLeaf,
+  ),
 });
 
 export const filterValidationSchema = groupNodeSchema
   .nullable()
+  .test(
+    'not-empty-root',
+    'Please add at least one rule, or choose "Without any checks".',
+    (value) => {
+      if (!value) {
+        return true;
+      }
+      return groupHasLeaf(value);
+    },
+  )
   .test(
     'no-serialization-collisions',
     '',

--- a/dashboard/src/features/orgs/projects/database/dataGrid/components/CustomCheckEditor/AddNodeButton.tsx
+++ b/dashboard/src/features/orgs/projects/database/dataGrid/components/CustomCheckEditor/AddNodeButton.tsx
@@ -25,14 +25,12 @@ import useCustomCheckEditor from './useCustomCheckEditor';
 
 interface AddNodeButtonProps {
   onSelect: (node: RuleNode) => void;
-  disabled?: boolean;
   fullWidth?: boolean;
   label?: string;
 }
 
 export default function AddNodeButton({
   onSelect,
-  disabled,
   fullWidth,
   label = 'Add check',
 }: AddNodeButtonProps) {
@@ -129,7 +127,7 @@ export default function AddNodeButton({
         <Button
           type="button"
           variant="outline"
-          disabled={disabled}
+          disabled={!hasTable}
           className={cn(
             'justify-start text-muted-foreground',
             fullWidth && 'w-full',

--- a/dashboard/src/features/orgs/projects/database/dataGrid/components/CustomCheckEditor/ConditionRow.tsx
+++ b/dashboard/src/features/orgs/projects/database/dataGrid/components/CustomCheckEditor/ConditionRow.tsx
@@ -21,7 +21,7 @@ type OnHandlerOptions = {
 };
 
 export default function ConditionRow({ name, onRemove }: ConditionRowProps) {
-  const { schema, table, disabled } = useCustomCheckEditor();
+  const { schema, table } = useCustomCheckEditor();
   const { control, setValue, clearErrors } = useFormContext();
 
   const [selectedTablePath, setSelectedTablePath] = useState('');
@@ -70,7 +70,6 @@ export default function ConditionRow({ name, onRemove }: ConditionRowProps) {
             <div className="flex flex-col gap-2">
               <ColumnAutocomplete
                 {...autocompleteField}
-                disabled={disabled}
                 schema={schema}
                 table={table}
                 disableRelationships
@@ -86,11 +85,7 @@ export default function ConditionRow({ name, onRemove }: ConditionRowProps) {
         }}
       />
 
-      <OperatorComboBox
-        name={name}
-        disabled={disabled}
-        selectedColumnType={selectedColumnType}
-      />
+      <OperatorComboBox name={name} selectedColumnType={selectedColumnType} />
       <ConditionValue
         selectedTablePath={selectedTablePath}
         name={name}
@@ -100,9 +95,8 @@ export default function ConditionRow({ name, onRemove }: ConditionRowProps) {
       <Button
         variant="ghost"
         size="icon"
-        className={cn('w-full xl:w-auto', { 'text-destructive': !disabled })}
+        className="w-full text-destructive xl:w-auto"
         onClick={onRemove}
-        disabled={disabled}
         aria-label="Delete condition"
       >
         <Trash2 className="h-4 w-4" />

--- a/dashboard/src/features/orgs/projects/database/dataGrid/components/CustomCheckEditor/ConditionValue.test.tsx
+++ b/dashboard/src/features/orgs/projects/database/dataGrid/components/CustomCheckEditor/ConditionValue.test.tsx
@@ -82,7 +82,6 @@ describe('ConditionValue', () => {
     mockUseCustomCheckEditor.mockReturnValue({
       schema: 'public',
       table: 'users',
-      disabled: false,
     });
 
     mockUseProject.mockReturnValue({
@@ -122,6 +121,56 @@ describe('ConditionValue', () => {
         shouldDirty: true,
       },
     );
+  });
+
+  it('should not add a duplicate when the same custom value is typed twice', async () => {
+    mocks.useGetRolesPermissionsQuery.mockImplementation(() => ({
+      data: mockPermissionsData,
+      loading: false,
+    }));
+
+    render(
+      <TestWrapper defaultValues={{ operator: '_in', value: [] }}>
+        <ConditionValue name="test" selectedTablePath="public.users" />
+      </TestWrapper>,
+    );
+    const user = new TestUserEvent();
+
+    const multiSelect = screen.getByPlaceholderText('Select options...');
+    await user.type(multiSelect, 'my-variable{Enter}');
+    expect(screen.getByTestId('badge-my-variable')).toBeInTheDocument();
+
+    mocks.setValueMock.mockClear();
+    await user.type(multiSelect, 'my-variable{Enter}');
+
+    expect(screen.queryAllByTestId('badge-my-variable')).toHaveLength(1);
+    expect(mocks.setValueMock).not.toHaveBeenCalled();
+  });
+
+  it('should clear the value when the last selected element is removed', async () => {
+    mocks.useGetRolesPermissionsQuery.mockImplementation(() => ({
+      data: mockPermissionsData,
+      loading: false,
+    }));
+
+    render(
+      <TestWrapper defaultValues={{ operator: '_in', value: [] }}>
+        <ConditionValue name="test" selectedTablePath="public.users" />
+      </TestWrapper>,
+    );
+    const user = new TestUserEvent();
+
+    const multiSelect = screen.getByPlaceholderText('Select options...');
+    await user.type(multiSelect, 'my-variable{Enter}');
+    expect(screen.getByTestId('badge-my-variable')).toBeInTheDocument();
+
+    mocks.setValueMock.mockClear();
+    await user.click(screen.getByLabelText('Remove my-variable'));
+
+    expect(screen.queryByTestId('badge-my-variable')).not.toBeInTheDocument();
+    expect(mocks.setValueMock).toHaveBeenCalledWith('test.value', [], {
+      shouldDirty: true,
+    });
   });
 
   it('should pass simple values as string array', async () => {

--- a/dashboard/src/features/orgs/projects/database/dataGrid/components/CustomCheckEditor/ConditionValue.tsx
+++ b/dashboard/src/features/orgs/projects/database/dataGrid/components/CustomCheckEditor/ConditionValue.tsx
@@ -68,7 +68,6 @@ function ColumnSelectorInput({
   selectedTablePath,
   schema,
   table,
-  disabled,
   ...props
 }: ColumnAutocompleteProps & { selectedTablePath: string; name: string }) {
   const { setValue, control } = useFormContext();
@@ -81,7 +80,6 @@ function ColumnSelectorInput({
     <ColumnAutocomplete
       {...props}
       {...field}
-      disabled={disabled}
       value={
         // this array can either be ['$', 'columnName'] or ['columnName']
         Array.isArray(field.value) ? field.value.slice(-1)[0] : field.value
@@ -122,7 +120,7 @@ function ConditionValue({
   selectedTablePath,
   className,
 }: ConditionValueProps) {
-  const { schema, table, disabled } = useCustomCheckEditor();
+  const { schema, table } = useCustomCheckEditor();
   const { project } = useProject();
   const { setValue, control } = useFormContext();
   const inputName = `${name}.value`;
@@ -148,7 +146,6 @@ function ConditionValue({
       'border hover:bg-accent-background hover:text-accent-foreground focus:ring-0 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2';
     return (
       <Select
-        disabled={disabled}
         name={inputName}
         onValueChange={(newValue: string) => {
           setValue(inputName, newValue, { shouldDirty: true });
@@ -183,6 +180,12 @@ function ConditionValue({
 
     function handleOnChange(value: Option[]) {
       const typedValue = value as Array<Option & { isSystemVariable: boolean }>;
+
+      if (typedValue.length === 0) {
+        setValue(inputName, [], { shouldDirty: true });
+        return;
+      }
+
       const [firstValue] = typedValue;
       const [lastElement] = typedValue.slice(-1);
 
@@ -212,7 +215,6 @@ function ConditionValue({
         className={className}
         options={availableHasuraPermissionVariables}
         creatable
-        disabled={disabled}
         value={defaultValue}
         onChange={handleOnChange}
       />
@@ -222,7 +224,6 @@ function ConditionValue({
   if (['_ceq', '_cne', '_cgt', '_clt', '_cgte', '_clte'].includes(operator)) {
     return (
       <ColumnSelectorInput
-        disabled={disabled}
         selectedTablePath={selectedTablePath}
         schema={schema}
         table={table}
@@ -245,7 +246,6 @@ function ConditionValue({
           variant="outline"
           role="combobox"
           aria-expanded={open}
-          disabled={disabled}
           className={cn('w-full justify-between', className)}
         >
           <span className="truncate">{comboboxLabel}</span>

--- a/dashboard/src/features/orgs/projects/database/dataGrid/components/CustomCheckEditor/CustomCheckEditor.test.tsx
+++ b/dashboard/src/features/orgs/projects/database/dataGrid/components/CustomCheckEditor/CustomCheckEditor.test.tsx
@@ -1,13 +1,14 @@
+import { yupResolver } from '@hookform/resolvers/yup';
 import { setupServer } from 'msw/node';
 import { FormProvider, useForm } from 'react-hook-form';
 import { vi } from 'vitest';
+import * as Yup from 'yup';
+import { filterValidationSchema } from '@/features/orgs/projects/common/utils/permissions/validationSchemas/basePermissionValidationSchema';
 import type { HasuraOperator } from '@/features/orgs/projects/database/dataGrid/types/dataBrowser';
 import type {
   ConditionNode,
-  ExistsNode,
   GroupNode,
   LogicalOperator,
-  RelationshipNode,
   RuleNode,
 } from '@/features/orgs/projects/database/dataGrid/utils/permissionUtils/types';
 import { getProjectQuery } from '@/tests/msw/mocks/graphql/getProjectQuery';
@@ -23,6 +24,11 @@ import {
   waitFor,
 } from '@/tests/testUtils';
 import CustomCheckEditor from './CustomCheckEditor';
+import {
+  type CustomCheckEditorMode,
+  CustomCheckModeProvider,
+} from './CustomCheckModeProvider';
+import CustomCheckModeToggle from './CustomCheckModeToggle';
 
 const mocks = vi.hoisted(() => ({
   useRouter: vi.fn(),
@@ -43,7 +49,7 @@ const server = setupServer(
 function condition(
   column: string,
   operator: HasuraOperator = '_eq',
-  value: unknown = '',
+  value: unknown = null,
 ): ConditionNode {
   return {
     type: 'condition',
@@ -63,41 +69,35 @@ function group(operator: LogicalOperator, children: RuleNode[]): GroupNode {
   };
 }
 
-function existsNode(
-  schema: string,
-  table: string,
-  where?: GroupNode,
-): ExistsNode {
-  return {
-    type: 'exists',
-    id: crypto.randomUUID(),
-    schema,
-    table,
-    where: where ?? group('_implicit', [condition('id')]),
-  };
-}
-
-function relationshipNode(
-  relationship: string,
-  child?: GroupNode,
-): RelationshipNode {
-  return {
-    type: 'relationship',
-    id: crypto.randomUUID(),
-    relationship,
-    child: child ?? group('_implicit', [condition('id')]),
-  };
-}
-
 function TestWrapper({
   children,
   defaultValues,
+  mode = 'builder',
+  withValidation = false,
 }: {
   children: React.ReactNode;
   defaultValues: Record<string, unknown>;
+  mode?: CustomCheckEditorMode;
+  withValidation?: boolean;
 }) {
-  const form = useForm({ defaultValues });
-  return <FormProvider {...form}>{children}</FormProvider>;
+  const form = useForm({
+    defaultValues,
+    resolver: withValidation
+      ? yupResolver(Yup.object({ rule: filterValidationSchema }))
+      : undefined,
+  });
+  return (
+    <FormProvider {...form}>
+      <CustomCheckModeProvider defaultMode={mode}>
+        {mode === 'json' && withValidation ? (
+          <button type="button" onClick={() => form.trigger()}>
+            validate
+          </button>
+        ) : null}
+        {children}
+      </CustomCheckModeProvider>
+    </FormProvider>
+  );
 }
 
 const defaultProps = {
@@ -106,10 +106,18 @@ const defaultProps = {
   name: 'rule',
 };
 
+function HarnessWithToggle() {
+  return (
+    <>
+      <CustomCheckModeToggle />
+      <CustomCheckEditor {...defaultProps} />
+    </>
+  );
+}
+
 describe('CustomCheckEditor', () => {
   beforeAll(() => {
     process.env.NEXT_PUBLIC_ENV = 'dev';
-    // Required so useLocalMimirClient sends GetRolesPermissions to a URL MSW can intercept
     process.env.NEXT_PUBLIC_NHOST_CONFIGSERVER_URL =
       'https://local.graphql.local.nhost.run/v1';
     server.listen();
@@ -150,31 +158,12 @@ describe('CustomCheckEditor', () => {
     server.close();
   });
 
-  describe('rendering', () => {
-    it('renders a single condition row from default values', async () => {
+  describe('mode switch', () => {
+    it('renders only the builder when mode is "builder"', async () => {
       render(
         <TestWrapper
           defaultValues={{
-            rule: group('_and', [condition('title')]),
-          }}
-        >
-          <CustomCheckEditor {...defaultProps} />
-        </TestWrapper>,
-      );
-
-      expect(screen.getByText('AND')).toBeInTheDocument();
-      expect(await screen.findByText('title')).toBeInTheDocument();
-    });
-
-    it('renders multiple conditions in order', async () => {
-      render(
-        <TestWrapper
-          defaultValues={{
-            rule: group('_and', [
-              condition('title'),
-              condition('release_date'),
-              condition('author_id'),
-            ]),
+            rule: group('_implicit', [condition('title', '_eq', 'foo')]),
           }}
         >
           <CustomCheckEditor {...defaultProps} />
@@ -182,1817 +171,242 @@ describe('CustomCheckEditor', () => {
       );
 
       expect(await screen.findByText('title')).toBeInTheDocument();
-      expect(screen.getByText('release_date')).toBeInTheDocument();
-      expect(screen.getByText('author_id')).toBeInTheDocument();
+      expect(screen.queryByRole('textbox')).not.toBeInTheDocument();
     });
 
-    it('renders nested groups recursively', async () => {
+    it('renders only the JSON editor when mode is "json"', () => {
       render(
         <TestWrapper
           defaultValues={{
-            rule: group('_and', [
-              condition('title'),
-              group('_or', [condition('release_date')]),
-            ]),
+            rule: group('_implicit', [condition('title', '_eq', 'foo')]),
           }}
+          mode="json"
         >
           <CustomCheckEditor {...defaultProps} />
         </TestWrapper>,
       );
 
-      expect(screen.getByText('AND')).toBeInTheDocument();
-      expect(screen.getByText('OR')).toBeInTheDocument();
-      expect(await screen.findByText('title')).toBeInTheDocument();
-      expect(screen.getByText('release_date')).toBeInTheDocument();
-    });
-
-    it('renders the correct operator label (AND/OR/NOT)', () => {
-      render(
-        <TestWrapper
-          defaultValues={{
-            rule: group('_not', [condition('title')]),
-          }}
-        >
-          <CustomCheckEditor {...defaultProps} />
-        </TestWrapper>,
-      );
-
-      expect(screen.getByText('NOT')).toBeInTheDocument();
-    });
-
-    it('renders "Implicit" label for _implicit operator', () => {
-      render(
-        <TestWrapper
-          defaultValues={{
-            rule: group('_implicit', [condition('title')]),
-          }}
-        >
-          <CustomCheckEditor {...defaultProps} />
-        </TestWrapper>,
-      );
-
-      expect(screen.getByText('Implicit')).toBeInTheDocument();
-    });
-
-    it('renders an empty group (no children) without crashing', () => {
-      render(
-        <TestWrapper
-          defaultValues={{
-            rule: group('_and', []),
-          }}
-        >
-          <CustomCheckEditor {...defaultProps} />
-        </TestWrapper>,
-      );
-
-      expect(screen.getByText('AND')).toBeInTheDocument();
-    });
-
-    it('applies depth-based background colors to nested groups', () => {
-      render(
-        <TestWrapper
-          defaultValues={{
-            rule: group('_and', [
-              group('_or', [group('_and', [condition('title')])]),
-            ]),
-          }}
-        >
-          <CustomCheckEditor {...defaultProps} />
-        </TestWrapper>,
-      );
-
-      const groupDivs = document.querySelectorAll(
-        'div.rounded-lg[class*="bg-secondary-"]',
-      );
-
-      expect(groupDivs).toHaveLength(3);
-      expect(groupDivs[0]).toHaveClass('bg-secondary-100');
-      expect(groupDivs[1]).toHaveClass('bg-secondary-200');
-      expect(groupDivs[2]).toHaveClass('bg-secondary-300');
+      expect(screen.getByRole('textbox')).toBeInTheDocument();
+      expect(screen.queryByText('title')).not.toBeInTheDocument();
     });
   });
 
-  describe('adding nodes', () => {
-    async function openAddPopover(user: TestUserEvent, index = -1) {
-      const buttons = screen.getAllByRole('button', { name: /Add/ });
-      const btn = index >= 0 ? buttons[index] : buttons[buttons.length - 1];
-      await user.click(btn);
-    }
-
-    it('selecting a column appends a condition row', async () => {
+  describe('json editor errors', () => {
+    it('typing malformed JSON shows "Invalid JSON"', async () => {
       render(
         <TestWrapper
           defaultValues={{
-            rule: group('_and', [condition('title')]),
+            rule: group('_implicit', [condition('title', '_eq', 'foo')]),
           }}
+          mode="json"
         >
           <CustomCheckEditor {...defaultProps} />
         </TestWrapper>,
       );
 
-      expect(await screen.findByText('title')).toBeInTheDocument();
+      const textarea = screen.getByRole('textbox') as HTMLTextAreaElement;
+      await TestUserEvent.fireTypeEvent(textarea, '{not valid json');
 
+      await waitFor(() => {
+        expect(screen.getByRole('alert')).toHaveTextContent('Invalid JSON');
+      });
+    });
+
+    it('typing a JSON array shows "Rule must be a JSON object"', async () => {
+      render(
+        <TestWrapper
+          defaultValues={{ rule: group('_implicit', []) }}
+          mode="json"
+        >
+          <CustomCheckEditor {...defaultProps} />
+        </TestWrapper>,
+      );
+
+      const textarea = screen.getByRole('textbox') as HTMLTextAreaElement;
       const user = new TestUserEvent();
-      await openAddPopover(user);
-      await user.click(
-        await screen.findByRole('option', { name: /release_date/ }),
-      );
+      await user.clear(textarea);
+      await user.paste('[1,2,3]');
 
       await waitFor(() => {
-        expect(screen.getByText('release_date')).toBeInTheDocument();
-      });
-    });
-
-    it('selecting "and" appends a nested group', async () => {
-      render(
-        <TestWrapper
-          defaultValues={{
-            rule: group('_and', [condition('title')]),
-          }}
-        >
-          <CustomCheckEditor {...defaultProps} />
-        </TestWrapper>,
-      );
-
-      const user = new TestUserEvent();
-      await openAddPopover(user);
-      await user.click(await screen.findByRole('option', { name: 'and' }));
-
-      await waitFor(() => {
-        expect(screen.getAllByText('AND')).toHaveLength(2);
-      });
-    });
-
-    it('selecting "or" appends a nested OR group', async () => {
-      render(
-        <TestWrapper
-          defaultValues={{
-            rule: group('_and', [condition('title')]),
-          }}
-        >
-          <CustomCheckEditor {...defaultProps} />
-        </TestWrapper>,
-      );
-
-      const user = new TestUserEvent();
-      await openAddPopover(user);
-      await user.click(await screen.findByRole('option', { name: 'or' }));
-
-      await waitFor(() => {
-        expect(screen.getByText('OR')).toBeInTheDocument();
-      });
-    });
-
-    it('selecting "exists" appends an exists node', async () => {
-      render(
-        <TestWrapper
-          defaultValues={{
-            rule: group('_and', [condition('title')]),
-          }}
-        >
-          <CustomCheckEditor {...defaultProps} />
-        </TestWrapper>,
-      );
-
-      const user = new TestUserEvent();
-      await openAddPopover(user);
-      await user.click(await screen.findByRole('option', { name: 'exists' }));
-
-      await waitFor(() => {
-        expect(screen.getByText('Exists')).toBeInTheDocument();
-        expect(screen.getByText('Select table...')).toBeInTheDocument();
-      });
-    });
-
-    it('adding multiple rules in sequence renders all of them', async () => {
-      render(
-        <TestWrapper
-          defaultValues={{
-            rule: group('_and', [condition('title')]),
-          }}
-        >
-          <CustomCheckEditor {...defaultProps} />
-        </TestWrapper>,
-      );
-
-      expect(await screen.findByText('title')).toBeInTheDocument();
-
-      const user = new TestUserEvent();
-
-      await openAddPopover(user);
-      await user.click(
-        await screen.findByRole('option', { name: /release_date/ }),
-      );
-      await waitFor(() => {
-        expect(screen.getByText('release_date')).toBeInTheDocument();
-      });
-
-      await openAddPopover(user);
-      await user.click(
-        await screen.findByRole('option', { name: /author_id/ }),
-      );
-      await waitFor(() => {
-        expect(screen.getByText('author_id')).toBeInTheDocument();
-      });
-
-      expect(screen.getByText('title')).toBeInTheDocument();
-      expect(screen.getByText('release_date')).toBeInTheDocument();
-      expect(screen.getByText('author_id')).toBeInTheDocument();
-    });
-
-    it('adding a rule inside a nested group adds it to the correct group', async () => {
-      render(
-        <TestWrapper
-          defaultValues={{
-            rule: group('_and', [
-              condition('title'),
-              group('_or', [condition('release_date')]),
-            ]),
-          }}
-        >
-          <CustomCheckEditor {...defaultProps} />
-        </TestWrapper>,
-      );
-
-      await screen.findByText('title');
-
-      const user = new TestUserEvent();
-      // The nested group's Add button renders before the root's in DOM order
-      await openAddPopover(user, 0);
-      await user.click(
-        await screen.findByRole('option', { name: /author_id/ }),
-      );
-
-      await waitFor(() => {
-        expect(screen.getByText('author_id')).toBeInTheDocument();
-      });
-
-      // All three conditions should be visible
-      expect(screen.getByText('title')).toBeInTheDocument();
-      expect(screen.getByText('release_date')).toBeInTheDocument();
-      expect(screen.getByText('author_id')).toBeInTheDocument();
-    });
-  });
-
-  describe('removing nodes', () => {
-    it('clicking remove button on a condition removes it', async () => {
-      render(
-        <TestWrapper
-          defaultValues={{
-            rule: group('_and', [
-              condition('title'),
-              condition('release_date'),
-            ]),
-          }}
-        >
-          <CustomCheckEditor {...defaultProps} />
-        </TestWrapper>,
-      );
-
-      expect(await screen.findByText('title')).toBeInTheDocument();
-      expect(screen.getByText('release_date')).toBeInTheDocument();
-
-      const user = new TestUserEvent();
-      const removeButtons = screen.getAllByRole('button', {
-        name: /delete condition/i,
-      });
-      await user.click(removeButtons[0]);
-
-      await waitFor(() => {
-        expect(screen.queryByText('title')).not.toBeInTheDocument();
-      });
-
-      expect(screen.getByText('release_date')).toBeInTheDocument();
-    });
-
-    it('remove button is enabled even when one child remains', async () => {
-      render(
-        <TestWrapper
-          defaultValues={{
-            rule: group('_and', [condition('title')]),
-          }}
-        >
-          <CustomCheckEditor {...defaultProps} />
-        </TestWrapper>,
-      );
-
-      expect(await screen.findByText('title')).toBeInTheDocument();
-
-      const removeButton = screen.getByRole('button', {
-        name: /delete condition/i,
-      });
-      expect(removeButton).toBeEnabled();
-    });
-
-    it('"Delete Group" button appears for nested groups and removes the group', async () => {
-      render(
-        <TestWrapper
-          defaultValues={{
-            rule: group('_and', [
-              condition('title'),
-              group('_or', [condition('release_date')]),
-            ]),
-          }}
-        >
-          <CustomCheckEditor {...defaultProps} />
-        </TestWrapper>,
-      );
-
-      expect(await screen.findByText('title')).toBeInTheDocument();
-      expect(screen.getByText('release_date')).toBeInTheDocument();
-      expect(screen.getByText('OR')).toBeInTheDocument();
-
-      const deleteGroupButtons = screen.getAllByRole('button', {
-        name: /delete group/i,
-      });
-      expect(deleteGroupButtons.length).toBeGreaterThanOrEqual(2);
-
-      const user = new TestUserEvent();
-      await user.click(deleteGroupButtons[deleteGroupButtons.length - 1]);
-
-      await waitFor(() => {
-        expect(
-          screen.getAllByRole('button', { name: /delete group/i }),
-        ).toHaveLength(1);
-      });
-
-      expect(screen.queryByText('OR')).not.toBeInTheDocument();
-      expect(screen.queryByText('release_date')).not.toBeInTheDocument();
-      expect(screen.getByText('title')).toBeInTheDocument();
-    });
-
-    it('"Delete Group" button appears on the root group (allows resetting to empty state)', () => {
-      render(
-        <TestWrapper
-          defaultValues={{
-            rule: group('_and', [condition('title')]),
-          }}
-        >
-          <CustomCheckEditor {...defaultProps} />
-        </TestWrapper>,
-      );
-
-      expect(
-        screen.getByRole('button', { name: /delete group/i }),
-      ).toBeInTheDocument();
-    });
-
-    it('remove button is enabled for the last child when operator is _implicit', async () => {
-      render(
-        <TestWrapper
-          defaultValues={{
-            rule: group('_implicit', [condition('title')]),
-          }}
-        >
-          <CustomCheckEditor {...defaultProps} />
-        </TestWrapper>,
-      );
-
-      expect(await screen.findByText('title')).toBeInTheDocument();
-
-      const removeButton = screen.getByRole('button', {
-        name: /delete condition/i,
-      });
-      expect(removeButton).not.toBeDisabled();
-    });
-
-    it('removing a nested group also removes all its children from the DOM', async () => {
-      render(
-        <TestWrapper
-          defaultValues={{
-            rule: group('_and', [
-              condition('title'),
-              group('_or', [condition('release_date'), condition('author_id')]),
-            ]),
-          }}
-        >
-          <CustomCheckEditor {...defaultProps} />
-        </TestWrapper>,
-      );
-
-      expect(await screen.findByText('title')).toBeInTheDocument();
-      expect(screen.getByText('release_date')).toBeInTheDocument();
-      expect(screen.getByText('author_id')).toBeInTheDocument();
-      expect(screen.getByText('OR')).toBeInTheDocument();
-
-      const user = new TestUserEvent();
-      const deleteGroupButtons = screen.getAllByRole('button', {
-        name: /delete group/i,
-      });
-      await user.click(deleteGroupButtons[deleteGroupButtons.length - 1]);
-
-      await waitFor(() => {
-        expect(screen.queryByText('OR')).not.toBeInTheDocument();
-      });
-
-      expect(screen.queryByText('release_date')).not.toBeInTheDocument();
-      expect(screen.queryByText('author_id')).not.toBeInTheDocument();
-      expect(screen.getByText('title')).toBeInTheDocument();
-    });
-  });
-
-  describe('operator switching', () => {
-    it('clicking the operator badge opens dropdown with all operator options', async () => {
-      render(
-        <TestWrapper
-          defaultValues={{
-            rule: group('_and', [condition('title')]),
-          }}
-        >
-          <CustomCheckEditor {...defaultProps} />
-        </TestWrapper>,
-      );
-
-      const user = new TestUserEvent();
-      await user.click(screen.getByText('AND'));
-
-      await waitFor(() => {
-        expect(
-          screen.getByRole('menuitemradio', { name: /Implicit/ }),
-        ).toBeInTheDocument();
-        expect(
-          screen.getByRole('menuitemradio', { name: 'AND' }),
-        ).toBeInTheDocument();
-        expect(
-          screen.getByRole('menuitemradio', { name: 'OR' }),
-        ).toBeInTheDocument();
-        expect(
-          screen.getByRole('menuitemradio', { name: 'NOT' }),
-        ).toBeInTheDocument();
-      });
-    });
-
-    it('selecting a different operator updates the displayed label', async () => {
-      render(
-        <TestWrapper
-          defaultValues={{
-            rule: group('_and', [condition('title')]),
-          }}
-        >
-          <CustomCheckEditor {...defaultProps} />
-        </TestWrapper>,
-      );
-
-      const user = new TestUserEvent();
-      await user.click(screen.getByText('AND'));
-
-      await waitFor(() => {
-        expect(
-          screen.getByRole('menuitemradio', { name: 'OR' }),
-        ).toBeInTheDocument();
-      });
-
-      await user.click(screen.getByRole('menuitemradio', { name: 'OR' }));
-
-      await waitFor(() => {
-        expect(screen.getByText('OR')).toBeInTheDocument();
-      });
-    });
-
-    it('selecting "Implicit" updates the displayed label', async () => {
-      render(
-        <TestWrapper
-          defaultValues={{
-            rule: group('_and', [condition('title')]),
-          }}
-        >
-          <CustomCheckEditor {...defaultProps} />
-        </TestWrapper>,
-      );
-
-      const user = new TestUserEvent();
-      await user.click(screen.getByText('AND'));
-
-      await waitFor(() => {
-        expect(
-          screen.getByRole('menuitemradio', { name: /Implicit/ }),
-        ).toBeInTheDocument();
-      });
-
-      await user.click(screen.getByRole('menuitemradio', { name: /Implicit/ }));
-
-      await waitFor(() => {
-        expect(screen.getByText('Implicit')).toBeInTheDocument();
-      });
-    });
-
-    it('operator badge dropdown is disabled when disabled prop is true', () => {
-      render(
-        <TestWrapper
-          defaultValues={{
-            rule: group('_and', [condition('title')]),
-          }}
-        >
-          <CustomCheckEditor {...defaultProps} disabled />
-        </TestWrapper>,
-      );
-
-      const badge = screen.getByText('AND');
-      // When disabled, Radix sets data-disabled on the trigger element
-      const trigger = badge.closest('[data-disabled]');
-      expect(trigger).toBeInTheDocument();
-    });
-
-    it('nested group operator changes independently from parent group operator', async () => {
-      render(
-        <TestWrapper
-          defaultValues={{
-            rule: group('_and', [
-              condition('title'),
-              group('_or', [condition('release_date')]),
-            ]),
-          }}
-        >
-          <CustomCheckEditor {...defaultProps} />
-        </TestWrapper>,
-      );
-
-      const user = new TestUserEvent();
-      await user.click(screen.getByText('OR'));
-
-      await waitFor(() => {
-        expect(
-          screen.getByRole('menuitemradio', { name: 'NOT' }),
-        ).toBeInTheDocument();
-      });
-
-      await user.click(screen.getByRole('menuitemradio', { name: 'NOT' }));
-
-      await waitFor(() => {
-        expect(screen.getByText('NOT')).toBeInTheDocument();
-      });
-
-      expect(screen.getByText('AND')).toBeInTheDocument();
-    });
-  });
-
-  describe('depth limiting', () => {
-    it('adding a group still works when maxDepth is set (AddNodeButton does not enforce maxDepth)', async () => {
-      render(
-        <TestWrapper
-          defaultValues={{
-            rule: group('_and', [condition('title')]),
-          }}
-        >
-          <CustomCheckEditor {...defaultProps} maxDepth={1} />
-        </TestWrapper>,
-      );
-
-      const user = new TestUserEvent();
-      await user.click(screen.getByText('Add'));
-      await user.click(await screen.findByRole('option', { name: 'and' }));
-
-      await waitFor(() => {
-        expect(screen.getAllByText('AND')).toHaveLength(2);
-      });
-    });
-
-    it('no maxDepth prop allows unlimited nesting', () => {
-      render(
-        <TestWrapper
-          defaultValues={{
-            rule: group('_and', [
-              group('_or', [
-                group('_and', [
-                  group('_or', [group('_and', [condition('title')])]),
-                ]),
-              ]),
-            ]),
-          }}
-        >
-          <CustomCheckEditor {...defaultProps} />
-        </TestWrapper>,
-      );
-
-      const addButtons = screen.getAllByRole('button', { name: /Add/ });
-      expect(addButtons).toHaveLength(5);
-    });
-
-    it('maxDepth limits rendering depth of existing nested groups', () => {
-      render(
-        <TestWrapper
-          defaultValues={{
-            rule: group('_and', [
-              group('_or', [group('_and', [condition('title')])]),
-            ]),
-          }}
-        >
-          <CustomCheckEditor {...defaultProps} maxDepth={2} />
-        </TestWrapper>,
-      );
-
-      // All existing groups still render since maxDepth controls the Add dropdown
-      expect(screen.getAllByText('AND')).toHaveLength(2);
-      expect(screen.getByText('OR')).toBeInTheDocument();
-    });
-  });
-
-  describe('disabled state', () => {
-    it('condition row remove buttons are disabled when disabled prop is true', () => {
-      render(
-        <TestWrapper
-          defaultValues={{
-            rule: group('_and', [
-              condition('title'),
-              condition('release_date'),
-            ]),
-          }}
-        >
-          <CustomCheckEditor {...defaultProps} disabled />
-        </TestWrapper>,
-      );
-
-      const removeButtons = screen.getAllByRole('button', {
-        name: /delete condition/i,
-      });
-
-      for (const btn of removeButtons) {
-        expect(btn).toBeDisabled();
-      }
-    });
-
-    it('"Add" button is disabled when disabled prop is true', () => {
-      render(
-        <TestWrapper
-          defaultValues={{
-            rule: group('_and', [condition('title')]),
-          }}
-        >
-          <CustomCheckEditor {...defaultProps} disabled />
-        </TestWrapper>,
-      );
-
-      expect(screen.getByText('Add')).toBeDisabled();
-    });
-
-    it('"Delete Group" and "Delete Exists" buttons are disabled when disabled prop is true', () => {
-      render(
-        <TestWrapper
-          defaultValues={{
-            rule: group('_and', [
-              condition('title'),
-              group('_or', [condition('release_date')]),
-              existsNode('public', 'authors'),
-            ]),
-          }}
-        >
-          <CustomCheckEditor {...defaultProps} disabled />
-        </TestWrapper>,
-      );
-
-      const deleteGroupButtons = screen.getAllByRole('button', {
-        name: /delete group/i,
-      });
-      for (const btn of deleteGroupButtons) {
-        expect(btn).toBeDisabled();
-      }
-
-      const deleteExistsButton = screen.getByRole('button', {
-        name: /delete exists/i,
-      });
-      expect(deleteExistsButton).toBeDisabled();
-    });
-
-    it('inner exists controls are disabled when disabled prop is true and table is selected', () => {
-      render(
-        <TestWrapper
-          defaultValues={{
-            rule: group('_and', [existsNode('public', 'authors')]),
-          }}
-        >
-          <CustomCheckEditor {...defaultProps} disabled />
-        </TestWrapper>,
-      );
-
-      const addButtons = screen.getAllByText('Add');
-      for (const btn of addButtons) {
-        expect(btn).toBeDisabled();
-      }
-
-      const innerOperator = screen.getByText('Implicit');
-      const trigger = innerOperator.closest('[data-disabled]');
-      expect(trigger).toBeInTheDocument();
-    });
-
-    it('ConditionValue is disabled when disabled prop is true', async () => {
-      render(
-        <TestWrapper
-          defaultValues={{
-            rule: group('_and', [
-              condition('title'),
-              condition('release_date'),
-            ]),
-          }}
-        >
-          <CustomCheckEditor {...defaultProps} disabled />
-        </TestWrapper>,
-      );
-
-      await waitFor(() => {
-        // ConditionValue renders combobox buttons that should be disabled
-        const comboboxes = screen.getAllByRole('combobox');
-        // Filter to the value comboboxes (not column autocompletes)
-        const disabledComboboxes = comboboxes.filter((cb) =>
-          cb.hasAttribute('disabled'),
+        expect(screen.getByRole('alert')).toHaveTextContent(
+          'Rule must be a JSON object',
         );
-        expect(disabledComboboxes.length).toBeGreaterThanOrEqual(2);
+      });
+    });
+
+    it('typing a JSON primitive shows "Rule must be a JSON object"', async () => {
+      render(
+        <TestWrapper
+          defaultValues={{ rule: group('_implicit', []) }}
+          mode="json"
+        >
+          <CustomCheckEditor {...defaultProps} />
+        </TestWrapper>,
+      );
+
+      const textarea = screen.getByRole('textbox') as HTMLTextAreaElement;
+      const user = new TestUserEvent();
+      await user.clear(textarea);
+      await user.paste('123');
+
+      await waitFor(() => {
+        expect(screen.getByRole('alert')).toHaveTextContent(
+          'Rule must be a JSON object',
+        );
+      });
+    });
+
+    it('clears the error once input becomes valid again', async () => {
+      render(
+        <TestWrapper
+          defaultValues={{ rule: group('_implicit', []) }}
+          mode="json"
+        >
+          <CustomCheckEditor {...defaultProps} />
+        </TestWrapper>,
+      );
+
+      const textarea = screen.getByRole('textbox') as HTMLTextAreaElement;
+      const user = new TestUserEvent();
+      await user.clear(textarea);
+      await user.paste('{bad');
+
+      await waitFor(() => {
+        expect(screen.getByRole('alert')).toHaveTextContent('Invalid JSON');
+      });
+
+      await user.clear(textarea);
+      await user.paste('{"title":{"_eq":"foo"}}');
+
+      await waitFor(() => {
+        expect(screen.queryByRole('alert')).not.toBeInTheDocument();
+      });
+    });
+
+    it('applies destructive border styling while an error is shown', async () => {
+      render(
+        <TestWrapper
+          defaultValues={{ rule: group('_implicit', []) }}
+          mode="json"
+        >
+          <CustomCheckEditor {...defaultProps} />
+        </TestWrapper>,
+      );
+
+      const textarea = screen.getByRole('textbox') as HTMLTextAreaElement;
+      const user = new TestUserEvent();
+      await user.clear(textarea);
+      await user.paste('{bad');
+
+      await waitFor(() => {
+        expect(screen.getByRole('alert')).toBeInTheDocument();
+      });
+      expect(textarea.className).toContain('border-destructive');
+    });
+
+    it('surfaces an invalid-node yup error for a primitive value at a column key', async () => {
+      render(
+        <TestWrapper
+          defaultValues={{ rule: group('_implicit', []) }}
+          mode="json"
+          withValidation
+        >
+          <CustomCheckEditor {...defaultProps} />
+        </TestWrapper>,
+      );
+
+      const textarea = screen.getByRole('textbox') as HTMLTextAreaElement;
+      const user = new TestUserEvent();
+      await user.clear(textarea);
+      await user.paste('{"user_id":5}');
+      await user.click(screen.getByRole('button', { name: 'validate' }));
+
+      await waitFor(() => {
+        expect(screen.getByRole('alert')).toHaveTextContent(
+          /"user_id" has a primitive value/,
+        );
+      });
+    });
+
+    it('surfaces an invalid-node yup error for an array at a non-_and/_or key', async () => {
+      render(
+        <TestWrapper
+          defaultValues={{ rule: group('_implicit', []) }}
+          mode="json"
+          withValidation
+        >
+          <CustomCheckEditor {...defaultProps} />
+        </TestWrapper>,
+      );
+
+      const textarea = screen.getByRole('textbox') as HTMLTextAreaElement;
+      const user = new TestUserEvent();
+      await user.clear(textarea);
+      await user.paste('{"_ad":[{"col":{"_eq":"a"}}]}');
+      await user.click(screen.getByRole('button', { name: 'validate' }));
+
+      await waitFor(() => {
+        expect(screen.getByRole('alert')).toHaveTextContent(
+          /"_ad" is not a valid operator/,
+        );
       });
     });
   });
 
-  describe('exists nodes', () => {
-    it('"exists" option is available in AddNodeButton', async () => {
+  describe('cross-mode sync', () => {
+    it('a builder edit is reflected in the JSON editor after switching mode', async () => {
       render(
         <TestWrapper
           defaultValues={{
-            rule: group('_and', [condition('title')]),
+            rule: group('_implicit', [condition('title', '_eq', 'foo')]),
           }}
         >
-          <CustomCheckEditor {...defaultProps} />
+          <HarnessWithToggle />
         </TestWrapper>,
       );
+
+      expect(await screen.findByText('title')).toBeInTheDocument();
 
       const user = new TestUserEvent();
       await user.click(screen.getByText('Add'));
-
-      expect(
-        await screen.findByRole('option', { name: 'exists' }),
-      ).toBeInTheDocument();
-    });
-
-    it('clicking "exists" menu item appends an exists node', async () => {
-      render(
-        <TestWrapper
-          defaultValues={{
-            rule: group('_and', [condition('title')]),
-          }}
-        >
-          <CustomCheckEditor {...defaultProps} />
-        </TestWrapper>,
+      await user.click(
+        await screen.findByRole('option', { name: /release_date/ }),
       );
 
-      const user = new TestUserEvent();
-      await user.click(screen.getByText('Add'));
-      await user.click(await screen.findByRole('option', { name: 'exists' }));
+      expect(await screen.findByText('release_date')).toBeInTheDocument();
 
-      await waitFor(() => {
-        expect(screen.getByText('Exists')).toBeInTheDocument();
-        expect(screen.getByText('Select table...')).toBeInTheDocument();
+      await user.click(screen.getByRole('button', { name: /json/i }));
+
+      const textarea = screen.getByRole('textbox') as HTMLTextAreaElement;
+      expect(JSON.parse(textarea.value)).toEqual({
+        title: { _eq: 'foo' },
+        release_date: { _eq: null },
       });
     });
 
-    it('renders an existing exists node from default values', () => {
+    it('a JSON edit is reflected in the builder after switching mode', async () => {
       render(
         <TestWrapper
-          defaultValues={{
-            rule: group('_and', [
-              condition('title'),
-              existsNode('public', 'authors'),
-            ]),
-          }}
+          defaultValues={{ rule: group('_implicit', []) }}
+          mode="json"
         >
-          <CustomCheckEditor {...defaultProps} />
+          <HarnessWithToggle />
         </TestWrapper>,
       );
 
-      expect(screen.getByText('Exists')).toBeInTheDocument();
-      expect(screen.getByText('public.authors')).toBeInTheDocument();
-    });
-
-    it('"exists" option appears inside an ExistsNodeRenderer Add button', async () => {
-      render(
-        <TestWrapper
-          defaultValues={{
-            rule: group('_and', [existsNode('public', 'authors')]),
-          }}
-        >
-          <CustomCheckEditor {...defaultProps} />
-        </TestWrapper>,
-      );
-
-      // Two Add buttons: one inside the exists where clause, one at the root
-      const addButtons = screen.getAllByText('Add');
-      expect(addButtons).toHaveLength(2);
-
+      const textarea = screen.getByRole('textbox') as HTMLTextAreaElement;
       const user = new TestUserEvent();
-      await user.click(addButtons[0]);
-
-      expect(
-        await screen.findByRole('option', { name: 'exists' }),
-      ).toBeInTheDocument();
-    });
-
-    it('renders a nested exists node inside an exists node', () => {
-      render(
-        <TestWrapper
-          defaultValues={{
-            rule: group('_and', [
-              existsNode(
-                'public',
-                'town',
-                group('_and', [
-                  condition('name'),
-                  existsNode('public', 'actor'),
-                ]),
-              ),
-            ]),
-          }}
-        >
-          <CustomCheckEditor {...defaultProps} />
-        </TestWrapper>,
+      await user.clear(textarea);
+      await user.paste(
+        '{"_and":[{"title":{"_eq":"foo"}},{"release_date":{"_gt":"2020-01-01"}}]}',
       );
 
-      expect(screen.getByText('public.town')).toBeInTheDocument();
-      expect(screen.getByText('public.actor')).toBeInTheDocument();
-    });
+      await user.click(screen.getByRole('button', { name: /visual/i }));
 
-    it('exists node renders a TableComboBox and a nested group for the WHERE clause', () => {
-      render(
-        <TestWrapper
-          defaultValues={{
-            rule: group('_and', [existsNode('public', 'town')]),
-          }}
-        >
-          <CustomCheckEditor {...defaultProps} />
-        </TestWrapper>,
-      );
-
-      expect(screen.getByText('public.town')).toBeInTheDocument();
-      expect(screen.getByText('Implicit')).toBeInTheDocument();
-      expect(screen.getAllByText('Add')).toHaveLength(2);
-    });
-
-    it('nested conditions inside an exists node render alongside the exists table', async () => {
-      render(
-        <TestWrapper
-          defaultValues={{
-            rule: group('_and', [
-              condition('title'),
-              existsNode(
-                'public',
-                'town',
-                group('_implicit', [condition('name')]),
-              ),
-            ]),
-          }}
-        >
-          <CustomCheckEditor {...defaultProps} />
-        </TestWrapper>,
-      );
-
-      // Root condition and exists node's inner condition both render
-      expect(await screen.findByText('title')).toBeInTheDocument();
-      expect(screen.getByText('name')).toBeInTheDocument();
-      // The exists node shows its table
-      expect(screen.getByText('public.town')).toBeInTheDocument();
-    });
-
-    it('"Delete Exists" button removes the exists node', async () => {
-      render(
-        <TestWrapper
-          defaultValues={{
-            rule: group('_and', [
-              condition('title'),
-              existsNode('public', 'authors'),
-            ]),
-          }}
-        >
-          <CustomCheckEditor {...defaultProps} />
-        </TestWrapper>,
-      );
-
-      expect(screen.getByText('public.authors')).toBeInTheDocument();
-
-      const user = new TestUserEvent();
-      await user.click(screen.getByRole('button', { name: /delete exists/i }));
-
-      await waitFor(() => {
-        expect(screen.queryByText('public.authors')).not.toBeInTheDocument();
-        expect(screen.queryByText('Exists')).not.toBeInTheDocument();
-      });
-
-      expect(await screen.findByText('title')).toBeInTheDocument();
-    });
-  });
-
-  describe('condition row behavior', () => {
-    it('changing the column resets operator to _eq', async () => {
-      render(
-        <TestWrapper
-          defaultValues={{
-            rule: group('_and', [
-              {
-                type: 'condition',
-                id: crypto.randomUUID(),
-                column: 'title',
-                operator: '_gt',
-                value: 18,
-              } satisfies ConditionNode,
-            ]),
-          }}
-        >
-          <CustomCheckEditor {...defaultProps} />
-        </TestWrapper>,
-      );
-
-      expect(await screen.findByText('title')).toBeInTheDocument();
+      expect(await screen.findByText('AND')).toBeInTheDocument();
+      expect(screen.getByText('title')).toBeInTheDocument();
+      expect(screen.getByText('release_date')).toBeInTheDocument();
       expect(screen.getByText('_gt')).toBeInTheDocument();
-
-      const user = new TestUserEvent();
-      await user.click(screen.getByText('title'));
-      await user.click(
-        await screen.findByRole('option', { name: /release_date/ }),
-      );
-
-      await waitFor(() => {
-        expect(screen.getByText('release_date')).toBeInTheDocument();
-        expect(screen.getByText('_eq')).toBeInTheDocument();
-      });
-
-      expect(screen.queryByText('_gt')).not.toBeInTheDocument();
-    });
-  });
-
-  describe('relationship nodes', () => {
-    it('selecting a relationship from AddNodeButton appends a relationship node', async () => {
-      render(
-        <TestWrapper
-          defaultValues={{
-            rule: group('_and', [condition('title')]),
-          }}
-        >
-          <CustomCheckEditor {...defaultProps} />
-        </TestWrapper>,
-      );
-
-      const user = new TestUserEvent();
-      await user.click(screen.getByText('Add'));
-      // Use exact match to avoid matching the 'author_id' column option
-      await user.click(await screen.findByRole('option', { name: 'author' }));
-
-      await waitFor(() => {
-        expect(screen.getByText('Relationship')).toBeInTheDocument();
-        expect(screen.getByText('author')).toBeInTheDocument();
-      });
-    });
-
-    it('renders an existing relationship node with badge and combobox', () => {
-      render(
-        <TestWrapper
-          defaultValues={{
-            rule: group('_and', [
-              condition('title'),
-              relationshipNode('author'),
-            ]),
-          }}
-        >
-          <CustomCheckEditor {...defaultProps} />
-        </TestWrapper>,
-      );
-
-      expect(screen.getByText('Relationship')).toBeInTheDocument();
-      expect(screen.getByText('author')).toBeInTheDocument();
-    });
-
-    it('"Delete relationship" button removes the relationship node', async () => {
-      render(
-        <TestWrapper
-          defaultValues={{
-            rule: group('_and', [
-              condition('title'),
-              relationshipNode('author'),
-            ]),
-          }}
-        >
-          <CustomCheckEditor {...defaultProps} />
-        </TestWrapper>,
-      );
-
-      expect(screen.getByText('author')).toBeInTheDocument();
-      expect(screen.getByText('Relationship')).toBeInTheDocument();
-
-      const user = new TestUserEvent();
-      await user.click(
-        screen.getByRole('button', { name: /delete relationship/i }),
-      );
-
-      await waitFor(() => {
-        expect(screen.queryByText('Relationship')).not.toBeInTheDocument();
-        expect(screen.queryByText('author')).not.toBeInTheDocument();
-      });
-
-      expect(await screen.findByText('title')).toBeInTheDocument();
-    });
-
-    it('renders inner conditions inside a relationship node', async () => {
-      render(
-        <TestWrapper
-          defaultValues={{
-            rule: group('_and', [
-              relationshipNode(
-                'author',
-                group('_and', [condition('name'), condition('birth_date')]),
-              ),
-            ]),
-          }}
-        >
-          <CustomCheckEditor {...defaultProps} />
-        </TestWrapper>,
-      );
-
-      expect(await screen.findByText('name')).toBeInTheDocument();
-      expect(await screen.findByText('birth_date')).toBeInTheDocument();
-      expect(await screen.findByText('Relationship')).toBeInTheDocument();
-    });
-
-    it('renders a nested relationship node inside a relationship node', () => {
-      render(
-        <TestWrapper
-          defaultValues={{
-            rule: group('_and', [
-              relationshipNode(
-                'author',
-                group('_and', [condition('title'), relationshipNode('posts')]),
-              ),
-            ]),
-          }}
-        >
-          <CustomCheckEditor {...defaultProps} />
-        </TestWrapper>,
-      );
-
-      expect(screen.getByText('author')).toBeInTheDocument();
-      expect(screen.getByText('posts')).toBeInTheDocument();
-      expect(screen.getAllByText('Relationship')).toHaveLength(2);
-    });
-
-    it('renders an exists node inside a relationship node', () => {
-      render(
-        <TestWrapper
-          defaultValues={{
-            rule: group('_and', [
-              relationshipNode(
-                'author',
-                group('_and', [
-                  condition('title'),
-                  existsNode('public', 'actor'),
-                ]),
-              ),
-            ]),
-          }}
-        >
-          <CustomCheckEditor {...defaultProps} />
-        </TestWrapper>,
-      );
-
-      expect(screen.getByText('author')).toBeInTheDocument();
-      expect(screen.getByText('Relationship')).toBeInTheDocument();
-      expect(screen.getByText('public.actor')).toBeInTheDocument();
-      expect(screen.getByText('Exists')).toBeInTheDocument();
-    });
-
-    it('renders a relationship node inside an exists node', () => {
-      render(
-        <TestWrapper
-          defaultValues={{
-            rule: group('_and', [
-              existsNode(
-                'public',
-                'town',
-                group('_and', [
-                  condition('title'),
-                  relationshipNode('customer'),
-                ]),
-              ),
-            ]),
-          }}
-        >
-          <CustomCheckEditor {...defaultProps} />
-        </TestWrapper>,
-      );
-
-      expect(screen.getByText('public.town')).toBeInTheDocument();
-      expect(screen.getByText('Exists')).toBeInTheDocument();
-      expect(screen.getByText('customer')).toBeInTheDocument();
-      expect(screen.getByText('Relationship')).toBeInTheDocument();
-    });
-
-    it('"Delete relationship" button is disabled when disabled prop is true', () => {
-      render(
-        <TestWrapper
-          defaultValues={{
-            rule: group('_and', [
-              condition('title'),
-              relationshipNode('author'),
-            ]),
-          }}
-        >
-          <CustomCheckEditor {...defaultProps} disabled />
-        </TestWrapper>,
-      );
-
-      const deleteButton = screen.getByRole('button', {
-        name: /delete relationship/i,
-      });
-      expect(deleteButton).toBeDisabled();
-    });
-  });
-
-  describe('edge cases', () => {
-    it('mixed node types at the same level (condition + group + exists + relationship) render correctly', async () => {
-      render(
-        <TestWrapper
-          defaultValues={{
-            rule: group('_and', [
-              condition('title'),
-              group('_or', [condition('release_date')]),
-              existsNode('public', 'town'),
-              relationshipNode('author'),
-            ]),
-          }}
-        >
-          <CustomCheckEditor {...defaultProps} />
-        </TestWrapper>,
-      );
-
-      expect(await screen.findByText('title')).toBeInTheDocument();
-      expect(screen.getByText('release_date')).toBeInTheDocument();
-      expect(screen.getByText('OR')).toBeInTheDocument();
-      expect(screen.getByText('Exists')).toBeInTheDocument();
-      expect(screen.getByText('public.town')).toBeInTheDocument();
-      expect(screen.getByText('Relationship')).toBeInTheDocument();
-      expect(screen.getByText('author')).toBeInTheDocument();
-    });
-
-    it('renders an exists node inside a nested group node', () => {
-      render(
-        <TestWrapper
-          defaultValues={{
-            rule: group('_and', [
-              group('_or', [condition('title'), existsNode('public', 'town')]),
-            ]),
-          }}
-        >
-          <CustomCheckEditor {...defaultProps} />
-        </TestWrapper>,
-      );
-
-      expect(screen.getByText('OR')).toBeInTheDocument();
-      expect(screen.getByText('Exists')).toBeInTheDocument();
-      expect(screen.getByText('public.town')).toBeInTheDocument();
-    });
-
-    it('renders a relationship node inside a nested group node', () => {
-      render(
-        <TestWrapper
-          defaultValues={{
-            rule: group('_and', [
-              group('_or', [condition('title'), relationshipNode('author')]),
-            ]),
-          }}
-        >
-          <CustomCheckEditor {...defaultProps} />
-        </TestWrapper>,
-      );
-
-      expect(screen.getByText('OR')).toBeInTheDocument();
-      expect(screen.getByText('Relationship')).toBeInTheDocument();
-      expect(screen.getByText('author')).toBeInTheDocument();
-    });
-
-    it('renders exists and relationship nodes inside deeply nested groups', () => {
-      render(
-        <TestWrapper
-          defaultValues={{
-            rule: group('_and', [
-              group('_or', [
-                group('_and', [
-                  existsNode('public', 'town'),
-                  relationshipNode('author'),
-                ]),
-              ]),
-            ]),
-          }}
-        >
-          <CustomCheckEditor {...defaultProps} />
-        </TestWrapper>,
-      );
-
-      expect(screen.getByText('Exists')).toBeInTheDocument();
-      expect(screen.getByText('public.town')).toBeInTheDocument();
-      expect(screen.getByText('Relationship')).toBeInTheDocument();
-      expect(screen.getByText('author')).toBeInTheDocument();
-    });
-
-    it('rapid add/remove operations do not cause state inconsistencies', async () => {
-      render(
-        <TestWrapper
-          defaultValues={{
-            rule: group('_and', [condition('title')]),
-          }}
-        >
-          <CustomCheckEditor {...defaultProps} />
-        </TestWrapper>,
-      );
-
-      expect(await screen.findByText('title')).toBeInTheDocument();
-
-      const user = new TestUserEvent();
-
-      // Add 2 conditions via the popover
-      await user.click(screen.getByText('Add'));
-      await user.click(
-        await screen.findByRole('option', { name: /release_date/ }),
-      );
-      await waitFor(() => {
-        expect(screen.getByText('release_date')).toBeInTheDocument();
-      });
-
-      await user.click(screen.getByText('Add'));
-      await user.click(
-        await screen.findByRole('option', { name: /author_id/ }),
-      );
-      await waitFor(() => {
-        expect(screen.getByText('author_id')).toBeInTheDocument();
-      });
-
-      // Remove the last condition
-      const removeButtons = screen.getAllByRole('button', {
-        name: /delete condition/i,
-      });
-      await user.click(removeButtons[removeButtons.length - 1]);
-
-      await waitFor(() => {
-        expect(
-          screen.getAllByRole('button', { name: /delete condition/i }),
-        ).toHaveLength(2);
-        expect(screen.queryByText('author_id')).not.toBeInTheDocument();
-        expect(screen.getByText('title')).toBeInTheDocument();
-        expect(screen.getByText('release_date')).toBeInTheDocument();
-      });
-    });
-
-    it('_not operator with multiple children renders correctly', async () => {
-      render(
-        <TestWrapper
-          defaultValues={{
-            rule: group('_not', [
-              condition('title'),
-              condition('release_date'),
-              condition('author_id'),
-            ]),
-          }}
-        >
-          <CustomCheckEditor {...defaultProps} />
-        </TestWrapper>,
-      );
-
-      expect(screen.getByText('NOT')).toBeInTheDocument();
-      expect(await screen.findByText('title')).toBeInTheDocument();
-      expect(screen.getByText('release_date')).toBeInTheDocument();
-      expect(screen.getByText('author_id')).toBeInTheDocument();
-      expect(
-        screen.getAllByRole('button', { name: /delete condition/i }),
-      ).toHaveLength(3);
-    });
-  });
-
-  describe('empty state (root level)', () => {
-    it('renders AddNodeButton when filter is an empty _implicit group', () => {
-      render(
-        <TestWrapper
-          defaultValues={{
-            rule: group('_implicit', []),
-          }}
-        >
-          <CustomCheckEditor {...defaultProps} />
-        </TestWrapper>,
-      );
-
-      // AddNodeButton is present
-      expect(
-        screen.getByRole('button', { name: /add check/i }),
-      ).toBeInTheDocument();
-      // No group UI elements are rendered
-      expect(screen.queryByText('AND')).not.toBeInTheDocument();
-      expect(screen.queryByText('OR')).not.toBeInTheDocument();
-      expect(screen.queryByText('NOT')).not.toBeInTheDocument();
-      expect(screen.queryByText('Implicit')).not.toBeInTheDocument();
-      expect(screen.queryByRole('combobox')).not.toBeInTheDocument();
-      expect(
-        screen.queryByRole('button', { name: /delete group/i }),
-      ).not.toBeInTheDocument();
-    });
-
-    it('renders AddNodeButton when filter is an empty object', () => {
-      render(
-        <TestWrapper defaultValues={{ rule: {} }}>
-          <CustomCheckEditor {...defaultProps} />
-        </TestWrapper>,
-      );
-
-      expect(
-        screen.getByRole('button', { name: /add check/i }),
-      ).toBeInTheDocument();
-      // No group UI
-      expect(screen.queryByText('AND')).not.toBeInTheDocument();
-      expect(screen.queryByText('OR')).not.toBeInTheDocument();
-      expect(screen.queryByRole('combobox')).not.toBeInTheDocument();
-      expect(
-        screen.queryByRole('button', { name: /delete group/i }),
-      ).not.toBeInTheDocument();
-    });
-
-    it('renders GroupNodeRenderer (not AddNodeButton at root) when filter has content', () => {
-      render(
-        <TestWrapper
-          defaultValues={{
-            rule: group('_and', [condition('title')]),
-          }}
-        >
-          <CustomCheckEditor {...defaultProps} />
-        </TestWrapper>,
-      );
-
-      // Group UI is rendered
-      expect(screen.getByText('AND')).toBeInTheDocument();
-      expect(
-        screen.getByRole('button', { name: /delete group/i }),
-      ).toBeInTheDocument();
-      // The root-level full-width "Add check" button should not be present
-      expect(
-        screen.queryByRole('button', { name: /add check/i }),
-      ).not.toBeInTheDocument();
-      // The group-level "Add" button should be present
-      expect(screen.getByText('Add')).toBeInTheDocument();
-    });
-
-    it('selecting a condition from AddNodeButton at root wraps it in an _implicit group', async () => {
-      render(
-        <TestWrapper defaultValues={{ rule: group('_implicit', []) }}>
-          <CustomCheckEditor {...defaultProps} />
-        </TestWrapper>,
-      );
-
-      const user = new TestUserEvent();
-      await user.click(screen.getByRole('button', { name: /add check/i }));
-      await user.click(await screen.findByRole('option', { name: /title/ }));
-
-      await waitFor(() => {
-        expect(screen.getByText('Implicit')).toBeInTheDocument();
-        expect(screen.getByText('title')).toBeInTheDocument();
-      });
-    });
-
-    it('selecting a group from AddNodeButton at root sets it directly as root (no _implicit wrapping)', async () => {
-      render(
-        <TestWrapper defaultValues={{ rule: group('_implicit', []) }}>
-          <CustomCheckEditor {...defaultProps} />
-        </TestWrapper>,
-      );
-
-      const user = new TestUserEvent();
-      await user.click(screen.getByRole('button', { name: /add check/i }));
-      await user.click(await screen.findByRole('option', { name: 'and' }));
-
-      await waitFor(() => {
-        expect(screen.getByText('AND')).toBeInTheDocument();
-        expect(screen.queryByText('Implicit')).not.toBeInTheDocument();
-        expect(
-          screen.queryByRole('button', { name: /add check/i }),
-        ).not.toBeInTheDocument();
-      });
-    });
-
-    it('selecting a relationship from AddNodeButton at root wraps it in an _implicit group', async () => {
-      render(
-        <TestWrapper defaultValues={{ rule: group('_implicit', []) }}>
-          <CustomCheckEditor {...defaultProps} />
-        </TestWrapper>,
-      );
-
-      const user = new TestUserEvent();
-      await user.click(screen.getByRole('button', { name: /add check/i }));
-      await user.click(await screen.findByRole('option', { name: 'author' }));
-
-      await waitFor(() => {
-        expect(screen.getByText('Implicit')).toBeInTheDocument();
-        expect(screen.getByText('Relationship')).toBeInTheDocument();
-        expect(screen.getByText('author')).toBeInTheDocument();
-      });
-    });
-
-    it('selecting exists from AddNodeButton at root wraps it in an _implicit group', async () => {
-      render(
-        <TestWrapper defaultValues={{ rule: group('_implicit', []) }}>
-          <CustomCheckEditor {...defaultProps} />
-        </TestWrapper>,
-      );
-
-      const user = new TestUserEvent();
-      await user.click(screen.getByRole('button', { name: /add check/i }));
-      await user.click(await screen.findByRole('option', { name: 'exists' }));
-
-      const existWrapper = screen.getAllByText('Implicit')[1];
-      expect(existWrapper).toBeInTheDocument();
-      expect(screen.getByText('Exists')).toBeInTheDocument();
-      expect(screen.getByText('Select table...')).toBeInTheDocument();
-    });
-  });
-
-  describe('root remove (reset to empty)', () => {
-    it('clicking the root delete button resets to empty state with no group UI', async () => {
-      render(
-        <TestWrapper
-          defaultValues={{
-            rule: group('_and', [condition('title')]),
-          }}
-        >
-          <CustomCheckEditor {...defaultProps} />
-        </TestWrapper>,
-      );
-
-      expect(screen.getByText('AND')).toBeInTheDocument();
-      expect(await screen.findByText('title')).toBeInTheDocument();
-
-      const user = new TestUserEvent();
-      await user.click(screen.getByRole('button', { name: /delete group/i }));
-
-      await waitFor(() => {
-        expect(screen.queryByText('AND')).not.toBeInTheDocument();
-        expect(screen.queryByText('title')).not.toBeInTheDocument();
-        expect(
-          screen.queryByRole('button', { name: /delete group/i }),
-        ).not.toBeInTheDocument();
-        expect(
-          screen.getByRole('button', { name: /add check/i }),
-        ).toBeInTheDocument();
-      });
-    });
-
-    it('after resetting to empty, selecting a new node works correctly', async () => {
-      render(
-        <TestWrapper
-          defaultValues={{
-            rule: group('_and', [condition('title')]),
-          }}
-        >
-          <CustomCheckEditor {...defaultProps} />
-        </TestWrapper>,
-      );
-
-      expect(await screen.findByText('title')).toBeInTheDocument();
-
-      const user = new TestUserEvent();
-      await user.click(screen.getByRole('button', { name: /delete group/i }));
-
-      await waitFor(() => {
-        expect(
-          screen.getByRole('button', { name: /add check/i }),
-        ).toBeInTheDocument();
-      });
-
-      await user.click(screen.getByRole('button', { name: /add check/i }));
-      await user.click(await screen.findByRole('option', { name: 'and' }));
-
-      await waitFor(() => {
-        expect(screen.getByText('AND')).toBeInTheDocument();
-      });
-    });
-  });
-
-  describe('empty groups (nested level)', () => {
-    it('a newly added nested group renders AddNodeButton (full-width) inside it', async () => {
-      render(
-        <TestWrapper
-          defaultValues={{
-            rule: group('_and', [condition('title')]),
-          }}
-        >
-          <CustomCheckEditor {...defaultProps} />
-        </TestWrapper>,
-      );
-
-      expect(await screen.findByText('title')).toBeInTheDocument();
-
-      const user = new TestUserEvent();
-      // Add a nested group via the popover
-      await user.click(screen.getByText('Add'));
-      await user.click(await screen.findByRole('option', { name: 'and' }));
-
-      await waitFor(() => {
-        // Root group AND + nested group AND
-        expect(screen.getAllByText('AND')).toHaveLength(2);
-        // Root group has one Add, nested empty group has one full-width Add
-        const addButtons = screen.getAllByText('Add');
-        expect(addButtons).toHaveLength(2);
-      });
-    });
-
-    it('selecting a rule from AddNodeButton inside a nested group appends it directly', async () => {
-      render(
-        <TestWrapper
-          defaultValues={{
-            rule: group('_and', [condition('title')]),
-          }}
-        >
-          <CustomCheckEditor {...defaultProps} />
-        </TestWrapper>,
-      );
-
-      expect(await screen.findByText('title')).toBeInTheDocument();
-
-      const user = new TestUserEvent();
-      // Add a nested group first
-      await user.click(screen.getByText('Add'));
-      await user.click(await screen.findByRole('option', { name: 'and' }));
-
-      await waitFor(() => {
-        expect(screen.getAllByText('AND')).toHaveLength(2);
-      });
-
-      // Click the nested group's Add button (first in DOM order)
-      const addButtons = screen.getAllByText('Add');
-      await user.click(addButtons[0]);
-      await user.click(await screen.findByRole('option', { name: /title/ }));
-
-      await waitFor(() => {
-        expect(screen.getAllByText('title')).toHaveLength(2);
-        expect(
-          screen.getAllByRole('button', { name: /delete condition/i }),
-        ).toHaveLength(2);
-      });
-    });
-
-    it('selecting a group from AddNodeButton inside a nested group appends it directly', async () => {
-      render(
-        <TestWrapper
-          defaultValues={{
-            rule: group('_and', [condition('title')]),
-          }}
-        >
-          <CustomCheckEditor {...defaultProps} />
-        </TestWrapper>,
-      );
-
-      expect(await screen.findByText('title')).toBeInTheDocument();
-
-      const user = new TestUserEvent();
-      // Add a nested group first
-      await user.click(screen.getByText('Add'));
-      await user.click(await screen.findByRole('option', { name: 'and' }));
-
-      await waitFor(() => {
-        expect(screen.getAllByText('AND')).toHaveLength(2);
-      });
-
-      // Click the nested group's Add button (first in DOM order)
-      const addButtons = screen.getAllByText('Add');
-      await user.click(addButtons[0]);
-      await user.click(await screen.findByRole('option', { name: 'or' }));
-
-      await waitFor(() => {
-        expect(screen.getAllByText('AND')).toHaveLength(2);
-        expect(screen.getByText('OR')).toBeInTheDocument();
-      });
-    });
-
-    it('removing the last child from a nested group shows AddNodeButton inside it', async () => {
-      render(
-        <TestWrapper
-          defaultValues={{
-            rule: group('_and', [
-              condition('title'),
-              group('_or', [condition('release_date')]),
-            ]),
-          }}
-        >
-          <CustomCheckEditor {...defaultProps} />
-        </TestWrapper>,
-      );
-
-      expect(await screen.findByText('title')).toBeInTheDocument();
-      expect(screen.getByText('release_date')).toBeInTheDocument();
-
-      const user = new TestUserEvent();
-      // Remove the condition inside the nested _or group
-      const removeButtons = screen.getAllByRole('button', {
-        name: /delete condition/i,
-      });
-      // The last trash button belongs to the nested condition
-      await user.click(removeButtons[removeButtons.length - 1]);
-
-      await waitFor(() => {
-        // release_date removed, title remains
-        expect(screen.queryByText('release_date')).not.toBeInTheDocument();
-        expect(screen.getByText('title')).toBeInTheDocument();
-        // The nested group still exists (OR badge) with an Add button inside
-        expect(screen.getByText('OR')).toBeInTheDocument();
-        // Root group Add + nested empty group Add
-        expect(screen.getAllByText('Add')).toHaveLength(2);
-      });
-    });
-  });
-
-  describe('exists/relationship empty children', () => {
-    it('a newly added exists node has an empty where clause that shows AddNodeButton', async () => {
-      render(
-        <TestWrapper
-          defaultValues={{
-            rule: group('_and', [condition('title')]),
-          }}
-        >
-          <CustomCheckEditor {...defaultProps} />
-        </TestWrapper>,
-      );
-
-      expect(await screen.findByText('title')).toBeInTheDocument();
-
-      const user = new TestUserEvent();
-      await user.click(screen.getByText('Add'));
-      await user.click(await screen.findByRole('option', { name: 'exists' }));
-
-      await waitFor(() => {
-        expect(screen.getByText('Exists')).toBeInTheDocument();
-        expect(screen.getByText('Select table...')).toBeInTheDocument();
-        // Root group Add + exists where clause Add
-        expect(screen.getAllByText('Add')).toHaveLength(2);
-      });
-    });
-
-    it('a newly added relationship node has an empty child group that shows AddNodeButton', async () => {
-      render(
-        <TestWrapper
-          defaultValues={{
-            rule: group('_and', [condition('title')]),
-          }}
-        >
-          <CustomCheckEditor {...defaultProps} />
-        </TestWrapper>,
-      );
-
-      expect(await screen.findByText('title')).toBeInTheDocument();
-
-      const user = new TestUserEvent();
-      await user.click(screen.getByText('Add'));
-      // Use exact match to avoid matching 'author_id' column
-      await user.click(await screen.findByRole('option', { name: 'author' }));
-
-      await waitFor(() => {
-        expect(screen.getByText('Relationship')).toBeInTheDocument();
-        expect(screen.getByText('author')).toBeInTheDocument();
-        // Root group Add + relationship child group Add
-        expect(screen.getAllByText('Add')).toHaveLength(2);
-      });
-    });
-  });
-
-  describe('node highlight styles', () => {
-    it('group node container has hover and focus-within highlight classes', () => {
-      render(
-        <TestWrapper
-          defaultValues={{
-            rule: group('_and', [condition('title')]),
-          }}
-        >
-          <CustomCheckEditor {...defaultProps} />
-        </TestWrapper>,
-      );
-
-      const groupContainer = screen
-        .getByText('AND')
-        .closest('[class*="rounded-lg"]');
-      expect(groupContainer?.className).toContain(
-        '[&:hover:not(:has(.group-node:hover))]:ring-2',
-      );
-      expect(groupContainer?.className).toContain(
-        '[&:hover:not(:has(.group-node:hover))]:ring-ring/50',
-      );
-      expect(groupContainer?.className).toContain(
-        '[&:focus-within:not(:has(.group-node:focus-within))]:ring-2',
-      );
-      expect(groupContainer?.className).toContain(
-        '[&:focus-within:not(:has(.group-node:focus-within))]:ring-ring/30',
-      );
-      expect(groupContainer?.className).toContain('transition-shadow');
-    });
-
-    it('condition row has hover and focus-within background highlight classes', () => {
-      render(
-        <TestWrapper
-          defaultValues={{
-            rule: group('_and', [condition('title')]),
-          }}
-        >
-          <CustomCheckEditor {...defaultProps} />
-        </TestWrapper>,
-      );
-
-      const conditionRow = screen
-        .getByRole('button', { name: /delete condition/i })
-        .closest('[class*="transition-colors"]');
-      expect(conditionRow).not.toBeNull();
-      expect(conditionRow?.className).toContain('hover:bg-accent');
-      expect(conditionRow?.className).toContain('transition-colors');
-    });
-
-    it('exists node container has hover and focus-within highlight classes with blue ring', async () => {
-      render(
-        <TestWrapper
-          defaultValues={{
-            rule: group('_and', [
-              {
-                type: 'exists',
-                id: crypto.randomUUID(),
-                schema: 'public',
-                table: 'authors',
-                where: group('_implicit', []),
-              } satisfies ExistsNode,
-            ]),
-          }}
-        >
-          <CustomCheckEditor {...defaultProps} />
-        </TestWrapper>,
-      );
-
-      const existsLabel = screen.getByLabelText('Delete exists');
-      const existsContainer = existsLabel.closest('[class*="bg-blue-50"]');
-      expect(existsContainer?.className).toContain(
-        '[&:hover:not(:has(.group-node:hover))]:ring-2',
-      );
-      expect(existsContainer?.className).toContain(
-        '[&:hover:not(:has(.group-node:hover))]:ring-blue-400/30',
-      );
-      expect(existsContainer?.className).toContain(
-        '[&:focus-within:not(:has(.group-node:focus-within))]:ring-2',
-      );
-      expect(existsContainer?.className).toContain(
-        '[&:focus-within:not(:has(.group-node:focus-within))]:ring-blue-400/40',
-      );
-      expect(existsContainer?.className).toContain('transition-shadow');
-    });
-
-    it('relationship node container has hover and focus-within highlight classes with emerald ring', async () => {
-      render(
-        <TestWrapper
-          defaultValues={{
-            rule: group('_and', [
-              {
-                type: 'relationship',
-                id: crypto.randomUUID(),
-                relationship: 'author',
-                child: group('_implicit', []),
-              } satisfies RelationshipNode,
-            ]),
-          }}
-        >
-          <CustomCheckEditor {...defaultProps} />
-        </TestWrapper>,
-      );
-
-      const relationshipLabel = screen.getByLabelText('Delete relationship');
-      const relationshipContainer = relationshipLabel.closest(
-        '[class*="bg-emerald-50"]',
-      );
-      expect(relationshipContainer?.className).toContain(
-        '[&:hover:not(:has(.group-node:hover))]:ring-2',
-      );
-      expect(relationshipContainer?.className).toContain(
-        '[&:hover:not(:has(.group-node:hover))]:ring-emerald-400/30',
-      );
-      expect(relationshipContainer?.className).toContain(
-        '[&:focus-within:not(:has(.group-node:focus-within))]:ring-2',
-      );
-      expect(relationshipContainer?.className).toContain(
-        '[&:focus-within:not(:has(.group-node:focus-within))]:ring-emerald-400/40',
-      );
-      expect(relationshipContainer?.className).toContain('transition-shadow');
-    });
-  });
-
-  describe('AddNodeButton disabled state', () => {
-    it('AddNodeButton at root level is disabled when disabled prop is true', () => {
-      render(
-        <TestWrapper defaultValues={{ rule: group('_implicit', []) }}>
-          <CustomCheckEditor {...defaultProps} disabled />
-        </TestWrapper>,
-      );
-
-      expect(screen.getByRole('button', { name: /add check/i })).toBeDisabled();
-    });
-
-    it('AddNodeButton inside nested groups is disabled when disabled prop is true', () => {
-      render(
-        <TestWrapper
-          defaultValues={{
-            rule: group('_and', [condition('title')]),
-          }}
-        >
-          <CustomCheckEditor {...defaultProps} disabled />
-        </TestWrapper>,
-      );
-
-      expect(screen.getByText('Add')).toBeDisabled();
     });
   });
 });

--- a/dashboard/src/features/orgs/projects/database/dataGrid/components/CustomCheckEditor/CustomCheckEditor.tsx
+++ b/dashboard/src/features/orgs/projects/database/dataGrid/components/CustomCheckEditor/CustomCheckEditor.tsx
@@ -1,102 +1,36 @@
-import { useMemo } from 'react';
-import { useFormContext, useWatch } from 'react-hook-form';
-import { v4 as uuidv4 } from 'uuid';
-import type { RuleNode } from '@/features/orgs/projects/database/dataGrid/utils/permissionUtils';
-import AddNodeButton from './AddNodeButton';
-import GroupNodeRenderer from './GroupNodeRenderer';
-import { CustomCheckEditorContext } from './useCustomCheckEditor';
+import { useCustomCheckMode } from './CustomCheckModeProvider';
+import FilterErrorsSummary from './FilterErrorsSummary';
+import JsonRuleEditor from './JsonRuleEditor';
+import VisualRuleEditor from './VisualRuleEditor';
 
 export interface CustomCheckEditorProps {
-  disabled?: boolean;
   schema: string;
   table: string;
   name: string;
   maxDepth?: number;
 }
 
-function isEmptyFilter(value: unknown): boolean {
-  if (!value || typeof value !== 'object') {
-    return true;
-  }
-
-  const obj = value as Record<string, unknown>;
-
-  if (Object.keys(obj).length === 0) {
-    return true;
-  }
-
-  if (
-    obj.type === 'group' &&
-    obj.operator === '_implicit' &&
-    Array.isArray(obj.children) &&
-    obj.children.length === 0
-  ) {
-    return true;
-  }
-
-  return false;
-}
-
 export default function CustomCheckEditor({
-  disabled,
   schema,
   table,
   name,
   maxDepth,
 }: CustomCheckEditorProps) {
-  const { setValue } = useFormContext();
-  const filterValue = useWatch({ name });
-
-  const contextValue = useMemo(
-    () => ({
-      disabled: !!disabled,
-      schema,
-      table,
-    }),
-    [disabled, schema, table],
-  );
-
-  const isEmpty = isEmptyFilter(filterValue);
-
-  function handleAddNodeSelect(node: RuleNode) {
-    if (node.type === 'group') {
-      setValue(name, node);
-    } else {
-      setValue(name, {
-        type: 'group',
-        id: uuidv4(),
-        operator: '_implicit',
-        children: [node],
-      });
-    }
-  }
-
-  function handleRootRemove() {
-    setValue(name, {
-      type: 'group',
-      operator: '_implicit',
-      children: [],
-      id: uuidv4(),
-    });
-  }
+  const { mode } = useCustomCheckMode();
 
   return (
-    <CustomCheckEditorContext.Provider value={contextValue}>
-      <div className="w-full overflow-x-auto p-0.5 text-primary-text">
-        {isEmpty ? (
-          <AddNodeButton
-            onSelect={handleAddNodeSelect}
-            disabled={disabled}
-            fullWidth
-          />
-        ) : (
-          <GroupNodeRenderer
-            name={name}
-            maxDepth={maxDepth}
-            onRemove={handleRootRemove}
-          />
-        )}
-      </div>
-    </CustomCheckEditorContext.Provider>
+    <div className="w-full overflow-x-auto p-0.5 text-primary-text">
+      <FilterErrorsSummary name={name} />
+      {mode === 'json' ? (
+        <JsonRuleEditor name={name} />
+      ) : (
+        <VisualRuleEditor
+          schema={schema}
+          table={table}
+          name={name}
+          maxDepth={maxDepth}
+        />
+      )}
+    </div>
   );
 }

--- a/dashboard/src/features/orgs/projects/database/dataGrid/components/CustomCheckEditor/CustomCheckModeProvider.tsx
+++ b/dashboard/src/features/orgs/projects/database/dataGrid/components/CustomCheckEditor/CustomCheckModeProvider.tsx
@@ -1,0 +1,45 @@
+import {
+  createContext,
+  type ReactNode,
+  useContext,
+  useMemo,
+  useState,
+} from 'react';
+
+export type CustomCheckEditorMode = 'builder' | 'json';
+
+interface CustomCheckModeContextValue {
+  mode: CustomCheckEditorMode;
+  setMode: (mode: CustomCheckEditorMode) => void;
+}
+
+const CustomCheckModeContext =
+  createContext<CustomCheckModeContextValue | null>(null);
+
+export interface CustomCheckModeProviderProps {
+  children: ReactNode;
+  defaultMode?: CustomCheckEditorMode;
+}
+
+export function CustomCheckModeProvider({
+  children,
+  defaultMode = 'builder',
+}: CustomCheckModeProviderProps) {
+  const [mode, setMode] = useState<CustomCheckEditorMode>(defaultMode);
+  const value = useMemo(() => ({ mode, setMode }), [mode]);
+  return (
+    <CustomCheckModeContext.Provider value={value}>
+      {children}
+    </CustomCheckModeContext.Provider>
+  );
+}
+
+export function useCustomCheckMode(): CustomCheckModeContextValue {
+  const ctx = useContext(CustomCheckModeContext);
+  if (!ctx) {
+    throw new Error(
+      'useCustomCheckMode must be used within a CustomCheckModeProvider',
+    );
+  }
+  return ctx;
+}

--- a/dashboard/src/features/orgs/projects/database/dataGrid/components/CustomCheckEditor/CustomCheckModeToggle.test.tsx
+++ b/dashboard/src/features/orgs/projects/database/dataGrid/components/CustomCheckEditor/CustomCheckModeToggle.test.tsx
@@ -1,0 +1,71 @@
+import { render, screen, TestUserEvent } from '@/tests/testUtils';
+import { CustomCheckModeProvider } from './CustomCheckModeProvider';
+import CustomCheckModeToggle from './CustomCheckModeToggle';
+
+describe('CustomCheckModeToggle', () => {
+  it('renders the "Edit as:" label and both mode buttons', () => {
+    render(
+      <CustomCheckModeProvider>
+        <CustomCheckModeToggle />
+      </CustomCheckModeProvider>,
+    );
+
+    expect(screen.getByText('Edit as:')).toBeInTheDocument();
+    expect(screen.getByRole('button', { name: 'Visual' })).toBeInTheDocument();
+    expect(screen.getByRole('button', { name: 'JSON' })).toBeInTheDocument();
+  });
+
+  it('marks the default mode (builder) with aria-pressed="true"', () => {
+    render(
+      <CustomCheckModeProvider>
+        <CustomCheckModeToggle />
+      </CustomCheckModeProvider>,
+    );
+
+    expect(screen.getByRole('button', { name: 'Visual' })).toHaveAttribute(
+      'aria-pressed',
+      'true',
+    );
+    expect(screen.getByRole('button', { name: 'JSON' })).toHaveAttribute(
+      'aria-pressed',
+      'false',
+    );
+  });
+
+  it('respects the provider defaultMode', () => {
+    render(
+      <CustomCheckModeProvider defaultMode="json">
+        <CustomCheckModeToggle />
+      </CustomCheckModeProvider>,
+    );
+
+    expect(screen.getByRole('button', { name: 'Visual' })).toHaveAttribute(
+      'aria-pressed',
+      'false',
+    );
+    expect(screen.getByRole('button', { name: 'JSON' })).toHaveAttribute(
+      'aria-pressed',
+      'true',
+    );
+  });
+
+  it('updates the active mode when a button is clicked', async () => {
+    render(
+      <CustomCheckModeProvider>
+        <CustomCheckModeToggle />
+      </CustomCheckModeProvider>,
+    );
+
+    const user = new TestUserEvent();
+    await user.click(screen.getByRole('button', { name: 'JSON' }));
+
+    expect(screen.getByRole('button', { name: 'JSON' })).toHaveAttribute(
+      'aria-pressed',
+      'true',
+    );
+    expect(screen.getByRole('button', { name: 'Visual' })).toHaveAttribute(
+      'aria-pressed',
+      'false',
+    );
+  });
+});

--- a/dashboard/src/features/orgs/projects/database/dataGrid/components/CustomCheckEditor/CustomCheckModeToggle.tsx
+++ b/dashboard/src/features/orgs/projects/database/dataGrid/components/CustomCheckEditor/CustomCheckModeToggle.tsx
@@ -1,0 +1,47 @@
+import { Button } from '@/components/ui/v3/button';
+import { cn } from '@/lib/utils';
+import {
+  type CustomCheckEditorMode,
+  useCustomCheckMode,
+} from './CustomCheckModeProvider';
+
+const options: { value: CustomCheckEditorMode; label: string }[] = [
+  { value: 'builder', label: 'Visual' },
+  { value: 'json', label: 'JSON' },
+];
+
+export default function CustomCheckModeToggle() {
+  const { mode, setMode } = useCustomCheckMode();
+
+  return (
+    <div className="flex items-center gap-2">
+      <span className="text-muted-foreground text-xs">Edit as:</span>
+      <fieldset
+        aria-label="Editor mode"
+        className="inline-flex items-center gap-0.5 rounded-md border border-border bg-muted p-0.5"
+      >
+        {options.map(({ value, label }) => {
+          const isActive = mode === value;
+          return (
+            <Button
+              key={value}
+              type="button"
+              aria-pressed={isActive}
+              variant="ghost"
+              size="sm"
+              className={cn(
+                'h-7 px-2.5 text-xs',
+                isActive
+                  ? 'bg-background shadow-sm hover:bg-background'
+                  : 'text-muted-foreground hover:bg-transparent hover:text-foreground',
+              )}
+              onClick={() => setMode(value)}
+            >
+              {label}
+            </Button>
+          );
+        })}
+      </fieldset>
+    </div>
+  );
+}

--- a/dashboard/src/features/orgs/projects/database/dataGrid/components/CustomCheckEditor/ExistsNodeRenderer.tsx
+++ b/dashboard/src/features/orgs/projects/database/dataGrid/components/CustomCheckEditor/ExistsNodeRenderer.tsx
@@ -4,9 +4,7 @@ import { useFormContext, useWatch } from 'react-hook-form';
 import { cn } from '@/lib/utils';
 import GroupNodeRenderer from './GroupNodeRenderer';
 import TableComboBox from './TableComboBox';
-import useCustomCheckEditor, {
-  CustomCheckEditorContext,
-} from './useCustomCheckEditor';
+import { CustomCheckEditorContext } from './useCustomCheckEditor';
 
 interface ExistsNodeRendererProps {
   name: string;
@@ -19,21 +17,21 @@ export default function ExistsNodeRenderer({
   onRemove,
   depth = 0,
 }: ExistsNodeRendererProps) {
-  const { disabled: editorDisabled } = useCustomCheckEditor();
-  const { setValue } = useFormContext();
+  const { setValue, getFieldState, formState } = useFormContext();
 
   const schema: string = useWatch({ name: `${name}.schema` }) ?? '';
   const table: string = useWatch({ name: `${name}.table` }) ?? '';
 
-  const hasTable = Boolean(schema && table);
+  const { error: whereError } = getFieldState(`${name}.where`, formState);
+  const { error: tableError } = getFieldState(`${name}.table`, formState);
+  const { error: schemaError } = getFieldState(`${name}.schema`, formState);
 
   const contextValue = useMemo(
     () => ({
-      disabled: editorDisabled || !hasTable,
       schema,
       table,
     }),
-    [editorDisabled, hasTable, schema, table],
+    [schema, table],
   );
 
   function handleTableChange(value: { schema: string; table: string }) {
@@ -57,9 +55,8 @@ export default function ExistsNodeRenderer({
         <button
           type="button"
           onClick={onRemove}
-          disabled={editorDisabled}
           aria-label="Delete exists"
-          className="absolute top-2 right-2 rounded p-0.5 opacity-50 hover:opacity-100 disabled:pointer-events-none disabled:opacity-30"
+          className="absolute top-2 right-2 rounded p-0.5 opacity-50 hover:opacity-100"
         >
           <X className="h-4 w-4" />
         </button>
@@ -70,14 +67,23 @@ export default function ExistsNodeRenderer({
         <TableComboBox
           schema={schema}
           table={table}
-          disabled={editorDisabled}
           onChange={handleTableChange}
         />
       </div>
 
+      {schemaError?.message || tableError?.message ? (
+        <p className="mb-2 text-destructive text-sm">
+          {schemaError?.message ?? tableError?.message}
+        </p>
+      ) : null}
+
       <CustomCheckEditorContext.Provider value={contextValue}>
         <GroupNodeRenderer name={`${name}.where`} depth={depth + 1} />
       </CustomCheckEditorContext.Provider>
+
+      {whereError?.message ? (
+        <p className="mt-2 text-destructive text-sm">{whereError.message}</p>
+      ) : null}
     </div>
   );
 }

--- a/dashboard/src/features/orgs/projects/database/dataGrid/components/CustomCheckEditor/FilterErrorsSummary.tsx
+++ b/dashboard/src/features/orgs/projects/database/dataGrid/components/CustomCheckEditor/FilterErrorsSummary.tsx
@@ -1,0 +1,147 @@
+import { useFormContext } from 'react-hook-form';
+import {
+  isConditionNode,
+  isExistsNode,
+  isInvalidNode,
+  isRelationshipNode,
+  type RuleNode,
+} from '@/features/orgs/projects/database/dataGrid/utils/permissionUtils';
+import { useCustomCheckMode } from './CustomCheckModeProvider';
+
+export interface FilterErrorsSummaryProps {
+  name: string;
+}
+
+interface CollectedError {
+  path: string;
+  message: string;
+  type?: string;
+}
+
+function nodeHeader(node: unknown): string {
+  if (!node || typeof node !== 'object') {
+    return '';
+  }
+  const tree = node as RuleNode;
+  if (isConditionNode(tree)) {
+    const column = tree.column || '[column]';
+    const operator = tree.operator || '[operator]';
+    return `${column} ${operator}`;
+  }
+  if (isRelationshipNode(tree)) {
+    return tree.relationship || '[relationship]';
+  }
+  if (isExistsNode(tree)) {
+    return tree.schema && tree.table
+      ? `exists in ${tree.schema}.${tree.table}`
+      : 'exists';
+  }
+  if (isInvalidNode(tree)) {
+    return tree.key || 'invalid';
+  }
+  return '';
+}
+
+function collect(
+  errors: unknown,
+  tree: unknown,
+  prefix: string[],
+  out: CollectedError[],
+): void {
+  if (!errors || typeof errors !== 'object') {
+    return;
+  }
+
+  const record = errors as Record<string, unknown>;
+
+  if (typeof record.message === 'string' && record.message.length > 0) {
+    const header = nodeHeader(tree);
+    const path = [...prefix, header].filter(Boolean).join(' → ');
+    out.push({
+      path,
+      message: record.message,
+      type: typeof record.type === 'string' ? record.type : undefined,
+    });
+  }
+
+  for (const [key, value] of Object.entries(record)) {
+    if (key === 'message' || key === 'type' || key === 'ref') {
+      continue;
+    }
+
+    if (key === 'root') {
+      collect(value, tree, prefix, out);
+      continue;
+    }
+
+    if (key === 'children' && Array.isArray(value)) {
+      const treeChildren = (tree as { children?: unknown[] })?.children ?? [];
+      for (let i = 0; i < value.length; i += 1) {
+        if (value[i]) {
+          collect(value[i], treeChildren[i], prefix, out);
+        }
+      }
+      continue;
+    }
+
+    if (key === 'child') {
+      const header = nodeHeader(tree);
+      const nextPrefix = header ? [...prefix, header] : prefix;
+      const nextTree = (tree as { child?: unknown })?.child;
+      collect(value, nextTree, nextPrefix, out);
+      continue;
+    }
+
+    if (key === 'where') {
+      const header = nodeHeader(tree);
+      const nextPrefix = header ? [...prefix, header] : prefix;
+      const nextTree = (tree as { where?: unknown })?.where;
+      collect(value, nextTree, nextPrefix, out);
+      continue;
+    }
+
+    collect(value, tree, prefix, out);
+  }
+}
+
+export default function FilterErrorsSummary({
+  name,
+}: FilterErrorsSummaryProps) {
+  const {
+    formState: { errors },
+    getValues,
+  } = useFormContext();
+  const { mode } = useCustomCheckMode();
+
+  const collected: CollectedError[] = [];
+  collect(errors[name], getValues(name), [], collected);
+
+  const visible =
+    mode === 'json' ? collected : collected.filter(({ path }) => !path);
+
+  if (visible.length === 0) {
+    return null;
+  }
+
+  return (
+    <ul className="mb-2 list-disc pl-5 text-destructive text-sm" role="alert">
+      {visible.map(({ path, message, type }) => {
+        const displayMessage =
+          mode === 'json' && type === 'no-serialization-collisions'
+            ? `${message} Switch to Visual to find and remove the duplicate.`
+            : message;
+        return (
+          <li key={`${path}:${message}`}>
+            {path ? (
+              <>
+                <span className="font-medium">{path}</span>: {displayMessage}
+              </>
+            ) : (
+              displayMessage
+            )}
+          </li>
+        );
+      })}
+    </ul>
+  );
+}

--- a/dashboard/src/features/orgs/projects/database/dataGrid/components/CustomCheckEditor/GroupNodeRenderer.tsx
+++ b/dashboard/src/features/orgs/projects/database/dataGrid/components/CustomCheckEditor/GroupNodeRenderer.tsx
@@ -5,9 +5,9 @@ import { cn } from '@/lib/utils';
 import AddNodeButton from './AddNodeButton';
 import ConditionRow from './ConditionRow';
 import ExistsNodeRenderer from './ExistsNodeRenderer';
+import InvalidNodeRenderer from './InvalidNodeRenderer';
 import LogicalOperatorBadge from './LogicalOperatorBadge';
 import RelationshipNodeRenderer from './RelationshipNodeRenderer';
-import useCustomCheckEditor from './useCustomCheckEditor';
 
 const depthBackgrounds = [
   'bg-secondary-100',
@@ -32,7 +32,6 @@ export default function GroupNodeRenderer({
   maxDepth,
   onRemove,
 }: GroupNodeRendererProps) {
-  const { disabled: editorDisabled } = useCustomCheckEditor();
   const { control } = useFormContext();
   const { fields, append, remove } = useFieldArray({
     control,
@@ -54,20 +53,15 @@ export default function GroupNodeRenderer({
       )}
     >
       <div className="absolute -top-3 left-3">
-        <LogicalOperatorBadge
-          name={name}
-          depth={depth}
-          disabled={editorDisabled}
-        />
+        <LogicalOperatorBadge name={name} depth={depth} />
       </div>
 
       {onRemove && (
         <button
           type="button"
           onClick={onRemove}
-          disabled={editorDisabled}
           aria-label="Delete group"
-          className="absolute top-2 right-2 rounded p-0.5 opacity-50 hover:opacity-100 disabled:pointer-events-none disabled:opacity-30"
+          className="absolute top-2 right-2 rounded p-0.5 opacity-50 hover:opacity-100"
         >
           <X className="h-4 w-4" />
         </button>
@@ -102,6 +96,16 @@ export default function GroupNodeRenderer({
             );
           }
 
+          if (child.type === 'invalid') {
+            return (
+              <InvalidNodeRenderer
+                key={field.id}
+                name={`${name}.children.${index}`}
+                onRemove={() => remove(index)}
+              />
+            );
+          }
+
           if (child.type === 'relationship') {
             return (
               <RelationshipNodeRenderer
@@ -129,7 +133,6 @@ export default function GroupNodeRenderer({
       <div className="mt-3">
         <AddNodeButton
           onSelect={handleAddNode}
-          disabled={editorDisabled}
           fullWidth={fields.length === 0}
           label="Add"
         />

--- a/dashboard/src/features/orgs/projects/database/dataGrid/components/CustomCheckEditor/InvalidNodeRenderer.tsx
+++ b/dashboard/src/features/orgs/projects/database/dataGrid/components/CustomCheckEditor/InvalidNodeRenderer.tsx
@@ -1,0 +1,35 @@
+import { Trash2 } from 'lucide-react';
+import { useWatch } from 'react-hook-form';
+import { Button } from '@/components/ui/v3/button';
+import type { InvalidNode } from '@/features/orgs/projects/database/dataGrid/utils/permissionUtils';
+
+interface InvalidNodeRendererProps {
+  name: string;
+  onRemove?: VoidFunction;
+}
+
+export default function InvalidNodeRenderer({
+  name,
+  onRemove,
+}: InvalidNodeRendererProps) {
+  const node = useWatch({ name }) as InvalidNode | undefined;
+  const label = node?.key ?? '';
+
+  return (
+    <div className="mt-4 flex items-center gap-2 rounded-md border border-destructive/60 bg-destructive/5 px-3 py-2 text-destructive text-sm">
+      <span className="flex-1 font-mono">Invalid rule: {label}</span>
+      {onRemove && (
+        <Button
+          type="button"
+          variant="ghost"
+          size="icon"
+          className="text-destructive"
+          onClick={onRemove}
+          aria-label="Delete invalid rule"
+        >
+          <Trash2 className="h-4 w-4" />
+        </Button>
+      )}
+    </div>
+  );
+}

--- a/dashboard/src/features/orgs/projects/database/dataGrid/components/CustomCheckEditor/JsonRuleEditor.test.tsx
+++ b/dashboard/src/features/orgs/projects/database/dataGrid/components/CustomCheckEditor/JsonRuleEditor.test.tsx
@@ -1,0 +1,197 @@
+import type { ReactNode } from 'react';
+import { FormProvider, useForm } from 'react-hook-form';
+import type { HasuraOperator } from '@/features/orgs/projects/database/dataGrid/types/dataBrowser';
+import type {
+  ConditionNode,
+  ExistsNode,
+  GroupNode,
+  LogicalOperator,
+  RelationshipNode,
+  RuleNode,
+} from '@/features/orgs/projects/database/dataGrid/utils/permissionUtils/types';
+import { render, screen, TestUserEvent } from '@/tests/testUtils';
+import JsonRuleEditor from './JsonRuleEditor';
+
+function condition(
+  column: string,
+  operator: HasuraOperator = '_eq',
+  value: unknown = null,
+): ConditionNode {
+  return {
+    type: 'condition',
+    id: crypto.randomUUID(),
+    column,
+    operator,
+    value,
+  };
+}
+
+function group(operator: LogicalOperator, children: RuleNode[]): GroupNode {
+  return {
+    type: 'group',
+    id: crypto.randomUUID(),
+    operator,
+    children,
+  };
+}
+
+function existsNode(
+  schema: string,
+  table: string,
+  where?: GroupNode,
+): ExistsNode {
+  return {
+    type: 'exists',
+    id: crypto.randomUUID(),
+    schema,
+    table,
+    where: where ?? group('_implicit', [condition('id')]),
+  };
+}
+
+function relationshipNode(
+  relationship: string,
+  child?: GroupNode,
+): RelationshipNode {
+  return {
+    type: 'relationship',
+    id: crypto.randomUUID(),
+    relationship,
+    child: child ?? group('_implicit', [condition('id')]),
+  };
+}
+
+function TestWrapper({
+  children,
+  defaultValues,
+}: {
+  children: ReactNode;
+  defaultValues: Record<string, unknown>;
+}) {
+  const form = useForm({ defaultValues });
+  return <FormProvider {...form}>{children}</FormProvider>;
+}
+
+describe('JsonRuleEditor', () => {
+  it('renders {} when the filter is an empty _implicit group', () => {
+    render(
+      <TestWrapper defaultValues={{ rule: group('_implicit', []) }}>
+        <JsonRuleEditor name="rule" />
+      </TestWrapper>,
+    );
+
+    const textarea = screen.getByRole('textbox') as HTMLTextAreaElement;
+    expect(textarea.value).toBe('{}');
+  });
+
+  it('serializes a single-condition group to the Hasura JSON shape', () => {
+    render(
+      <TestWrapper
+        defaultValues={{
+          rule: group('_implicit', [condition('title', '_eq', 'foo')]),
+        }}
+      >
+        <JsonRuleEditor name="rule" />
+      </TestWrapper>,
+    );
+
+    const textarea = screen.getByRole('textbox') as HTMLTextAreaElement;
+    expect(JSON.parse(textarea.value)).toEqual({
+      title: { _eq: 'foo' },
+    });
+  });
+
+  it('serializes a nested _and/_or group to nested JSON', () => {
+    render(
+      <TestWrapper
+        defaultValues={{
+          rule: group('_and', [
+            condition('title', '_eq', 'foo'),
+            group('_or', [
+              condition('release_date', '_gt', '2020-01-01'),
+              condition('author_id', '_eq', 1),
+            ]),
+          ]),
+        }}
+      >
+        <JsonRuleEditor name="rule" />
+      </TestWrapper>,
+    );
+
+    const textarea = screen.getByRole('textbox') as HTMLTextAreaElement;
+    expect(JSON.parse(textarea.value)).toEqual({
+      _and: [
+        { title: { _eq: 'foo' } },
+        {
+          _or: [
+            { release_date: { _gt: '2020-01-01' } },
+            { author_id: { _eq: 1 } },
+          ],
+        },
+      ],
+    });
+  });
+
+  it('serializes an exists node to {_exists: {_table, _where}}', () => {
+    render(
+      <TestWrapper
+        defaultValues={{
+          rule: group('_implicit', [
+            existsNode(
+              'public',
+              'authors',
+              group('_implicit', [condition('id', '_eq', 1)]),
+            ),
+          ]),
+        }}
+      >
+        <JsonRuleEditor name="rule" />
+      </TestWrapper>,
+    );
+
+    const textarea = screen.getByRole('textbox') as HTMLTextAreaElement;
+    expect(JSON.parse(textarea.value)).toEqual({
+      _exists: {
+        _table: { schema: 'public', name: 'authors' },
+        _where: { id: { _eq: 1 } },
+      },
+    });
+  });
+
+  it('serializes a relationship node to {<relationship>: {...}}', () => {
+    render(
+      <TestWrapper
+        defaultValues={{
+          rule: group('_implicit', [
+            relationshipNode(
+              'author',
+              group('_implicit', [condition('name', '_eq', 'John')]),
+            ),
+          ]),
+        }}
+      >
+        <JsonRuleEditor name="rule" />
+      </TestWrapper>,
+    );
+
+    const textarea = screen.getByRole('textbox') as HTMLTextAreaElement;
+    expect(JSON.parse(textarea.value)).toEqual({
+      author: { name: { _eq: 'John' } },
+    });
+  });
+
+  it('preserves the user draft (whitespace) while typing', async () => {
+    render(
+      <TestWrapper defaultValues={{ rule: group('_implicit', []) }}>
+        <JsonRuleEditor name="rule" />
+      </TestWrapper>,
+    );
+
+    const textarea = screen.getByRole('textbox') as HTMLTextAreaElement;
+    const user = new TestUserEvent();
+    await user.clear(textarea);
+    await user.paste('{  "title":  {"_eq":  "foo"}  }');
+
+    expect(textarea.value).toBe('{  "title":  {"_eq":  "foo"}  }');
+  });
+});

--- a/dashboard/src/features/orgs/projects/database/dataGrid/components/CustomCheckEditor/JsonRuleEditor.tsx
+++ b/dashboard/src/features/orgs/projects/database/dataGrid/components/CustomCheckEditor/JsonRuleEditor.tsx
@@ -1,0 +1,117 @@
+import { useEffect, useLayoutEffect, useRef, useState } from 'react';
+import { useFormContext } from 'react-hook-form';
+import { Textarea } from '@/components/ui/v3/textarea';
+import {
+  type RuleNode,
+  serializeNode,
+  wrapPermissionsInAGroup,
+} from '@/features/orgs/projects/database/dataGrid/utils/permissionUtils';
+import { cn } from '@/lib/utils';
+
+export interface JsonRuleEditorProps {
+  name: string;
+}
+
+function serializeRule(value: unknown): string {
+  if (!value || typeof value !== 'object') {
+    return '{}';
+  }
+
+  if (!('type' in (value as object))) {
+    return JSON.stringify(value, null, 2);
+  }
+
+  try {
+    return JSON.stringify(serializeNode(value as RuleNode), null, 2);
+  } catch {
+    return '{}';
+  }
+}
+
+export default function JsonRuleEditor({ name }: JsonRuleEditorProps) {
+  const {
+    setValue,
+    watch,
+    setError,
+    clearErrors,
+    formState: { errors },
+  } = useFormContext();
+  const value = watch(name);
+
+  const [draft, setDraft] = useState<string | null>(null);
+  const [overflowing, setOverflowing] = useState(false);
+  const textareaRef = useRef<HTMLTextAreaElement | null>(null);
+
+  const displayed = draft ?? serializeRule(value);
+  const error = errors[name]?.message as string | undefined;
+
+  // biome-ignore lint/correctness/useExhaustiveDependencies: run only on unmount — name prop and clearErrors reference are stable
+  useEffect(
+    () => () => {
+      clearErrors(name);
+    },
+    [],
+  );
+
+  // biome-ignore lint/correctness/useExhaustiveDependencies: re-run on `displayed` so the textarea resizes whenever its rendered content changes
+  useLayoutEffect(() => {
+    const el = textareaRef.current;
+    if (!el) {
+      return;
+    }
+    el.style.height = 'auto';
+    const maxHeight = 384;
+    const next = Math.min(el.scrollHeight, maxHeight);
+    el.style.height = `${next}px`;
+    setOverflowing(el.scrollHeight > maxHeight);
+  }, [displayed]);
+
+  function handleChange(event: React.ChangeEvent<HTMLTextAreaElement>) {
+    const next = event.target.value;
+    setDraft(next);
+
+    const trimmed = next.trim();
+    if (trimmed === '') {
+      clearErrors(name);
+      setValue(name, wrapPermissionsInAGroup({}), { shouldDirty: true });
+      return;
+    }
+
+    let parsed: unknown;
+    try {
+      parsed = JSON.parse(trimmed);
+    } catch {
+      setError(name, { type: 'manual', message: 'Invalid JSON' });
+      return;
+    }
+
+    if (!parsed || typeof parsed !== 'object' || Array.isArray(parsed)) {
+      setError(name, {
+        type: 'manual',
+        message: 'Rule must be a JSON object',
+      });
+      return;
+    }
+
+    const tree = wrapPermissionsInAGroup(parsed as Record<string, unknown>);
+    clearErrors(name);
+    setValue(name, tree, { shouldDirty: true });
+  }
+
+  return (
+    <div className="mb-2">
+      <Textarea
+        ref={textareaRef}
+        rows={1}
+        spellCheck={false}
+        value={displayed}
+        onChange={handleChange}
+        className={cn(
+          'min-h-10 resize-none overflow-x-auto whitespace-pre py-2.5 font-mono text-xs leading-5',
+          overflowing ? 'overflow-y-auto' : 'overflow-y-hidden',
+          error && 'border-destructive focus-visible:ring-destructive',
+        )}
+      />
+    </div>
+  );
+}

--- a/dashboard/src/features/orgs/projects/database/dataGrid/components/CustomCheckEditor/LogicalOperatorBadge.tsx
+++ b/dashboard/src/features/orgs/projects/database/dataGrid/components/CustomCheckEditor/LogicalOperatorBadge.tsx
@@ -39,13 +39,11 @@ const parentBackgrounds = [
 
 interface LogicalOperatorBadgeProps {
   name: string;
-  disabled?: boolean;
   depth?: number;
 }
 
 export default function LogicalOperatorBadge({
   name,
-  disabled,
   depth = 0,
 }: LogicalOperatorBadgeProps) {
   const { setValue } = useFormContext();
@@ -59,7 +57,7 @@ export default function LogicalOperatorBadge({
 
   return (
     <DropdownMenu>
-      <DropdownMenuTrigger asChild disabled={disabled}>
+      <DropdownMenuTrigger asChild>
         <Badge
           variant="outline"
           className={cn(

--- a/dashboard/src/features/orgs/projects/database/dataGrid/components/CustomCheckEditor/OperatorComboBox.tsx
+++ b/dashboard/src/features/orgs/projects/database/dataGrid/components/CustomCheckEditor/OperatorComboBox.tsx
@@ -20,13 +20,11 @@ import { getAvailableOperators } from './getAvailableOperators';
 
 interface OperatorComboBoxProps {
   name: string;
-  disabled?: boolean;
   selectedColumnType?: string;
 }
 
 export default function OperatorComboBox({
   name,
-  disabled,
   selectedColumnType,
 }: OperatorComboBoxProps) {
   const [open, setOpen] = useState(false);
@@ -53,7 +51,6 @@ export default function OperatorComboBox({
     <Popover open={open} onOpenChange={setOpen}>
       <PopoverTrigger asChild>
         <Button
-          disabled={disabled}
           variant="outline"
           role="combobox"
           aria-expanded={open}

--- a/dashboard/src/features/orgs/projects/database/dataGrid/components/CustomCheckEditor/RelationshipComboBox.tsx
+++ b/dashboard/src/features/orgs/projects/database/dataGrid/components/CustomCheckEditor/RelationshipComboBox.tsx
@@ -26,14 +26,12 @@ interface RelationshipComboBoxProps {
   name: string;
   relationship: string;
   onChange: (value: { name: string; schema: string; table: string }) => void;
-  disabled?: boolean;
 }
 
 export default function RelationshipComboBox({
   name,
   relationship,
   onChange,
-  disabled,
 }: RelationshipComboBoxProps) {
   const [open, setOpen] = useState(false);
   const { control } = useFormContext();
@@ -63,6 +61,8 @@ export default function RelationshipComboBox({
     (option) => option.group === 'relationships',
   );
 
+  const metadataLoaded = Boolean(tableData && metadata);
+
   const handleSelect = (value: string) => {
     const found = relationships.find((r) => r.value === value);
     if (found) {
@@ -84,6 +84,16 @@ export default function RelationshipComboBox({
     <FormField
       name={`${name}.relationship`}
       control={control}
+      rules={{
+        validate: (value) => {
+          return (
+            !value ||
+            !metadataLoaded ||
+            relationships.some((r) => r.value === value) ||
+            `Unknown relationship "${value}"`
+          );
+        },
+      }}
       render={({ fieldState }) => {
         const hasError = isNotEmptyValue(fieldState.error?.message);
         return (
@@ -91,7 +101,6 @@ export default function RelationshipComboBox({
             <Popover open={open} onOpenChange={setOpen}>
               <PopoverTrigger asChild>
                 <Button
-                  disabled={disabled}
                   variant="outline"
                   role="combobox"
                   aria-expanded={open}

--- a/dashboard/src/features/orgs/projects/database/dataGrid/components/CustomCheckEditor/RelationshipNodeRenderer.test.tsx
+++ b/dashboard/src/features/orgs/projects/database/dataGrid/components/CustomCheckEditor/RelationshipNodeRenderer.test.tsx
@@ -16,7 +16,7 @@ import hasuraMetadataQuery from '@/tests/msw/mocks/rest/hasuraMetadataQuery';
 import tableQuery from '@/tests/msw/mocks/rest/tableQuery';
 import tokenQuery from '@/tests/msw/mocks/rest/tokenQuery';
 import { mockPointerEvent, render, screen } from '@/tests/testUtils';
-import CustomCheckEditor from './CustomCheckEditor';
+import VisualRuleEditor from './VisualRuleEditor';
 
 const mocks = vi.hoisted(() => ({
   useRouter: vi.fn(),
@@ -128,7 +128,7 @@ describe('RelationshipNodeRenderer - nested context propagation', () => {
           ]),
         }}
       >
-        <CustomCheckEditor schema="public" table="books" name="rule" />
+        <VisualRuleEditor schema="public" table="books" name="rule" />
       </TestWrapper>,
     );
 
@@ -153,7 +153,7 @@ describe('RelationshipNodeRenderer - nested context propagation', () => {
           ]),
         }}
       >
-        <CustomCheckEditor schema="public" table="books" name="rule" />
+        <VisualRuleEditor schema="public" table="books" name="rule" />
       </TestWrapper>,
     );
 

--- a/dashboard/src/features/orgs/projects/database/dataGrid/components/CustomCheckEditor/RelationshipNodeRenderer.tsx
+++ b/dashboard/src/features/orgs/projects/database/dataGrid/components/CustomCheckEditor/RelationshipNodeRenderer.tsx
@@ -24,12 +24,10 @@ export default function RelationshipNodeRenderer({
   depth = 0,
   maxDepth,
 }: RelationshipNodeRendererProps) {
-  const {
-    disabled: editorDisabled,
-    schema: parentSchema,
-    table: parentTable,
-  } = useCustomCheckEditor();
-  const { setValue } = useFormContext();
+  const { schema: parentSchema, table: parentTable } = useCustomCheckEditor();
+  const { setValue, getFieldState, formState } = useFormContext();
+
+  const { error: childError } = getFieldState(`${name}.child`, formState);
 
   const relationshipName: string =
     useWatch({ name: `${name}.relationship` }) ?? '';
@@ -79,22 +77,12 @@ export default function RelationshipNodeRenderer({
     };
   }, [relationshipName, options]);
 
-  const hasRelationship = Boolean(
-    relationshipName && resolvedTarget.schema && resolvedTarget.table,
-  );
-
   const contextValue = useMemo(
     () => ({
-      disabled: editorDisabled || !hasRelationship,
       schema: resolvedTarget.schema,
       table: resolvedTarget.table,
     }),
-    [
-      editorDisabled,
-      hasRelationship,
-      resolvedTarget.schema,
-      resolvedTarget.table,
-    ],
+    [resolvedTarget.schema, resolvedTarget.table],
   );
 
   function handleRelationshipChange(value: {
@@ -121,9 +109,8 @@ export default function RelationshipNodeRenderer({
         <button
           type="button"
           onClick={onRemove}
-          disabled={editorDisabled}
           aria-label="Delete relationship"
-          className="absolute top-2 right-2 rounded p-0.5 opacity-50 hover:opacity-100 disabled:pointer-events-none disabled:opacity-30"
+          className="absolute top-2 right-2 rounded p-0.5 opacity-50 hover:opacity-100"
         >
           <X className="h-4 w-4" />
         </button>
@@ -137,7 +124,6 @@ export default function RelationshipNodeRenderer({
           name={name}
           relationship={relationshipName}
           onChange={handleRelationshipChange}
-          disabled={editorDisabled}
         />
       </div>
 
@@ -149,6 +135,10 @@ export default function RelationshipNodeRenderer({
           maxDepth={maxDepth}
         />
       </CustomCheckEditorContext.Provider>
+
+      {childError?.message ? (
+        <p className="mt-2 text-destructive text-sm">{childError.message}</p>
+      ) : null}
     </div>
   );
 }

--- a/dashboard/src/features/orgs/projects/database/dataGrid/components/CustomCheckEditor/TableComboBox.tsx
+++ b/dashboard/src/features/orgs/projects/database/dataGrid/components/CustomCheckEditor/TableComboBox.tsx
@@ -21,14 +21,12 @@ interface TableComboBoxProps {
   schema: string;
   table: string;
   onChange: (value: { schema: string; table: string }) => void;
-  disabled?: boolean;
 }
 
 export default function TableComboBox({
   schema,
   table,
   onChange,
-  disabled,
 }: TableComboBoxProps) {
   const [open, setOpen] = useState(false);
 
@@ -55,7 +53,6 @@ export default function TableComboBox({
     <Popover open={open} onOpenChange={setOpen}>
       <PopoverTrigger asChild>
         <Button
-          disabled={disabled}
           variant="outline"
           role="combobox"
           aria-expanded={open}

--- a/dashboard/src/features/orgs/projects/database/dataGrid/components/CustomCheckEditor/VisualRuleEditor.test.tsx
+++ b/dashboard/src/features/orgs/projects/database/dataGrid/components/CustomCheckEditor/VisualRuleEditor.test.tsx
@@ -1,0 +1,1822 @@
+import { setupServer } from 'msw/node';
+import { FormProvider, useForm } from 'react-hook-form';
+import { vi } from 'vitest';
+import type { HasuraOperator } from '@/features/orgs/projects/database/dataGrid/types/dataBrowser';
+import type {
+  ConditionNode,
+  ExistsNode,
+  GroupNode,
+  LogicalOperator,
+  RelationshipNode,
+  RuleNode,
+} from '@/features/orgs/projects/database/dataGrid/utils/permissionUtils/types';
+import { getProjectQuery } from '@/tests/msw/mocks/graphql/getProjectQuery';
+import permissionVariablesQuery from '@/tests/msw/mocks/graphql/permissionVariablesQuery';
+import hasuraMetadataQuery from '@/tests/msw/mocks/rest/hasuraMetadataQuery';
+import tableQuery from '@/tests/msw/mocks/rest/tableQuery';
+import tokenQuery from '@/tests/msw/mocks/rest/tokenQuery';
+import {
+  mockPointerEvent,
+  render,
+  screen,
+  TestUserEvent,
+  waitFor,
+} from '@/tests/testUtils';
+import VisualRuleEditor from './VisualRuleEditor';
+
+const mocks = vi.hoisted(() => ({
+  useRouter: vi.fn(),
+}));
+
+vi.mock('next/router', () => ({
+  useRouter: mocks.useRouter,
+}));
+
+const server = setupServer(
+  tokenQuery,
+  tableQuery,
+  hasuraMetadataQuery,
+  getProjectQuery,
+  permissionVariablesQuery,
+);
+
+function condition(
+  column: string,
+  operator: HasuraOperator = '_eq',
+  value: unknown = null,
+): ConditionNode {
+  return {
+    type: 'condition',
+    id: crypto.randomUUID(),
+    column,
+    operator,
+    value,
+  };
+}
+
+function group(operator: LogicalOperator, children: RuleNode[]): GroupNode {
+  return {
+    type: 'group',
+    id: crypto.randomUUID(),
+    operator,
+    children,
+  };
+}
+
+function existsNode(
+  schema: string,
+  table: string,
+  where?: GroupNode,
+): ExistsNode {
+  return {
+    type: 'exists',
+    id: crypto.randomUUID(),
+    schema,
+    table,
+    where: where ?? group('_implicit', [condition('id')]),
+  };
+}
+
+function relationshipNode(
+  relationship: string,
+  child?: GroupNode,
+): RelationshipNode {
+  return {
+    type: 'relationship',
+    id: crypto.randomUUID(),
+    relationship,
+    child: child ?? group('_implicit', [condition('id')]),
+  };
+}
+
+function TestWrapper({
+  children,
+  defaultValues,
+}: {
+  children: React.ReactNode;
+  defaultValues: Record<string, unknown>;
+}) {
+  const form = useForm({ defaultValues });
+  return <FormProvider {...form}>{children}</FormProvider>;
+}
+
+const defaultProps = {
+  schema: 'public',
+  table: 'books',
+  name: 'rule',
+};
+
+describe('VisualRuleEditor', () => {
+  beforeAll(() => {
+    process.env.NEXT_PUBLIC_ENV = 'dev';
+    // Required so useLocalMimirClient sends GetRolesPermissions to a URL MSW can intercept
+    process.env.NEXT_PUBLIC_NHOST_CONFIGSERVER_URL =
+      'https://local.graphql.local.nhost.run/v1';
+    server.listen();
+  });
+
+  beforeEach(() => {
+    mockPointerEvent();
+    mocks.useRouter.mockReturnValue({
+      basePath: '',
+      pathname: '/orgs/xyz/projects/test-project',
+      route: '/orgs/[orgSlug]/projects/[appSubdomain]',
+      asPath: '/orgs/xyz/projects/test-project',
+      isLocaleDomain: false,
+      isReady: true,
+      isPreview: false,
+      query: {
+        orgSlug: 'xyz',
+        appSubdomain: 'test-project',
+        dataSourceSlug: 'default',
+      },
+      push: vi.fn(),
+      replace: vi.fn(),
+      reload: vi.fn(),
+      back: vi.fn(),
+      prefetch: vi.fn(),
+      beforePopState: vi.fn(),
+      events: { on: vi.fn(), off: vi.fn(), emit: vi.fn() },
+      isFallback: false,
+      forward: vi.fn(),
+    });
+  });
+
+  afterEach(() => {
+    server.resetHandlers();
+  });
+
+  afterAll(() => {
+    server.close();
+  });
+
+  describe('rendering', () => {
+    it('renders a single condition row from default values', async () => {
+      render(
+        <TestWrapper
+          defaultValues={{
+            rule: group('_and', [condition('title')]),
+          }}
+        >
+          <VisualRuleEditor {...defaultProps} />
+        </TestWrapper>,
+      );
+
+      expect(screen.getByText('AND')).toBeInTheDocument();
+      expect(await screen.findByText('title')).toBeInTheDocument();
+    });
+
+    it('renders multiple conditions in order', async () => {
+      render(
+        <TestWrapper
+          defaultValues={{
+            rule: group('_and', [
+              condition('title'),
+              condition('release_date'),
+              condition('author_id'),
+            ]),
+          }}
+        >
+          <VisualRuleEditor {...defaultProps} />
+        </TestWrapper>,
+      );
+
+      expect(await screen.findByText('title')).toBeInTheDocument();
+      expect(screen.getByText('release_date')).toBeInTheDocument();
+      expect(screen.getByText('author_id')).toBeInTheDocument();
+    });
+
+    it('renders nested groups recursively', async () => {
+      render(
+        <TestWrapper
+          defaultValues={{
+            rule: group('_and', [
+              condition('title'),
+              group('_or', [condition('release_date')]),
+            ]),
+          }}
+        >
+          <VisualRuleEditor {...defaultProps} />
+        </TestWrapper>,
+      );
+
+      expect(screen.getByText('AND')).toBeInTheDocument();
+      expect(screen.getByText('OR')).toBeInTheDocument();
+      expect(await screen.findByText('title')).toBeInTheDocument();
+      expect(screen.getByText('release_date')).toBeInTheDocument();
+    });
+
+    it('renders the correct operator label (AND/OR/NOT)', () => {
+      render(
+        <TestWrapper
+          defaultValues={{
+            rule: group('_not', [condition('title')]),
+          }}
+        >
+          <VisualRuleEditor {...defaultProps} />
+        </TestWrapper>,
+      );
+
+      expect(screen.getByText('NOT')).toBeInTheDocument();
+    });
+
+    it('renders "Implicit" label for _implicit operator', () => {
+      render(
+        <TestWrapper
+          defaultValues={{
+            rule: group('_implicit', [condition('title')]),
+          }}
+        >
+          <VisualRuleEditor {...defaultProps} />
+        </TestWrapper>,
+      );
+
+      expect(screen.getByText('Implicit')).toBeInTheDocument();
+    });
+
+    it('renders an empty group (no children) without crashing', () => {
+      render(
+        <TestWrapper
+          defaultValues={{
+            rule: group('_and', []),
+          }}
+        >
+          <VisualRuleEditor {...defaultProps} />
+        </TestWrapper>,
+      );
+
+      expect(screen.getByText('AND')).toBeInTheDocument();
+    });
+
+    it('applies depth-based background colors to nested groups', () => {
+      render(
+        <TestWrapper
+          defaultValues={{
+            rule: group('_and', [
+              group('_or', [group('_and', [condition('title')])]),
+            ]),
+          }}
+        >
+          <VisualRuleEditor {...defaultProps} />
+        </TestWrapper>,
+      );
+
+      const groupDivs = document.querySelectorAll(
+        'div.rounded-lg[class*="bg-secondary-"]',
+      );
+
+      expect(groupDivs).toHaveLength(3);
+      expect(groupDivs[0]).toHaveClass('bg-secondary-100');
+      expect(groupDivs[1]).toHaveClass('bg-secondary-200');
+      expect(groupDivs[2]).toHaveClass('bg-secondary-300');
+    });
+  });
+
+  describe('adding nodes', () => {
+    async function openAddPopover(user: TestUserEvent, index = -1) {
+      const buttons = screen.getAllByRole('button', { name: /Add/ });
+      const btn = index >= 0 ? buttons[index] : buttons[buttons.length - 1];
+      await user.click(btn);
+    }
+
+    it('selecting a column appends a condition row', async () => {
+      render(
+        <TestWrapper
+          defaultValues={{
+            rule: group('_and', [condition('title')]),
+          }}
+        >
+          <VisualRuleEditor {...defaultProps} />
+        </TestWrapper>,
+      );
+
+      expect(await screen.findByText('title')).toBeInTheDocument();
+
+      const user = new TestUserEvent();
+      await openAddPopover(user);
+      await user.click(
+        await screen.findByRole('option', { name: /release_date/ }),
+      );
+
+      await waitFor(() => {
+        expect(screen.getByText('release_date')).toBeInTheDocument();
+      });
+    });
+
+    it('selecting "and" appends a nested group', async () => {
+      render(
+        <TestWrapper
+          defaultValues={{
+            rule: group('_and', [condition('title')]),
+          }}
+        >
+          <VisualRuleEditor {...defaultProps} />
+        </TestWrapper>,
+      );
+
+      const user = new TestUserEvent();
+      await openAddPopover(user);
+      await user.click(await screen.findByRole('option', { name: 'and' }));
+
+      await waitFor(() => {
+        expect(screen.getAllByText('AND')).toHaveLength(2);
+      });
+    });
+
+    it('selecting "or" appends a nested OR group', async () => {
+      render(
+        <TestWrapper
+          defaultValues={{
+            rule: group('_and', [condition('title')]),
+          }}
+        >
+          <VisualRuleEditor {...defaultProps} />
+        </TestWrapper>,
+      );
+
+      const user = new TestUserEvent();
+      await openAddPopover(user);
+      await user.click(await screen.findByRole('option', { name: 'or' }));
+
+      await waitFor(() => {
+        expect(screen.getByText('OR')).toBeInTheDocument();
+      });
+    });
+
+    it('selecting "exists" appends an exists node', async () => {
+      render(
+        <TestWrapper
+          defaultValues={{
+            rule: group('_and', [condition('title')]),
+          }}
+        >
+          <VisualRuleEditor {...defaultProps} />
+        </TestWrapper>,
+      );
+
+      const user = new TestUserEvent();
+      await openAddPopover(user);
+      await user.click(await screen.findByRole('option', { name: 'exists' }));
+
+      await waitFor(() => {
+        expect(screen.getByText('Exists')).toBeInTheDocument();
+        expect(screen.getByText('Select table...')).toBeInTheDocument();
+      });
+    });
+
+    it('adding multiple rules in sequence renders all of them', async () => {
+      render(
+        <TestWrapper
+          defaultValues={{
+            rule: group('_and', [condition('title')]),
+          }}
+        >
+          <VisualRuleEditor {...defaultProps} />
+        </TestWrapper>,
+      );
+
+      expect(await screen.findByText('title')).toBeInTheDocument();
+
+      const user = new TestUserEvent();
+
+      await openAddPopover(user);
+      await user.click(
+        await screen.findByRole('option', { name: /release_date/ }),
+      );
+      await waitFor(() => {
+        expect(screen.getByText('release_date')).toBeInTheDocument();
+      });
+
+      await openAddPopover(user);
+      await user.click(
+        await screen.findByRole('option', { name: /author_id/ }),
+      );
+      await waitFor(() => {
+        expect(screen.getByText('author_id')).toBeInTheDocument();
+      });
+
+      expect(screen.getByText('title')).toBeInTheDocument();
+      expect(screen.getByText('release_date')).toBeInTheDocument();
+      expect(screen.getByText('author_id')).toBeInTheDocument();
+    });
+
+    it('adding a rule inside a nested group adds it to the correct group', async () => {
+      render(
+        <TestWrapper
+          defaultValues={{
+            rule: group('_and', [
+              condition('title'),
+              group('_or', [condition('release_date')]),
+            ]),
+          }}
+        >
+          <VisualRuleEditor {...defaultProps} />
+        </TestWrapper>,
+      );
+
+      await screen.findByText('title');
+
+      const user = new TestUserEvent();
+      // The nested group's Add button renders before the root's in DOM order
+      await openAddPopover(user, 0);
+      await user.click(
+        await screen.findByRole('option', { name: /author_id/ }),
+      );
+
+      await waitFor(() => {
+        expect(screen.getByText('author_id')).toBeInTheDocument();
+      });
+
+      // All three conditions should be visible
+      expect(screen.getByText('title')).toBeInTheDocument();
+      expect(screen.getByText('release_date')).toBeInTheDocument();
+      expect(screen.getByText('author_id')).toBeInTheDocument();
+    });
+  });
+
+  describe('removing nodes', () => {
+    it('clicking remove button on a condition removes it', async () => {
+      render(
+        <TestWrapper
+          defaultValues={{
+            rule: group('_and', [
+              condition('title'),
+              condition('release_date'),
+            ]),
+          }}
+        >
+          <VisualRuleEditor {...defaultProps} />
+        </TestWrapper>,
+      );
+
+      expect(await screen.findByText('title')).toBeInTheDocument();
+      expect(screen.getByText('release_date')).toBeInTheDocument();
+
+      const user = new TestUserEvent();
+      const removeButtons = screen.getAllByRole('button', {
+        name: /delete condition/i,
+      });
+      await user.click(removeButtons[0]);
+
+      await waitFor(() => {
+        expect(screen.queryByText('title')).not.toBeInTheDocument();
+      });
+
+      expect(screen.getByText('release_date')).toBeInTheDocument();
+    });
+
+    it('remove button is enabled even when one child remains', async () => {
+      render(
+        <TestWrapper
+          defaultValues={{
+            rule: group('_and', [condition('title')]),
+          }}
+        >
+          <VisualRuleEditor {...defaultProps} />
+        </TestWrapper>,
+      );
+
+      expect(await screen.findByText('title')).toBeInTheDocument();
+
+      const removeButton = screen.getByRole('button', {
+        name: /delete condition/i,
+      });
+      expect(removeButton).toBeEnabled();
+    });
+
+    it('"Delete Group" button appears for nested groups and removes the group', async () => {
+      render(
+        <TestWrapper
+          defaultValues={{
+            rule: group('_and', [
+              condition('title'),
+              group('_or', [condition('release_date')]),
+            ]),
+          }}
+        >
+          <VisualRuleEditor {...defaultProps} />
+        </TestWrapper>,
+      );
+
+      expect(await screen.findByText('title')).toBeInTheDocument();
+      expect(screen.getByText('release_date')).toBeInTheDocument();
+      expect(screen.getByText('OR')).toBeInTheDocument();
+
+      const deleteGroupButtons = screen.getAllByRole('button', {
+        name: /delete group/i,
+      });
+      expect(deleteGroupButtons.length).toBeGreaterThanOrEqual(2);
+
+      const user = new TestUserEvent();
+      await user.click(deleteGroupButtons[deleteGroupButtons.length - 1]);
+
+      await waitFor(() => {
+        expect(
+          screen.getAllByRole('button', { name: /delete group/i }),
+        ).toHaveLength(1);
+      });
+
+      expect(screen.queryByText('OR')).not.toBeInTheDocument();
+      expect(screen.queryByText('release_date')).not.toBeInTheDocument();
+      expect(screen.getByText('title')).toBeInTheDocument();
+    });
+
+    it('"Delete Group" button appears on the root group (allows resetting to empty state)', () => {
+      render(
+        <TestWrapper
+          defaultValues={{
+            rule: group('_and', [condition('title')]),
+          }}
+        >
+          <VisualRuleEditor {...defaultProps} />
+        </TestWrapper>,
+      );
+
+      expect(
+        screen.getByRole('button', { name: /delete group/i }),
+      ).toBeInTheDocument();
+    });
+
+    it('remove button is enabled for the last child when operator is _implicit', async () => {
+      render(
+        <TestWrapper
+          defaultValues={{
+            rule: group('_implicit', [condition('title')]),
+          }}
+        >
+          <VisualRuleEditor {...defaultProps} />
+        </TestWrapper>,
+      );
+
+      expect(await screen.findByText('title')).toBeInTheDocument();
+
+      const removeButton = screen.getByRole('button', {
+        name: /delete condition/i,
+      });
+      expect(removeButton).not.toBeDisabled();
+    });
+
+    it('removing a nested group also removes all its children from the DOM', async () => {
+      render(
+        <TestWrapper
+          defaultValues={{
+            rule: group('_and', [
+              condition('title'),
+              group('_or', [condition('release_date'), condition('author_id')]),
+            ]),
+          }}
+        >
+          <VisualRuleEditor {...defaultProps} />
+        </TestWrapper>,
+      );
+
+      expect(await screen.findByText('title')).toBeInTheDocument();
+      expect(screen.getByText('release_date')).toBeInTheDocument();
+      expect(screen.getByText('author_id')).toBeInTheDocument();
+      expect(screen.getByText('OR')).toBeInTheDocument();
+
+      const user = new TestUserEvent();
+      const deleteGroupButtons = screen.getAllByRole('button', {
+        name: /delete group/i,
+      });
+      await user.click(deleteGroupButtons[deleteGroupButtons.length - 1]);
+
+      await waitFor(() => {
+        expect(screen.queryByText('OR')).not.toBeInTheDocument();
+      });
+
+      expect(screen.queryByText('release_date')).not.toBeInTheDocument();
+      expect(screen.queryByText('author_id')).not.toBeInTheDocument();
+      expect(screen.getByText('title')).toBeInTheDocument();
+    });
+  });
+
+  describe('operator switching', () => {
+    it('clicking the operator badge opens dropdown with all operator options', async () => {
+      render(
+        <TestWrapper
+          defaultValues={{
+            rule: group('_and', [condition('title')]),
+          }}
+        >
+          <VisualRuleEditor {...defaultProps} />
+        </TestWrapper>,
+      );
+
+      const user = new TestUserEvent();
+      await user.click(screen.getByText('AND'));
+
+      await waitFor(() => {
+        expect(
+          screen.getByRole('menuitemradio', { name: /Implicit/ }),
+        ).toBeInTheDocument();
+        expect(
+          screen.getByRole('menuitemradio', { name: 'AND' }),
+        ).toBeInTheDocument();
+        expect(
+          screen.getByRole('menuitemradio', { name: 'OR' }),
+        ).toBeInTheDocument();
+        expect(
+          screen.getByRole('menuitemradio', { name: 'NOT' }),
+        ).toBeInTheDocument();
+      });
+    });
+
+    it('selecting a different operator updates the displayed label', async () => {
+      render(
+        <TestWrapper
+          defaultValues={{
+            rule: group('_and', [condition('title')]),
+          }}
+        >
+          <VisualRuleEditor {...defaultProps} />
+        </TestWrapper>,
+      );
+
+      const user = new TestUserEvent();
+      await user.click(screen.getByText('AND'));
+
+      await waitFor(() => {
+        expect(
+          screen.getByRole('menuitemradio', { name: 'OR' }),
+        ).toBeInTheDocument();
+      });
+
+      await user.click(screen.getByRole('menuitemradio', { name: 'OR' }));
+
+      await waitFor(() => {
+        expect(screen.getByText('OR')).toBeInTheDocument();
+      });
+    });
+
+    it('selecting "Implicit" updates the displayed label', async () => {
+      render(
+        <TestWrapper
+          defaultValues={{
+            rule: group('_and', [condition('title')]),
+          }}
+        >
+          <VisualRuleEditor {...defaultProps} />
+        </TestWrapper>,
+      );
+
+      const user = new TestUserEvent();
+      await user.click(screen.getByText('AND'));
+
+      await waitFor(() => {
+        expect(
+          screen.getByRole('menuitemradio', { name: /Implicit/ }),
+        ).toBeInTheDocument();
+      });
+
+      await user.click(screen.getByRole('menuitemradio', { name: /Implicit/ }));
+
+      await waitFor(() => {
+        expect(screen.getByText('Implicit')).toBeInTheDocument();
+      });
+    });
+
+    it('nested group operator changes independently from parent group operator', async () => {
+      render(
+        <TestWrapper
+          defaultValues={{
+            rule: group('_and', [
+              condition('title'),
+              group('_or', [condition('release_date')]),
+            ]),
+          }}
+        >
+          <VisualRuleEditor {...defaultProps} />
+        </TestWrapper>,
+      );
+
+      const user = new TestUserEvent();
+      await user.click(screen.getByText('OR'));
+
+      await waitFor(() => {
+        expect(
+          screen.getByRole('menuitemradio', { name: 'NOT' }),
+        ).toBeInTheDocument();
+      });
+
+      await user.click(screen.getByRole('menuitemradio', { name: 'NOT' }));
+
+      await waitFor(() => {
+        expect(screen.getByText('NOT')).toBeInTheDocument();
+      });
+
+      expect(screen.getByText('AND')).toBeInTheDocument();
+    });
+  });
+
+  describe('depth limiting', () => {
+    it('adding a group still works when maxDepth is set (AddNodeButton does not enforce maxDepth)', async () => {
+      render(
+        <TestWrapper
+          defaultValues={{
+            rule: group('_and', [condition('title')]),
+          }}
+        >
+          <VisualRuleEditor {...defaultProps} maxDepth={1} />
+        </TestWrapper>,
+      );
+
+      const user = new TestUserEvent();
+      await user.click(screen.getByText('Add'));
+      await user.click(await screen.findByRole('option', { name: 'and' }));
+
+      await waitFor(() => {
+        expect(screen.getAllByText('AND')).toHaveLength(2);
+      });
+    });
+
+    it('no maxDepth prop allows unlimited nesting', () => {
+      render(
+        <TestWrapper
+          defaultValues={{
+            rule: group('_and', [
+              group('_or', [
+                group('_and', [
+                  group('_or', [group('_and', [condition('title')])]),
+                ]),
+              ]),
+            ]),
+          }}
+        >
+          <VisualRuleEditor {...defaultProps} />
+        </TestWrapper>,
+      );
+
+      const addButtons = screen.getAllByRole('button', { name: /Add/ });
+      expect(addButtons).toHaveLength(5);
+    });
+
+    it('maxDepth limits rendering depth of existing nested groups', () => {
+      render(
+        <TestWrapper
+          defaultValues={{
+            rule: group('_and', [
+              group('_or', [group('_and', [condition('title')])]),
+            ]),
+          }}
+        >
+          <VisualRuleEditor {...defaultProps} maxDepth={2} />
+        </TestWrapper>,
+      );
+
+      // All existing groups still render since maxDepth controls the Add dropdown
+      expect(screen.getAllByText('AND')).toHaveLength(2);
+      expect(screen.getByText('OR')).toBeInTheDocument();
+    });
+  });
+
+  describe('exists nodes', () => {
+    it('"exists" option is available in AddNodeButton', async () => {
+      render(
+        <TestWrapper
+          defaultValues={{
+            rule: group('_and', [condition('title')]),
+          }}
+        >
+          <VisualRuleEditor {...defaultProps} />
+        </TestWrapper>,
+      );
+
+      const user = new TestUserEvent();
+      await user.click(screen.getByText('Add'));
+
+      expect(
+        await screen.findByRole('option', { name: 'exists' }),
+      ).toBeInTheDocument();
+    });
+
+    it('clicking "exists" menu item appends an exists node', async () => {
+      render(
+        <TestWrapper
+          defaultValues={{
+            rule: group('_and', [condition('title')]),
+          }}
+        >
+          <VisualRuleEditor {...defaultProps} />
+        </TestWrapper>,
+      );
+
+      const user = new TestUserEvent();
+      await user.click(screen.getByText('Add'));
+      await user.click(await screen.findByRole('option', { name: 'exists' }));
+
+      await waitFor(() => {
+        expect(screen.getByText('Exists')).toBeInTheDocument();
+        expect(screen.getByText('Select table...')).toBeInTheDocument();
+      });
+    });
+
+    it('renders an existing exists node from default values', () => {
+      render(
+        <TestWrapper
+          defaultValues={{
+            rule: group('_and', [
+              condition('title'),
+              existsNode('public', 'authors'),
+            ]),
+          }}
+        >
+          <VisualRuleEditor {...defaultProps} />
+        </TestWrapper>,
+      );
+
+      expect(screen.getByText('Exists')).toBeInTheDocument();
+      expect(screen.getByText('public.authors')).toBeInTheDocument();
+    });
+
+    it('"exists" option appears inside an ExistsNodeRenderer Add button', async () => {
+      render(
+        <TestWrapper
+          defaultValues={{
+            rule: group('_and', [existsNode('public', 'authors')]),
+          }}
+        >
+          <VisualRuleEditor {...defaultProps} />
+        </TestWrapper>,
+      );
+
+      // Two Add buttons: one inside the exists where clause, one at the root
+      const addButtons = screen.getAllByText('Add');
+      expect(addButtons).toHaveLength(2);
+
+      const user = new TestUserEvent();
+      await user.click(addButtons[0]);
+
+      expect(
+        await screen.findByRole('option', { name: 'exists' }),
+      ).toBeInTheDocument();
+    });
+
+    it('renders a nested exists node inside an exists node', () => {
+      render(
+        <TestWrapper
+          defaultValues={{
+            rule: group('_and', [
+              existsNode(
+                'public',
+                'town',
+                group('_and', [
+                  condition('name'),
+                  existsNode('public', 'actor'),
+                ]),
+              ),
+            ]),
+          }}
+        >
+          <VisualRuleEditor {...defaultProps} />
+        </TestWrapper>,
+      );
+
+      expect(screen.getByText('public.town')).toBeInTheDocument();
+      expect(screen.getByText('public.actor')).toBeInTheDocument();
+    });
+
+    it('exists node renders a TableComboBox and a nested group for the WHERE clause', () => {
+      render(
+        <TestWrapper
+          defaultValues={{
+            rule: group('_and', [existsNode('public', 'town')]),
+          }}
+        >
+          <VisualRuleEditor {...defaultProps} />
+        </TestWrapper>,
+      );
+
+      expect(screen.getByText('public.town')).toBeInTheDocument();
+      expect(screen.getByText('Implicit')).toBeInTheDocument();
+      expect(screen.getAllByText('Add')).toHaveLength(2);
+    });
+
+    it('nested conditions inside an exists node render alongside the exists table', async () => {
+      render(
+        <TestWrapper
+          defaultValues={{
+            rule: group('_and', [
+              condition('title'),
+              existsNode(
+                'public',
+                'town',
+                group('_implicit', [condition('name')]),
+              ),
+            ]),
+          }}
+        >
+          <VisualRuleEditor {...defaultProps} />
+        </TestWrapper>,
+      );
+
+      // Root condition and exists node's inner condition both render
+      expect(await screen.findByText('title')).toBeInTheDocument();
+      expect(screen.getByText('name')).toBeInTheDocument();
+      // The exists node shows its table
+      expect(screen.getByText('public.town')).toBeInTheDocument();
+    });
+
+    it('"Delete Exists" button removes the exists node', async () => {
+      render(
+        <TestWrapper
+          defaultValues={{
+            rule: group('_and', [
+              condition('title'),
+              existsNode('public', 'authors'),
+            ]),
+          }}
+        >
+          <VisualRuleEditor {...defaultProps} />
+        </TestWrapper>,
+      );
+
+      expect(screen.getByText('public.authors')).toBeInTheDocument();
+
+      const user = new TestUserEvent();
+      await user.click(screen.getByRole('button', { name: /delete exists/i }));
+
+      await waitFor(() => {
+        expect(screen.queryByText('public.authors')).not.toBeInTheDocument();
+        expect(screen.queryByText('Exists')).not.toBeInTheDocument();
+      });
+
+      expect(await screen.findByText('title')).toBeInTheDocument();
+    });
+  });
+
+  describe('condition row behavior', () => {
+    it('changing the column resets operator to _eq', async () => {
+      render(
+        <TestWrapper
+          defaultValues={{
+            rule: group('_and', [
+              {
+                type: 'condition',
+                id: crypto.randomUUID(),
+                column: 'title',
+                operator: '_gt',
+                value: 18,
+              } satisfies ConditionNode,
+            ]),
+          }}
+        >
+          <VisualRuleEditor {...defaultProps} />
+        </TestWrapper>,
+      );
+
+      expect(await screen.findByText('title')).toBeInTheDocument();
+      expect(screen.getByText('_gt')).toBeInTheDocument();
+
+      const user = new TestUserEvent();
+      await user.click(screen.getByText('title'));
+      await user.click(
+        await screen.findByRole('option', { name: /release_date/ }),
+      );
+
+      await waitFor(() => {
+        expect(screen.getByText('release_date')).toBeInTheDocument();
+        expect(screen.getByText('_eq')).toBeInTheDocument();
+      });
+
+      expect(screen.queryByText('_gt')).not.toBeInTheDocument();
+    });
+  });
+
+  describe('relationship nodes', () => {
+    it('selecting a relationship from AddNodeButton appends a relationship node', async () => {
+      render(
+        <TestWrapper
+          defaultValues={{
+            rule: group('_and', [condition('title')]),
+          }}
+        >
+          <VisualRuleEditor {...defaultProps} />
+        </TestWrapper>,
+      );
+
+      const user = new TestUserEvent();
+      await user.click(screen.getByText('Add'));
+      // Use exact match to avoid matching the 'author_id' column option
+      await user.click(await screen.findByRole('option', { name: 'author' }));
+
+      await waitFor(() => {
+        expect(screen.getByText('Relationship')).toBeInTheDocument();
+        expect(screen.getByText('author')).toBeInTheDocument();
+      });
+    });
+
+    it('renders an existing relationship node with badge and combobox', () => {
+      render(
+        <TestWrapper
+          defaultValues={{
+            rule: group('_and', [
+              condition('title'),
+              relationshipNode('author'),
+            ]),
+          }}
+        >
+          <VisualRuleEditor {...defaultProps} />
+        </TestWrapper>,
+      );
+
+      expect(screen.getByText('Relationship')).toBeInTheDocument();
+      expect(screen.getByText('author')).toBeInTheDocument();
+    });
+
+    it('"Delete relationship" button removes the relationship node', async () => {
+      render(
+        <TestWrapper
+          defaultValues={{
+            rule: group('_and', [
+              condition('title'),
+              relationshipNode('author'),
+            ]),
+          }}
+        >
+          <VisualRuleEditor {...defaultProps} />
+        </TestWrapper>,
+      );
+
+      expect(screen.getByText('author')).toBeInTheDocument();
+      expect(screen.getByText('Relationship')).toBeInTheDocument();
+
+      const user = new TestUserEvent();
+      await user.click(
+        screen.getByRole('button', { name: /delete relationship/i }),
+      );
+
+      await waitFor(() => {
+        expect(screen.queryByText('Relationship')).not.toBeInTheDocument();
+        expect(screen.queryByText('author')).not.toBeInTheDocument();
+      });
+
+      expect(await screen.findByText('title')).toBeInTheDocument();
+    });
+
+    it('renders inner conditions inside a relationship node', async () => {
+      render(
+        <TestWrapper
+          defaultValues={{
+            rule: group('_and', [
+              relationshipNode(
+                'author',
+                group('_and', [condition('name'), condition('birth_date')]),
+              ),
+            ]),
+          }}
+        >
+          <VisualRuleEditor {...defaultProps} />
+        </TestWrapper>,
+      );
+
+      expect(await screen.findByText('name')).toBeInTheDocument();
+      expect(await screen.findByText('birth_date')).toBeInTheDocument();
+      expect(await screen.findByText('Relationship')).toBeInTheDocument();
+    });
+
+    it('renders a nested relationship node inside a relationship node', () => {
+      render(
+        <TestWrapper
+          defaultValues={{
+            rule: group('_and', [
+              relationshipNode(
+                'author',
+                group('_and', [condition('title'), relationshipNode('posts')]),
+              ),
+            ]),
+          }}
+        >
+          <VisualRuleEditor {...defaultProps} />
+        </TestWrapper>,
+      );
+
+      expect(screen.getByText('author')).toBeInTheDocument();
+      expect(screen.getByText('posts')).toBeInTheDocument();
+      expect(screen.getAllByText('Relationship')).toHaveLength(2);
+    });
+
+    it('renders an exists node inside a relationship node', () => {
+      render(
+        <TestWrapper
+          defaultValues={{
+            rule: group('_and', [
+              relationshipNode(
+                'author',
+                group('_and', [
+                  condition('title'),
+                  existsNode('public', 'actor'),
+                ]),
+              ),
+            ]),
+          }}
+        >
+          <VisualRuleEditor {...defaultProps} />
+        </TestWrapper>,
+      );
+
+      expect(screen.getByText('author')).toBeInTheDocument();
+      expect(screen.getByText('Relationship')).toBeInTheDocument();
+      expect(screen.getByText('public.actor')).toBeInTheDocument();
+      expect(screen.getByText('Exists')).toBeInTheDocument();
+    });
+
+    it('renders a relationship node inside an exists node', () => {
+      render(
+        <TestWrapper
+          defaultValues={{
+            rule: group('_and', [
+              existsNode(
+                'public',
+                'town',
+                group('_and', [
+                  condition('title'),
+                  relationshipNode('customer'),
+                ]),
+              ),
+            ]),
+          }}
+        >
+          <VisualRuleEditor {...defaultProps} />
+        </TestWrapper>,
+      );
+
+      expect(screen.getByText('public.town')).toBeInTheDocument();
+      expect(screen.getByText('Exists')).toBeInTheDocument();
+      expect(screen.getByText('customer')).toBeInTheDocument();
+      expect(screen.getByText('Relationship')).toBeInTheDocument();
+    });
+  });
+
+  describe('edge cases', () => {
+    it('mixed node types at the same level (condition + group + exists + relationship) render correctly', async () => {
+      render(
+        <TestWrapper
+          defaultValues={{
+            rule: group('_and', [
+              condition('title'),
+              group('_or', [condition('release_date')]),
+              existsNode('public', 'town'),
+              relationshipNode('author'),
+            ]),
+          }}
+        >
+          <VisualRuleEditor {...defaultProps} />
+        </TestWrapper>,
+      );
+
+      expect(await screen.findByText('title')).toBeInTheDocument();
+      expect(screen.getByText('release_date')).toBeInTheDocument();
+      expect(screen.getByText('OR')).toBeInTheDocument();
+      expect(screen.getByText('Exists')).toBeInTheDocument();
+      expect(screen.getByText('public.town')).toBeInTheDocument();
+      expect(screen.getByText('Relationship')).toBeInTheDocument();
+      expect(screen.getByText('author')).toBeInTheDocument();
+    });
+
+    it('renders an exists node inside a nested group node', () => {
+      render(
+        <TestWrapper
+          defaultValues={{
+            rule: group('_and', [
+              group('_or', [condition('title'), existsNode('public', 'town')]),
+            ]),
+          }}
+        >
+          <VisualRuleEditor {...defaultProps} />
+        </TestWrapper>,
+      );
+
+      expect(screen.getByText('OR')).toBeInTheDocument();
+      expect(screen.getByText('Exists')).toBeInTheDocument();
+      expect(screen.getByText('public.town')).toBeInTheDocument();
+    });
+
+    it('renders a relationship node inside a nested group node', () => {
+      render(
+        <TestWrapper
+          defaultValues={{
+            rule: group('_and', [
+              group('_or', [condition('title'), relationshipNode('author')]),
+            ]),
+          }}
+        >
+          <VisualRuleEditor {...defaultProps} />
+        </TestWrapper>,
+      );
+
+      expect(screen.getByText('OR')).toBeInTheDocument();
+      expect(screen.getByText('Relationship')).toBeInTheDocument();
+      expect(screen.getByText('author')).toBeInTheDocument();
+    });
+
+    it('renders exists and relationship nodes inside deeply nested groups', () => {
+      render(
+        <TestWrapper
+          defaultValues={{
+            rule: group('_and', [
+              group('_or', [
+                group('_and', [
+                  existsNode('public', 'town'),
+                  relationshipNode('author'),
+                ]),
+              ]),
+            ]),
+          }}
+        >
+          <VisualRuleEditor {...defaultProps} />
+        </TestWrapper>,
+      );
+
+      expect(screen.getByText('Exists')).toBeInTheDocument();
+      expect(screen.getByText('public.town')).toBeInTheDocument();
+      expect(screen.getByText('Relationship')).toBeInTheDocument();
+      expect(screen.getByText('author')).toBeInTheDocument();
+    });
+
+    it('rapid add/remove operations do not cause state inconsistencies', async () => {
+      render(
+        <TestWrapper
+          defaultValues={{
+            rule: group('_and', [condition('title')]),
+          }}
+        >
+          <VisualRuleEditor {...defaultProps} />
+        </TestWrapper>,
+      );
+
+      expect(await screen.findByText('title')).toBeInTheDocument();
+
+      const user = new TestUserEvent();
+
+      // Add 2 conditions via the popover
+      await user.click(screen.getByText('Add'));
+      await user.click(
+        await screen.findByRole('option', { name: /release_date/ }),
+      );
+      await waitFor(() => {
+        expect(screen.getByText('release_date')).toBeInTheDocument();
+      });
+
+      await user.click(screen.getByText('Add'));
+      await user.click(
+        await screen.findByRole('option', { name: /author_id/ }),
+      );
+      await waitFor(() => {
+        expect(screen.getByText('author_id')).toBeInTheDocument();
+      });
+
+      // Remove the last condition
+      const removeButtons = screen.getAllByRole('button', {
+        name: /delete condition/i,
+      });
+      await user.click(removeButtons[removeButtons.length - 1]);
+
+      await waitFor(() => {
+        expect(
+          screen.getAllByRole('button', { name: /delete condition/i }),
+        ).toHaveLength(2);
+        expect(screen.queryByText('author_id')).not.toBeInTheDocument();
+        expect(screen.getByText('title')).toBeInTheDocument();
+        expect(screen.getByText('release_date')).toBeInTheDocument();
+      });
+    });
+
+    it('_not operator with multiple children renders correctly', async () => {
+      render(
+        <TestWrapper
+          defaultValues={{
+            rule: group('_not', [
+              condition('title'),
+              condition('release_date'),
+              condition('author_id'),
+            ]),
+          }}
+        >
+          <VisualRuleEditor {...defaultProps} />
+        </TestWrapper>,
+      );
+
+      expect(screen.getByText('NOT')).toBeInTheDocument();
+      expect(await screen.findByText('title')).toBeInTheDocument();
+      expect(screen.getByText('release_date')).toBeInTheDocument();
+      expect(screen.getByText('author_id')).toBeInTheDocument();
+      expect(
+        screen.getAllByRole('button', { name: /delete condition/i }),
+      ).toHaveLength(3);
+    });
+  });
+
+  describe('empty state (root level)', () => {
+    it('renders AddNodeButton when filter is an empty _implicit group', () => {
+      render(
+        <TestWrapper
+          defaultValues={{
+            rule: group('_implicit', []),
+          }}
+        >
+          <VisualRuleEditor {...defaultProps} />
+        </TestWrapper>,
+      );
+
+      // AddNodeButton is present
+      expect(
+        screen.getByRole('button', { name: /add check/i }),
+      ).toBeInTheDocument();
+      // No group UI elements are rendered
+      expect(screen.queryByText('AND')).not.toBeInTheDocument();
+      expect(screen.queryByText('OR')).not.toBeInTheDocument();
+      expect(screen.queryByText('NOT')).not.toBeInTheDocument();
+      expect(screen.queryByText('Implicit')).not.toBeInTheDocument();
+      expect(screen.queryByRole('combobox')).not.toBeInTheDocument();
+      expect(
+        screen.queryByRole('button', { name: /delete group/i }),
+      ).not.toBeInTheDocument();
+    });
+
+    it('renders AddNodeButton when filter is an empty object', () => {
+      render(
+        <TestWrapper defaultValues={{ rule: {} }}>
+          <VisualRuleEditor {...defaultProps} />
+        </TestWrapper>,
+      );
+
+      expect(
+        screen.getByRole('button', { name: /add check/i }),
+      ).toBeInTheDocument();
+      // No group UI
+      expect(screen.queryByText('AND')).not.toBeInTheDocument();
+      expect(screen.queryByText('OR')).not.toBeInTheDocument();
+      expect(screen.queryByRole('combobox')).not.toBeInTheDocument();
+      expect(
+        screen.queryByRole('button', { name: /delete group/i }),
+      ).not.toBeInTheDocument();
+    });
+
+    it('renders GroupNodeRenderer (not AddNodeButton at root) when filter has content', () => {
+      render(
+        <TestWrapper
+          defaultValues={{
+            rule: group('_and', [condition('title')]),
+          }}
+        >
+          <VisualRuleEditor {...defaultProps} />
+        </TestWrapper>,
+      );
+
+      // Group UI is rendered
+      expect(screen.getByText('AND')).toBeInTheDocument();
+      expect(
+        screen.getByRole('button', { name: /delete group/i }),
+      ).toBeInTheDocument();
+      // The root-level full-width "Add check" button should not be present
+      expect(
+        screen.queryByRole('button', { name: /add check/i }),
+      ).not.toBeInTheDocument();
+      // The group-level "Add" button should be present
+      expect(screen.getByText('Add')).toBeInTheDocument();
+    });
+
+    it('selecting a condition from AddNodeButton at root wraps it in an _implicit group', async () => {
+      render(
+        <TestWrapper defaultValues={{ rule: group('_implicit', []) }}>
+          <VisualRuleEditor {...defaultProps} />
+        </TestWrapper>,
+      );
+
+      const user = new TestUserEvent();
+      await user.click(screen.getByRole('button', { name: /add check/i }));
+      await user.click(await screen.findByRole('option', { name: /title/ }));
+
+      await waitFor(() => {
+        expect(screen.getByText('Implicit')).toBeInTheDocument();
+        expect(screen.getByText('title')).toBeInTheDocument();
+      });
+    });
+
+    it('selecting a group from AddNodeButton at root sets it directly as root (no _implicit wrapping)', async () => {
+      render(
+        <TestWrapper defaultValues={{ rule: group('_implicit', []) }}>
+          <VisualRuleEditor {...defaultProps} />
+        </TestWrapper>,
+      );
+
+      const user = new TestUserEvent();
+      await user.click(screen.getByRole('button', { name: /add check/i }));
+      await user.click(await screen.findByRole('option', { name: 'and' }));
+
+      await waitFor(() => {
+        expect(screen.getByText('AND')).toBeInTheDocument();
+        expect(screen.queryByText('Implicit')).not.toBeInTheDocument();
+        expect(
+          screen.queryByRole('button', { name: /add check/i }),
+        ).not.toBeInTheDocument();
+      });
+    });
+
+    it('selecting a relationship from AddNodeButton at root wraps it in an _implicit group', async () => {
+      render(
+        <TestWrapper defaultValues={{ rule: group('_implicit', []) }}>
+          <VisualRuleEditor {...defaultProps} />
+        </TestWrapper>,
+      );
+
+      const user = new TestUserEvent();
+      await user.click(screen.getByRole('button', { name: /add check/i }));
+      await user.click(await screen.findByRole('option', { name: 'author' }));
+
+      await waitFor(() => {
+        expect(screen.getByText('Implicit')).toBeInTheDocument();
+        expect(screen.getByText('Relationship')).toBeInTheDocument();
+        expect(screen.getByText('author')).toBeInTheDocument();
+      });
+    });
+
+    it('selecting exists from AddNodeButton at root wraps it in an _implicit group', async () => {
+      render(
+        <TestWrapper defaultValues={{ rule: group('_implicit', []) }}>
+          <VisualRuleEditor {...defaultProps} />
+        </TestWrapper>,
+      );
+
+      const user = new TestUserEvent();
+      await user.click(screen.getByRole('button', { name: /add check/i }));
+      await user.click(await screen.findByRole('option', { name: 'exists' }));
+
+      const existWrapper = screen.getAllByText('Implicit')[1];
+      expect(existWrapper).toBeInTheDocument();
+      expect(screen.getByText('Exists')).toBeInTheDocument();
+      expect(screen.getByText('Select table...')).toBeInTheDocument();
+    });
+  });
+
+  describe('root remove (reset to empty)', () => {
+    it('clicking the root delete button resets to empty state with no group UI', async () => {
+      render(
+        <TestWrapper
+          defaultValues={{
+            rule: group('_and', [condition('title')]),
+          }}
+        >
+          <VisualRuleEditor {...defaultProps} />
+        </TestWrapper>,
+      );
+
+      expect(screen.getByText('AND')).toBeInTheDocument();
+      expect(await screen.findByText('title')).toBeInTheDocument();
+
+      const user = new TestUserEvent();
+      await user.click(screen.getByRole('button', { name: /delete group/i }));
+
+      await waitFor(() => {
+        expect(screen.queryByText('AND')).not.toBeInTheDocument();
+        expect(screen.queryByText('title')).not.toBeInTheDocument();
+        expect(
+          screen.queryByRole('button', { name: /delete group/i }),
+        ).not.toBeInTheDocument();
+        expect(
+          screen.getByRole('button', { name: /add check/i }),
+        ).toBeInTheDocument();
+      });
+    });
+
+    it('after resetting to empty, selecting a new node works correctly', async () => {
+      render(
+        <TestWrapper
+          defaultValues={{
+            rule: group('_and', [condition('title')]),
+          }}
+        >
+          <VisualRuleEditor {...defaultProps} />
+        </TestWrapper>,
+      );
+
+      expect(await screen.findByText('title')).toBeInTheDocument();
+
+      const user = new TestUserEvent();
+      await user.click(screen.getByRole('button', { name: /delete group/i }));
+
+      await waitFor(() => {
+        expect(
+          screen.getByRole('button', { name: /add check/i }),
+        ).toBeInTheDocument();
+      });
+
+      await user.click(screen.getByRole('button', { name: /add check/i }));
+      await user.click(await screen.findByRole('option', { name: 'and' }));
+
+      await waitFor(() => {
+        expect(screen.getByText('AND')).toBeInTheDocument();
+      });
+    });
+  });
+
+  describe('empty groups (nested level)', () => {
+    it('a newly added nested group renders AddNodeButton (full-width) inside it', async () => {
+      render(
+        <TestWrapper
+          defaultValues={{
+            rule: group('_and', [condition('title')]),
+          }}
+        >
+          <VisualRuleEditor {...defaultProps} />
+        </TestWrapper>,
+      );
+
+      expect(await screen.findByText('title')).toBeInTheDocument();
+
+      const user = new TestUserEvent();
+      // Add a nested group via the popover
+      await user.click(screen.getByText('Add'));
+      await user.click(await screen.findByRole('option', { name: 'and' }));
+
+      await waitFor(() => {
+        // Root group AND + nested group AND
+        expect(screen.getAllByText('AND')).toHaveLength(2);
+        // Root group has one Add, nested empty group has one full-width Add
+        const addButtons = screen.getAllByText('Add');
+        expect(addButtons).toHaveLength(2);
+      });
+    });
+
+    it('selecting a rule from AddNodeButton inside a nested group appends it directly', async () => {
+      render(
+        <TestWrapper
+          defaultValues={{
+            rule: group('_and', [condition('title')]),
+          }}
+        >
+          <VisualRuleEditor {...defaultProps} />
+        </TestWrapper>,
+      );
+
+      expect(await screen.findByText('title')).toBeInTheDocument();
+
+      const user = new TestUserEvent();
+      // Add a nested group first
+      await user.click(screen.getByText('Add'));
+      await user.click(await screen.findByRole('option', { name: 'and' }));
+
+      await waitFor(() => {
+        expect(screen.getAllByText('AND')).toHaveLength(2);
+      });
+
+      // Click the nested group's Add button (first in DOM order)
+      const addButtons = screen.getAllByText('Add');
+      await user.click(addButtons[0]);
+      await user.click(await screen.findByRole('option', { name: /title/ }));
+
+      await waitFor(() => {
+        expect(screen.getAllByText('title')).toHaveLength(2);
+        expect(
+          screen.getAllByRole('button', { name: /delete condition/i }),
+        ).toHaveLength(2);
+      });
+    });
+
+    it('selecting a group from AddNodeButton inside a nested group appends it directly', async () => {
+      render(
+        <TestWrapper
+          defaultValues={{
+            rule: group('_and', [condition('title')]),
+          }}
+        >
+          <VisualRuleEditor {...defaultProps} />
+        </TestWrapper>,
+      );
+
+      expect(await screen.findByText('title')).toBeInTheDocument();
+
+      const user = new TestUserEvent();
+      // Add a nested group first
+      await user.click(screen.getByText('Add'));
+      await user.click(await screen.findByRole('option', { name: 'and' }));
+
+      await waitFor(() => {
+        expect(screen.getAllByText('AND')).toHaveLength(2);
+      });
+
+      // Click the nested group's Add button (first in DOM order)
+      const addButtons = screen.getAllByText('Add');
+      await user.click(addButtons[0]);
+      await user.click(await screen.findByRole('option', { name: 'or' }));
+
+      await waitFor(() => {
+        expect(screen.getAllByText('AND')).toHaveLength(2);
+        expect(screen.getByText('OR')).toBeInTheDocument();
+      });
+    });
+
+    it('removing the last child from a nested group shows AddNodeButton inside it', async () => {
+      render(
+        <TestWrapper
+          defaultValues={{
+            rule: group('_and', [
+              condition('title'),
+              group('_or', [condition('release_date')]),
+            ]),
+          }}
+        >
+          <VisualRuleEditor {...defaultProps} />
+        </TestWrapper>,
+      );
+
+      expect(await screen.findByText('title')).toBeInTheDocument();
+      expect(screen.getByText('release_date')).toBeInTheDocument();
+
+      const user = new TestUserEvent();
+      // Remove the condition inside the nested _or group
+      const removeButtons = screen.getAllByRole('button', {
+        name: /delete condition/i,
+      });
+      // The last trash button belongs to the nested condition
+      await user.click(removeButtons[removeButtons.length - 1]);
+
+      await waitFor(() => {
+        // release_date removed, title remains
+        expect(screen.queryByText('release_date')).not.toBeInTheDocument();
+        expect(screen.getByText('title')).toBeInTheDocument();
+        // The nested group still exists (OR badge) with an Add button inside
+        expect(screen.getByText('OR')).toBeInTheDocument();
+        // Root group Add + nested empty group Add
+        expect(screen.getAllByText('Add')).toHaveLength(2);
+      });
+    });
+  });
+
+  describe('exists/relationship empty children', () => {
+    it('a newly added exists node has an empty where clause that shows AddNodeButton', async () => {
+      render(
+        <TestWrapper
+          defaultValues={{
+            rule: group('_and', [condition('title')]),
+          }}
+        >
+          <VisualRuleEditor {...defaultProps} />
+        </TestWrapper>,
+      );
+
+      expect(await screen.findByText('title')).toBeInTheDocument();
+
+      const user = new TestUserEvent();
+      await user.click(screen.getByText('Add'));
+      await user.click(await screen.findByRole('option', { name: 'exists' }));
+
+      await waitFor(() => {
+        expect(screen.getByText('Exists')).toBeInTheDocument();
+        expect(screen.getByText('Select table...')).toBeInTheDocument();
+        // Root group Add + exists where clause Add
+        expect(screen.getAllByText('Add')).toHaveLength(2);
+      });
+    });
+
+    it('a newly added relationship node has an empty child group that shows AddNodeButton', async () => {
+      render(
+        <TestWrapper
+          defaultValues={{
+            rule: group('_and', [condition('title')]),
+          }}
+        >
+          <VisualRuleEditor {...defaultProps} />
+        </TestWrapper>,
+      );
+
+      expect(await screen.findByText('title')).toBeInTheDocument();
+
+      const user = new TestUserEvent();
+      await user.click(screen.getByText('Add'));
+      // Use exact match to avoid matching 'author_id' column
+      await user.click(await screen.findByRole('option', { name: 'author' }));
+
+      await waitFor(() => {
+        expect(screen.getByText('Relationship')).toBeInTheDocument();
+        expect(screen.getByText('author')).toBeInTheDocument();
+        // Root group Add + relationship child group Add
+        expect(screen.getAllByText('Add')).toHaveLength(2);
+      });
+    });
+  });
+
+  describe('node highlight styles', () => {
+    it('group node container has hover and focus-within highlight classes', () => {
+      render(
+        <TestWrapper
+          defaultValues={{
+            rule: group('_and', [condition('title')]),
+          }}
+        >
+          <VisualRuleEditor {...defaultProps} />
+        </TestWrapper>,
+      );
+
+      const groupContainer = screen
+        .getByText('AND')
+        .closest('[class*="rounded-lg"]');
+      expect(groupContainer?.className).toContain(
+        '[&:hover:not(:has(.group-node:hover))]:ring-2',
+      );
+      expect(groupContainer?.className).toContain(
+        '[&:hover:not(:has(.group-node:hover))]:ring-ring/50',
+      );
+      expect(groupContainer?.className).toContain(
+        '[&:focus-within:not(:has(.group-node:focus-within))]:ring-2',
+      );
+      expect(groupContainer?.className).toContain(
+        '[&:focus-within:not(:has(.group-node:focus-within))]:ring-ring/30',
+      );
+      expect(groupContainer?.className).toContain('transition-shadow');
+    });
+
+    it('condition row has hover and focus-within background highlight classes', () => {
+      render(
+        <TestWrapper
+          defaultValues={{
+            rule: group('_and', [condition('title')]),
+          }}
+        >
+          <VisualRuleEditor {...defaultProps} />
+        </TestWrapper>,
+      );
+
+      const conditionRow = screen
+        .getByRole('button', { name: /delete condition/i })
+        .closest('[class*="transition-colors"]');
+      expect(conditionRow).not.toBeNull();
+      expect(conditionRow?.className).toContain('hover:bg-accent');
+      expect(conditionRow?.className).toContain('transition-colors');
+    });
+
+    it('exists node container has hover and focus-within highlight classes with blue ring', async () => {
+      render(
+        <TestWrapper
+          defaultValues={{
+            rule: group('_and', [
+              {
+                type: 'exists',
+                id: crypto.randomUUID(),
+                schema: 'public',
+                table: 'authors',
+                where: group('_implicit', []),
+              } satisfies ExistsNode,
+            ]),
+          }}
+        >
+          <VisualRuleEditor {...defaultProps} />
+        </TestWrapper>,
+      );
+
+      const existsLabel = screen.getByLabelText('Delete exists');
+      const existsContainer = existsLabel.closest('[class*="bg-blue-50"]');
+      expect(existsContainer?.className).toContain(
+        '[&:hover:not(:has(.group-node:hover))]:ring-2',
+      );
+      expect(existsContainer?.className).toContain(
+        '[&:hover:not(:has(.group-node:hover))]:ring-blue-400/30',
+      );
+      expect(existsContainer?.className).toContain(
+        '[&:focus-within:not(:has(.group-node:focus-within))]:ring-2',
+      );
+      expect(existsContainer?.className).toContain(
+        '[&:focus-within:not(:has(.group-node:focus-within))]:ring-blue-400/40',
+      );
+      expect(existsContainer?.className).toContain('transition-shadow');
+    });
+
+    it('relationship node container has hover and focus-within highlight classes with emerald ring', async () => {
+      render(
+        <TestWrapper
+          defaultValues={{
+            rule: group('_and', [
+              {
+                type: 'relationship',
+                id: crypto.randomUUID(),
+                relationship: 'author',
+                child: group('_implicit', []),
+              } satisfies RelationshipNode,
+            ]),
+          }}
+        >
+          <VisualRuleEditor {...defaultProps} />
+        </TestWrapper>,
+      );
+
+      const relationshipLabel = screen.getByLabelText('Delete relationship');
+      const relationshipContainer = relationshipLabel.closest(
+        '[class*="bg-emerald-50"]',
+      );
+      expect(relationshipContainer?.className).toContain(
+        '[&:hover:not(:has(.group-node:hover))]:ring-2',
+      );
+      expect(relationshipContainer?.className).toContain(
+        '[&:hover:not(:has(.group-node:hover))]:ring-emerald-400/30',
+      );
+      expect(relationshipContainer?.className).toContain(
+        '[&:focus-within:not(:has(.group-node:focus-within))]:ring-2',
+      );
+      expect(relationshipContainer?.className).toContain(
+        '[&:focus-within:not(:has(.group-node:focus-within))]:ring-emerald-400/40',
+      );
+      expect(relationshipContainer?.className).toContain('transition-shadow');
+    });
+  });
+});

--- a/dashboard/src/features/orgs/projects/database/dataGrid/components/CustomCheckEditor/VisualRuleEditor.tsx
+++ b/dashboard/src/features/orgs/projects/database/dataGrid/components/CustomCheckEditor/VisualRuleEditor.tsx
@@ -1,0 +1,95 @@
+import { useMemo } from 'react';
+import { useFormContext, useWatch } from 'react-hook-form';
+import { v4 as uuidv4 } from 'uuid';
+import type { RuleNode } from '@/features/orgs/projects/database/dataGrid/utils/permissionUtils';
+import AddNodeButton from './AddNodeButton';
+import GroupNodeRenderer from './GroupNodeRenderer';
+import { CustomCheckEditorContext } from './useCustomCheckEditor';
+
+export interface VisualRuleEditorProps {
+  schema: string;
+  table: string;
+  name: string;
+  maxDepth?: number;
+}
+
+function isEmptyFilter(value: unknown): boolean {
+  if (!value || typeof value !== 'object') {
+    return true;
+  }
+
+  const obj = value as Record<string, unknown>;
+
+  if (Object.keys(obj).length === 0) {
+    return true;
+  }
+
+  if (
+    obj.type === 'group' &&
+    obj.operator === '_implicit' &&
+    Array.isArray(obj.children) &&
+    obj.children.length === 0
+  ) {
+    return true;
+  }
+
+  return false;
+}
+
+export default function VisualRuleEditor({
+  schema,
+  table,
+  name,
+  maxDepth,
+}: VisualRuleEditorProps) {
+  const { setValue, resetField } = useFormContext();
+  const filterValue = useWatch({ name });
+
+  const contextValue = useMemo(
+    () => ({
+      schema,
+      table,
+    }),
+    [schema, table],
+  );
+
+  const isEmpty = isEmptyFilter(filterValue);
+
+  function handleAddNodeSelect(node: RuleNode) {
+    if (node.type === 'group') {
+      setValue(name, node);
+    } else {
+      setValue(name, {
+        type: 'group',
+        id: uuidv4(),
+        operator: '_implicit',
+        children: [node],
+      });
+    }
+  }
+
+  function handleRootRemove() {
+    resetField(name, {
+      defaultValue: {
+        type: 'group',
+        operator: '_implicit',
+        children: [],
+        id: uuidv4(),
+      },
+    });
+  }
+
+  return (
+    <CustomCheckEditorContext.Provider value={contextValue}>
+      {isEmpty ? (
+        <AddNodeButton onSelect={handleAddNodeSelect} fullWidth />
+      ) : (
+        <GroupNodeRenderer
+          name={name}
+          maxDepth={maxDepth}
+          onRemove={handleRootRemove}
+        />
+      )}
+    </CustomCheckEditorContext.Provider>
+  );
+}

--- a/dashboard/src/features/orgs/projects/database/dataGrid/components/CustomCheckEditor/index.ts
+++ b/dashboard/src/features/orgs/projects/database/dataGrid/components/CustomCheckEditor/index.ts
@@ -1,2 +1,7 @@
 export * from './CustomCheckEditor';
 export { default as CustomCheckEditor } from './CustomCheckEditor';
+export * from './CustomCheckModeProvider';
+export { default as CustomCheckModeToggle } from './CustomCheckModeToggle';
+export { default as JsonRuleEditor } from './JsonRuleEditor';
+export * from './VisualRuleEditor';
+export { default as VisualRuleEditor } from './VisualRuleEditor';

--- a/dashboard/src/features/orgs/projects/database/dataGrid/components/CustomCheckEditor/useCustomCheckEditor.ts
+++ b/dashboard/src/features/orgs/projects/database/dataGrid/components/CustomCheckEditor/useCustomCheckEditor.ts
@@ -3,11 +3,9 @@ import { createContext, useContext } from 'react';
 export const CustomCheckEditorContext = createContext<{
   schema: string;
   table: string;
-  disabled: boolean;
 }>({
   schema: '',
   table: '',
-  disabled: false,
 });
 
 export default function useCustomCheckEditor() {

--- a/dashboard/src/features/orgs/projects/database/dataGrid/components/EditPermissionsForm/RolePermissionEditorForm.tsx
+++ b/dashboard/src/features/orgs/projects/database/dataGrid/components/EditPermissionsForm/RolePermissionEditorForm.tsx
@@ -16,7 +16,7 @@ import type {
 } from '@/features/orgs/projects/database/dataGrid/types/dataBrowser';
 import type { GroupNode } from '@/features/orgs/projects/database/dataGrid/utils/permissionUtils';
 import {
-  unWrapRuleNodes,
+  serializeNode,
   wrapPermissionsInAGroup,
 } from '@/features/orgs/projects/database/dataGrid/utils/permissionUtils';
 import { execPromiseWithErrorToast } from '@/features/orgs/utils/execPromiseWithErrorToast';
@@ -270,7 +270,7 @@ export default function RolePermissionEditorForm({
   async function handleSubmit(values: RolePermissionEditorFormValues) {
     const permissionFilter =
       values.rowCheckType === 'custom'
-        ? unWrapRuleNodes(values.filter as GroupNode)
+        ? serializeNode(values.filter as GroupNode)
         : (values.filter ?? {});
 
     const managePermissionPromise = managePermission({

--- a/dashboard/src/features/orgs/projects/database/dataGrid/components/EditPermissionsForm/sections/RowPermissionsSection.tsx
+++ b/dashboard/src/features/orgs/projects/database/dataGrid/components/EditPermissionsForm/sections/RowPermissionsSection.tsx
@@ -1,4 +1,4 @@
-import type { FocusEvent, ReactNode } from 'react';
+import type { FocusEvent } from 'react';
 import { useFormContext, useWatch } from 'react-hook-form';
 import { v4 as uuidv4 } from 'uuid';
 import { HighlightedText } from '@/components/presentational/HighlightedText';
@@ -6,7 +6,11 @@ import { Input } from '@/components/ui/v2/Input';
 import { Radio } from '@/components/ui/v2/Radio';
 import { RadioGroup } from '@/components/ui/v2/RadioGroup';
 import { Text } from '@/components/ui/v2/Text';
-import { CustomCheckEditor } from '@/features/orgs/projects/database/dataGrid/components/CustomCheckEditor';
+import {
+  CustomCheckEditor,
+  CustomCheckModeProvider,
+  CustomCheckModeToggle,
+} from '@/features/orgs/projects/database/dataGrid/components/CustomCheckEditor';
 import type {
   RolePermissionEditorFormValues,
   RowCheckType,
@@ -58,35 +62,30 @@ export default function RowPermissionsSection({
 
   return (
     <PermissionSettingsSection title={`Row ${action} permissions`}>
-      <Text>
-        Allow role <HighlightedText>{role}</HighlightedText> to{' '}
-        <HighlightedText>{action}</HighlightedText> rows:
-      </Text>
-
-      <RadioGroup
-        value={rowCheckType}
-        className="grid grid-flow-col justify-start gap-4"
-        onChange={(_event, value) =>
-          handleCheckTypeChange(value as typeof rowCheckType)
-        }
-      >
-        <Radio value="none" label="Without any checks" />
-        <Radio value="custom" label="With custom check" />
-      </RadioGroup>
-
-      {errors?.filter?.root?.message || errors?.filter?.message ? (
-        <Text
-          variant="subtitle2"
-          className="font-normal"
-          sx={{ color: (theme) => `${theme.palette.error.main} !important` }}
-        >
-          {(errors.filter.root?.message ?? errors.filter.message) as ReactNode}
+      <CustomCheckModeProvider>
+        <Text>
+          Allow role <HighlightedText>{role}</HighlightedText> to{' '}
+          <HighlightedText>{action}</HighlightedText> rows:
         </Text>
-      ) : null}
 
-      {rowCheckType === 'custom' && (
-        <CustomCheckEditor name="filter" schema={schema} table={table} />
-      )}
+        <div className="flex items-center justify-between gap-4">
+          <RadioGroup
+            value={rowCheckType}
+            className="grid grid-flow-col justify-start gap-4"
+            onChange={(_event, value) =>
+              handleCheckTypeChange(value as typeof rowCheckType)
+            }
+          >
+            <Radio value="none" label="Without any checks" />
+            <Radio value="custom" label="With custom check" />
+          </RadioGroup>
+          {rowCheckType === 'custom' && <CustomCheckModeToggle />}
+        </div>
+
+        {rowCheckType === 'custom' && (
+          <CustomCheckEditor name="filter" schema={schema} table={table} />
+        )}
+      </CustomCheckModeProvider>
 
       {action === 'select' && (
         <Input

--- a/dashboard/src/features/orgs/projects/database/dataGrid/utils/permissionUtils/index.ts
+++ b/dashboard/src/features/orgs/projects/database/dataGrid/utils/permissionUtils/index.ts
@@ -1,12 +1,12 @@
 export * from './parsePermissionRule';
 export { default as parsePermissionRule } from './parsePermissionRule';
-export * from './ruleNodesToPermission';
-export { default as ruleNodesToPermission } from './ruleNodesToPermission';
+export { default as serializeNode } from './serializeNode';
 
 export type {
   ConditionNode,
   ExistsNode,
   GroupNode,
+  InvalidNode,
   LogicalOperator,
   RelationshipNode,
   RuleNode,
@@ -15,5 +15,6 @@ export {
   isConditionNode,
   isExistsNode,
   isGroupNode,
+  isInvalidNode,
   isRelationshipNode,
 } from './types';

--- a/dashboard/src/features/orgs/projects/database/dataGrid/utils/permissionUtils/parsePermissionRule.test.ts
+++ b/dashboard/src/features/orgs/projects/database/dataGrid/utils/permissionUtils/parsePermissionRule.test.ts
@@ -1,4 +1,3 @@
-import { vi } from 'vitest';
 import parsePermissionRule from './parsePermissionRule';
 
 describe('parsePermissionRule', () => {
@@ -6,14 +5,25 @@ describe('parsePermissionRule', () => {
     expect(parsePermissionRule({})).toEqual([]);
   });
 
-  it('returns an empty array and logs an error when the value is a primitive (not an object)', () => {
-    const consoleSpy = vi.spyOn(console, 'error').mockImplementation(() => {});
-    expect(parsePermissionRule({ invalid: 'string' })).toEqual([]);
-    expect(consoleSpy).toHaveBeenCalledWith(
-      'parsePermissionRule: unexpected primitive value for key "invalid":',
-      'string',
-    );
-    consoleSpy.mockRestore();
+  it('returns an InvalidNode with reason "primitive" when value is a primitive', () => {
+    const result = parsePermissionRule({ user_id: 5 });
+    expect(result).toHaveLength(1);
+    expect(result[0]).toMatchObject({
+      type: 'invalid',
+      reason: 'primitive',
+      key: 'user_id',
+      raw: 5,
+    });
+  });
+
+  it('returns an InvalidNode with reason "operator" when value is an array at a non-_and/_or key', () => {
+    const result = parsePermissionRule({ _ad: [{ col: { _eq: 'a' } }] });
+    expect(result).toHaveLength(1);
+    expect(result[0]).toMatchObject({
+      type: 'invalid',
+      reason: 'operator',
+      key: '_ad',
+    });
   });
 
   it('parses a simple equality condition', () => {

--- a/dashboard/src/features/orgs/projects/database/dataGrid/utils/permissionUtils/parsePermissionRule.ts
+++ b/dashboard/src/features/orgs/projects/database/dataGrid/utils/permissionUtils/parsePermissionRule.ts
@@ -133,11 +133,27 @@ function parsePermissionRule(
   }
 
   if (typeof value !== 'object' || value === null) {
-    console.error(
-      `parsePermissionRule: unexpected primitive value for key "${currentKey}":`,
-      value,
-    );
-    return [];
+    return [
+      {
+        type: 'invalid',
+        id: uuidv4(),
+        reason: 'primitive',
+        raw: value,
+        key: currentKey,
+      },
+    ];
+  }
+
+  if (Array.isArray(value)) {
+    return [
+      {
+        type: 'invalid',
+        id: uuidv4(),
+        reason: 'operator',
+        raw: value,
+        key: currentKey,
+      },
+    ];
   }
 
   const valueObj = value as Record<string, unknown>;

--- a/dashboard/src/features/orgs/projects/database/dataGrid/utils/permissionUtils/serializeNode.test.ts
+++ b/dashboard/src/features/orgs/projects/database/dataGrid/utils/permissionUtils/serializeNode.test.ts
@@ -1,10 +1,6 @@
 import { v4 as uuidv4 } from 'uuid';
-import parsePermissionRule, {
-  wrapPermissionsInAGroup,
-} from '@/features/orgs/projects/database/dataGrid/utils/permissionUtils/parsePermissionRule';
-import ruleNodesToPermission, {
-  unWrapRuleNodes,
-} from '@/features/orgs/projects/database/dataGrid/utils/permissionUtils/ruleNodesToPermission';
+import { wrapPermissionsInAGroup } from '@/features/orgs/projects/database/dataGrid/utils/permissionUtils/parsePermissionRule';
+import serializeNode from '@/features/orgs/projects/database/dataGrid/utils/permissionUtils/serializeNode';
 import type {
   ConditionNode,
   ExistsNode,
@@ -33,14 +29,10 @@ function group(
 }
 
 function roundTrip(input: Record<string, unknown>): Record<string, unknown> {
-  return ruleNodesToPermission(parsePermissionRule(input));
+  return serializeNode(wrapPermissionsInAGroup(input));
 }
 
-function uiRoundTrip(input: Record<string, unknown>): Record<string, unknown> {
-  return unWrapRuleNodes(wrapPermissionsInAGroup(input));
-}
-
-describe('ruleNodesToPermission round-trip', () => {
+describe('serializeNode round-trip', () => {
   it('round-trips an empty object', () => {
     expect(roundTrip({})).toEqual({});
   });
@@ -245,54 +237,62 @@ describe('ruleNodesToPermission round-trip', () => {
   });
 });
 
-describe('ruleNodesToPermission unit', () => {
-  it('returns an empty object for an empty array', () => {
-    expect(ruleNodesToPermission([])).toEqual({});
+describe('serializeNode unit', () => {
+  it('returns an empty object for an empty _implicit group', () => {
+    expect(serializeNode(group('_implicit', []))).toEqual({});
   });
 
   it('serializes _is_null string "true" as boolean true', () => {
-    expect(
-      ruleNodesToPermission([condition('col', '_is_null', 'true')]),
-    ).toEqual({
+    expect(serializeNode(condition('col', '_is_null', 'true'))).toEqual({
       col: { _is_null: true },
     });
   });
 
   it('serializes _is_null string "false" as boolean false', () => {
-    expect(
-      ruleNodesToPermission([condition('col', '_is_null', 'false')]),
-    ).toEqual({
+    expect(serializeNode(condition('col', '_is_null', 'false'))).toEqual({
       col: { _is_null: false },
     });
   });
 
   it('serializes _not with a single child without wrapping in _and', () => {
     expect(
-      ruleNodesToPermission([group('_not', [condition('col', '_eq', 'val')])]),
+      serializeNode(group('_not', [condition('col', '_eq', 'val')])),
     ).toEqual({
       _not: { col: { _eq: 'val' } },
     });
   });
 
+  it('serializes an invalid node by reconstructing the original key/value pair', () => {
+    expect(
+      serializeNode({
+        type: 'invalid',
+        id: uuidv4(),
+        reason: 'operator',
+        key: '_ad',
+        raw: [{ id: { _eq: '21313' } }],
+      }),
+    ).toEqual({ _ad: [{ id: { _eq: '21313' } }] });
+  });
+
   it('serializes _not with multiple children by merging them into a single object', () => {
     expect(
-      ruleNodesToPermission([
+      serializeNode(
         group('_not', [
           condition('col1', '_eq', 'a'),
           condition('col2', '_eq', 'b'),
         ]),
-      ]),
+      ),
     ).toEqual({ _not: { col1: { _eq: 'a' }, col2: { _eq: 'b' } } });
   });
 
   it('serializes a nested _implicit group by flattening its children (no _implicit key in output)', () => {
     expect(
-      ruleNodesToPermission([
+      serializeNode(
         group('_and', [
           condition('col1', '_eq', 'a'),
           group('_implicit', [condition('col2', '_eq', 'b')]),
         ]),
-      ]),
+      ),
     ).toEqual({
       _and: [{ col1: { _eq: 'a' } }, { col2: { _eq: 'b' } }],
     });
@@ -308,7 +308,7 @@ describe('ruleNodesToPermission unit', () => {
     };
 
     expect(
-      ruleNodesToPermission([
+      serializeNode(
         group('_and', [
           condition('ident', '_gt', '45'),
           condition('uniqueConstraints', '_eq', 'Hello'),
@@ -317,7 +317,7 @@ describe('ruleNodesToPermission unit', () => {
             existsNode,
           ]),
         ]),
-      ]),
+      ),
     ).toEqual({
       _and: [
         { ident: { _gt: '45' } },
@@ -334,34 +334,39 @@ describe('ruleNodesToPermission unit', () => {
   });
 });
 
-describe('UI round-trip (wrapPermissionsInAGroup → unWrapRuleNodes)', () => {
+describe('UI round-trip (wrapPermissionsInAGroup → serializeNode)', () => {
   it('round-trips an empty object', () => {
-    expect(uiRoundTrip({})).toEqual({});
+    expect(roundTrip({})).toEqual({});
+  });
+
+  it('round-trips an unknown operator with an array value (invalid node)', () => {
+    const input = { _ad: [{ id: { _eq: '21313' } }] };
+    expect(roundTrip(input)).toEqual(input);
   });
 
   it('round-trips a flat permission object without adding an _and wrapper', () => {
     const input = { col: { _eq: 'val' } };
-    expect(uiRoundTrip(input)).toEqual(input);
+    expect(roundTrip(input)).toEqual(input);
   });
 
   it('round-trips multiple flat keys without adding an _and wrapper', () => {
     const input = { col1: { _eq: 'a' }, col2: { _eq: 'b' } };
-    expect(uiRoundTrip(input)).toEqual(input);
+    expect(roundTrip(input)).toEqual(input);
   });
 
   it('round-trips an explicit _and without double-wrapping', () => {
     const input = { _and: [{ col: { _eq: 'a' } }, { col: { _eq: 'b' } }] };
-    expect(uiRoundTrip(input)).toEqual(input);
+    expect(roundTrip(input)).toEqual(input);
   });
 
   it('round-trips an explicit _or without double-wrapping', () => {
     const input = { _or: [{ col: { _eq: 'a' } }, { col: { _eq: 'b' } }] };
-    expect(uiRoundTrip(input)).toEqual(input);
+    expect(roundTrip(input)).toEqual(input);
   });
 
   it('round-trips a _not group', () => {
     const input = { _not: { col: { _eq: 'val' } } };
-    expect(uiRoundTrip(input)).toEqual(input);
+    expect(roundTrip(input)).toEqual(input);
   });
 
   it('round-trips an _exists with a flat _where', () => {
@@ -371,7 +376,7 @@ describe('UI round-trip (wrapPermissionsInAGroup → unWrapRuleNodes)', () => {
         _where: { id: { _eq: 'X-Hasura-User-Id' } },
       },
     };
-    expect(uiRoundTrip(input)).toEqual(input);
+    expect(roundTrip(input)).toEqual(input);
   });
 
   it('round-trips an _exists with an empty _where', () => {
@@ -381,7 +386,7 @@ describe('UI round-trip (wrapPermissionsInAGroup → unWrapRuleNodes)', () => {
         _where: {},
       },
     };
-    expect(uiRoundTrip(input)).toEqual(input);
+    expect(roundTrip(input)).toEqual(input);
   });
 
   it('round-trips a complex permission matching the shape produced by the UI', () => {
@@ -398,6 +403,6 @@ describe('UI round-trip (wrapPermissionsInAGroup → unWrapRuleNodes)', () => {
         },
       ],
     };
-    expect(uiRoundTrip(input)).toEqual(input);
+    expect(roundTrip(input)).toEqual(input);
   });
 });

--- a/dashboard/src/features/orgs/projects/database/dataGrid/utils/permissionUtils/serializeNode.ts
+++ b/dashboard/src/features/orgs/projects/database/dataGrid/utils/permissionUtils/serializeNode.ts
@@ -1,7 +1,4 @@
-import type {
-  GroupNode,
-  RuleNode,
-} from '@/features/orgs/projects/database/dataGrid/utils/permissionUtils/types';
+import type { RuleNode } from '@/features/orgs/projects/database/dataGrid/utils/permissionUtils/types';
 
 function deepMerge(
   target: Record<string, unknown>,
@@ -59,7 +56,7 @@ function createNestedObject(
   };
 }
 
-function serializeNode(node: RuleNode): Record<string, unknown> {
+export default function serializeNode(node: RuleNode): Record<string, unknown> {
   if (node.type === 'condition') {
     const parts = node.column.split('.');
     return createNestedObject(parts, node.operator, node.value);
@@ -69,7 +66,7 @@ function serializeNode(node: RuleNode): Record<string, unknown> {
     return {
       _exists: {
         _table: { schema: node.schema, name: node.table },
-        _where: unWrapRuleNodes(node.where),
+        _where: serializeNode(node.where),
       },
     };
   }
@@ -83,11 +80,18 @@ function serializeNode(node: RuleNode): Record<string, unknown> {
     );
   }
 
-  if (node.operator === '_implicit') {
-    return ruleNodesToPermission(node.children);
+  if (node.type === 'invalid') {
+    return { [node.key]: node.raw };
   }
 
   const childObjects = node.children.map(serializeNode);
+
+  if (node.operator === '_implicit') {
+    return childObjects.reduce(
+      (permission, ruleNode) => deepMerge(permission, ruleNode),
+      {} as Record<string, unknown>,
+    );
+  }
 
   if (node.operator === '_not') {
     if (childObjects.length === 1) {
@@ -99,31 +103,4 @@ function serializeNode(node: RuleNode): Record<string, unknown> {
   }
 
   return { [node.operator]: childObjects };
-}
-
-export default function ruleNodesToPermission(
-  nodes: RuleNode[],
-): Record<string, unknown> {
-  if (nodes.length === 0) {
-    return {};
-  }
-
-  if (nodes.length === 1) {
-    return serializeNode(nodes[0]);
-  }
-
-  return nodes
-    .map(serializeNode)
-    .reduce(
-      (permission, ruleNode) => deepMerge(permission, ruleNode),
-      {} as Record<string, unknown>,
-    );
-}
-
-export function unWrapRuleNodes(root: GroupNode): Record<string, unknown> {
-  if (root.operator === '_implicit') {
-    return ruleNodesToPermission(root.children);
-  }
-
-  return ruleNodesToPermission([root]);
 }

--- a/dashboard/src/features/orgs/projects/database/dataGrid/utils/permissionUtils/types.ts
+++ b/dashboard/src/features/orgs/projects/database/dataGrid/utils/permissionUtils/types.ts
@@ -31,11 +31,20 @@ export interface RelationshipNode {
   child: GroupNode;
 }
 
+export interface InvalidNode {
+  type: 'invalid';
+  id: string;
+  reason: 'primitive' | 'operator';
+  raw: unknown;
+  key: string;
+}
+
 export type RuleNode =
   | ConditionNode
   | GroupNode
   | ExistsNode
-  | RelationshipNode;
+  | RelationshipNode
+  | InvalidNode;
 
 export function isConditionNode(node: RuleNode): node is ConditionNode {
   return node.type === 'condition';
@@ -51,4 +60,8 @@ export function isExistsNode(node: RuleNode): node is ExistsNode {
 
 export function isRelationshipNode(node: RuleNode): node is RelationshipNode {
   return node.type === 'relationship';
+}
+
+export function isInvalidNode(node: RuleNode): node is InvalidNode {
+  return node.type === 'invalid';
 }

--- a/dashboard/src/features/orgs/projects/storage/dataGrid/components/EditStoragePermissions/StorageRolePermissionEditorForm.tsx
+++ b/dashboard/src/features/orgs/projects/storage/dataGrid/components/EditStoragePermissions/StorageRolePermissionEditorForm.tsx
@@ -13,7 +13,7 @@ import { useManagePermissionMutation } from '@/features/orgs/projects/database/d
 import type { HasuraMetadataPermission } from '@/features/orgs/projects/database/dataGrid/types/dataBrowser';
 import type { GroupNode } from '@/features/orgs/projects/database/dataGrid/utils/permissionUtils';
 import {
-  unWrapRuleNodes,
+  serializeNode,
   wrapPermissionsInAGroup,
 } from '@/features/orgs/projects/database/dataGrid/utils/permissionUtils';
 import { execPromiseWithErrorToast } from '@/features/orgs/utils/execPromiseWithErrorToast';
@@ -135,7 +135,7 @@ export default function StorageRolePermissionEditorForm({
   async function handleSubmit(values: StoragePermissionEditorFormValues) {
     const permissionFilter =
       values.rowCheckType === 'custom'
-        ? unWrapRuleNodes(values.filter as GroupNode)
+        ? serializeNode(values.filter as GroupNode)
         : (values.filter ?? {});
 
     const primaryPermission: HasuraMetadataPermission['permission'] = {
@@ -236,7 +236,7 @@ export default function StorageRolePermissionEditorForm({
         <div className="-mt-3 mb-4 px-6">
           <Alert
             variant="destructive"
-            className="grid grid-flow-col items-center justify-between px-4 py-3"
+            className="grid grid-flow-col items-center justify-between bg-destructive/10 px-4 py-3"
           >
             <span className="text-left text-sm+">
               <strong>Error:</strong> {error.message}

--- a/dashboard/src/features/orgs/projects/storage/dataGrid/components/EditStoragePermissions/StorageRowPermissionsSection.tsx
+++ b/dashboard/src/features/orgs/projects/storage/dataGrid/components/EditStoragePermissions/StorageRowPermissionsSection.tsx
@@ -1,11 +1,14 @@
-import type { ReactNode } from 'react';
 import { useFormContext, useWatch } from 'react-hook-form';
 import { v4 as uuidv4 } from 'uuid';
 import { PermissionSettingsSectionV3 as PermissionSettingsSection } from '@/components/common/PermissionSettingsSection';
 import { InlineCode } from '@/components/ui/v3/inline-code';
 import { Label } from '@/components/ui/v3/label';
 import { RadioGroup, RadioGroupItem } from '@/components/ui/v3/radio-group';
-import { CustomCheckEditor } from '@/features/orgs/projects/database/dataGrid/components/CustomCheckEditor';
+import {
+  CustomCheckEditor,
+  CustomCheckModeProvider,
+  CustomCheckModeToggle,
+} from '@/features/orgs/projects/database/dataGrid/components/CustomCheckEditor';
 import type { GroupNode } from '@/features/orgs/projects/database/dataGrid/utils/permissionUtils';
 import applyPreset from './applyPreset';
 import PermissionPresetCombobox from './PermissionPresetCombobox';
@@ -28,12 +31,8 @@ export default function StorageRowPermissionsSection({
   role,
   storageAction,
 }: StorageRowPermissionsSectionProps) {
-  const {
-    setValue,
-    getValues,
-    reset,
-    formState: { errors },
-  } = useFormContext<StoragePermissionEditorFormValues>();
+  const { setValue, getValues, reset } =
+    useFormContext<StoragePermissionEditorFormValues>();
 
   const rowCheckType = useWatch<
     StoragePermissionEditorFormValues,
@@ -69,47 +68,46 @@ export default function StorageRowPermissionsSection({
 
   return (
     <PermissionSettingsSection title={`File ${actionLabel} permissions`}>
-      <p className="text-sm+">
-        Allow role <InlineCode className="!text-sm+">{role}</InlineCode> to{' '}
-        <InlineCode className="!text-sm+">{actionLabel}</InlineCode> files:
-      </p>
-
-      <RadioGroup
-        value={rowCheckType}
-        className="flex gap-4"
-        onValueChange={(value) =>
-          handleCheckTypeChange(value as typeof rowCheckType)
-        }
-      >
-        <div className="flex items-center gap-2">
-          <RadioGroupItem value="none" id="row-check-none" />
-          <Label htmlFor="row-check-none" className="text-sm+">
-            Without any checks
-          </Label>
-        </div>
-        <div className="flex items-center gap-2">
-          <RadioGroupItem value="custom" id="row-check-custom" />
-          <Label htmlFor="row-check-custom" className="text-sm+">
-            With custom check
-          </Label>
-        </div>
-      </RadioGroup>
-
-      <PermissionPresetCombobox onSelect={handlePresetSelect} />
-
-      {errors?.filter?.root?.message || errors?.filter?.message ? (
-        <p className="text-destructive text-sm">
-          {(errors.filter.root?.message ?? errors.filter.message) as ReactNode}
+      <CustomCheckModeProvider>
+        <p className="text-sm+">
+          Allow role <InlineCode className="!text-sm+">{role}</InlineCode> to{' '}
+          <InlineCode className="!text-sm+">{actionLabel}</InlineCode> files:
         </p>
-      ) : null}
 
-      {rowCheckType === 'custom' && (
-        <CustomCheckEditor
-          name="filter"
-          schema={STORAGE_SCHEMA}
-          table={STORAGE_TABLE}
-        />
-      )}
+        <div className="flex items-center justify-between gap-4">
+          <RadioGroup
+            value={rowCheckType}
+            className="flex gap-4"
+            onValueChange={(value) =>
+              handleCheckTypeChange(value as typeof rowCheckType)
+            }
+          >
+            <div className="flex items-center gap-2">
+              <RadioGroupItem value="none" id="row-check-none" />
+              <Label htmlFor="row-check-none" className="text-sm+">
+                Without any checks
+              </Label>
+            </div>
+            <div className="flex items-center gap-2">
+              <RadioGroupItem value="custom" id="row-check-custom" />
+              <Label htmlFor="row-check-custom" className="text-sm+">
+                With custom check
+              </Label>
+            </div>
+          </RadioGroup>
+          {rowCheckType === 'custom' && <CustomCheckModeToggle />}
+        </div>
+
+        <PermissionPresetCombobox onSelect={handlePresetSelect} />
+
+        {rowCheckType === 'custom' && (
+          <CustomCheckEditor
+            name="filter"
+            schema={STORAGE_SCHEMA}
+            table={STORAGE_TABLE}
+          />
+        )}
+      </CustomCheckModeProvider>
     </PermissionSettingsSection>
   );
 }

--- a/dashboard/src/tests/testUtils.tsx
+++ b/dashboard/src/tests/testUtils.tsx
@@ -245,6 +245,12 @@ export class TestUserEvent {
     });
   }
 
+  async paste(value: string) {
+    await waitFor(async () => {
+      await this.user.paste(value);
+    });
+  }
+
   static async fireClickEvent(element: Document | Element | Window | Node) {
     await waitFor(() => {
       fireEvent(


### PR DESCRIPTION
### Checklist

- [ ] No breaking changes
- [ ] Tests pass
- [ ] New features have new tests
- [ ] Documentation is updated (if applicable)
- [ ] Title of the PR is in the correct format (see below)

<!-- nhost-reviewer:start -->
### **PR Type**
Enhancement

___

### **Description**
- Adds a new `JsonRuleEditor` textarea above the `CustomCheckEditor` rule builder so users can view and edit a custom-check permission as Hasura-shaped JSON, with bidirectional sync between the textarea and the builder.
- Removes the `disabled` prop from `CustomCheckEditor` and all of its child components (`AddNodeButton`, `ConditionRow`, `ConditionValue`, `ExistsNodeRenderer`, `GroupNodeRenderer`, `LogicalOperatorBadge`, `OperatorComboBox`, `RelationshipComboBox`, `RelationshipNodeRenderer`, `TableComboBox`) and drops `disabled` from the editor context.
- Fixes `FancyMultiSelect` so that removing a selection via the chip "x" or `Backspace`/`Delete` also fires `onChange`, instead of only updating internal state.
- Switches the root-remove action in `CustomCheckEditor` from `setValue` to `resetField`, so clearing the rule no longer marks the form dirty.
- Adds a `paste` helper on `TestUserEvent` and a large suite of integration tests for the JSON editor round-trip (valid / invalid / array / primitive / blur / whitespace / reset); removes the now-obsolete `disabled`-state tests.

___

### Diagram Walkthrough

```mermaid
flowchart LR
  U["User"] -->|"edit JSON"| JRE["JsonRuleEditor"]
  U -->|"click Add / Remove"| Builder["GroupNodeRenderer / ConditionRow / ..."]
  JRE -->|"wrapPermissionsInAGroup"| RHF["react-hook-form state (name)"]
  Builder -->|"setValue / useFieldArray"| RHF
  RHF -->|"watch(name)"| JRE
  RHF -->|"useWatch"| Builder
  RHF -->|"unWrapRuleNodes"| Hasura["Hasura JSON shape"]
```

<details> <summary><h3> File Walkthrough</h3></summary>

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody>
<tr><td><strong>New feature</strong></td><td><details><summary>2 files</summary><table>
<tr>
  <td><strong>JsonRuleEditor.tsx</strong><dd><code>New textarea-based JSON editor bidirectionally bound to the rule form field</code></dd></td>
  <td><a href="https://github.com/nhost/nhost/pull/4166/files#diff-00a337d8eefb6dca01eb0fc4476921b40dd97510355b7d6bbe28a0e9ddb95d87">+116/-0</a></td>
</tr>
<tr>
  <td><strong>CustomCheckEditor.tsx</strong><dd><code>Mounts JsonRuleEditor, drops disabled prop, uses resetField for root remove</code></dd></td>
  <td><a href="https://github.com/nhost/nhost/pull/4166/files#diff-142cbdc65f09465703b0f9577ab113513e8ef2fba9a7ced7ba7ee47b8e7a48af">+12/-15</a></td>
</tr>
</table></details></td></tr>

<tr><td><strong>Disabled prop removal</strong></td><td><details><summary>10 files</summary><table>
<tr>
  <td><strong>AddNodeButton.tsx</strong><dd><code>Remove disabled prop and button disabled attribute</code></dd></td>
  <td><a href="https://github.com/nhost/nhost/pull/4166/files#diff-ffd4ef60cd6e57fa2ae50d9ac43bd8870ab6d28e1241cb0b14c9fae755e61e5d">+0/-3</a></td>
</tr>
<tr>
  <td><strong>ConditionRow.tsx</strong><dd><code>Drop disabled from context destructure and propagated props</code></dd></td>
  <td><a href="https://github.com/nhost/nhost/pull/4166/files#diff-f2c4497812d350a232054faa771ab084737a4df41bc0b80f86eb80838d9f5aec">+3/-9</a></td>
</tr>
<tr>
  <td><strong>ConditionValue.tsx</strong><dd><code>Drop disabled from all rendered input branches</code></dd></td>
  <td><a href="https://github.com/nhost/nhost/pull/4166/files#diff-810657158af1493e2b841f61a1dfa02c99077838c527e860607fd0c5ca311f08">+1/-7</a></td>
</tr>
<tr>
  <td><strong>ExistsNodeRenderer.tsx</strong><dd><code>Remove editorDisabled / hasTable gating and disabled button styling</code></dd></td>
  <td><a href="https://github.com/nhost/nhost/pull/4166/files#diff-7e61c7e4a4716fefb09f657817e481259bda4f38d7c9c0e3372023dad8edb0db">+3/-11</a></td>
</tr>
<tr>
  <td><strong>GroupNodeRenderer.tsx</strong><dd><code>Remove editorDisabled; drop disabled from badge, delete button, AddNodeButton</code></dd></td>
  <td><a href="https://github.com/nhost/nhost/pull/4166/files#diff-7ebb4460f85bd8c837eda10b2a6a74c42350d7e74f83b932c73cd2f0bc7cd881">+2/-10</a></td>
</tr>
<tr>
  <td><strong>LogicalOperatorBadge.tsx</strong><dd><code>Drop disabled prop from trigger</code></dd></td>
  <td><a href="https://github.com/nhost/nhost/pull/4166/files#diff-85e63b6485b8adf4a1efaa5929e9a25ca758cf5120d2f23ae231ff12ba71e576">+1/-3</a></td>
</tr>
<tr>
  <td><strong>OperatorComboBox.tsx</strong><dd><code>Drop disabled prop from combobox</code></dd></td>
  <td><a href="https://github.com/nhost/nhost/pull/4166/files#diff-2c1fd15a094b4461ee2aa42a0d43ef90ced8098baaf87b2b05d26c491269cc05">+0/-3</a></td>
</tr>
<tr>
  <td><strong>RelationshipComboBox.tsx</strong><dd><code>Drop disabled prop from combobox</code></dd></td>
  <td><a href="https://github.com/nhost/nhost/pull/4166/files#diff-c3f86a2cdae37406aff54f4c0c0ae795cdb49287e1c8c3bd36d5dcc6384d60ea">+0/-3</a></td>
</tr>
<tr>
  <td><strong>RelationshipNodeRenderer.tsx</strong><dd><code>Remove editorDisabled / hasRelationship gating and related styling</code></dd></td>
  <td><a href="https://github.com/nhost/nhost/pull/4166/files#diff-561252e77b7ded926114e5c05d668eca636986bf67fd58a7e5a769cb208283e0">+3/-19</a></td>
</tr>
<tr>
  <td><strong>TableComboBox.tsx</strong><dd><code>Drop disabled prop from combobox</code></dd></td>
  <td><a href="https://github.com/nhost/nhost/pull/4166/files#diff-37badf2d5b6551d8803446122871efa030b23798b1ae05d241e3719e5eeb024c">+0/-3</a></td>
</tr>
</table></details></td></tr>

<tr><td><strong>Context & utilities</strong></td><td><details><summary>3 files</summary><table>
<tr>
  <td><strong>useCustomCheckEditor.ts</strong><dd><code>Remove disabled from editor context type and default</code></dd></td>
  <td><a href="https://github.com/nhost/nhost/pull/4166/files#diff-a555da8d793d9308562a28825eb8e2dfdff22cf6abaa0611439d8b090540cade">+0/-2</a></td>
</tr>
<tr>
  <td><strong>fancy-multi-select.tsx</strong><dd><code>Fire onChange when removing selection via chip or Backspace/Delete</code></dd></td>
  <td><a href="https://github.com/nhost/nhost/pull/4166/files#diff-6e6a7965a2c8e30e9a2c021a5009ff79e71de73892b86a3468d3474163dfeb03">+29/-19</a></td>
</tr>
<tr>
  <td><strong>ruleNodesToPermission.ts</strong><dd><code>Minor whitespace cleanup</code></dd></td>
  <td><a href="https://github.com/nhost/nhost/pull/4166/files#diff-59cf5e8ac239eb4d95270aecd3e2d16e81c9e28ce9915c2647939228f9ff8d95">+0/-1</a></td>
</tr>
</table></details></td></tr>

<tr><td><strong>Tests</strong></td><td><details><summary>3 files</summary><table>
<tr>
  <td><strong>CustomCheckEditor.test.tsx</strong><dd><code>Drop disabled-state tests; add full JSON-editor round-trip suite</code></dd></td>
  <td><a href="https://github.com/nhost/nhost/pull/4166/files#diff-2b4e72005dc7f0c2b5a33cc54aa127adfbba70f54903aa28d9eab45aedcc32a3">+492/-177</a></td>
</tr>
<tr>
  <td><strong>ConditionValue.test.tsx</strong><dd><code>Drop disabled from mocked editor context</code></dd></td>
  <td><a href="https://github.com/nhost/nhost/pull/4166/files#diff-19fa3f88d3784d5a287e92b6b48ca0e9542916589235e0a00372d75f79abd5a4">+0/-1</a></td>
</tr>
<tr>
  <td><strong>testUtils.tsx</strong><dd><code>Add paste helper on TestUserEvent</code></dd></td>
  <td><a href="https://github.com/nhost/nhost/pull/4166/files#diff-78f29250407edf853a353b48242d3cee59aa5724f38a60bb23bebdfc1ea2f9b5">+6/-0</a></td>
</tr>
</table></details></td></tr>

</tbody></table>

</details>

___

<!-- nhost-reviewer:end -->
