### PR TITLE
release(cli): 1.44.0

### DIFF
--- a/cli/CHANGELOG.md
+++ b/cli/CHANGELOG.md
@@ -1,3 +1,15 @@
+## [cli@1.44.0] - 2026-04-20
+
+### 🚀 Features
+
+- *(auth)* Allow disabling auto-signup (#4168)
+- *(cli)* Add support for logs and update functions to new v2 (#4159)
+
+
+### ⚙️ Miscellaneous Tasks
+
+- *(ci)* Bump version references as part of the changelog (#4169)
+
 ## [cli@1.43.1] - 2026-04-17
 
 ### ⚙️ Miscellaneous Tasks

--- a/cli/get.sh
+++ b/cli/get.sh
@@ -1,7 +1,7 @@
 #!/usr/bin/env bash
 
 # This pinned version is bumped automatically by the changelog workflow.
-VERSION="1.43.1"
+VERSION="1.44.0"
 
 # helper functions
 yell() { echo -e "${RED}FAILED> $* ${NC}" >&2; }


### PR DESCRIPTION
Automated release preparation for cli version 1.44.0

Changes:
- Updated CHANGELOG.md
- Bumped version references (`make changelog-bump-refs`) in dependent files