### PR TITLE
release(packages/nhost-js): 4.7.1

### DIFF
--- a/packages/nhost-js/CHANGELOG.md
+++ b/packages/nhost-js/CHANGELOG.md
@@ -1,3 +1,25 @@
+## [@nhost/nhost-js@4.7.1] - 2026-05-18
+
+### 🐛 Bug Fixes
+
+- *(deps)* Bump up uuid, Astro and xmldom due to CVEs (#4187)
+- *(deps)* Fix postcss XSS advisory (GHSA-qx2v-qp2m-jg93) (#4197)
+- *(nhost-js)* Rename session.Session to StoredSession to disambiguate from auth.Session (#4194)
+- *(auth)* Revoke all sessions on password change  (#4192)
+- *(ci)* Make build and check work on NixOS (#4234)
+- *(deps)* Fix fast-uri advisory (GHSA-v39h-62p7-jpjc) (#4265)
+- *(deps)* Update biome to 2.4.15 (#4270)
+
+
+### ⚙️ Miscellaneous Tasks
+
+- *(nixops)* Bump nhost cli (#4173)
+
+
+### Chore
+
+- *(deps)* Update pnpm to v11 (#4275)
+
 ## [@nhost/nhost-js@4.7.0] - 2026-04-20
 
 ### 🚀 Features


### PR DESCRIPTION
Automated release preparation for packages/nhost-js version 4.7.1.

Version references in dependent files (CLI sources, docs, etc.) are bumped in a follow-up PR after the release publishes — see `wf_bump_refs.yaml`.