### PR TITLE
fix(dashboard): handle non-trackable postgres functions in database page

### DIFF
--- a/dashboard/e2e/database/functions/functions.test.ts
+++ b/dashboard/e2e/database/functions/functions.test.ts
@@ -43,13 +43,15 @@ test.describe
       await expect(
         page.getByRole('heading', { name: /function definition/i }),
       ).toBeVisible();
-      await expect(page.getByText(`public.${functionName}`)).toBeVisible();
+      await expect(
+        page.getByText(`public.${functionName}`, { exact: true }),
+      ).toBeVisible();
       await expect(page.getByText('STABLE').first()).toBeVisible();
       await expect(page.getByText('SQL function')).toBeVisible();
       await expect(page.getByText('Query-only')).toBeVisible();
 
       await expect(page.getByText('Parameters')).toBeVisible();
-      await expect(page.getByText('filter_title')).toBeVisible();
+      await expect(page.getByText('filter_title').first()).toBeVisible();
 
       await page
         .locator(
@@ -59,9 +61,10 @@ test.describe
 
       await page.getByRole('menuitem', { name: /edit function/i }).click();
 
-      await expect(page.locator('.cm-content')).toBeVisible();
+      const editor = page.locator('.cm-content[contenteditable="true"]');
+      await expect(editor).toBeVisible();
       await expect(
-        page.locator('.cm-content').getByText('CREATE OR REPLACE FUNCTION'),
+        editor.getByText('CREATE OR REPLACE FUNCTION'),
       ).toBeVisible();
     });
 

--- a/dashboard/src/features/orgs/projects/database/dataGrid/components/EditFunctionForm/EditFunctionForm.tsx
+++ b/dashboard/src/features/orgs/projects/database/dataGrid/components/EditFunctionForm/EditFunctionForm.tsx
@@ -75,7 +75,7 @@ export default function EditFunctionForm({
             <InlineCode className="bg-opacity-80 px-1.5 text-sm">
               {schema}.{functionName}
             </InlineCode>{' '}
-            does not exist or is not a table-returning function.
+            does not exist.
           </span>
         }
       />

--- a/dashboard/src/features/orgs/projects/database/dataGrid/components/FunctionDefinitionView/FunctionDefinitionView.test.tsx
+++ b/dashboard/src/features/orgs/projects/database/dataGrid/components/FunctionDefinitionView/FunctionDefinitionView.test.tsx
@@ -1,0 +1,143 @@
+import { vi } from 'vitest';
+import type { FetchFunctionDefinitionReturnType } from '@/features/orgs/projects/database/dataGrid/hooks/useFunctionQuery';
+import { render, screen } from '@/tests/testUtils';
+import FunctionDefinitionView from './FunctionDefinitionView';
+
+type FunctionMetadata = NonNullable<
+  FetchFunctionDefinitionReturnType['functionMetadata']
+>;
+
+const mocks = vi.hoisted(() => ({
+  useRouter: vi.fn(),
+  useFunctionQuery: vi.fn(),
+  useIsTrackedFunction: vi.fn(),
+  useFunctionCustomizationQuery: vi.fn(),
+}));
+
+vi.mock('next/router', () => ({
+  useRouter: mocks.useRouter,
+}));
+
+vi.mock(
+  '@/features/orgs/projects/database/dataGrid/hooks/useFunctionQuery',
+  () => ({
+    useFunctionQuery: mocks.useFunctionQuery,
+  }),
+);
+
+vi.mock(
+  '@/features/orgs/projects/database/dataGrid/hooks/useIsTrackedFunction',
+  () => ({
+    useIsTrackedFunction: mocks.useIsTrackedFunction,
+  }),
+);
+
+vi.mock(
+  '@/features/orgs/projects/database/dataGrid/hooks/useFunctionCustomizationQuery',
+  () => ({
+    useFunctionCustomizationQuery: mocks.useFunctionCustomizationQuery,
+  }),
+);
+
+vi.mock('@uiw/react-codemirror', () => ({
+  default: ({ value }: { value: string }) => (
+    <div data-testid="codemirror">{value}</div>
+  ),
+}));
+
+function meta(overrides: Partial<FunctionMetadata> = {}): FunctionMetadata {
+  return {
+    functionName: 'my_fn',
+    functionSchema: 'public',
+    functionType: 'VOLATILE',
+    returnTypeName: 'mytable',
+    returnTypeSchema: 'public',
+    returnTypeKind: 'c',
+    returnsSet: true,
+    hasVariadic: false,
+    language: 'sql',
+    parameters: [],
+    defaultArgsCount: 0,
+    returnTableName: 'mytable',
+    returnTableSchema: 'public',
+    comment: null,
+    ...overrides,
+  };
+}
+
+function renderWith({
+  functionMetadata,
+  functionDefinition = '',
+}: {
+  functionMetadata: FunctionMetadata | null;
+  functionDefinition?: string;
+}) {
+  mocks.useFunctionQuery.mockReturnValue({
+    data: { functionMetadata, functionDefinition, error: null },
+    status: 'success',
+    error: null,
+  });
+  render(<FunctionDefinitionView />);
+}
+
+describe('FunctionDefinitionView', () => {
+  beforeEach(() => {
+    mocks.useRouter.mockReturnValue({
+      query: {
+        schemaSlug: 'public',
+        functionOID: '1',
+        dataSourceSlug: 'default',
+      },
+    });
+    mocks.useIsTrackedFunction.mockReturnValue({ data: false });
+    mocks.useFunctionCustomizationQuery.mockReturnValue({ data: null });
+  });
+
+  it('shows no non-exposable alert for a trackable composite-returning function', () => {
+    renderWith({ functionMetadata: meta() });
+    expect(
+      screen.queryByText('Not exposable in GraphQL'),
+    ).not.toBeInTheDocument();
+  });
+
+  it('shows the VARIADIC alert and badge when the function has a variadic argument', () => {
+    renderWith({ functionMetadata: meta({ hasVariadic: true }) });
+    expect(screen.getByText('Not exposable in GraphQL')).toBeInTheDocument();
+    expect(screen.getByText(/uses VARIADIC arguments/)).toBeInTheDocument();
+  });
+
+  it('shows the non-composite alert when the return type is not composite', () => {
+    renderWith({
+      functionMetadata: meta({
+        returnTypeKind: 'e',
+        returnTypeName: 'mood',
+        returnTableName: null,
+        returnTableSchema: null,
+      }),
+    });
+    expect(screen.getByText('Not exposable in GraphQL')).toBeInTheDocument();
+    expect(screen.getByText(/"mood"/)).toBeInTheDocument();
+  });
+
+  it('omits the SETOF prefix when returnsSet is false', () => {
+    renderWith({ functionMetadata: meta({ returnsSet: false }) });
+    expect(screen.queryByText(/SETOF/)).not.toBeInTheDocument();
+  });
+
+  it('renders the source definition panel with an Edit button when a definition is present', () => {
+    renderWith({
+      functionMetadata: meta(),
+      functionDefinition: 'CREATE FUNCTION my_fn() ...',
+    });
+    expect(screen.getByText('Source Definition')).toBeInTheDocument();
+    expect(screen.getByRole('button', { name: /edit/i })).toBeInTheDocument();
+  });
+
+  it('renders the "Function not found" empty state when metadata is null', () => {
+    renderWith({ functionMetadata: null });
+    expect(screen.getByText('Function not found')).toBeInTheDocument();
+    expect(
+      screen.getByText('The function does not exist.'),
+    ).toBeInTheDocument();
+  });
+});

--- a/dashboard/src/features/orgs/projects/database/dataGrid/components/FunctionDefinitionView/FunctionDefinitionView.tsx
+++ b/dashboard/src/features/orgs/projects/database/dataGrid/components/FunctionDefinitionView/FunctionDefinitionView.tsx
@@ -143,7 +143,7 @@ export default function FunctionDefinitionView() {
   const returnPrefix = functionMetadata.returnsSet ? 'SETOF ' : '';
 
   const nonTrackableReason = !isCompositeReturn
-    ? `This function returns the scalar type "${functionMetadata.returnTypeName}", so it can't be exposed in GraphQL.`
+    ? `This function returns the type "${functionMetadata.returnTypeName}", so it can't be exposed in GraphQL.`
     : "This function uses VARIADIC arguments, so it can't be exposed in GraphQL.";
 
   return (

--- a/dashboard/src/features/orgs/projects/database/dataGrid/components/FunctionDefinitionView/FunctionDefinitionView.tsx
+++ b/dashboard/src/features/orgs/projects/database/dataGrid/components/FunctionDefinitionView/FunctionDefinitionView.tsx
@@ -1,5 +1,21 @@
+import { PostgreSQL, sql } from '@codemirror/lang-sql';
+import { useTheme } from '@mui/material';
+import { githubDark, githubLight } from '@uiw/codemirror-theme-github';
+import CodeMirror from '@uiw/react-codemirror';
+import { ChevronDown, ChevronRight, Info, Pencil } from 'lucide-react';
+import dynamic from 'next/dynamic';
 import { useRouter } from 'next/router';
+import { useState } from 'react';
+import { useDialog } from '@/components/common/DialogProvider';
+import { FormActivityIndicator } from '@/components/form/FormActivityIndicator';
+import { Alert, AlertDescription, AlertTitle } from '@/components/ui/v3/alert';
 import { Badge } from '@/components/ui/v3/badge';
+import { Button } from '@/components/ui/v3/button';
+import {
+  Collapsible,
+  CollapsibleContent,
+  CollapsibleTrigger,
+} from '@/components/ui/v3/collapsible';
 import { InlineCode } from '@/components/ui/v3/inline-code';
 import { Spinner } from '@/components/ui/v3/spinner';
 import { DataBrowserEmptyState } from '@/features/orgs/projects/database/dataGrid/components/DataBrowserEmptyState';
@@ -8,7 +24,19 @@ import { useFunctionCustomizationQuery } from '@/features/orgs/projects/database
 import { useFunctionQuery } from '@/features/orgs/projects/database/dataGrid/hooks/useFunctionQuery';
 import { useIsTrackedFunction } from '@/features/orgs/projects/database/dataGrid/hooks/useIsTrackedFunction';
 
+const EditFunctionForm = dynamic(
+  () =>
+    import(
+      '@/features/orgs/projects/database/dataGrid/components/EditFunctionForm/EditFunctionForm'
+    ),
+  {
+    ssr: false,
+    loading: () => <FormActivityIndicator />,
+  },
+);
+
 export default function FunctionDefinitionView() {
+  const theme = useTheme();
   const router = useRouter();
   const {
     query: { schemaSlug, functionOID: routerFunctionOID, dataSourceSlug },
@@ -32,8 +60,13 @@ export default function FunctionDefinitionView() {
     },
   );
 
-  const { functionMetadata, error: functionError } = data || {
+  const {
+    functionMetadata,
+    functionDefinition,
+    error: functionError,
+  } = data || {
     functionMetadata: null,
+    functionDefinition: '',
     error: null,
   };
 
@@ -50,6 +83,10 @@ export default function FunctionDefinitionView() {
     function: { name: functionName || '', schema },
     dataSource,
   });
+
+  const { openDrawer } = useDialog();
+
+  const [isSourceOpen, setIsSourceOpen] = useState(true);
 
   const effectiveExposedAs =
     functionConfig?.configuration?.exposed_as ??
@@ -88,11 +125,7 @@ export default function FunctionDefinitionView() {
     return (
       <DataBrowserEmptyState
         title="Function not found"
-        description={
-          <span>
-            The function does not exist or is not a table-returning function.
-          </span>
-        }
+        description={<span>The function does not exist.</span>}
       />
     );
   }
@@ -100,18 +133,33 @@ export default function FunctionDefinitionView() {
   const requiredParamsCount =
     functionMetadata.parameters.length - functionMetadata.defaultArgsCount;
 
+  const isCompositeReturn = functionMetadata.returnTypeKind === 'c';
+  const isTrackable = isCompositeReturn && !functionMetadata.hasVariadic;
+
+  const returnTypeDisplay = functionMetadata.returnTableName
+    ? `${functionMetadata.returnTableSchema}.${functionMetadata.returnTableName}`
+    : functionMetadata.returnTypeName;
+
+  const returnPrefix = functionMetadata.returnsSet ? 'SETOF ' : '';
+
+  const nonTrackableReason = !isCompositeReturn
+    ? `This function returns the scalar type "${functionMetadata.returnTypeName}", so it can't be exposed in GraphQL.`
+    : "This function uses VARIADIC arguments, so it can't be exposed in GraphQL.";
+
   return (
-    <div className="flex h-full flex-col overflow-hidden">
+    <div className="flex h-full flex-col overflow-y-auto">
       <div className="border-b p-4">
         <div className="mb-8 flex flex-col gap-4">
-          <TrackFunctionButton
-            schema={schema}
-            functionName={functionMetadata.functionName}
-            returnTableName={functionMetadata.returnTableName}
-            returnTableSchema={functionMetadata.returnTableSchema}
-            functionType={functionMetadata.functionType}
-          />
-          {isTracked && (
+          {isTrackable && (
+            <TrackFunctionButton
+              schema={schema}
+              functionName={functionMetadata.functionName}
+              returnTableName={functionMetadata.returnTableName}
+              returnTableSchema={functionMetadata.returnTableSchema}
+              functionType={functionMetadata.functionType}
+            />
+          )}
+          {isTrackable && isTracked && (
             <div className="flex items-center gap-2">
               <span className="h-2 w-2 shrink-0 rounded-full bg-primary" />
               <span className="font-medium text-sm">Tracked in GraphQL</span>
@@ -120,6 +168,13 @@ export default function FunctionDefinitionView() {
                 {effectiveExposedAs === 'mutation' ? 'Mutation' : 'Query'}
               </Badge>
             </div>
+          )}
+          {!isTrackable && (
+            <Alert>
+              <Info className="h-4 w-4" />
+              <AlertTitle>Not exposable in GraphQL</AlertTitle>
+              <AlertDescription>{nonTrackableReason}</AlertDescription>
+            </Alert>
           )}
           <div>
             <h2 className="font-semibold text-lg">Function Definition</h2>
@@ -152,11 +207,10 @@ export default function FunctionDefinitionView() {
                   </span>
                 </>
               )}{' '}
-              · Returns SETOF{' '}
+              · Returns{' '}
               <InlineCode className="bg-opacity-80 px-1 text-xs">
-                {functionMetadata.returnTableName
-                  ? `${functionMetadata.returnTableSchema}.${functionMetadata.returnTableName}`
-                  : functionMetadata.returnTypeName}
+                {returnPrefix}
+                {returnTypeDisplay}
               </InlineCode>
             </p>
           </div>
@@ -167,12 +221,18 @@ export default function FunctionDefinitionView() {
               </Badge>
             )}
             <Badge variant="outline" className="font-medium">
-              SETOF {functionMetadata.returnTypeName}
+              {returnPrefix}
+              {functionMetadata.returnTypeName}
             </Badge>
             {functionMetadata.returnTableName && (
               <Badge variant="outline" className="font-medium">
                 Returns table: {functionMetadata.returnTableSchema}.
                 {functionMetadata.returnTableName}
+              </Badge>
+            )}
+            {functionMetadata.hasVariadic && (
+              <Badge variant="outline" className="font-medium">
+                VARIADIC
               </Badge>
             )}
             {functionMetadata.functionType === 'STABLE' ||
@@ -207,6 +267,60 @@ export default function FunctionDefinitionView() {
               ))}
             </div>
           </div>
+        )}
+        {functionDefinition && (
+          <Collapsible
+            open={isSourceOpen}
+            onOpenChange={setIsSourceOpen}
+            className="mt-4 rounded-md border"
+          >
+            <div className="flex items-center justify-between gap-2 p-3">
+              <CollapsibleTrigger className="flex flex-1 items-center gap-2 text-left">
+                {isSourceOpen ? (
+                  <ChevronDown className="h-4 w-4 text-muted-foreground" />
+                ) : (
+                  <ChevronRight className="h-4 w-4 text-muted-foreground" />
+                )}
+                <h4 className="font-medium text-sm">Source Definition</h4>
+              </CollapsibleTrigger>
+              <Button
+                variant="outline"
+                size="sm"
+                onClick={() =>
+                  openDrawer({
+                    title: 'Function Definition',
+                    component: (
+                      <EditFunctionForm
+                        schema={schema}
+                        functionName={functionMetadata.functionName}
+                        functionOID={functionOID}
+                        dataSource={dataSource}
+                      />
+                    ),
+                  })
+                }
+              >
+                <Pencil className="mr-2 h-3.5 w-3.5" />
+                Edit
+              </Button>
+            </div>
+            <CollapsibleContent>
+              <div className="overflow-hidden border-t">
+                <CodeMirror
+                  value={functionDefinition}
+                  theme={
+                    theme.palette.mode === 'light' ? githubLight : githubDark
+                  }
+                  extensions={[sql({ dialect: PostgreSQL })]}
+                  editable={false}
+                  basicSetup={{
+                    lineNumbers: true,
+                    highlightActiveLine: false,
+                  }}
+                />
+              </div>
+            </CollapsibleContent>
+          </Collapsible>
         )}
       </div>
     </div>

--- a/dashboard/src/features/orgs/projects/database/dataGrid/hooks/useDatabaseQuery/fetchDatabase.ts
+++ b/dashboard/src/features/orgs/projects/database/dataGrid/hooks/useDatabaseQuery/fetchDatabase.ts
@@ -78,7 +78,7 @@ export default async function fetchDatabase({
             WHERE n.nspname NOT LIKE 'pg_%'
               AND n.nspname != 'information_schema'
               AND pg_type.typtype ='c'
-              AND p.proretset = true
+              AND p.provariadic = 0
             ORDER BY p.proname ASC
           ) func_data`,
           '',

--- a/dashboard/src/features/orgs/projects/database/dataGrid/hooks/useFunctionQuery/fetchFunctionDefinition.test.ts
+++ b/dashboard/src/features/orgs/projects/database/dataGrid/hooks/useFunctionQuery/fetchFunctionDefinition.test.ts
@@ -1,0 +1,102 @@
+import { afterEach, beforeEach, vi } from 'vitest';
+import fetchFunctionDefinition, {
+  type FunctionDefinitionRow,
+} from './fetchFunctionDefinition';
+
+const fetchMock = vi.fn();
+
+function row(
+  overrides: Partial<FunctionDefinitionRow> = {},
+): FunctionDefinitionRow {
+  return {
+    function_definition:
+      'CREATE FUNCTION my_fn() RETURNS SETOF public.mytable ...',
+    function_name: 'my_fn',
+    function_schema: 'public',
+    function_type: 'VOLATILE',
+    return_type_name: 'mytable',
+    return_type_schema: 'public',
+    return_type_kind: 'c',
+    returns_set: true,
+    has_variadic: false,
+    language: 'sql',
+    input_arg_types: [],
+    default_args_count: 0,
+    return_table_name: 'mytable',
+    return_table_schema: 'public',
+    comment: null,
+    ...overrides,
+  };
+}
+
+function ok(body: unknown) {
+  return { ok: true, json: async () => body } as Response;
+}
+
+function rowsResponse(rowOverrides: Partial<FunctionDefinitionRow> = {}) {
+  return ok([{ result: [['data'], [JSON.stringify(row(rowOverrides))]] }]);
+}
+
+const callArgs = {
+  appUrl: 'https://hasura.example',
+  adminSecret: 'secret',
+  dataSource: 'default',
+  functionOID: '42',
+};
+
+describe('fetchFunctionDefinition', () => {
+  beforeEach(() => {
+    vi.stubGlobal('fetch', fetchMock);
+  });
+
+  afterEach(() => {
+    vi.unstubAllGlobals();
+    fetchMock.mockReset();
+  });
+
+  it('maps SETOF composite function metadata including the new fields', async () => {
+    fetchMock.mockResolvedValueOnce(rowsResponse());
+    const result = await fetchFunctionDefinition(callArgs);
+    expect(result.functionMetadata).toMatchObject({
+      functionName: 'my_fn',
+      returnTypeKind: 'c',
+      returnsSet: true,
+      hasVariadic: false,
+      returnTableName: 'mytable',
+    });
+    expect(result.error).toBeNull();
+  });
+
+  it('sets returnsSet=false for single-row composite functions', async () => {
+    fetchMock.mockResolvedValueOnce(rowsResponse({ returns_set: false }));
+    const result = await fetchFunctionDefinition(callArgs);
+    expect(result.functionMetadata?.returnsSet).toBe(false);
+  });
+
+  it('sets hasVariadic=true when the function declares a VARIADIC argument', async () => {
+    fetchMock.mockResolvedValueOnce(rowsResponse({ has_variadic: true }));
+    const result = await fetchFunctionDefinition(callArgs);
+    expect(result.functionMetadata?.hasVariadic).toBe(true);
+  });
+
+  it('passes non-composite returnTypeKind through (e.g. enum)', async () => {
+    fetchMock.mockResolvedValueOnce(
+      rowsResponse({
+        return_type_kind: 'e',
+        return_type_name: 'mood',
+        return_table_name: null,
+        return_table_schema: null,
+      }),
+    );
+    const result = await fetchFunctionDefinition(callArgs);
+    expect(result.functionMetadata?.returnTypeKind).toBe('e');
+    expect(result.functionMetadata?.returnTypeName).toBe('mood');
+  });
+
+  it('returns a not-found error when the query yields no rows', async () => {
+    fetchMock.mockResolvedValueOnce(ok([{ result: [['data']] }]));
+    const result = await fetchFunctionDefinition(callArgs);
+    expect(result.functionMetadata).toBeNull();
+    expect(result.error).toBe('Function definition not found.');
+  });
+});

--- a/dashboard/src/features/orgs/projects/database/dataGrid/hooks/useFunctionQuery/fetchFunctionDefinition.ts
+++ b/dashboard/src/features/orgs/projects/database/dataGrid/hooks/useFunctionQuery/fetchFunctionDefinition.ts
@@ -22,6 +22,18 @@ export interface FunctionParameter {
   schema: string | null;
 }
 
+/**
+ * Return type kind from `pg_type.typtype`:
+ * - `b` base/scalar
+ * - `c` composite
+ * - `d` domain
+ * - `e` enum
+ * - `p` pseudo
+ * - `r` range
+ * - `m` multirange
+ */
+export type PostgresTypeKind = 'b' | 'c' | 'd' | 'e' | 'p' | 'r' | 'm';
+
 export interface FetchFunctionDefinitionReturnType {
   /**
    * The CREATE FUNCTION SQL definition.
@@ -36,8 +48,7 @@ export interface FetchFunctionDefinitionReturnType {
     functionType: 'IMMUTABLE' | 'STABLE' | 'VOLATILE' | null;
     returnTypeName: string;
     returnTypeSchema: string;
-    /** Return type kind from pg_type.typtype: 'c' composite, 'b' base/scalar, 'd' domain, 'e' enum, 'p' pseudo, 'r' range */
-    returnTypeKind: string;
+    returnTypeKind: PostgresTypeKind;
     /** Whether the function returns a set (SETOF). */
     returnsSet: boolean;
     /** Whether the function has any variadic argument. */
@@ -197,7 +208,7 @@ export default async function fetchFunctionDefinition({
           | null,
         returnTypeName: result.return_type_name,
         returnTypeSchema: result.return_type_schema,
-        returnTypeKind: result.return_type_kind,
+        returnTypeKind: result.return_type_kind as PostgresTypeKind,
         returnsSet: Boolean(result.returns_set),
         hasVariadic: Boolean(result.has_variadic),
         language: result.language,

--- a/dashboard/src/features/orgs/projects/database/dataGrid/hooks/useFunctionQuery/fetchFunctionDefinition.ts
+++ b/dashboard/src/features/orgs/projects/database/dataGrid/hooks/useFunctionQuery/fetchFunctionDefinition.ts
@@ -36,6 +36,12 @@ export interface FetchFunctionDefinitionReturnType {
     functionType: 'IMMUTABLE' | 'STABLE' | 'VOLATILE' | null;
     returnTypeName: string;
     returnTypeSchema: string;
+    /** Return type kind from pg_type.typtype: 'c' composite, 'b' base/scalar, 'd' domain, 'e' enum, 'p' pseudo, 'r' range */
+    returnTypeKind: string;
+    /** Whether the function returns a set (SETOF). */
+    returnsSet: boolean;
+    /** Whether the function has any variadic argument. */
+    hasVariadic: boolean;
     language: string;
     parameters: FunctionParameter[];
     defaultArgsCount: number;
@@ -85,6 +91,9 @@ export default async function fetchFunctionDefinition({
               END AS function_type,
               rt.typname as return_type_name,
               rtn.nspname as return_type_schema,
+              rt.typtype as return_type_kind,
+              p.proretset as returns_set,
+              (p.provariadic <> 0) as has_variadic,
               l.lanname as language,
               (SELECT COALESCE(json_agg(json_build_object(
                 'name', pt.typname,
@@ -188,6 +197,9 @@ export default async function fetchFunctionDefinition({
           | null,
         returnTypeName: result.return_type_name,
         returnTypeSchema: result.return_type_schema,
+        returnTypeKind: result.return_type_kind,
+        returnsSet: Boolean(result.returns_set),
+        hasVariadic: Boolean(result.has_variadic),
         language: result.language,
         parameters,
         defaultArgsCount,

--- a/dashboard/src/features/orgs/projects/database/dataGrid/hooks/useFunctionQuery/fetchFunctionDefinition.ts
+++ b/dashboard/src/features/orgs/projects/database/dataGrid/hooks/useFunctionQuery/fetchFunctionDefinition.ts
@@ -34,6 +34,34 @@ export interface FunctionParameter {
  */
 export type PostgresTypeKind = 'b' | 'c' | 'd' | 'e' | 'p' | 'r' | 'm';
 
+/**
+ * Shape of a single row returned by the SQL query in
+ * `fetchFunctionDefinition`. Keys are snake_case to mirror the Postgres
+ * columns; the function maps them to the camelCase `FunctionMetadata`.
+ */
+export interface FunctionDefinitionRow {
+  function_definition: string;
+  function_name: string;
+  function_schema: string;
+  function_type: 'IMMUTABLE' | 'STABLE' | 'VOLATILE' | null;
+  return_type_name: string;
+  return_type_schema: string;
+  return_type_kind: PostgresTypeKind;
+  returns_set: boolean;
+  has_variadic: boolean;
+  language: string;
+  input_arg_types: Array<{
+    name: string;
+    schema: string;
+    display_type: string;
+    arg_name: string | null;
+  }>;
+  default_args_count: number;
+  return_table_name: string | null;
+  return_table_schema: string | null;
+  comment: string | null;
+}
+
 export interface FetchFunctionDefinitionReturnType {
   /**
    * The CREATE FUNCTION SQL definition.
@@ -179,16 +207,11 @@ export default async function fetchFunctionDefinition({
     };
   }
 
-  const result = JSON.parse(rawResults[0]);
+  const result: FunctionDefinitionRow = JSON.parse(rawResults[0]);
   const functionDefinition = result.function_definition || '';
 
-  const inputArgTypes: Array<{
-    name: string;
-    schema: string;
-    display_type: string;
-    arg_name: string | null;
-  }> = result.input_arg_types || [];
-  const defaultArgsCount: number = result.default_args_count || 0;
+  const inputArgTypes = result.input_arg_types || [];
+  const defaultArgsCount = result.default_args_count || 0;
 
   const parameters: FunctionParameter[] = inputArgTypes.map((argType) => ({
     name: argType.arg_name || null,
@@ -201,14 +224,10 @@ export default async function fetchFunctionDefinition({
     ? {
         functionName: result.function_name,
         functionSchema: result.function_schema,
-        functionType: result.function_type as
-          | 'IMMUTABLE'
-          | 'STABLE'
-          | 'VOLATILE'
-          | null,
+        functionType: result.function_type,
         returnTypeName: result.return_type_name,
         returnTypeSchema: result.return_type_schema,
-        returnTypeKind: result.return_type_kind as PostgresTypeKind,
+        returnTypeKind: result.return_type_kind,
         returnsSet: Boolean(result.returns_set),
         hasVariadic: Boolean(result.has_variadic),
         language: result.language,

--- a/dashboard/src/features/orgs/projects/database/dataGrid/hooks/useFunctionQuery/index.ts
+++ b/dashboard/src/features/orgs/projects/database/dataGrid/hooks/useFunctionQuery/index.ts
@@ -1,6 +1,7 @@
 export type {
   FetchFunctionDefinitionOptions,
   FetchFunctionDefinitionReturnType,
+  FunctionDefinitionRow,
 } from './fetchFunctionDefinition';
 export { default as fetchFunctionDefinition } from './fetchFunctionDefinition';
 export type { UseFunctionQueryOptions } from './useFunctionQuery';


### PR DESCRIPTION
### Checklist

- [x] No breaking changes
- [x] Tests pass
- [x] New features have new tests
- [x] Documentation is updated (if applicable)
- [x] Title of the PR is in the correct format (see below)

<!-- nhost-reviewer:start -->
### **PR Type**
Bug fix

___

### **Description**
- Relaxes the database listing filter so any composite-returning Postgres function without `VARIADIC` arguments appears, not just `SETOF` functions (`fetchDatabase.ts`).
- Reworks the function details view to render both trackable and non-trackable functions: shows a `Not exposable in GraphQL` alert (distinguishing scalar-return vs. variadic reasons) and hides the track button when the function cannot be exposed.
- Embeds the `CREATE FUNCTION` source in a new collapsible CodeMirror panel with an `Edit` button that opens `EditFunctionForm` in a drawer.
- Extends `fetchFunctionDefinition` to return `returnTypeKind`, `returnsSet`, and `hasVariadic`, introduces a `PostgresTypeKind` type alias and a typed `FunctionDefinitionRow` row shape, and re-exports the row type from the hook barrel.
- Prefixes `SETOF` only when the function actually returns a set in both the "Returns" line and the return-type badge; adds a `VARIADIC` badge when applicable.
- Updates the "function not found" empty state copy from "does not exist or is not a table-returning function" to "does not exist" in both `FunctionDefinitionView` and `EditFunctionForm`.
- Adds unit tests for the new `fetchFunctionDefinition` mapping (SETOF, single-row, variadic, enum return, not-found) and for the `FunctionDefinitionView` rendering branches (trackable, variadic alert, non-composite alert, SETOF toggle, source panel, empty state).

___

### Diagram Walkthrough

```mermaid
flowchart LR
  A["fetchDatabase.ts<br/>(proretset → provariadic)"] --> B["Database list<br/>shows more functions"]
  B --> C["FunctionDefinitionView"]
  D["fetchFunctionDefinition.ts<br/>+returnTypeKind, returnsSet, hasVariadic"] --> C
  C --> E["Trackable?<br/>composite && !variadic"]
  E -->|Yes| F["TrackFunctionButton"]
  E -->|No| G["Not-exposable Alert"]
  C --> H["CodeMirror source panel<br/>+ Edit drawer"]
  H --> I["EditFunctionForm"]
```

<details> <summary><h3> File Walkthrough</h3></summary>

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody>
<tr><td><strong>Data fetching</strong></td><td><details><summary>3 files</summary><table>
<tr>
  <td><strong>fetchDatabase.ts</strong><dd><code>Swap SETOF-only filter for non-variadic filter on composite-returning functions.</code></dd></td>
  <td><a href="https://github.com/nhost/nhost/pull/4176/files#diff-af0053eb0760ab67aec49f66890f35435f7f7696d4c948e953d12ff8f3c57b56">+1/-1</a></td>
</tr>
<tr>
  <td><strong>fetchFunctionDefinition.ts</strong><dd><code>Expose returnTypeKind/returnsSet/hasVariadic, add PostgresTypeKind and FunctionDefinitionRow types, and type-narrow the JSON mapping.</code></dd></td>
  <td><a href="https://github.com/nhost/nhost/pull/4176/files#diff-c82f3a5624d7040adfabbfe9ee3d216b8a97231d6af1fc49818eed71e6d95575">+55/-13</a></td>
</tr>
<tr>
  <td><strong>index.ts</strong><dd><code>Re-export the new FunctionDefinitionRow type from the useFunctionQuery barrel.</code></dd></td>
  <td><a href="https://github.com/nhost/nhost/pull/4176/files#diff-bc661760ff2cb47c64fa94edc529584674e712d175ccd577e7b4d992c07d934b">+1/-0</a></td>
</tr>
</table></details></td></tr>
<tr><td><strong>UI</strong></td><td><details><summary>2 files</summary><table>
<tr>
  <td><strong>FunctionDefinitionView.tsx</strong><dd><code>Trackable/non-trackable branching, non-exposable alert, source-code panel with Edit drawer, VARIADIC badge, conditional SETOF prefix, updated empty-state copy.</code></dd></td>
  <td><a href="https://github.com/nhost/nhost/pull/4176/files#diff-6dd6c35e2bf85c39495bef4c6afe505c73f8034502f439204f7913e3f7d7f99b">+134/-20</a></td>
</tr>
<tr>
  <td><strong>EditFunctionForm.tsx</strong><dd><code>Update empty-state copy to match the relaxed filter.</code></dd></td>
  <td><a href="https://github.com/nhost/nhost/pull/4176/files#diff-d3c764dd60f53061af6d0ad2779b708d19a0cb4d52d349eadee5012aa82d8a7d">+1/-1</a></td>
</tr>
</table></details></td></tr>
<tr><td><strong>Tests</strong></td><td><details><summary>2 files</summary><table>
<tr>
  <td><strong>FunctionDefinitionView.test.tsx</strong><dd><code>Cover trackable/non-trackable branches, variadic and non-composite alerts, SETOF toggle, source panel, and empty state.</code></dd></td>
  <td><a href="https://github.com/nhost/nhost/pull/4176/files#diff-81632a69d7dfddf80f10e94609ecdb38c73eaabcde0f982da08f2d4ddce93481">+143/-0</a></td>
</tr>
<tr>
  <td><strong>fetchFunctionDefinition.test.ts</strong><dd><code>Verify row→metadata mapping for SETOF composite, single-row composite, variadic, enum return, and not-found cases.</code></dd></td>
  <td><a href="https://github.com/nhost/nhost/pull/4176/files#diff-5233e78ce899578fd129286892258058789f89daaddb5b4071c5aa6c159d4436">+102/-0</a></td>
</tr>
</table></details></td></tr>
</tbody></table>

</details>

___

<!-- nhost-reviewer:end -->
