### PR TITLE
release(dashboard): 2.61.0

### DIFF
--- a/cli/cmd/dev/cloud.go
+++ b/cli/cmd/dev/cloud.go
@@ -56,7 +56,7 @@ func CommandCloud() *cli.Command {
 			&cli.StringFlag{ //nolint:exhaustruct
 				Name:    flagDashboardVersion,
 				Usage:   "Dashboard version to use",
-				Value:   "nhost/dashboard:2.60.0",
+				Value:   "nhost/dashboard:2.61.0",
 				Sources: cli.EnvVars("NHOST_DASHBOARD_VERSION"),
 			},
 			&cli.StringFlag{ //nolint:exhaustruct

--- a/cli/cmd/dev/up.go
+++ b/cli/cmd/dev/up.go
@@ -112,7 +112,7 @@ func CommandUp() *cli.Command { //nolint:funlen
 			&cli.StringFlag{ //nolint:exhaustruct
 				Name:    flagDashboardVersion,
 				Usage:   "Dashboard version to use",
-				Value:   "nhost/dashboard:2.60.0",
+				Value:   "nhost/dashboard:2.61.0",
 				Sources: cli.EnvVars("NHOST_DASHBOARD_VERSION"),
 			},
 			&cli.StringFlag{ //nolint:exhaustruct

--- a/dashboard/CHANGELOG.md
+++ b/dashboard/CHANGELOG.md
@@ -1,3 +1,23 @@
+## [@nhost/dashboard@2.61.0] - 2026-04-29
+
+### 🚀 Features
+
+- *(dashboard)* Display constraints, triggers and indexes in database view (#3875)
+- *(dashboard)* Switch role and action via dropdowns in permissions editor (#4196)
+- *(dashboard)* Add JSON editor to custom check (#4166)
+- *(dashboard)* Serverless functions view (#4141)
+
+
+### 🐛 Bug Fixes
+
+- *(dashboard)* Handle non-trackable postgres functions in database page (#4176)
+- *(deps)* Bump up uuid, Astro and xmldom due to CVEs (#4187)
+- *(dashboard)* Revalidate remote schema introspection after reload (#4178)
+- *(dashboard)* Stick permissions button to bottom of storage sidebar (#4188)
+- *(dashboard)* Include schema prefix in GraphQL root field placeholders (#4179)
+- *(deps)* Fix postcss XSS advisory (GHSA-qx2v-qp2m-jg93) (#4197)
+- *(dashboard)* Remove unused maintenance mode (#4180)
+
 ## [@nhost/dashboard@2.60.0] - 2026-04-20
 
 ### 🚀 Features

--- a/docs/src/content/docs/reference/cli/commands.mdx
+++ b/docs/src/content/docs/reference/cli/commands.mdx
@@ -254,7 +254,7 @@ Start local development environment
 
 **--ca-certificates**="": Mounts and everrides path to CA certificates in the containers [$NHOST_CA_CERTIFICATES]
 
-**--dashboard-version**="": Dashboard version to use (default: "nhost/dashboard:2.60.0") [$NHOST_DASHBOARD_VERSION]
+**--dashboard-version**="": Dashboard version to use (default: "nhost/dashboard:2.61.0") [$NHOST_DASHBOARD_VERSION]
 
 **--disable-tls**: Disable TLS [$NHOST_DISABLE_TLS]
 
@@ -286,7 +286,7 @@ Start local development environment connected to an Nhost Cloud project (BETA)
 
 **--ca-certificates**="": Mounts and everrides path to CA certificates in the containers [$NHOST_CA_CERTIFICATES]
 
-**--dashboard-version**="": Dashboard version to use (default: "nhost/dashboard:2.60.0") [$NHOST_DASHBOARD_VERSION]
+**--dashboard-version**="": Dashboard version to use (default: "nhost/dashboard:2.61.0") [$NHOST_DASHBOARD_VERSION]
 
 **--disable-tls**: Disable TLS [$NHOST_DISABLE_TLS]
 


### PR DESCRIPTION
Automated release preparation for dashboard version 2.61.0

Changes:
- Updated CHANGELOG.md
- Bumped version references (`make changelog-bump-refs`) in dependent files