### PR TITLE
fix(dashboard): Add support for generated columns

### DIFF
--- a/dashboard/src/features/orgs/projects/database/dataGrid/components/BaseRecordForm/BaseRecordForm.test.tsx
+++ b/dashboard/src/features/orgs/projects/database/dataGrid/components/BaseRecordForm/BaseRecordForm.test.tsx
@@ -23,11 +23,17 @@ const mockColumns: DataBrowserColumnMetadata[] = [
 ];
 
 function TestRecordFormWrapper(props: Partial<BaseRecordFormProps>) {
-  const methods = useForm();
+  const columns = props.columns ?? mockColumns;
+  const methods = useForm({
+    defaultValues: columns.reduce<Record<string, null>>(
+      (acc, col) => ({ ...acc, [col.id]: null }),
+      {},
+    ),
+  });
   return (
     <FormProvider {...methods}>
       <BaseRecordForm
-        columns={mockColumns}
+        columns={columns}
         onSubmit={mocks.onSubmit}
         onCancel={mocks.onCancel}
         {...props}
@@ -35,6 +41,32 @@ function TestRecordFormWrapper(props: Partial<BaseRecordFormProps>) {
     </FormProvider>
   );
 }
+
+const mockColumnsWithGenerated: DataBrowserColumnMetadata[] = [
+  {
+    id: 'price',
+    isPrimary: false,
+    isNullable: false,
+    isIdentity: false,
+    isGenerated: false,
+    defaultValue: undefined,
+    type: 'number',
+    specificType: 'numeric',
+    dataType: 'numeric',
+  },
+  {
+    id: 'total',
+    isPrimary: false,
+    isNullable: false,
+    isIdentity: false,
+    isGenerated: true,
+    generationExpression: 'price * quantity',
+    defaultValue: undefined,
+    type: 'number',
+    specificType: 'numeric',
+    dataType: 'numeric',
+  },
+];
 
 describe('BaseRecordForm', () => {
   it('should not call onSubmit when cancel is clicked', async () => {
@@ -47,5 +79,30 @@ describe('BaseRecordForm', () => {
 
     expect(mocks.onCancel).toHaveBeenCalled();
     expect(mocks.onSubmit).not.toHaveBeenCalled();
+  });
+
+  it('should exclude generated columns from the form', () => {
+    render(<TestRecordFormWrapper columns={mockColumnsWithGenerated} />);
+
+    expect(
+      screen.queryByRole('textbox', { name: /total/i }),
+    ).not.toBeInTheDocument();
+  });
+
+  it('should not include generated columns in the submit payload', async () => {
+    render(<TestRecordFormWrapper columns={mockColumnsWithGenerated} />);
+
+    const user = new TestUserEvent();
+    await user.click(screen.getByRole('button', { name: /save/i }));
+
+    expect(mocks.onSubmit).toHaveBeenCalledWith(
+      expect.not.objectContaining({ total: expect.anything() }),
+    );
+  });
+
+  it('should show the omitted note when there are generated columns', () => {
+    render(<TestRecordFormWrapper columns={mockColumnsWithGenerated} />);
+
+    expect(screen.getByText(/1 generated column omitted/i)).toBeInTheDocument();
   });
 });

--- a/dashboard/src/features/orgs/projects/database/dataGrid/components/BaseRecordForm/BaseRecordForm.tsx
+++ b/dashboard/src/features/orgs/projects/database/dataGrid/components/BaseRecordForm/BaseRecordForm.tsx
@@ -40,11 +40,17 @@ export default function BaseRecordForm({
   location,
 }: BaseRecordFormProps) {
   const { onDirtyStateChange } = useDialog();
+  const generatedColumnsCount = columns.filter((c) => c.isGenerated).length;
+
   const { requiredColumns, optionalColumns } = columns.reduce<{
     requiredColumns: DataBrowserColumnMetadata[];
     optionalColumns: DataBrowserColumnMetadata[];
   }>(
     (accumulator, column) => {
+      if (column.isGenerated) {
+        return accumulator;
+      }
+
       if (
         column.isPrimary ||
         (!column.isNullable && !column.defaultValue && !column.isIdentity)
@@ -98,6 +104,10 @@ export default function BaseRecordForm({
       columnIds.reduce((options, columnId) => {
         const gridColumn = gridColumnMap.get(columnId);
         const value = columnValues[columnId];
+
+        if (gridColumn?.isGenerated) {
+          return options;
+        }
 
         if (!value && (gridColumn?.defaultValue || gridColumn?.isIdentity)) {
           return {
@@ -161,6 +171,13 @@ export default function BaseRecordForm({
           />
         )}
       </div>
+
+      {generatedColumnsCount > 0 && (
+        <p className="border-t-1 px-6 py-2 text-muted-foreground text-sm">
+          {generatedColumnsCount} generated column
+          {generatedColumnsCount > 1 ? 's' : ''} omitted
+        </p>
+      )}
 
       <div className="box grid flex-shrink-0 grid-flow-col justify-between gap-3 border-t-1 p-2">
         <Button

--- a/dashboard/src/features/orgs/projects/database/dataGrid/components/BaseTableForm/ColumnEditorRow/ColumnEditorRow.test.tsx
+++ b/dashboard/src/features/orgs/projects/database/dataGrid/components/BaseTableForm/ColumnEditorRow/ColumnEditorRow.test.tsx
@@ -1,0 +1,146 @@
+import { FormProvider, useForm } from 'react-hook-form';
+import { render, screen } from '@/tests/testUtils';
+import ColumnEditorRow from './ColumnEditorRow';
+
+interface FormData {
+  columns: Array<{
+    name: string;
+    type: { value: string; label: string } | null;
+    defaultValue: null;
+    isNullable: boolean;
+    isUnique: boolean;
+    isGenerated: boolean;
+    generationExpression: string | null;
+  }>;
+  foreignKeyRelations: [];
+  primaryKeyIndices: string[];
+  identityColumnIndex: number | null;
+}
+
+function TestWrapper({
+  children,
+  defaultValues,
+}: {
+  children: React.ReactNode;
+  defaultValues: FormData;
+}) {
+  const methods = useForm<FormData>({ defaultValues });
+  return <FormProvider {...methods}>{children}</FormProvider>;
+}
+
+const baseColumn = {
+  name: 'price',
+  type: { value: 'numeric', label: 'numeric' },
+  defaultValue: null,
+  isNullable: true,
+  isUnique: false,
+  isGenerated: false,
+  generationExpression: null,
+};
+
+const generatedColumn = {
+  name: 'total',
+  type: { value: 'numeric', label: 'numeric' },
+  defaultValue: null,
+  isNullable: false,
+  isUnique: false,
+  isGenerated: true,
+  generationExpression: 'price * quantity',
+};
+
+const baseFormValues: FormData = {
+  columns: [baseColumn],
+  foreignKeyRelations: [],
+  primaryKeyIndices: [],
+  identityColumnIndex: null,
+};
+
+describe('ColumnEditorRow', () => {
+  describe('regular column', () => {
+    it('should not show the Generated badge', () => {
+      render(
+        <TestWrapper defaultValues={baseFormValues}>
+          <ColumnEditorRow index={0} remove={() => {}} />
+        </TestWrapper>,
+      );
+
+      expect(
+        screen.queryByLabelText('Generated column'),
+      ).not.toBeInTheDocument();
+    });
+
+    it('should have the type field enabled', () => {
+      render(
+        <TestWrapper defaultValues={baseFormValues}>
+          <ColumnEditorRow index={0} remove={() => {}} />
+        </TestWrapper>,
+      );
+
+      expect(screen.getByTestId('columns.0.type')).not.toBeDisabled();
+    });
+
+    it('should have the nullable checkbox enabled', () => {
+      render(
+        <TestWrapper defaultValues={baseFormValues}>
+          <ColumnEditorRow index={0} remove={() => {}} />
+        </TestWrapper>,
+      );
+
+      expect(screen.getByTestId('columns.0.isNullable')).not.toBeDisabled();
+    });
+  });
+
+  describe('generated column', () => {
+    const generatedFormValues: FormData = {
+      columns: [generatedColumn],
+      foreignKeyRelations: [],
+      primaryKeyIndices: [],
+      identityColumnIndex: null,
+    };
+
+    it('should show the Generated badge', () => {
+      render(
+        <TestWrapper defaultValues={generatedFormValues}>
+          <ColumnEditorRow index={0} remove={() => {}} />
+        </TestWrapper>,
+      );
+
+      expect(screen.getByLabelText('Generated column')).toBeInTheDocument();
+    });
+
+    it('should show the generation expression in place of the default value field', () => {
+      render(
+        <TestWrapper defaultValues={generatedFormValues}>
+          <ColumnEditorRow index={0} remove={() => {}} />
+        </TestWrapper>,
+      );
+
+      expect(screen.getByTestId('columns.0.generationExpression')).toHaveValue(
+        'price * quantity',
+      );
+    });
+
+    it('should have the type field disabled', () => {
+      render(
+        <TestWrapper defaultValues={generatedFormValues}>
+          <ColumnEditorRow index={0} remove={() => {}} />
+        </TestWrapper>,
+      );
+
+      expect(screen.getByTestId('columns.0.type')).toBeDisabled();
+    });
+
+    it('should have the nullable checkbox disabled', () => {
+      render(
+        <TestWrapper defaultValues={generatedFormValues}>
+          <ColumnEditorRow index={0} remove={() => {}} />
+        </TestWrapper>,
+      );
+
+      expect(screen.getByTestId('columns.0.isNullable')).toHaveAttribute(
+        'aria-disabled',
+        'true',
+      );
+    });
+  });
+});

--- a/dashboard/src/features/orgs/projects/database/dataGrid/components/BaseTableForm/ColumnEditorRow/ColumnEditorRow.tsx
+++ b/dashboard/src/features/orgs/projects/database/dataGrid/components/BaseTableForm/ColumnEditorRow/ColumnEditorRow.tsx
@@ -1,4 +1,5 @@
 import clsx from 'clsx';
+import { Sigma } from 'lucide-react';
 import type { PropsWithoutRef } from 'react';
 import { memo, useEffect, useState } from 'react';
 import type { FieldError } from 'react-hook-form';
@@ -12,6 +13,11 @@ import { InlineCode } from '@/components/presentational/InlineCode';
 import type { CheckboxProps } from '@/components/ui/v2/Checkbox';
 import { Input } from '@/components/ui/v2/Input';
 import { OptionBase } from '@/components/ui/v2/Option';
+import {
+  Tooltip,
+  TooltipContent,
+  TooltipTrigger,
+} from '@/components/ui/v3/tooltip';
 import type {
   ColumnType,
   ForeignKeyRelation,
@@ -31,6 +37,27 @@ export interface FieldArrayInputProps {
   index: number;
 }
 
+function GeneratedBadge({
+  generationExpression,
+}: {
+  generationExpression: string | null | undefined;
+}) {
+  return (
+    <Tooltip>
+      <TooltipTrigger asChild>
+        <span className="mr-1 flex cursor-help items-center text-muted-foreground">
+          <Sigma width={14} height={14} aria-label="Generated column" />
+        </span>
+      </TooltipTrigger>
+      <TooltipContent sideOffset={8}>
+        <span className="font-semibold">Generated column</span> — value is
+        computed from {generationExpression}. Type and constraints are fixed,
+        but you can rename, edit the comment, or drop the column.
+      </TooltipContent>
+    </Tooltip>
+  );
+}
+
 function NameInput({ index }: FieldArrayInputProps) {
   const { register, clearErrors, setValue, getValues } = useFormContext();
   const originalColumnName = getValues(`columns.${index}.name`);
@@ -45,6 +72,10 @@ function NameInput({ index }: FieldArrayInputProps) {
   });
 
   const primaryKeyIndices: string[] = useWatch({ name: 'primaryKeyIndices' });
+  const isGenerated = useWatch({ name: `columns.${index}.isGenerated` });
+  const generationExpression = useWatch({
+    name: `columns.${index}.generationExpression`,
+  });
 
   return (
     <Input
@@ -78,6 +109,11 @@ function NameInput({ index }: FieldArrayInputProps) {
       error={Boolean(errors?.columns?.[index]?.name)}
       helperText={errors?.columns?.[index]?.name?.message}
       inputProps={{ 'data-testid': `columns.${index}.name` }}
+      endAdornment={
+        isGenerated ? (
+          <GeneratedBadge generationExpression={generationExpression} />
+        ) : undefined
+      }
     />
   );
 }
@@ -87,6 +123,7 @@ function TypeAutocomplete({ index }: FieldArrayInputProps) {
   const { setValue } = useFormContext();
   const { errors } = useFormState({ name: `columns.${index}.type` });
   const identityColumnIndex = useWatch({ name: 'identityColumnIndex' });
+  const isGenerated = useWatch({ name: `columns.${index}.isGenerated` });
   const type = useWatch({ name: `columns.${index}.type` });
 
   useEffect(() => {
@@ -123,6 +160,7 @@ function TypeAutocomplete({ index }: FieldArrayInputProps) {
       }}
       clearOnBlur
       showCustomOption="first"
+      disabled={isGenerated}
       filterOptions={defaultFilterGroupedOptions}
       error={Boolean(errors?.columns?.[index]?.type)}
       helperText={(errors?.columns?.[index]?.type as FieldError)?.message}
@@ -175,6 +213,10 @@ function DefaultValueAutocomplete({ index }: FieldArrayInputProps) {
   const type = useWatch({ name: `columns.${index}.type` });
   const identityColumnIndex = useWatch({ name: 'identityColumnIndex' });
   const isIdentity = identityColumnIndex === index;
+  const isGenerated = useWatch({ name: `columns.${index}.isGenerated` });
+  const generationExpression = useWatch({
+    name: `columns.${index}.generationExpression`,
+  });
 
   const availableFunctions = (postgresFunctions[type?.value] || []).map(
     (functionName: string) => ({
@@ -188,6 +230,18 @@ function DefaultValueAutocomplete({ index }: FieldArrayInputProps) {
       setInputValue('');
     }
   }, [defaultValue]);
+
+  if (isGenerated) {
+    return (
+      <Input
+        value={generationExpression || ''}
+        disabled
+        hideEmptyHelperText
+        aria-label="Generation expression"
+        inputProps={{ 'data-testid': `columns.${index}.generationExpression` }}
+      />
+    );
+  }
 
   return (
     <ControlledAutocomplete
@@ -232,6 +286,7 @@ function Checkbox({
 }: FieldArrayInputProps & PropsWithoutRef<CheckboxProps>) {
   const primaryKeyIndices = useWatch({ name: 'primaryKeyIndices' });
   const identityColumnIndex = useWatch({ name: 'identityColumnIndex' });
+  const isGenerated = useWatch({ name: `columns.${index}.isGenerated` });
 
   const isPrimary = primaryKeyIndices.includes(`${index}`);
   const isIdentity = identityColumnIndex === index;
@@ -239,7 +294,7 @@ function Checkbox({
   return (
     <ControlledCheckbox
       name={name}
-      disabled={isIdentity || isPrimary}
+      disabled={isGenerated || isIdentity || isPrimary}
       uncheckWhenDisabled
       {...props}
     />

--- a/dashboard/src/features/orgs/projects/database/dataGrid/components/DataBrowserGrid/DataBrowserGrid.tsx
+++ b/dashboard/src/features/orgs/projects/database/dataGrid/components/DataBrowserGrid/DataBrowserGrid.tsx
@@ -42,6 +42,7 @@ import { DataGridNumericCell } from '@/features/orgs/projects/storage/dataGrid/c
 import { DataGridTextCell } from '@/features/orgs/projects/storage/dataGrid/components/DataGridTextCell';
 import { isEmptyValue, isNotEmptyValue } from '@/lib/utils';
 import { useDataGridQueryParams } from './DataGridQueryParamsProvider';
+import GeneratedColumnIndicator from './GeneratedColumnIndicator';
 import NoMatchesFound from './NoMatchesFound';
 
 const CreateRecordForm = dynamic(
@@ -61,12 +62,16 @@ export function extractColumnMetadata(
   const { normalizedDefaultValue, custom: isDefaultValueCustom } =
     normalizeDefaultValue(column.column_default);
 
+  const isGeneratedColumn = column.is_generated === 'ALWAYS';
+
   const metadata: DataBrowserColumnMetadata = {
     id: column.column_name,
-    isEditable,
+    isEditable: isGeneratedColumn ? false : isEditable,
     isPrimary: column.is_primary,
     isNullable: column.is_nullable !== 'NO',
     isIdentity: column.is_identity === 'YES',
+    isGenerated: isGeneratedColumn,
+    generationExpression: column.generation_expression ?? null,
     defaultValue: normalizedDefaultValue,
     isDefaultValueCustom,
     isUnique: column.is_unique,
@@ -102,6 +107,11 @@ export function createDataGridColumn(
     header: () => (
       <div className="grid grid-flow-col items-center justify-start gap-1 font-normal">
         {column.is_primary && <KeyRound width={14} height={14} />}
+        {meta.isGenerated && meta.generationExpression && (
+          <GeneratedColumnIndicator
+            generationExpression={meta.generationExpression}
+          />
+        )}
 
         <span className="truncate font-bold" title={column.column_name}>
           {column.column_name}

--- a/dashboard/src/features/orgs/projects/database/dataGrid/components/DataBrowserGrid/GeneratedColumnIndicator.tsx
+++ b/dashboard/src/features/orgs/projects/database/dataGrid/components/DataBrowserGrid/GeneratedColumnIndicator.tsx
@@ -1,0 +1,26 @@
+import { Sigma } from 'lucide-react';
+import {
+  Tooltip,
+  TooltipContent,
+  TooltipTrigger,
+} from '@/components/ui/v3/tooltip';
+
+interface GeneratedColumnIndicatorProps {
+  generationExpression: string;
+}
+
+export default function GeneratedColumnIndicator({
+  generationExpression,
+}: GeneratedColumnIndicatorProps) {
+  return (
+    <Tooltip>
+      <TooltipTrigger asChild>
+        <Sigma width={14} height={14} aria-label="Generated Column" />
+      </TooltipTrigger>
+      <TooltipContent sideOffset={8}>
+        <span className="font-semibold">Generated column</span> — automatically
+        generated from {generationExpression}. Cannot be edited.
+      </TooltipContent>
+    </Tooltip>
+  );
+}

--- a/dashboard/src/features/orgs/projects/database/dataGrid/components/EditTableForm/EditTableForm.tsx
+++ b/dashboard/src/features/orgs/projects/database/dataGrid/components/EditTableForm/EditTableForm.tsx
@@ -123,8 +123,6 @@ export default function EditTableForm({
       form.reset({
         name: originalTableName,
         columns: dataGridColumns.map((column) => ({
-          // ID can't be changed through the form, so we can use it to
-          // identify the column in the original array.
           id: column.id,
           name: column.id,
           type: column.type,
@@ -132,6 +130,8 @@ export default function EditTableForm({
           isNullable: column.isNullable,
           isUnique: column.isUnique,
           comment: column.comment || '',
+          isGenerated: column.isGenerated,
+          generationExpression: column.generationExpression,
         })),
         primaryKeyIndices,
         identityColumnIndex:

--- a/dashboard/src/features/orgs/projects/database/dataGrid/types/dataBrowser/dataBrowser.ts
+++ b/dashboard/src/features/orgs/projects/database/dataGrid/types/dataBrowser/dataBrowser.ts
@@ -452,6 +452,14 @@ export interface DatabaseColumn {
    */
   isIdentity?: boolean;
   /**
+   * Determines whether or not the column is a generated column (GENERATED ALWAYS AS ... STORED).
+   */
+  isGenerated?: boolean;
+  /**
+   * The generation expression for generated columns.
+   */
+  generationExpression?: string | null;
+  /**
    * Determines whether or not the column is a primary key of the table.
    */
   isPrimary?: boolean;
@@ -535,6 +543,14 @@ export interface DataBrowserColumnMetadata {
    * Determines whether or not the column is identity.
    */
   isIdentity?: boolean;
+  /**
+   * Determines whether or not the column is a generated column (GENERATED ALWAYS AS ... STORED).
+   */
+  isGenerated?: boolean;
+  /**
+   * The generation expression for generated columns.
+   */
+  generationExpression?: string | null;
   /**
    * Determines whether or not the column is unique.
    */

--- a/dashboard/src/features/orgs/projects/database/dataGrid/utils/normalizeDatabaseColumn/normalizeDatabaseColumn.test.ts
+++ b/dashboard/src/features/orgs/projects/database/dataGrid/utils/normalizeDatabaseColumn/normalizeDatabaseColumn.test.ts
@@ -116,6 +116,41 @@ test('should set identity to true if the column is an identity column', () => {
   });
 });
 
+test('should set isGenerated to true and map generationExpression for generated columns', () => {
+  const rawGeneratedColumn: typeof rawColumn = {
+    ...rawColumn,
+    column_name: 'total',
+    udt_name: 'numeric',
+    data_type: 'numeric',
+    full_data_type: 'numeric',
+    column_default: null,
+    is_generated: 'ALWAYS',
+    generation_expression: 'price * quantity',
+    is_primary: false,
+    is_unique: false,
+    primary_constraints: [],
+  };
+
+  const column = normalizeDatabaseColumn(rawGeneratedColumn);
+
+  expect(column).toMatchObject<DatabaseColumn>({
+    id: 'total',
+    name: 'total',
+    isIdentity: false,
+    isGenerated: true,
+    generationExpression: 'price * quantity',
+    isNullable: false,
+    isUnique: false,
+    isPrimary: false,
+    type: { value: 'numeric', label: 'numeric' },
+    defaultValue: null,
+    comment: null,
+    primaryConstraints: [],
+    uniqueConstraints: [],
+    foreignKeyRelation: null,
+  });
+});
+
 test('should set nullable to true if the column is nullable', () => {
   const rawNullableColumn: typeof rawColumn = {
     ...rawColumn,

--- a/dashboard/src/features/orgs/projects/database/dataGrid/utils/normalizeDatabaseColumn/normalizeDatabaseColumn.ts
+++ b/dashboard/src/features/orgs/projects/database/dataGrid/utils/normalizeDatabaseColumn/normalizeDatabaseColumn.ts
@@ -22,6 +22,8 @@ export default function normalizeDatabaseColumn(
     type: normalizeColumnType(rawColumn),
     isPrimary: rawColumn.is_primary,
     isIdentity: rawColumn.is_identity === 'YES',
+    isGenerated: rawColumn.is_generated === 'ALWAYS',
+    generationExpression: rawColumn.generation_expression ?? null,
     isNullable: rawColumn.is_nullable === 'YES',
     isUnique: rawColumn.is_unique,
     comment: rawColumn.column_comment || null,

--- a/dashboard/src/features/orgs/projects/storage/dataGrid/components/DataGridBooleanCell/DataGridBooleanCell.test.tsx
+++ b/dashboard/src/features/orgs/projects/storage/dataGrid/components/DataGridBooleanCell/DataGridBooleanCell.test.tsx
@@ -1,0 +1,52 @@
+import { expect, it, vi } from 'vitest';
+import DataGridCellProvider from '@/features/orgs/projects/storage/dataGrid/components/DataGridCell/DataGridCellProvider';
+import { render, screen } from '@/tests/testUtils';
+import type { DataGridBooleanCellProps } from './DataGridBooleanCell';
+import DataGridBooleanCell from './DataGridBooleanCell';
+
+function renderCell(
+  meta: { isEditable: boolean; isNullable?: boolean },
+  optimisticValue: boolean | null = true,
+) {
+  const props = {
+    cell: {
+      id: 'row-1_col',
+      column: {
+        getSize: () => 140,
+        columnDef: { meta },
+      },
+    },
+    optimisticValue,
+    onSave: vi.fn(),
+    onTemporaryValueChange: vi.fn(),
+    onOptimisticValueChange: vi.fn(),
+  } as unknown as DataGridBooleanCellProps;
+
+  return render(
+    <DataGridCellProvider>
+      <DataGridBooleanCell {...props} />
+    </DataGridCellProvider>,
+  );
+}
+
+describe('DataGridBooleanCell', () => {
+  it('renders a clickable trigger when the column is editable', () => {
+    renderCell({ isEditable: true });
+
+    expect(screen.getByRole('button')).toBeInTheDocument();
+  });
+
+  it('renders a read-only toggle without a trigger when the column is not editable', () => {
+    renderCell({ isEditable: false });
+
+    expect(screen.queryByRole('button')).not.toBeInTheDocument();
+    expect(screen.getByText('true')).toBeInTheDocument();
+  });
+
+  it('renders a read-only toggle when meta is missing isEditable', () => {
+    renderCell({ isEditable: undefined as unknown as boolean }, false);
+
+    expect(screen.queryByRole('button')).not.toBeInTheDocument();
+    expect(screen.getByText('false')).toBeInTheDocument();
+  });
+});

--- a/dashboard/src/features/orgs/projects/storage/dataGrid/components/DataGridBooleanCell/DataGridBooleanCell.tsx
+++ b/dashboard/src/features/orgs/projects/storage/dataGrid/components/DataGridBooleanCell/DataGridBooleanCell.tsx
@@ -30,6 +30,11 @@ export default function DataGridBooleanCell<
     useDataGridCell<HTMLButtonElement>();
   const [open, setOpen] = useState(false);
   const isNullable = column.columnDef.meta?.isNullable;
+  const isEditable = column.columnDef.meta?.isEditable;
+
+  if (!isEditable) {
+    return <ReadOnlyToggle checked={optimisticValue} />;
+  }
 
   async function handleMenuClick(
     event: MouseEvent<HTMLDivElement> | ReactKeyboardEvent<HTMLDivElement>,


### PR DESCRIPTION
### Checklist

- [x] No breaking changes
- [x] Tests pass
- [x] New features have new tests
- [ ] Documentation is updated (if applicable)
- [x] Title of the PR is in the correct format (see below)

<!-- nhost-reviewer:start -->
### **PR Type**
Enhancement

___

### **Description**
- Adds metadata plumbing for PostgreSQL generated columns (`isGenerated`, `generationExpression`) from the raw column payload through `DatabaseColumn` / `DataBrowserColumnMetadata`.
- Surfaces generated columns in the data browser grid header via a new `GeneratedColumnIndicator` (Sigma icon + tooltip with the expression) and forces such columns to be non-editable.
- Excludes generated columns from the create/edit record form and shows a trailing "N generated column(s) omitted" note so users understand why the columns are missing.
- Updates the column editor row used by the edit-table form to show a "generated" badge, disable type/nullable/unique inputs, and render the generation expression in place of the default-value field.
- Threads `isGenerated` / `generationExpression` through `EditTableForm`'s form reset so existing generated columns survive the edit round-trip.
- Adds unit tests for `BaseRecordForm`, `ColumnEditorRow`, and `normalizeDatabaseColumn` covering the new behavior.

___

### Diagram Walkthrough

```mermaid
flowchart LR
  A["raw column<br/>(is_generated, generation_expression)"] --> B["normalizeDatabaseColumn"]
  A --> C["extractColumnMetadata<br/>(DataBrowserGrid)"]
  B --> D["EditTableForm<br/>form.reset"]
  C --> E["GeneratedColumnIndicator<br/>(grid header)"]
  C --> F["BaseRecordForm<br/>(omit + note)"]
  D --> G["ColumnEditorRow<br/>(badge + disabled fields)"]
```

<details> <summary><h3> File Walkthrough</h3></summary>

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody>
<tr><td><strong>Types</strong></td><td><details><summary>1 file</summary><table>
<tr>
  <td><strong>dataBrowser.ts</strong><dd><code>Adds isGenerated and generationExpression to DatabaseColumn and DataBrowserColumnMetadata.</code></dd></td>
  <td><a href="https://github.com/OWNER/REPO/pull/XXX/files#diff-33c6810dbd7e2910c86a15009467a348f064380b0e1dd787ef320b4e7543403b">+16/-0</a></td>
</tr>
</table></details></td></tr>

<tr><td><strong>Core logic</strong></td><td><details><summary>5 files</summary><table>
<tr>
  <td><strong>normalizeDatabaseColumn.ts</strong><dd><code>Maps is_generated/generation_expression from raw column data.</code></dd></td>
  <td><a href="https://github.com/OWNER/REPO/pull/XXX/files#diff-e00d1c71fcbc63286896b597ce820388987e0a7edb005bda8a13bb0c0813434b">+2/-0</a></td>
</tr>
<tr>
  <td><strong>DataBrowserGrid.tsx</strong><dd><code>Flags generated columns as non-editable and renders the indicator in the header.</code></dd></td>
  <td><a href="https://github.com/OWNER/REPO/pull/XXX/files#diff-5910fd8730fbe65c60aa5f54031989a7868e944d5958f69535e5684b72ca1396">+11/-1</a></td>
</tr>
<tr>
  <td><strong>GeneratedColumnIndicator.tsx</strong><dd><code>New Sigma-icon tooltip describing the generation expression.</code></dd></td>
  <td><a href="https://github.com/OWNER/REPO/pull/XXX/files#diff-e25a49aa7056255d4355cac6667115648c53ca7cc2002892d592b500f29899cf">+26/-0</a></td>
</tr>
<tr>
  <td><strong>BaseRecordForm.tsx</strong><dd><code>Filters generated columns out of the form and submit payload; adds omitted-count note.</code></dd></td>
  <td><a href="https://github.com/OWNER/REPO/pull/XXX/files#diff-b6bf356211ea3f56b05941761c63104cbfdea0588e986413ec33f9afff58bcdd">+17/-0</a></td>
</tr>
<tr>
  <td><strong>ColumnEditorRow.tsx</strong><dd><code>Adds generated badge, disables type/nullable/unique, shows expression in default-value slot.</code></dd></td>
  <td><a href="https://github.com/OWNER/REPO/pull/XXX/files#diff-264f067037cfa5d08dbb97964a9ddb8f6296129441682b78f6984c37051ea3f8">+67/-39</a></td>
</tr>
</table></details></td></tr>

<tr><td><strong>Form wiring</strong></td><td><details><summary>1 file</summary><table>
<tr>
  <td><strong>EditTableForm.tsx</strong><dd><code>Threads isGenerated/generationExpression through form.reset defaults.</code></dd></td>
  <td><a href="https://github.com/OWNER/REPO/pull/XXX/files#diff-e628e74884ed048e1498960b80ad4d2a9fa6b4e05c89545c404e0ed50b43e50a">+2/-2</a></td>
</tr>
</table></details></td></tr>

<tr><td><strong>Tests</strong></td><td><details><summary>3 files</summary><table>
<tr>
  <td><strong>BaseRecordForm.test.tsx</strong><dd><code>Covers omission of generated columns from UI and submit payload.</code></dd></td>
  <td><a href="https://github.com/OWNER/REPO/pull/XXX/files#diff-14f015e82f9ea8e15fe72e3b8c15fbb93087f9d94313ca48f1166b59b7124905">+59/-2</a></td>
</tr>
<tr>
  <td><strong>ColumnEditorRow.test.tsx</strong><dd><code>New suite covering regular vs generated column rendering/disabled states.</code></dd></td>
  <td><a href="https://github.com/OWNER/REPO/pull/XXX/files#diff-a1771e24947ddcb3abed8b4aa8e8cf0a01630cf8136cc39f3ed0f92be8e469c1">+144/-0</a></td>
</tr>
<tr>
  <td><strong>normalizeDatabaseColumn.test.ts</strong><dd><code>Verifies generation metadata is carried through normalization.</code></dd></td>
  <td><a href="https://github.com/OWNER/REPO/pull/XXX/files#diff-a451c29ffa35243d4dbb462e3a048088c514f8056effedf782fcc57d5235e338">+35/-0</a></td>
</tr>
</table></details></td></tr>

</tbody></table>

</details>

___

<!-- nhost-reviewer:end -->

