### PR TITLE
fix(dashboard): stick permissions button to bottom of storage sidebar

### DIFF
--- a/dashboard/src/components/layout/FeatureSidebar/FeatureSidebar.tsx
+++ b/dashboard/src/components/layout/FeatureSidebar/FeatureSidebar.tsx
@@ -73,7 +73,7 @@ export default function FeatureSidebar({
 
       <aside
         className={cn(
-          'absolute top-0 z-[35] h-full w-full max-w-sidebar overflow-auto border-r-1 pt-2 pb-17 motion-safe:transition-transform',
+          'absolute top-0 z-[35] h-full w-full max-w-sidebar overflow-auto border-r-1 bg-background pt-2 pb-17 motion-safe:transition-transform',
           mobileBreakpoint === 'sm' &&
             'sm:relative sm:z-0 sm:h-full sm:pt-2.5 sm:pb-0 sm:transition-none',
           mobileBreakpoint === 'md' &&

--- a/dashboard/src/features/orgs/projects/storage/components/StorageSidebar/StorageSidebar.tsx
+++ b/dashboard/src/features/orgs/projects/storage/components/StorageSidebar/StorageSidebar.tsx
@@ -169,8 +169,8 @@ function StorageSidebarContent({
   }
 
   return (
-    <div className="flex h-full flex-col justify-between">
-      <div className="flex flex-col px-2">
+    <div className="flex h-full flex-col">
+      <div className="flex shrink-0 flex-col px-2">
         <Button
           variant="link"
           className="!text-sm+ mt-1 flex w-full justify-between px-[0.625rem] text-primary hover:bg-accent hover:no-underline disabled:text-disabled"
@@ -178,6 +178,8 @@ function StorageSidebarContent({
         >
           New Bucket <Plus className="h-4 w-4" />
         </Button>
+      </div>
+      <div className="min-h-0 flex-1 overflow-y-auto px-2">
         {buckets.length === 0 && (
           <p className="px-2 py-1.5 text-disabled text-xs">No buckets found.</p>
         )}
@@ -212,7 +214,7 @@ function StorageSidebarContent({
           />
         )}
       </div>
-      <div className="box border-t">
+      <div className="shrink-0 border-t">
         <StoragePermissionsButton />
       </div>
     </div>


### PR DESCRIPTION
### Checklist

- [ ] No breaking changes
- [ ] Tests pass
- [ ] New features have new tests
- [ ] Documentation is updated (if applicable)
- [ ] Title of the PR is in the correct format (see below)

<!-- nhost-reviewer:start -->
### **PR Type**
Bug fix

___

### **Description**
- Fix the Storage sidebar layout so the "Storage Permissions" button always sticks to the bottom, instead of being pushed down only when the bucket list fills the available space.
- Make the bucket list area independently scrollable by constraining its height with `min-h-0 flex-1 overflow-y-auto`, preventing content overflow from pushing the permissions button out of view.

___

<details> <summary><h3> File Walkthrough</h3></summary>

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody>
<tr><td><strong>UI layout fix</strong></td><td><details><summary>1 file</summary><table>
<tr>
  <td><strong>StorageSidebar.tsx</strong><dd><code>Restructure flex layout so permissions button is always visible at the bottom of the sidebar</code></dd></td>
  <td><a href="https://github.com/OWNER/REPO/pull/XXX/files#diff-37d98e387a489aa3f46c40acb7a30d6fcef16270620bd27d4e1e50fa16d425c9">+5/-3</a></td>
</tr>
</table></details></td></tr>
</tbody></table>

</details>

___

<!-- nhost-reviewer:end -->
