### PR TITLE
feat(dashboard): switch role and action via dropdowns in permissions editor

### DIFF
--- a/dashboard/src/components/common/RoleActionSwitcher/RoleActionSwitcher.tsx
+++ b/dashboard/src/components/common/RoleActionSwitcher/RoleActionSwitcher.tsx
@@ -1,0 +1,107 @@
+import { useDialog } from '@/components/common/DialogProvider';
+import {
+  Select,
+  SelectContent,
+  SelectItem,
+  SelectTrigger,
+  SelectValue,
+} from '@/components/ui/v3/select';
+
+export interface RoleActionSwitcherProps<A extends string> {
+  role: string;
+  action: A;
+  availableRoles: string[];
+  availableActions: A[];
+  actionLabels: Record<A, string>;
+  /**
+   * Whether the surrounding form has unsaved changes. When true, changing
+   * either dropdown opens the discard-confirmation dialog before applying.
+   */
+  isDirty: boolean;
+  /**
+   * Location passed to DialogProvider's onDirtyStateChange when the user
+   * confirms discarding changes.
+   */
+  location?: 'drawer' | 'dialog';
+  onRoleChange: (role: string) => void;
+  onActionChange: (action: A) => void;
+}
+
+export default function RoleActionSwitcher<A extends string>({
+  role,
+  action,
+  availableRoles,
+  availableActions,
+  actionLabels,
+  isDirty,
+  location,
+  onRoleChange,
+  onActionChange,
+}: RoleActionSwitcherProps<A>) {
+  const { openDirtyConfirmation, onDirtyStateChange } = useDialog();
+
+  function guardedSwitch(apply: VoidFunction) {
+    if (isDirty) {
+      openDirtyConfirmation({
+        props: {
+          onPrimaryAction: () => {
+            onDirtyStateChange(false, location);
+            apply();
+          },
+        },
+      });
+      return;
+    }
+    apply();
+  }
+
+  return (
+    <>
+      <div className="grid grid-flow-col items-center gap-2">
+        <label htmlFor="role-action-switcher-role" className="text-sm">
+          Role:
+        </label>
+        <Select
+          value={role}
+          onValueChange={(newRole) =>
+            guardedSwitch(() => onRoleChange(newRole))
+          }
+        >
+          <SelectTrigger id="role-action-switcher-role" className="w-48">
+            <SelectValue />
+          </SelectTrigger>
+          <SelectContent>
+            {availableRoles.map((r) => (
+              <SelectItem key={r} value={r}>
+                {r}
+              </SelectItem>
+            ))}
+          </SelectContent>
+        </Select>
+      </div>
+
+      <div className="grid grid-flow-col items-center gap-2">
+        <label htmlFor="role-action-switcher-action" className="text-sm">
+          Action:
+        </label>
+        <Select
+          value={action}
+          onValueChange={(newAction) =>
+            guardedSwitch(() => onActionChange(newAction as A))
+          }
+        >
+          <SelectTrigger id="role-action-switcher-action" className="w-40">
+            <SelectValue />
+          </SelectTrigger>
+          <SelectContent>
+            {availableActions.map((a) => (
+              <SelectItem key={a} value={a}>
+                {actionLabels[a]}
+              </SelectItem>
+            ))}
+          </SelectContent>
+        </Select>
+      </div>
+    </>
+  );
+}

--- a/dashboard/src/components/common/RoleActionSwitcher/index.ts
+++ b/dashboard/src/components/common/RoleActionSwitcher/index.ts
@@ -1,0 +1,2 @@
+export type { RoleActionSwitcherProps } from './RoleActionSwitcher';
+export { default as RoleActionSwitcher } from './RoleActionSwitcher';

--- a/dashboard/src/features/orgs/hooks/useRemoteApplicationGQLClient/useRemoteApplicationGQLClient.tsx
+++ b/dashboard/src/features/orgs/hooks/useRemoteApplicationGQLClient/useRemoteApplicationGQLClient.tsx
@@ -1,25 +1,64 @@
-import { ApolloClient, HttpLink, InMemoryCache } from '@apollo/client';
+import {
+  ApolloClient,
+  HttpLink,
+  InMemoryCache,
+  type NormalizedCacheObject,
+} from '@apollo/client';
 import { useMemo } from 'react';
 import { generateAppServiceUrl } from '@/features/orgs/projects/common/utils/generateAppServiceUrl';
 import { useProject } from '@/features/orgs/projects/hooks/useProject';
 import { isNotEmptyValue } from '@/lib/utils';
 import { getHasuraAdminSecret } from '@/utils/env';
 
+// Module-level cache so the same ApolloClient (and its warm cache) is reused
+// across component mounts. Without this, remounting a consumer would build a
+// fresh client and refetch, causing visible flicker.
+const clientCache = new Map<string, ApolloClient<NormalizedCacheObject>>();
+
+function getCachedClient(
+  key: string,
+  build: () => ApolloClient<NormalizedCacheObject>,
+) {
+  // Tests run against per-file MSW servers with different handler setups; a
+  // module-level cache would leak a warm Apollo cache across test files and
+  // return stale data. Skip caching in test mode.
+  if (process.env.TEST_MODE === 'true') {
+    return build();
+  }
+  const existing = clientCache.get(key);
+  if (existing) {
+    return existing;
+  }
+  const created = build();
+  clientCache.set(key, created);
+  return created;
+}
+
 /**
- * It creates a new Apollo Client instance that connects to the remote application's GraphQL endpoint
- * @returns A function that returns a new ApolloClient instance.
+ * Returns the Apollo client that talks to the project's remote GraphQL
+ * endpoint. Clients are cached per project so repeated mounts share the same
+ * cache — avoids redundant refetches and UI flicker.
  */
 export default function useRemoteApplicationGQLClient() {
   const { project } = useProject();
 
   const userApplicationClient = useMemo(() => {
-    if (isNotEmptyValue(project)) {
+    if (!isNotEmptyValue(project)) {
+      return getCachedClient(
+        '__no_project__',
+        () => new ApolloClient({ cache: new InMemoryCache() }),
+      );
+    }
+
+    const projectAdminSecret = project.config!.hasura.adminSecret;
+    const cacheKey = `${project.subdomain}.${project.region}.${projectAdminSecret}`;
+
+    return getCachedClient(cacheKey, () => {
       const serviceUrl = generateAppServiceUrl(
         project.subdomain,
         project.region,
         'graphql',
       );
-      const projectAdminSecret = project.config!.hasura.adminSecret;
 
       return new ApolloClient({
         cache: new InMemoryCache(),
@@ -33,8 +72,7 @@ export default function useRemoteApplicationGQLClient() {
           },
         }),
       });
-    }
-    return new ApolloClient({ cache: new InMemoryCache() });
+    });
   }, [project]);
 
   return userApplicationClient;

--- a/dashboard/src/features/orgs/projects/database/dataGrid/components/ColumnAutocomplete/ColumnAutocomplete.tsx
+++ b/dashboard/src/features/orgs/projects/database/dataGrid/components/ColumnAutocomplete/ColumnAutocomplete.tsx
@@ -211,7 +211,7 @@ export default forwardRef(
           title={
             buttonPrefix
               ? `${buttonPrefix}.${selectedColumn?.label}`
-              : selectedColumn?.label || 'Select a column'
+              : selectedColumn?.label || externalValue || 'Select a column'
           }
         >
           <Button
@@ -231,7 +231,7 @@ export default forwardRef(
               </div>
             ) : (
               <span className="truncate">
-                {selectedColumn?.label || 'Select a column'}
+                {selectedColumn?.label || externalValue || 'Select a column'}
               </span>
             )}
             <ChevronsUpDown className="ml-2 h-5 w-5 shrink-0 opacity-50" />

--- a/dashboard/src/features/orgs/projects/database/dataGrid/components/EditPermissionsForm/EditPermissionsForm.tsx
+++ b/dashboard/src/features/orgs/projects/database/dataGrid/components/EditPermissionsForm/EditPermissionsForm.tsx
@@ -174,12 +174,18 @@ export default function EditPermissionsForm({
   if (role && action) {
     return (
       <RolePermissionEditorForm
+        key={`${role}.${action}`}
         location={location}
         resourceVersion={metadata?.resourceVersion as number}
         schema={schema}
         table={table}
         role={role}
         action={action}
+        availableRoles={availableRoles}
+        allowedActions={allowedActions}
+        actionLabels={actionLabels}
+        onRoleChange={setRole}
+        onActionChange={setAction}
         onSubmit={handleSubmit}
         onCancel={handleCancel}
         permission={findPermission(metadataForTable, role, action)}

--- a/dashboard/src/features/orgs/projects/database/dataGrid/components/EditPermissionsForm/RolePermissionEditorForm.tsx
+++ b/dashboard/src/features/orgs/projects/database/dataGrid/components/EditPermissionsForm/RolePermissionEditorForm.tsx
@@ -3,12 +3,12 @@ import { useQueryClient } from '@tanstack/react-query';
 import { useEffect } from 'react';
 import { FormProvider, useForm } from 'react-hook-form';
 import { useDialog } from '@/components/common/DialogProvider';
+import { RoleActionSwitcher } from '@/components/common/RoleActionSwitcher';
 import { Form } from '@/components/form/Form';
 import { HighlightedText } from '@/components/presentational/HighlightedText';
 import { Alert } from '@/components/ui/v2/Alert';
 import { Box } from '@/components/ui/v2/Box';
 import { Button } from '@/components/ui/v2/Button';
-import { Text } from '@/components/ui/v2/Text';
 import { useManagePermissionMutation } from '@/features/orgs/projects/database/dataGrid/hooks/useManagePermissionMutation';
 import type {
   DatabaseAction,
@@ -104,6 +104,26 @@ export interface RolePermissionEditorFormProps extends DialogFormProps {
    */
   action: DatabaseAction;
   /**
+   * All roles selectable in the role dropdown.
+   */
+  availableRoles: string[];
+  /**
+   * All actions selectable in the action dropdown.
+   */
+  allowedActions: DatabaseAction[];
+  /**
+   * Human-readable labels for each action.
+   */
+  actionLabels: Record<DatabaseAction, string>;
+  /**
+   * Called when the user picks a different role from the dropdown.
+   */
+  onRoleChange: (role: string) => void;
+  /**
+   * Called when the user picks a different action from the dropdown.
+   */
+  onActionChange: (action: DatabaseAction) => void;
+  /**
    * Function to be called when the form is submitted.
    */
   onSubmit: VoidFunction;
@@ -186,6 +206,11 @@ export default function RolePermissionEditorForm({
   role,
   resourceVersion,
   action,
+  availableRoles,
+  allowedActions,
+  actionLabels,
+  onRoleChange,
+  onActionChange,
   onSubmit,
   onCancel,
   permission,
@@ -377,21 +402,19 @@ export default function RolePermissionEditorForm({
         <div className="grid flex-auto grid-flow-row content-start gap-6 overflow-auto py-4">
           <PermissionSettingsSection
             title="Selected role & action"
-            className="grid-flow-col justify-between"
+            className="grid-flow-col justify-start gap-6"
           >
-            <div className="grid grid-flow-col gap-4">
-              <Text>
-                Role: <HighlightedText>{role}</HighlightedText>
-              </Text>
-
-              <Text>
-                Action: <HighlightedText>{action}</HighlightedText>
-              </Text>
-            </div>
-
-            <Button variant="borderless" onClick={handleCancelClick}>
-              Change
-            </Button>
+            <RoleActionSwitcher
+              role={role}
+              action={action}
+              availableRoles={availableRoles}
+              availableActions={allowedActions}
+              actionLabels={actionLabels}
+              isDirty={isDirty}
+              location={location}
+              onRoleChange={onRoleChange}
+              onActionChange={onActionChange}
+            />
           </PermissionSettingsSection>
 
           <RowPermissionsSection

--- a/dashboard/src/features/orgs/projects/database/dataGrid/components/EditPermissionsForm/sections/ColumnPresetValueCombobox.tsx
+++ b/dashboard/src/features/orgs/projects/database/dataGrid/components/EditPermissionsForm/sections/ColumnPresetValueCombobox.tsx
@@ -1,0 +1,98 @@
+import { Check, ChevronsUpDown } from 'lucide-react';
+import { useState } from 'react';
+import { useController, useFormContext } from 'react-hook-form';
+import { Button } from '@/components/ui/v3/button';
+import {
+  Command,
+  CommandCreateItem,
+  CommandEmpty,
+  CommandGroup,
+  CommandInput,
+  CommandItem,
+  CommandList,
+} from '@/components/ui/v3/command';
+import {
+  Popover,
+  PopoverContent,
+  PopoverTrigger,
+} from '@/components/ui/v3/popover';
+import { cn } from '@/lib/utils';
+
+interface VariableOption {
+  value: string;
+  label: string;
+}
+
+interface ColumnPresetValueComboboxProps {
+  name: string;
+  options: VariableOption[];
+  hasError?: boolean;
+}
+
+export default function ColumnPresetValueCombobox({
+  name,
+  options,
+  hasError,
+}: ColumnPresetValueComboboxProps) {
+  const { control } = useFormContext();
+  const { field } = useController({ name, control });
+  const [open, setOpen] = useState(false);
+
+  const triggerLabel = field.value || 'Select value';
+
+  function commit(value: string) {
+    field.onChange(value);
+    setOpen(false);
+  }
+
+  return (
+    <Popover open={open} onOpenChange={setOpen}>
+      <PopoverTrigger asChild>
+        <Button
+          variant="outline"
+          role="combobox"
+          aria-expanded={open}
+          className={cn(
+            'w-full justify-between font-normal',
+            !field.value && 'text-muted-foreground',
+            hasError && 'border-destructive text-destructive',
+          )}
+        >
+          <span className="truncate">{triggerLabel}</span>
+          <ChevronsUpDown className="h-4 w-4 shrink-0 opacity-50" />
+        </Button>
+      </PopoverTrigger>
+      <PopoverContent
+        align="start"
+        className="w-[var(--radix-popover-trigger-width)] p-0"
+      >
+        <Command>
+          <CommandInput placeholder="Type value or search variable" />
+          <CommandList>
+            <CommandEmpty>No variable found.</CommandEmpty>
+            {options.length > 0 && (
+              <CommandGroup heading="Permission variables">
+                {options.map((opt) => (
+                  <CommandItem
+                    key={opt.value}
+                    value={opt.value}
+                    onSelect={() => commit(opt.value)}
+                  >
+                    {opt.label}
+                    <Check
+                      className={cn(
+                        'ml-auto h-4 w-4',
+                        field.value === opt.value ? 'opacity-100' : 'opacity-0',
+                      )}
+                    />
+                  </CommandItem>
+                ))}
+              </CommandGroup>
+            )}
+            <CommandCreateItem onCreate={commit} />
+          </CommandList>
+        </Command>
+      </PopoverContent>
+    </Popover>
+  );
+}

--- a/dashboard/src/features/orgs/projects/database/dataGrid/components/EditPermissionsForm/sections/ColumnPresetsSection.test.tsx
+++ b/dashboard/src/features/orgs/projects/database/dataGrid/components/EditPermissionsForm/sections/ColumnPresetsSection.test.tsx
@@ -1,0 +1,217 @@
+import { setupServer } from 'msw/node';
+import type { ReactNode } from 'react';
+import { FormProvider, useForm, useFormState } from 'react-hook-form';
+import { vi } from 'vitest';
+import { getProjectQuery } from '@/tests/msw/mocks/graphql/getProjectQuery';
+import permissionVariablesQuery from '@/tests/msw/mocks/graphql/permissionVariablesQuery';
+import hasuraMetadataQuery from '@/tests/msw/mocks/rest/hasuraMetadataQuery';
+import tableQuery from '@/tests/msw/mocks/rest/tableQuery';
+import tokenQuery from '@/tests/msw/mocks/rest/tokenQuery';
+import {
+  mockPointerEvent,
+  render,
+  screen,
+  TestUserEvent,
+  waitFor,
+} from '@/tests/testUtils';
+import ColumnPresetsSection from './ColumnPresetsSection';
+
+const mocks = vi.hoisted(() => ({
+  useRouter: vi.fn(),
+}));
+
+vi.mock('next/router', () => ({
+  useRouter: mocks.useRouter,
+}));
+
+const server = setupServer(
+  tokenQuery,
+  tableQuery,
+  hasuraMetadataQuery,
+  getProjectQuery,
+  permissionVariablesQuery,
+);
+
+function DirtyProbe() {
+  const { isDirty } = useFormState();
+  return <span data-testid="is-dirty">{isDirty ? 'dirty' : 'clean'}</span>;
+}
+
+function TestWrapper({
+  children,
+  columnPresets = [{ column: '', value: '' }],
+}: {
+  children: ReactNode;
+  columnPresets?: { column: string; value: string }[];
+}) {
+  const form = useForm({ defaultValues: { columnPresets } });
+  return (
+    <FormProvider {...form}>
+      <DirtyProbe />
+      {children}
+    </FormProvider>
+  );
+}
+
+const defaultProps = {
+  schema: 'public',
+  table: 'books',
+};
+
+describe('ColumnPresetsSection', () => {
+  beforeAll(() => {
+    process.env.NEXT_PUBLIC_ENV = 'dev';
+    process.env.NEXT_PUBLIC_NHOST_CONFIGSERVER_URL =
+      'https://local.graphql.local.nhost.run/v1';
+    server.listen();
+  });
+
+  beforeEach(() => {
+    mockPointerEvent();
+    mocks.useRouter.mockReturnValue({
+      basePath: '',
+      pathname: '/orgs/xyz/projects/test-project',
+      route: '/orgs/[orgSlug]/projects/[appSubdomain]',
+      asPath: '/orgs/xyz/projects/test-project',
+      isLocaleDomain: false,
+      isReady: true,
+      isPreview: false,
+      query: {
+        orgSlug: 'xyz',
+        appSubdomain: 'test-project',
+        dataSourceSlug: 'default',
+      },
+      push: vi.fn(),
+      replace: vi.fn(),
+      reload: vi.fn(),
+      back: vi.fn(),
+      prefetch: vi.fn(),
+      beforePopState: vi.fn(),
+      events: { on: vi.fn(), off: vi.fn(), emit: vi.fn() },
+      isFallback: false,
+      forward: vi.fn(),
+    });
+  });
+
+  afterEach(() => {
+    server.resetHandlers();
+  });
+
+  afterAll(() => {
+    server.close();
+  });
+
+  it('stays clean on mount with the default empty preset row', async () => {
+    render(
+      <TestWrapper>
+        <ColumnPresetsSection {...defaultProps} />
+      </TestWrapper>,
+    );
+
+    await waitFor(() => {
+      expect(screen.getByText('Column Name')).toBeInTheDocument();
+    });
+
+    expect(screen.getByTestId('is-dirty')).toHaveTextContent('clean');
+  });
+
+  it('"Add Column" appends a new empty row', async () => {
+    render(
+      <TestWrapper>
+        <ColumnPresetsSection {...defaultProps} />
+      </TestWrapper>,
+    );
+
+    await waitFor(() => {
+      expect(
+        screen.getAllByRole('button', { name: 'Delete preset' }),
+      ).toHaveLength(1);
+    });
+
+    const user = new TestUserEvent();
+    await user.click(screen.getByRole('button', { name: /add column/i }));
+
+    await waitFor(() => {
+      expect(
+        screen.getAllByRole('button', { name: 'Delete preset' }),
+      ).toHaveLength(2);
+    });
+  });
+
+  it('removing the last remaining row keeps one empty placeholder row', async () => {
+    render(
+      <TestWrapper
+        columnPresets={[{ column: 'title', value: 'X-Hasura-User-Id' }]}
+      >
+        <ColumnPresetsSection {...defaultProps} />
+      </TestWrapper>,
+    );
+
+    await waitFor(() => {
+      expect(screen.getByText('title')).toBeInTheDocument();
+    });
+
+    const user = new TestUserEvent();
+    await user.click(screen.getByRole('button', { name: 'Delete preset' }));
+
+    await waitFor(() => {
+      expect(
+        screen.getAllByRole('button', { name: 'Delete preset' }),
+      ).toHaveLength(1);
+      expect(screen.queryByText('title')).not.toBeInTheDocument();
+      expect(screen.getByText('Select column')).toBeInTheDocument();
+    });
+  });
+
+  it('a column used in one row is disabled in other rows but remains selectable in its own row', async () => {
+    render(
+      <TestWrapper
+        columnPresets={[
+          { column: 'title', value: '' },
+          { column: '', value: '' },
+        ]}
+      >
+        <ColumnPresetsSection {...defaultProps} />
+      </TestWrapper>,
+    );
+
+    await waitFor(() => {
+      expect(screen.getByText('title')).toBeInTheDocument();
+      expect(screen.getByText('Select column')).toBeInTheDocument();
+    });
+
+    const row0ColumnTrigger = screen
+      .getByText('title')
+      .closest('[role="combobox"]') as HTMLElement;
+    const row1ColumnTrigger = screen
+      .getByText('Select column')
+      .closest('[role="combobox"]') as HTMLElement;
+
+    const user = new TestUserEvent();
+
+    await user.click(row1ColumnTrigger);
+
+    const titleOptionInOtherRow = await screen.findByRole('option', {
+      name: 'title',
+    });
+    expect(titleOptionInOtherRow).toHaveAttribute('data-disabled');
+
+    const releaseDateOption = screen.getByRole('option', {
+      name: 'release_date',
+    });
+    expect(releaseDateOption).not.toHaveAttribute('data-disabled');
+
+    await user.keyboard('{Escape}');
+
+    await waitFor(() => {
+      expect(screen.queryByRole('option', { name: 'title' })).toBeNull();
+    });
+
+    await user.click(row0ColumnTrigger);
+
+    const titleOptionInOwnRow = await screen.findByRole('option', {
+      name: 'title',
+    });
+    expect(titleOptionInOwnRow).not.toHaveAttribute('data-disabled');
+  });
+});

--- a/dashboard/src/features/orgs/projects/database/dataGrid/components/EditPermissionsForm/sections/ColumnPresetsSection.tsx
+++ b/dashboard/src/features/orgs/projects/database/dataGrid/components/EditPermissionsForm/sections/ColumnPresetsSection.tsx
@@ -1,22 +1,25 @@
-import { useTheme } from '@mui/material';
-import clsx from 'clsx';
-import { useFieldArray, useFormContext, useWatch } from 'react-hook-form';
-import { ControlledSelect } from '@/components/form/ControlledSelect';
-import { ActivityIndicator } from '@/components/ui/v2/ActivityIndicator';
-import { Autocomplete } from '@/components/ui/v2/Autocomplete';
-import { Button } from '@/components/ui/v2/Button';
-import { IconButton } from '@/components/ui/v2/IconButton';
-import { InputLabel } from '@/components/ui/v2/InputLabel';
-import { PlusIcon } from '@/components/ui/v2/icons/PlusIcon';
-import { XIcon } from '@/components/ui/v2/icons/XIcon';
-import { Option } from '@/components/ui/v2/Option';
-import { Text } from '@/components/ui/v2/Text';
+import { Plus, X } from 'lucide-react';
+import {
+  Controller,
+  useFieldArray,
+  useFormContext,
+  useWatch,
+} from 'react-hook-form';
+import { Button } from '@/components/ui/v3/button';
+import {
+  Select,
+  SelectContent,
+  SelectItem,
+  SelectTrigger,
+  SelectValue,
+} from '@/components/ui/v3/select';
 import { useTableSchemaQuery } from '@/features/orgs/projects/database/common/hooks/useTableSchemaQuery';
 import type { RolePermissionEditorFormValues } from '@/features/orgs/projects/database/dataGrid/components/EditPermissionsForm/RolePermissionEditorForm';
 import { useProject } from '@/features/orgs/projects/hooks/useProject';
 import { getAllPermissionVariables } from '@/features/orgs/projects/permissions/settings/utils/getAllPermissionVariables';
-import { isNotEmptyValue } from '@/lib/utils';
+import { cn } from '@/lib/utils';
 import { useGetRolesPermissionsQuery } from '@/utils/__generated__/graphql';
+import ColumnPresetValueCombobox from './ColumnPresetValueCombobox';
 import PermissionSettingsSection from './PermissionSettingsSection';
 
 export interface ColumnPreset {
@@ -25,13 +28,7 @@ export interface ColumnPreset {
 }
 
 export interface ColumnPresetSectionProps {
-  /**
-   * Schema to use for fetching available columns.
-   */
   schema: string;
-  /**
-   * Table to use for fetching available columns.
-   */
   table: string;
 }
 
@@ -39,12 +36,10 @@ export default function ColumnPresetsSection({
   schema,
   table,
 }: ColumnPresetSectionProps) {
-  const theme = useTheme();
-  const {
-    data: tableData,
-    status: tableStatus,
-    error: tableError,
-  } = useTableSchemaQuery([`default.${schema}.${table}`], { schema, table });
+  const { data: tableData, error: tableError } = useTableSchemaQuery(
+    [`default.${schema}.${table}`],
+    { schema, table },
+  );
 
   const { project } = useProject();
 
@@ -53,15 +48,20 @@ export default function ColumnPresetsSection({
     skip: !project?.id,
   });
   const {
-    setValue,
+    control,
     formState: { errors },
   } = useFormContext<RolePermissionEditorFormValues>();
-  const { fields, append, remove } = useFieldArray({ name: 'columnPresets' });
-  const columnPresets = useWatch({ name: 'columnPresets' }) as ColumnPreset[];
+  const { fields, append, remove } = useFieldArray({
+    control,
+    name: 'columnPresets',
+  });
+  const columnPresets = useWatch({
+    control,
+    name: 'columnPresets',
+  }) as ColumnPreset[];
 
   const allColumnNames: string[] =
     tableData?.columns.map((column) => column.column_name) || [];
-  const selectedColumns = fields as (ColumnPreset & { id: string })[];
   const selectedColumnsMap = columnPresets.reduce(
     (map, { column }) => map.set(column, true),
     new Map<string, boolean>(),
@@ -76,143 +76,103 @@ export default function ColumnPresetsSection({
   ).map(({ key }) => ({
     label: `X-Hasura-${key}`,
     value: `X-Hasura-${key}`,
-    group: 'Permission variables',
   }));
 
   return (
     <PermissionSettingsSection title="Column presets" className="gap-6">
-      <Text variant="subtitle1">
+      <p className="text-secondary text-sm">
         Set static values or session variables as pre-determined values for
         columns while inserting.
-      </Text>
+      </p>
 
       <div className="grid grid-flow-row gap-2">
         <div className="grid grid-cols-[1fr_1fr_40px] gap-2">
-          <InputLabel as="span">Column Name</InputLabel>
-          <InputLabel as="span">Column Value</InputLabel>
+          <span className="font-medium text-sm">Column Name</span>
+          <span className="font-medium text-sm">Column Value</span>
         </div>
 
-        {tableStatus === 'loading' && (
-          <ActivityIndicator label="Loading columns..." />
-        )}
-
         <div className="grid grid-flow-row gap-4">
-          {tableStatus === 'success' &&
-            selectedColumns.map((field, index) => (
+          {fields.map((field, index) => {
+            const columnError =
+              errors?.columnPresets?.at?.(index)?.column?.message;
+            const valueError =
+              errors?.columnPresets?.at?.(index)?.value?.message;
+
+            return (
               <div
                 key={field.id}
                 className="grid grid-cols-[1fr_1fr_40px] gap-2"
               >
-                <ControlledSelect
+                <Controller
                   name={`columnPresets.${index}.column`}
-                  error={Boolean(
-                    errors?.columnPresets?.at?.(index)?.column?.message,
-                  )}
-                >
-                  {allColumnNames.map((column) => (
-                    <Option
-                      value={column}
-                      disabled={selectedColumnsMap.has(column)}
-                      key={column}
+                  control={control}
+                  render={({ field: columnField }) => (
+                    <Select
+                      value={columnField.value || undefined}
+                      onValueChange={columnField.onChange}
                     >
-                      {column}
-                    </Option>
-                  ))}
-                </ControlledSelect>
-
-                <Autocomplete
-                  options={permissionVariableOptions}
-                  groupBy={(option) => option.group || ''}
-                  name={`columnPresets.${index}.value`}
-                  inputValue={field.value}
-                  value={field.value}
-                  freeSolo
-                  fullWidth
-                  disableClearable={false}
-                  clearIcon={
-                    <XIcon
-                      className="mt-px h-4 w-4"
-                      sx={{ color: theme.palette.text.primary }}
-                    />
-                  }
-                  autoSelect
-                  autoHighlight={false}
-                  error={Boolean(
-                    errors?.columnPresets?.at?.(index)?.value?.message,
+                      <SelectTrigger
+                        className={cn(
+                          Boolean(columnError) &&
+                            'border-destructive text-destructive',
+                        )}
+                      >
+                        <SelectValue placeholder="Select column" />
+                      </SelectTrigger>
+                      <SelectContent>
+                        {allColumnNames.map((column) => (
+                          <SelectItem
+                            key={column}
+                            value={column}
+                            disabled={
+                              selectedColumnsMap.has(column) &&
+                              columnField.value !== column
+                            }
+                          >
+                            {column}
+                          </SelectItem>
+                        ))}
+                      </SelectContent>
+                    </Select>
                   )}
-                  slotProps={{
-                    paper: {
-                      className: clsx(
-                        permissionVariableOptions.length === 0 && 'hidden',
-                      ),
-                    },
-                  }}
-                  isOptionEqualToValue={(option, value) => {
-                    if (typeof value === 'string') {
-                      return (
-                        option.value.toLowerCase() ===
-                        (value as string).toLowerCase()
-                      );
-                    }
-
-                    return (
-                      option.value.toLowerCase() === value.value.toLowerCase()
-                    );
-                  }}
-                  onChange={(_event, _value, reason, details) => {
-                    if (reason === 'clear') {
-                      setValue(`columnPresets.${index}.value`, '', {
-                        shouldDirty: true,
-                      });
-
-                      return;
-                    }
-                    if (
-                      isNotEmptyValue(details) &&
-                      typeof details.option === 'string'
-                    ) {
-                      setValue(`columnPresets.${index}.value`, details.option, {
-                        shouldDirty: true,
-                      });
-                    } else if (isNotEmptyValue(details?.option?.value)) {
-                      setValue(
-                        `columnPresets.${index}.value`,
-                        details.option.value,
-                        { shouldDirty: true },
-                      );
-                    }
-                  }}
                 />
 
-                <IconButton
-                  variant="outlined"
-                  color="secondary"
-                  className="flex-[40px] shrink-0 grow-0"
+                <ColumnPresetValueCombobox
+                  name={`columnPresets.${index}.value`}
+                  options={permissionVariableOptions}
+                  hasError={Boolean(valueError)}
+                />
+
+                <Button
+                  variant="outline"
+                  size="icon"
+                  type="button"
+                  aria-label="Delete preset"
                   onClick={() => {
                     if (fields.length === 1) {
                       remove(index);
                       append({ column: '', value: '' });
-
                       return;
                     }
-
                     remove(index);
                   }}
                 >
-                  <XIcon className="h-4 w-4" />
-                </IconButton>
+                  <X className="h-4 w-4" />
+                </Button>
               </div>
-            ))}
+            );
+          })}
         </div>
 
         <Button
-          variant="borderless"
-          startIcon={<PlusIcon />}
-          size="small"
+          variant="ghost"
+          size="sm"
+          type="button"
           onClick={() => append({ column: '', value: '' })}
-          disabled={selectedColumns.length === allColumnNames.length}
-          className="justify-self-start"
+          disabled={fields.length === allColumnNames.length}
+          className="justify-self-start text-primary hover:text-primary"
         >
+          <Plus className="mr-2 h-4 w-4" />
           Add Column
         </Button>
       </div>

--- a/dashboard/src/features/orgs/projects/storage/dataGrid/components/EditStoragePermissions/StoragePermissionsForm.test.tsx
+++ b/dashboard/src/features/orgs/projects/storage/dataGrid/components/EditStoragePermissions/StoragePermissionsForm.test.tsx
@@ -290,16 +290,14 @@ describe('StoragePermissionsForm', () => {
     const noPermIcons = screen.getAllByLabelText('No permission');
     await user.click(noPermIcons[1].closest('button')!);
 
-    // The editor form should now be visible with role and action
     await waitFor(() => {
       expect(
         screen.queryByText('Roles & Actions overview'),
       ).not.toBeInTheDocument();
     });
-    // "Upload" in the action label (InlineCode renders as <code>)
-    expect(
-      screen.getByText('Upload', { selector: 'code' }),
-    ).toBeInTheDocument();
+    expect(screen.getByRole('combobox', { name: /action/i })).toHaveTextContent(
+      'Upload',
+    );
     expect(screen.getByText('File upload permissions')).toBeInTheDocument();
   });
 
@@ -322,34 +320,8 @@ describe('StoragePermissionsForm', () => {
         screen.queryByText('Roles & Actions overview'),
       ).not.toBeInTheDocument();
     });
-    // select DB action maps to "Download" storage action
-    expect(screen.getByText('Download')).toBeInTheDocument();
-  });
-
-  it('resetting selection returns to grid view', async () => {
-    server.use(rolesQuery, createMetadataHandler(), ...editorHandlers);
-    render(<StoragePermissionsForm />);
-
-    await waitFor(() => {
-      expect(screen.getByText('public')).toBeInTheDocument();
-    });
-
-    const user = userEvent.setup();
-    const noPermIcons = screen.getAllByLabelText('No permission');
-    await user.click(noPermIcons[1].closest('button')!);
-
-    // Wait for editor to appear
-    await waitFor(() => {
-      expect(
-        screen.queryByText('Roles & Actions overview'),
-      ).not.toBeInTheDocument();
-    });
-
-    // Click "Change" to go back to grid (this calls onCancel → resetSelection)
-    await user.click(screen.getByText('Change'));
-
-    await waitFor(() => {
-      expect(screen.getByText('Roles & Actions overview')).toBeInTheDocument();
-    });
+    expect(screen.getByRole('combobox', { name: /action/i })).toHaveTextContent(
+      'Download',
+    );
   });
 });

--- a/dashboard/src/features/orgs/projects/storage/dataGrid/components/EditStoragePermissions/StoragePermissionsForm.tsx
+++ b/dashboard/src/features/orgs/projects/storage/dataGrid/components/EditStoragePermissions/StoragePermissionsForm.tsx
@@ -103,10 +103,17 @@ export default function StoragePermissionsForm({
     const dbAction = STORAGE_ACTION_TO_DB_ACTION[selectedAction];
     return (
       <StorageRolePermissionEditorForm
+        key={`${selectedRole}.${selectedAction}`}
         location={location}
         resourceVersion={metadata?.resourceVersion as number}
         role={selectedRole}
         storageAction={selectedAction}
+        availableRoles={availableRoles}
+        availableStorageActions={
+          Object.values(DB_ACTION_TO_STORAGE_ACTION) as StorageAction[]
+        }
+        onRoleChange={setSelectedRole}
+        onStorageActionChange={setSelectedAction}
         onSubmit={resetSelection}
         onCancel={resetSelection}
         permission={findPermission(metadataForTable, selectedRole, dbAction)}

--- a/dashboard/src/features/orgs/projects/storage/dataGrid/components/EditStoragePermissions/StorageRolePermissionEditorForm.test.tsx
+++ b/dashboard/src/features/orgs/projects/storage/dataGrid/components/EditStoragePermissions/StorageRolePermissionEditorForm.test.tsx
@@ -63,6 +63,10 @@ function renderEditor(
     role: 'user',
     resourceVersion: 1,
     storageAction: 'upload',
+    availableRoles: ['public', 'user'],
+    availableStorageActions: ['upload', 'download', 'replace', 'delete'],
+    onRoleChange: vi.fn(),
+    onStorageActionChange: vi.fn(),
     onSubmit: vi.fn(),
     onCancel: vi.fn(),
     ...props,
@@ -156,20 +160,18 @@ describe('StorageRolePermissionEditorForm', () => {
 
   describe('UI rendering', () => {
     it('displays role name and action label in header', () => {
-      renderEditor({ role: 'editor', storageAction: 'download' });
+      renderEditor({
+        role: 'editor',
+        storageAction: 'download',
+        availableRoles: ['public', 'user', 'editor'],
+      });
 
+      expect(screen.getByRole('combobox', { name: /role/i })).toHaveTextContent(
+        'editor',
+      );
       expect(
-        screen.getByText(
-          (_, el) =>
-            el?.tagName === 'SPAN' && el.textContent === 'Role: editor',
-        ),
-      ).toBeInTheDocument();
-      expect(
-        screen.getByText(
-          (_, el) =>
-            el?.tagName === 'SPAN' && el.textContent === 'Action: Download',
-        ),
-      ).toBeInTheDocument();
+        screen.getByRole('combobox', { name: /action/i }),
+      ).toHaveTextContent('Download');
     });
 
     it('shows upload preset section for upload action', () => {

--- a/dashboard/src/features/orgs/projects/storage/dataGrid/components/EditStoragePermissions/StorageRolePermissionEditorForm.tsx
+++ b/dashboard/src/features/orgs/projects/storage/dataGrid/components/EditStoragePermissions/StorageRolePermissionEditorForm.tsx
@@ -5,10 +5,10 @@ import { FormProvider, useForm } from 'react-hook-form';
 
 import { useDialog } from '@/components/common/DialogProvider';
 import { PermissionSettingsSectionV3 as PermissionSettingsSection } from '@/components/common/PermissionSettingsSection';
+import { RoleActionSwitcher } from '@/components/common/RoleActionSwitcher';
 import { Form } from '@/components/form/Form';
 import { Alert } from '@/components/ui/v3/alert';
 import { ButtonWithLoading as Button } from '@/components/ui/v3/button';
-import { InlineCode } from '@/components/ui/v3/inline-code';
 import { useManagePermissionMutation } from '@/features/orgs/projects/database/dataGrid/hooks/useManagePermissionMutation';
 import type { HasuraMetadataPermission } from '@/features/orgs/projects/database/dataGrid/types/dataBrowser';
 import type { GroupNode } from '@/features/orgs/projects/database/dataGrid/utils/permissionUtils';
@@ -38,6 +38,10 @@ export interface StorageRolePermissionEditorFormProps extends DialogFormProps {
   role: string;
   resourceVersion: number;
   storageAction: StorageAction;
+  availableRoles: string[];
+  availableStorageActions: StorageAction[];
+  onRoleChange: (role: string) => void;
+  onStorageActionChange: (storageAction: StorageAction) => void;
   onSubmit: VoidFunction;
   onCancel: VoidFunction;
   permission?: HasuraMetadataPermission['permission'];
@@ -77,6 +81,10 @@ export default function StorageRolePermissionEditorForm({
   role,
   resourceVersion,
   storageAction,
+  availableRoles,
+  availableStorageActions,
+  onRoleChange,
+  onStorageActionChange,
   onSubmit,
   onCancel,
   permission,
@@ -248,26 +256,19 @@ export default function StorageRolePermissionEditorForm({
         <div className="grid flex-auto grid-flow-row content-start gap-6 overflow-auto py-4">
           <PermissionSettingsSection
             title="Selected role & action"
-            className="grid-flow-col justify-between"
+            className="grid-flow-col justify-start gap-6"
           >
-            <div className="grid grid-flow-col gap-4 text-sm+">
-              <span>
-                Role: <InlineCode className="text-sm+">{role}</InlineCode>
-              </span>
-              <span>
-                Action:{' '}
-                <InlineCode className="text-sm+">{actionLabel}</InlineCode>
-              </span>
-            </div>
-
-            <Button
-              variant="ghost"
-              size="sm"
-              type="button"
-              onClick={handleCancelClick}
-            >
-              Change
-            </Button>
+            <RoleActionSwitcher
+              role={role}
+              action={storageAction}
+              availableRoles={availableRoles}
+              availableActions={availableStorageActions}
+              actionLabels={STORAGE_ACTION_LABELS}
+              isDirty={isDirty}
+              location={location}
+              onRoleChange={onRoleChange}
+              onActionChange={onStorageActionChange}
+            />
           </PermissionSettingsSection>
 
           <StorageRowPermissionsSection


### PR DESCRIPTION
### Checklist

- [ ] No breaking changes
- [ ] Tests pass
- [ ] New features have new tests
- [ ] Documentation is updated (if applicable)
- [ ] Title of the PR is in the correct format (see below)

<!-- nhost-reviewer:start -->
### **PR Type**
Enhancement

___

### **Description**
- Replaces the static "Role: X / Action: Y" header plus "Change" button with inline role/action dropdowns (`RoleActionSwitcher`) in both the database and storage permission editors, with a discard-confirmation guard when the form is dirty.
- Forces a remount of the editor form when role/action changes by setting `key={`${role}.${action}`}` on the editor, so the form re-initializes against the new permission record.
- Caches the remote-application Apollo client at module level keyed by `subdomain.region` to avoid rebuilding the client (and refetching) on every consumer remount; cache is bypassed when `TEST_MODE === 'true'`.
- Migrates `ColumnPresetsSection` from MUI v2 components to v3 (Shadcn) — replaces `ControlledSelect`/`Autocomplete` with `Select` and a new `ColumnPresetValueCombobox`, refines the per-row "disable column already used elsewhere" rule so the row's own value stays selectable, and adds a test file covering the section's interactions.
- Falls back to `externalValue` in `ColumnAutocomplete` button label/title when no matching column is found in the schema.
- Updates storage permission tests for the new dropdown-based header (queries `combobox` by accessible name) and removes the now-defunct "Change" button test.

___

### Diagram Walkthrough

```mermaid
flowchart LR
  EPF["EditPermissionsForm /<br/>StoragePermissionsForm"] -->|role, action,<br/>onRoleChange, onActionChange,<br/>availableRoles, availableActions| RPE["RolePermissionEditorForm /<br/>StorageRolePermissionEditorForm"]
  RPE -->|isDirty, location,<br/>actionLabels| RAS["RoleActionSwitcher"]
  RAS -->|guarded by<br/>openDirtyConfirmation| EPF
  CPS["ColumnPresetsSection<br/>(v3 migration)"] --> CPVC["ColumnPresetValueCombobox"]
  URC["useRemoteApplicationGQLClient"] --> CACHE["module-level<br/>clientCache Map"]
```

<details> <summary><h3> File Walkthrough</h3></summary>

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody>
<tr><td><strong>New shared component</strong></td><td><details><summary>2 files</summary><table>
<tr>
  <td><strong>RoleActionSwitcher.tsx</strong><dd><code>New generic role/action dropdown pair with dirty-confirmation guard</code></dd></td>
  <td><a href="https://github.com/nhost/nhost/pull/4196/files#diff-02e856f2ccd7f84b990e620aeaf939fdc1138f8930bd931be366dcff9075ac52">+107/-0</a></td>
</tr>
<tr>
  <td><strong>index.ts</strong><dd><code>Barrel export for the new component</code></dd></td>
  <td><a href="https://github.com/nhost/nhost/pull/4196/files#diff-3b5f189f2a95905d92195d35c2d81e63584f7a746f6ab5f2c9e922b0ad76a0f7">+2/-0</a></td>
</tr>
</table></details></td></tr>

<tr><td><strong>Database permissions editor</strong></td><td><details><summary>5 files</summary><table>
<tr>
  <td><strong>EditPermissionsForm.tsx</strong><dd><code>Pass roles/actions/labels and change handlers to the editor; key on role.action</code></dd></td>
  <td><a href="https://github.com/nhost/nhost/pull/4196/files#diff-f69ec2ff6a1d783fb7120b80b1b076d4f9b84f5129ea23b2eaa420d4685552f0">+6/-0</a></td>
</tr>
<tr>
  <td><strong>RolePermissionEditorForm.tsx</strong><dd><code>Replace static role/action header + Change button with RoleActionSwitcher</code></dd></td>
  <td><a href="https://github.com/nhost/nhost/pull/4196/files#diff-c7cc670c499aaa76537a1ac3848721988fa0196d4cca8f6b5376b4a14f01341d">+38/-15</a></td>
</tr>
<tr>
  <td><strong>ColumnPresetsSection.tsx</strong><dd><code>Migrate from MUI v2 to v3 (Select + Combobox), tighten own-row disable rule</code></dd></td>
  <td><a href="https://github.com/nhost/nhost/pull/4196/files#diff-41718098ed14645ea20bcec28b089569aa9a7337fe90df3ea36ca3db163990ef">+90/-130</a></td>
</tr>
<tr>
  <td><strong>ColumnPresetValueCombobox.tsx</strong><dd><code>New v3 popover-based combobox supporting permission variables and free entry</code></dd></td>
  <td><a href="https://github.com/nhost/nhost/pull/4196/files#diff-cca971ca6481c8de13082ffa278cf01083986f3c53cee7e99d16d69746526e75">+98/-0</a></td>
</tr>
<tr>
  <td><strong>ColumnAutocomplete.tsx</strong><dd><code>Fall back to externalValue in label/title when no matching column</code></dd></td>
  <td><a href="https://github.com/nhost/nhost/pull/4196/files#diff-c89efa530042890e7d6277c2e3c763cb7c9b9fc1d7c14c62839f4cf7c42528f7">+2/-2</a></td>
</tr>
</table></details></td></tr>

<tr><td><strong>Storage permissions editor</strong></td><td><details><summary>2 files</summary><table>
<tr>
  <td><strong>StoragePermissionsForm.tsx</strong><dd><code>Pass roles/actions and change handlers; key editor on role.action</code></dd></td>
  <td><a href="https://github.com/nhost/nhost/pull/4196/files#diff-631e86b7f3ffb4cba3cbac3c30d4175d614ddf2d760e14f1e40b19b566422dce">+7/-0</a></td>
</tr>
<tr>
  <td><strong>StorageRolePermissionEditorForm.tsx</strong><dd><code>Replace static header + Change button with RoleActionSwitcher</code></dd></td>
  <td><a href="https://github.com/nhost/nhost/pull/4196/files#diff-23854c76d75ba27fb4029b136ac5bafc19618827eda27583f6d5b7a07e9361bd">+21/-20</a></td>
</tr>
</table></details></td></tr>

<tr><td><strong>Apollo client caching</strong></td><td><details><summary>1 file</summary><table>
<tr>
  <td><strong>useRemoteApplicationGQLClient.tsx</strong><dd><code>Cache ApolloClient at module level keyed by subdomain.region; bypass in tests</code></dd></td>
  <td><a href="https://github.com/nhost/nhost/pull/4196/files#diff-3323409c3168ed8475247d08c5b868de300441b3363ae647fa298a90c4e3c973">+44/-6</a></td>
</tr>
</table></details></td></tr>

<tr><td><strong>Tests</strong></td><td><details><summary>3 files</summary><table>
<tr>
  <td><strong>ColumnPresetsSection.test.tsx</strong><dd><code>New tests for default state, add/remove rows, cross-row disable rule</code></dd></td>
  <td><a href="https://github.com/nhost/nhost/pull/4196/files#diff-e81518a84ead080ebe885bcb4abb4909baddee6003453ca54d18c06b20cd1641">+217/-0</a></td>
</tr>
<tr>
  <td><strong>StoragePermissionsForm.test.tsx</strong><dd><code>Use combobox role queries; remove obsolete Change-button test</code></dd></td>
  <td><a href="https://github.com/nhost/nhost/pull/4196/files#diff-b43c824016823bcb9c39ab9715dda58de892ce8567a33d44e97662ed5637de20">+6/-34</a></td>
</tr>
<tr>
  <td><strong>StorageRolePermissionEditorForm.test.tsx</strong><dd><code>Pass new props in renderEditor; assert dropdown contents instead of static text</code></dd></td>
  <td><a href="https://github.com/nhost/nhost/pull/4196/files#diff-3e1036533b942604c44a8384b854b7e442cabbd2ef556d148d001af6bc9c104a">+13/-11</a></td>
</tr>
</table></details></td></tr>
</tbody></table>

</details>

___

<!-- nhost-reviewer:end -->


