### PR TITLE
feat(dashboard): Allow empty string as default

### DIFF
--- a/dashboard/src/components/ui/v3/input-group.tsx
+++ b/dashboard/src/components/ui/v3/input-group.tsx
@@ -63,22 +63,16 @@ function InputGroupAddon({
 }: React.ComponentProps<'div'> & VariantProps<typeof inputGroupAddonVariants>) {
   return (
     <div
-      role="button"
+      role="group"
       data-slot="input-group-addon"
       data-align={align}
       className={cn(inputGroupAddonVariants({ align }), className)}
-      tabIndex={0}
-      onClick={(e) => {
+      onMouseDown={(e) => {
         if ((e.target as HTMLElement).closest('button')) {
           return;
         }
+        e.preventDefault();
         e.currentTarget.parentElement?.querySelector('input')?.focus();
-      }}
-      onKeyDown={(e) => {
-        if (e.key === 'Enter' || e.key === ' ') {
-          e.preventDefault();
-          (e.currentTarget as HTMLDivElement).click();
-        }
       }}
       {...props}
     />
@@ -152,10 +146,10 @@ const InputGroupInput = React.forwardRef<
 });
 InputGroupInput.displayName = 'InputGroupInput';
 
-function InputGroupTextarea({
-  className,
-  ...props
-}: React.ComponentProps<'textarea'>) {
+const InputGroupTextarea = React.forwardRef<
+  HTMLTextAreaElement,
+  React.ComponentProps<'textarea'>
+>(({ className, ...props }, ref) => {
   return (
     <Textarea
       data-slot="input-group-control"
@@ -163,10 +157,12 @@ function InputGroupTextarea({
         'flex-1 resize-none rounded-none border-0 bg-transparent py-3 shadow-none focus-visible:ring-0 dark:bg-transparent',
         className,
       )}
+      ref={ref}
       {...props}
     />
   );
-}
+});
+InputGroupTextarea.displayName = 'InputGroupTextarea';
 
 export {
   InputGroup,

--- a/dashboard/src/features/orgs/projects/database/dataGrid/components/BaseRecordForm/BaseRecordForm.test.tsx
+++ b/dashboard/src/features/orgs/projects/database/dataGrid/components/BaseRecordForm/BaseRecordForm.test.tsx
@@ -1,6 +1,7 @@
 import { FormProvider, useForm } from 'react-hook-form';
 import { vi } from 'vitest';
 import type { DataBrowserColumnMetadata } from '@/features/orgs/projects/database/dataGrid/types/dataBrowser';
+import { POSTGRES_DEFAULT_PLACEHOLDER } from '@/features/orgs/projects/database/dataGrid/utils/postgresDefaultPlaceholder';
 import { render, screen, TestUserEvent } from '@/tests/testUtils';
 import BaseRecordForm, { type BaseRecordFormProps } from './BaseRecordForm';
 
@@ -22,14 +23,12 @@ const mockColumns: DataBrowserColumnMetadata[] = [
   },
 ];
 
-function TestRecordFormWrapper(props: Partial<BaseRecordFormProps>) {
-  const columns = props.columns ?? mockColumns;
-  const methods = useForm({
-    defaultValues: columns.reduce<Record<string, null>>(
-      (acc, col) => ({ ...acc, [col.id]: null }),
-      {},
-    ),
-  });
+function TestRecordFormWrapper({
+  columns = mockColumns,
+  defaultValues = {},
+  ...props
+}: Partial<BaseRecordFormProps> & { defaultValues?: Record<string, unknown> }) {
+  const methods = useForm({ defaultValues });
   return (
     <FormProvider {...methods}>
       <BaseRecordForm
@@ -104,5 +103,123 @@ describe('BaseRecordForm', () => {
     render(<TestRecordFormWrapper columns={mockColumnsWithGenerated} />);
 
     expect(screen.getByText(/1 generated column omitted/i)).toBeInTheDocument();
+  });
+});
+
+describe('BaseRecordForm handleSubmit', () => {
+  beforeEach(() => {
+    mocks.onSubmit.mockResolvedValue(undefined);
+  });
+
+  const nullableColumnWithDefault: DataBrowserColumnMetadata = {
+    id: 'col',
+    type: 'text',
+    specificType: 'text',
+    dataType: 'text',
+    isNullable: true,
+    defaultValue: 'some_default',
+  };
+
+  const requiredColumnWithDefault: DataBrowserColumnMetadata = {
+    id: 'col',
+    type: 'text',
+    specificType: 'text',
+    dataType: 'text',
+    isNullable: false,
+    defaultValue: 'some_default',
+  };
+
+  const nullableColumnWithoutDefault: DataBrowserColumnMetadata = {
+    id: 'col',
+    type: 'text',
+    specificType: 'text',
+    dataType: 'text',
+    isNullable: true,
+    defaultValue: undefined,
+  };
+
+  it('nullable column with default uses DEFAULT when field is cleared', async () => {
+    render(
+      <TestRecordFormWrapper
+        columns={[nullableColumnWithDefault]}
+        defaultValues={{ col: POSTGRES_DEFAULT_PLACEHOLDER }}
+      />,
+    );
+
+    await new TestUserEvent().click(
+      screen.getByRole('button', { name: /save/i }),
+    );
+
+    expect(mocks.onSubmit).toHaveBeenCalledWith({
+      col: { fallbackValue: 'DEFAULT' },
+    });
+  });
+
+  it('nullable column with default uses NULL when NULL toggle is active', async () => {
+    render(
+      <TestRecordFormWrapper
+        columns={[nullableColumnWithDefault]}
+        defaultValues={{ col: null }}
+      />,
+    );
+
+    await new TestUserEvent().click(
+      screen.getByRole('button', { name: /save/i }),
+    );
+
+    expect(mocks.onSubmit).toHaveBeenCalledWith({
+      col: { value: null, fallbackValue: 'NULL' },
+    });
+  });
+
+  it('required column with default uses DEFAULT when field is empty', async () => {
+    render(
+      <TestRecordFormWrapper
+        columns={[requiredColumnWithDefault]}
+        defaultValues={{ col: null }}
+      />,
+    );
+
+    await new TestUserEvent().click(
+      screen.getByRole('button', { name: /save/i }),
+    );
+
+    expect(mocks.onSubmit).toHaveBeenCalledWith({
+      col: { value: null, fallbackValue: 'DEFAULT' },
+    });
+  });
+
+  it('nullable column without default uses NULL when field is empty', async () => {
+    render(
+      <TestRecordFormWrapper
+        columns={[nullableColumnWithoutDefault]}
+        defaultValues={{ col: null }}
+      />,
+    );
+
+    await new TestUserEvent().click(
+      screen.getByRole('button', { name: /save/i }),
+    );
+
+    expect(mocks.onSubmit).toHaveBeenCalledWith({
+      col: { value: null, fallbackValue: 'NULL' },
+    });
+  });
+
+  it('nullable column with default submits a literal empty string verbatim', async () => {
+    render(
+      <TestRecordFormWrapper
+        columns={[nullableColumnWithDefault]}
+        defaultValues={{ col: '' }}
+      />,
+    );
+
+    await new TestUserEvent().click(
+      screen.getByRole('button', { name: /save/i }),
+    );
+
+    expect(mocks.onSubmit).toHaveBeenCalledWith({
+      col: { value: '', specificType: 'text' },
+    });
   });
 });

--- a/dashboard/src/features/orgs/projects/database/dataGrid/components/BaseRecordForm/BaseRecordForm.tsx
+++ b/dashboard/src/features/orgs/projects/database/dataGrid/components/BaseRecordForm/BaseRecordForm.tsx
@@ -8,6 +8,7 @@ import type {
   ColumnInsertOptions,
   DataBrowserColumnMetadata,
 } from '@/features/orgs/projects/database/dataGrid/types/dataBrowser';
+import { POSTGRES_DEFAULT_PLACEHOLDER } from '@/features/orgs/projects/database/dataGrid/utils/postgresDefaultPlaceholder';
 import { cn } from '@/lib/utils';
 import type { DialogFormProps } from '@/types/common';
 
@@ -109,23 +110,30 @@ export default function BaseRecordForm({
           return options;
         }
 
-        if (!value && (gridColumn?.defaultValue || gridColumn?.isIdentity)) {
+        if (value === POSTGRES_DEFAULT_PLACEHOLDER) {
           return {
             ...options,
-            [columnId]: {
-              value,
-              fallbackValue: 'DEFAULT',
-            },
+            [columnId]: { fallbackValue: 'DEFAULT' },
           };
         }
 
-        if (!value && gridColumn?.isNullable) {
+        const isEmpty = value === null || value === undefined;
+
+        if (
+          isEmpty &&
+          !gridColumn?.isNullable &&
+          (gridColumn?.defaultValue || gridColumn?.isIdentity)
+        ) {
           return {
             ...options,
-            [columnId]: {
-              value,
-              fallbackValue: 'NULL',
-            },
+            [columnId]: { value, fallbackValue: 'DEFAULT' },
+          };
+        }
+
+        if (isEmpty && gridColumn?.isNullable) {
+          return {
+            ...options,
+            [columnId]: { value, fallbackValue: 'NULL' },
           };
         }
 

--- a/dashboard/src/features/orgs/projects/database/dataGrid/components/BaseTableForm/BaseTableForm.test.tsx
+++ b/dashboard/src/features/orgs/projects/database/dataGrid/components/BaseTableForm/BaseTableForm.test.tsx
@@ -115,7 +115,7 @@ async function fillColumnForm(
     const kind = defaultValueKind ?? 'literal';
     await pickAutocompleteOption(
       `columns.${index}.defaultValue`,
-      'Search functions...',
+      'Search...',
       kind === 'function' ? defaultValue : `Use '${defaultValue}' as a literal`,
       defaultValue,
       user,
@@ -601,6 +601,33 @@ describe('BaseTableForm', () => {
     expect(mocks.onSubmit.mock.calls[0][0].columns[0].defaultValue).toEqual({
       value: 'version()',
       custom: true,
+    });
+  });
+
+  it('should submit the cast literal when EMPTY STRING is picked for a text column', async () => {
+    render(<TestTableFormWrapper />);
+
+    const user = new TestUserEvent();
+
+    await user.type(screen.getByTestId('tableNameInput'), 'test_table');
+
+    await fillColumnForm(
+      {
+        columnName: 'note',
+        optionName: /^text.*text/,
+        typeValue: 'text',
+        defaultValue: 'EMPTY STRING',
+        defaultValueKind: 'function',
+      },
+      0,
+      user,
+    );
+
+    await TestUserEvent.fireClickEvent(screen.getByText('Save'));
+
+    expect(mocks.onSubmit.mock.calls[0][0].columns[0].defaultValue).toEqual({
+      value: "''::text",
+      custom: false,
     });
   });
 });

--- a/dashboard/src/features/orgs/projects/database/dataGrid/components/BaseTableForm/ColumnEditorRow/Checkbox.tsx
+++ b/dashboard/src/features/orgs/projects/database/dataGrid/components/BaseTableForm/ColumnEditorRow/Checkbox.tsx
@@ -1,0 +1,31 @@
+import { useFormContext, useWatch } from 'react-hook-form';
+import { FormCheckbox } from '@/components/form/FormCheckbox';
+import type { FieldArrayInputProps } from './ColumnEditorRow';
+
+export interface CheckboxProps extends FieldArrayInputProps {
+  name: string;
+  'aria-label'?: string;
+  'data-testid'?: string;
+}
+
+export function Checkbox({ name, index, ...props }: CheckboxProps) {
+  const { control } = useFormContext();
+  const primaryKeyIndices = useWatch({ name: 'primaryKeyIndices' });
+  const identityColumnIndex = useWatch({ name: 'identityColumnIndex' });
+  const isGenerated = useWatch({ name: `columns.${index}.isGenerated` });
+
+  const isPrimary = primaryKeyIndices.includes(`${index}`);
+  const isIdentity = identityColumnIndex === index;
+
+  return (
+    <FormCheckbox
+      control={control}
+      name={name}
+      disabled={isGenerated || isIdentity || isPrimary}
+      uncheckWhenDisabled
+      {...props}
+    />
+  );
+}
+
+export default Checkbox;

--- a/dashboard/src/features/orgs/projects/database/dataGrid/components/BaseTableForm/ColumnEditorRow/ColumnEditorRow.tsx
+++ b/dashboard/src/features/orgs/projects/database/dataGrid/components/BaseTableForm/ColumnEditorRow/ColumnEditorRow.tsx
@@ -1,192 +1,16 @@
-import { Sigma } from 'lucide-react';
 import { memo } from 'react';
-import { useFormContext, useWatch } from 'react-hook-form';
-import {
-  FormAutocomplete,
-  type FormAutocompleteOption,
-} from '@/components/form/FormAutocomplete';
-import { FormCheckbox } from '@/components/form/FormCheckbox';
-import { FormInput } from '@/components/form/FormInput';
-import { InlineCode } from '@/components/ui/v3/inline-code';
-import {
-  Tooltip,
-  TooltipContent,
-  TooltipTrigger,
-} from '@/components/ui/v3/tooltip';
-import type { ForeignKeyRelation } from '@/features/orgs/projects/database/dataGrid/types/dataBrowser';
-import {
-  identityTypes,
-  postgresTypeGroups,
-} from '@/features/orgs/projects/database/dataGrid/utils/postgresqlConstants';
+import { Checkbox } from './Checkbox';
 import ColumnComment from './ColumnComment';
 import DefaultValueAutocomplete from './DefaultValueAutocomplete';
+import { NameInput } from './NameInput';
 import { RemoveButton } from './RemoveButton';
+import { TypeAutocomplete } from './TypeAutocomplete';
 
 export interface FieldArrayInputProps {
   /**
    * Index of the field in the field array.
    */
   index: number;
-}
-
-function GeneratedBadge({
-  generationExpression,
-}: {
-  generationExpression: string | null | undefined;
-}) {
-  return (
-    <Tooltip>
-      <TooltipTrigger asChild>
-        <span className="mr-1 flex cursor-help items-center text-muted-foreground">
-          <Sigma width={14} height={14} aria-label="Generated column" />
-        </span>
-      </TooltipTrigger>
-      <TooltipContent sideOffset={8}>
-        <span className="font-semibold">Generated column</span> — value is
-        computed from {generationExpression}. Type and constraints are fixed,
-        but you can rename, edit the comment, or drop the column.
-      </TooltipContent>
-    </Tooltip>
-  );
-}
-
-function NameInput({ index }: FieldArrayInputProps) {
-  const { control, clearErrors, setValue, getValues } = useFormContext();
-  const originalColumnName = getValues(`columns.${index}.name`);
-  const foreignKeyRelations = getValues(`foreignKeyRelations`);
-  const originalForeignKeyRelationIndex = foreignKeyRelations.findIndex(
-    (relation: ForeignKeyRelation) =>
-      relation.columnName === originalColumnName,
-  );
-
-  const primaryKeyIndices: string[] = useWatch({ name: 'primaryKeyIndices' });
-  const isGenerated = useWatch({ name: `columns.${index}.isGenerated` });
-  const generationExpression = useWatch({
-    name: `columns.${index}.generationExpression`,
-  });
-
-  return (
-    <FormInput
-      control={control}
-      name={`columns.${index}.name`}
-      aria-label="Name"
-      placeholder="Enter name"
-      autoComplete="off"
-      className="border-border"
-      data-testid={`columns.${index}.name`}
-      addonEnd={
-        isGenerated ? (
-          <GeneratedBadge generationExpression={generationExpression} />
-        ) : undefined
-      }
-      onChange={(event) => {
-        if (originalForeignKeyRelationIndex > -1) {
-          setValue(
-            `foreignKeyRelations.${originalForeignKeyRelationIndex}.columnName`,
-            event.target.value,
-          );
-        }
-      }}
-      onBlur={(event) => {
-        clearErrors('columns');
-        if (!event.target.value && primaryKeyIndices.includes(`${index}`)) {
-          setValue(
-            'primaryKeyIndices',
-            primaryKeyIndices.filter((pk) => pk !== `${index}`),
-          );
-        }
-      }}
-    />
-  );
-}
-
-const typeOptions: FormAutocompleteOption[] = postgresTypeGroups.map(
-  ({ group, label, value }) => ({
-    value,
-    group,
-    label,
-    render: (
-      <div className="grid grid-flow-col items-baseline justify-start justify-items-start gap-1.5">
-        <span>{label}</span>
-        <InlineCode>{value}</InlineCode>
-      </div>
-    ),
-  }),
-);
-
-function TypeAutocomplete({ index }: FieldArrayInputProps) {
-  const { control, setValue } = useFormContext();
-  const identityColumnIndex = useWatch({ name: 'identityColumnIndex' });
-  const isGenerated = useWatch({ name: `columns.${index}.isGenerated` });
-  const type: string | null = useWatch({ name: `columns.${index}.type` });
-
-  if (isGenerated) {
-    return (
-      <div
-        className="flex h-10 w-full cursor-not-allowed items-center rounded-md border bg-background px-4 py-2 text-sm opacity-50"
-        data-testid={`columns.${index}.type`}
-      >
-        <span className="truncate">{type ?? ''}</span>
-      </div>
-    );
-  }
-
-  return (
-    <FormAutocomplete
-      control={control}
-      name={`columns.${index}.type`}
-      placeholder="Select type"
-      aria-label="Type"
-      searchPlaceholder="Search types..."
-      options={typeOptions}
-      filter={(value, search, keywords) => {
-        const haystack = [value, ...(keywords ?? [])].join(' ').toLowerCase();
-        return haystack.includes(search.toLowerCase()) ? 1 : 0;
-      }}
-      allowCustomValue
-      customValueLabel={(input) => `Use type: "${input}"`}
-      data-testid={`columns.${index}.type`}
-      popoverContentClassName="w-80"
-      onChange={(value) => {
-        setValue(`columns.${index}.defaultValue`, null);
-        if (
-          value !== null &&
-          !(identityTypes as readonly string[]).includes(value) &&
-          identityColumnIndex !== null &&
-          identityColumnIndex !== undefined &&
-          identityColumnIndex === index
-        ) {
-          setValue('identityColumnIndex', null);
-        }
-      }}
-    />
-  );
-}
-
-interface CheckboxProps extends FieldArrayInputProps {
-  name: string;
-  'aria-label'?: string;
-  'data-testid'?: string;
-}
-
-function Checkbox({ name, index, ...props }: CheckboxProps) {
-  const { control } = useFormContext();
-  const primaryKeyIndices = useWatch({ name: 'primaryKeyIndices' });
-  const identityColumnIndex = useWatch({ name: 'identityColumnIndex' });
-  const isGenerated = useWatch({ name: `columns.${index}.isGenerated` });
-
-  const isPrimary = primaryKeyIndices.includes(`${index}`);
-  const isIdentity = identityColumnIndex === index;
-
-  return (
-    <FormCheckbox
-      control={control}
-      name={name}
-      disabled={isGenerated || isIdentity || isPrimary}
-      uncheckWhenDisabled
-      {...props}
-    />
-  );
 }
 
 export interface ColumnEditorRowProps extends FieldArrayInputProps {
@@ -197,7 +21,7 @@ export interface ColumnEditorRowProps extends FieldArrayInputProps {
 }
 
 const ColumnEditorRow = memo(({ index, remove }: ColumnEditorRowProps) => (
-  <div className="flex w-full gap-2">
+  <div className="flex w-full items-start gap-2">
     <div className="w-52 flex-none">
       <NameInput index={index} />
     </div>
@@ -210,11 +34,11 @@ const ColumnEditorRow = memo(({ index, remove }: ColumnEditorRowProps) => (
       <DefaultValueAutocomplete index={index} />
     </div>
 
-    <div className="flex w-8 flex-none items-center justify-center">
+    <div className="flex h-10 w-8 flex-none items-center justify-center">
       <ColumnComment index={index} />
     </div>
 
-    <div className="flex w-13 flex-none items-center justify-center">
+    <div className="flex h-10 w-13 flex-none items-center justify-center">
       <Checkbox
         name={`columns.${index}.isNullable`}
         aria-label="Nullable"
@@ -223,7 +47,7 @@ const ColumnEditorRow = memo(({ index, remove }: ColumnEditorRowProps) => (
       />
     </div>
 
-    <div className="flex w-13 flex-none items-center justify-center">
+    <div className="flex h-10 w-13 flex-none items-center justify-center">
       <Checkbox
         name={`columns.${index}.isUnique`}
         aria-label="Unique"
@@ -232,7 +56,7 @@ const ColumnEditorRow = memo(({ index, remove }: ColumnEditorRowProps) => (
       />
     </div>
 
-    <div className="flex w-9 flex-none items-center justify-center">
+    <div className="flex h-10 w-9 flex-none items-center justify-center">
       <RemoveButton
         index={index}
         onClick={() => {

--- a/dashboard/src/features/orgs/projects/database/dataGrid/components/BaseTableForm/ColumnEditorRow/DefaultValueAutocomplete.test.tsx
+++ b/dashboard/src/features/orgs/projects/database/dataGrid/components/BaseTableForm/ColumnEditorRow/DefaultValueAutocomplete.test.tsx
@@ -1,0 +1,220 @@
+import { FormProvider, useForm, useWatch } from 'react-hook-form';
+import {
+  mockPointerEvent,
+  render,
+  screen,
+  TestUserEvent,
+} from '@/tests/testUtils';
+import DefaultValueAutocomplete from './DefaultValueAutocomplete';
+
+mockPointerEvent();
+
+interface WrapperProps {
+  type?: string | null;
+  isNullable?: boolean;
+  isGenerated?: boolean;
+  generationExpression?: string | null;
+  defaultValue?: { value: string; custom: boolean } | null;
+  identityColumnIndex?: number | null;
+}
+
+function Wrapper({
+  type = 'text',
+  isNullable = true,
+  isGenerated = false,
+  generationExpression = null,
+  defaultValue = null,
+  identityColumnIndex = null,
+}: WrapperProps) {
+  const form = useForm({
+    defaultValues: {
+      columns: [
+        {
+          type,
+          isNullable,
+          isGenerated,
+          generationExpression,
+          defaultValue,
+        },
+      ],
+      identityColumnIndex,
+    },
+  });
+
+  return (
+    <FormProvider {...form}>
+      <DefaultValueAutocomplete index={0} />
+      <DefaultValueProbe />
+    </FormProvider>
+  );
+}
+
+function DefaultValueProbe() {
+  const value = useWatch({ name: 'columns.0.defaultValue' });
+  return (
+    <div data-testid="default-value-probe">{JSON.stringify(value ?? null)}</div>
+  );
+}
+
+describe('DefaultValueAutocomplete', () => {
+  describe('trigger placeholder', () => {
+    it('shows "NULL" when the column is nullable and has no default', () => {
+      render(<Wrapper isNullable defaultValue={null} />);
+      expect(screen.getByTestId('columns.0.defaultValue')).toHaveTextContent(
+        'NULL',
+      );
+    });
+
+    it('shows "NO DEFAULT VALUE" when the column is not nullable and has no default', () => {
+      render(<Wrapper isNullable={false} defaultValue={null} />);
+      expect(screen.getByTestId('columns.0.defaultValue')).toHaveTextContent(
+        'NO DEFAULT VALUE',
+      );
+    });
+  });
+
+  describe('trigger label for a loaded default', () => {
+    it('renders "EMPTY STRING" for a ""::text default', () => {
+      render(
+        <Wrapper
+          type="text"
+          defaultValue={{ value: "''::text", custom: false }}
+        />,
+      );
+      expect(screen.getByTestId('columns.0.defaultValue')).toHaveTextContent(
+        'EMPTY STRING',
+      );
+    });
+
+    it('renders "EMPTY STRING" for a ""::character varying default', () => {
+      render(
+        <Wrapper
+          type="character varying"
+          defaultValue={{ value: "''::character varying", custom: false }}
+        />,
+      );
+      expect(screen.getByTestId('columns.0.defaultValue')).toHaveTextContent(
+        'EMPTY STRING',
+      );
+    });
+
+    it('renders a function expression verbatim', () => {
+      render(
+        <Wrapper
+          type="text"
+          defaultValue={{ value: 'version()', custom: false }}
+        />,
+      );
+      expect(screen.getByTestId('columns.0.defaultValue')).toHaveTextContent(
+        'version()',
+      );
+    });
+
+    it('renders a custom literal wrapped in quotes', () => {
+      render(
+        <Wrapper type="text" defaultValue={{ value: 'hello', custom: true }} />,
+      );
+      expect(screen.getByTestId('columns.0.defaultValue')).toHaveTextContent(
+        "'hello'",
+      );
+    });
+  });
+
+  describe('dropdown contents', () => {
+    async function openDropdown() {
+      const user = new TestUserEvent();
+      await user.click(screen.getByTestId('columns.0.defaultValue'));
+    }
+
+    it('lists EMPTY STRING for a text column', async () => {
+      render(<Wrapper type="text" />);
+      await openDropdown();
+      expect(
+        screen.getByRole('option', { name: 'EMPTY STRING' }),
+      ).toBeInTheDocument();
+    });
+
+    it('lists EMPTY STRING for a varchar column', async () => {
+      render(<Wrapper type="varchar" />);
+      await openDropdown();
+      expect(
+        screen.getByRole('option', { name: 'EMPTY STRING' }),
+      ).toBeInTheDocument();
+    });
+
+    it('lists EMPTY STRING for a varchar(10) column', async () => {
+      render(<Wrapper type="varchar(10)" />);
+      await openDropdown();
+      expect(
+        screen.getByRole('option', { name: 'EMPTY STRING' }),
+      ).toBeInTheDocument();
+    });
+
+    it('does not list EMPTY STRING for an int4 column', async () => {
+      render(<Wrapper type="int4" />);
+      await openDropdown();
+      expect(
+        screen.queryByRole('option', { name: 'EMPTY STRING' }),
+      ).not.toBeInTheDocument();
+    });
+
+    it('puts the NULL clear option first when the column is nullable', async () => {
+      render(<Wrapper type="text" isNullable />);
+      await openDropdown();
+      const options = screen.getAllByRole('option');
+      expect(options[0]).toHaveTextContent('NULL');
+    });
+
+    it('puts the NO DEFAULT VALUE clear option first when the column is not nullable', async () => {
+      render(<Wrapper type="text" isNullable={false} />);
+      await openDropdown();
+      const options = screen.getAllByRole('option');
+      expect(options[0]).toHaveTextContent('NO DEFAULT VALUE');
+    });
+  });
+
+  describe('selection', () => {
+    it('writes the cast literal to form state when EMPTY STRING is picked', async () => {
+      const user = new TestUserEvent();
+      render(<Wrapper type="text" defaultValue={null} />);
+
+      await user.click(screen.getByTestId('columns.0.defaultValue'));
+      await user.click(screen.getByRole('option', { name: 'EMPTY STRING' }));
+
+      expect(screen.getByTestId('default-value-probe')).toHaveTextContent(
+        JSON.stringify({ value: "''::text", custom: false }),
+      );
+    });
+
+    it('clears the form value back to null when the clear option is picked', async () => {
+      const user = new TestUserEvent();
+      render(
+        <Wrapper
+          type="text"
+          isNullable
+          defaultValue={{ value: 'version()', custom: false }}
+        />,
+      );
+
+      await user.click(screen.getByTestId('columns.0.defaultValue'));
+      await user.click(screen.getByRole('option', { name: 'NULL' }));
+
+      expect(screen.getByTestId('default-value-probe')).toHaveTextContent(
+        'null',
+      );
+    });
+  });
+
+  describe('generated column', () => {
+    it('renders the generation expression read-only and hides the autocomplete', () => {
+      render(<Wrapper isGenerated generationExpression="price * quantity" />);
+
+      expect(
+        screen.getByTestId('columns.0.generationExpression'),
+      ).toHaveTextContent('price * quantity');
+      expect(
+        screen.queryByTestId('columns.0.defaultValue'),
+      ).not.toBeInTheDocument();
+    });
+  });
+});

--- a/dashboard/src/features/orgs/projects/database/dataGrid/components/BaseTableForm/ColumnEditorRow/DefaultValueAutocomplete.tsx
+++ b/dashboard/src/features/orgs/projects/database/dataGrid/components/BaseTableForm/ColumnEditorRow/DefaultValueAutocomplete.tsx
@@ -5,14 +5,21 @@ import {
 } from '@/components/form/FormAutocomplete';
 import { InlineCode } from '@/components/ui/v3/inline-code';
 import type { ColumnDefaultValue } from '@/features/orgs/projects/database/dataGrid/types/dataBrowser';
-import { postgresFunctions } from '@/features/orgs/projects/database/dataGrid/utils/postgresqlConstants';
+import { getPostgresFunctionsKey } from '@/features/orgs/projects/database/dataGrid/utils/getPostgresFunctionsKey';
+import {
+  POSTGRESQL_FUNCTION_LABELS,
+  postgresFunctions,
+} from '@/features/orgs/projects/database/dataGrid/utils/postgresqlConstants';
 import type { FieldArrayInputProps } from './ColumnEditorRow';
+
+const CLEAR_DEFAULT_SENTINEL = '__nhost_clear_default__';
 
 export default function DefaultValueAutocomplete({
   index,
 }: FieldArrayInputProps) {
   const { control } = useFormContext();
   const type: string | null = useWatch({ name: `columns.${index}.type` });
+  const isNullable = useWatch({ name: `columns.${index}.isNullable` });
   const identityColumnIndex = useWatch({ name: 'identityColumnIndex' });
   const isIdentity = identityColumnIndex === index;
   const isGenerated = useWatch({ name: `columns.${index}.isGenerated` });
@@ -20,17 +27,30 @@ export default function DefaultValueAutocomplete({
     name: `columns.${index}.generationExpression`,
   });
 
-  const availableFunctions: FormAutocompleteOption[] = (
-    postgresFunctions[type as keyof typeof postgresFunctions] ?? []
-  ).map((functionName) => ({
-    value: functionName,
-    label: functionName,
-    render: (
-      <InlineCode className="bg-transparent px-0 text-xs dark:bg-transparent">
-        {functionName}
-      </InlineCode>
-    ),
-  }));
+  const clearLabel = isNullable ? 'NULL' : 'NO DEFAULT VALUE';
+  const clearOption: FormAutocompleteOption = {
+    value: CLEAR_DEFAULT_SENTINEL,
+    label: clearLabel,
+    render: <span className="text-muted-foreground">{clearLabel}</span>,
+  };
+
+  const functionKey = getPostgresFunctionsKey(type ?? undefined);
+  const functionOptions: FormAutocompleteOption[] = (
+    postgresFunctions[functionKey as keyof typeof postgresFunctions] ?? []
+  ).map((functionName) => {
+    const label = POSTGRESQL_FUNCTION_LABELS[functionName] ?? functionName;
+    return {
+      value: functionName,
+      label,
+      render: (
+        <InlineCode className="bg-transparent px-0 text-xs dark:bg-transparent">
+          {label}
+        </InlineCode>
+      ),
+    };
+  });
+
+  const availableFunctions = [clearOption, ...functionOptions];
 
   if (isGenerated) {
     return (
@@ -54,7 +74,7 @@ export default function DefaultValueAutocomplete({
             <span className="italic">{`'${current.value}'`}</span>
           ) : (
             <InlineCode className="bg-transparent px-0 text-xs dark:bg-transparent">
-              {current.value}
+              {POSTGRESQL_FUNCTION_LABELS[current.value] ?? current.value}
             </InlineCode>
           )
         ) : undefined;
@@ -63,7 +83,7 @@ export default function DefaultValueAutocomplete({
             value={current?.value ?? null}
             triggerLabel={triggerLabel}
             onChange={(next, meta) => {
-              if (next === null) {
+              if (next === null || next === CLEAR_DEFAULT_SENTINEL) {
                 field.onChange(null);
                 return;
               }
@@ -74,9 +94,9 @@ export default function DefaultValueAutocomplete({
             }}
             onBlur={field.onBlur}
             options={availableFunctions}
-            placeholder="NULL"
+            placeholder={isNullable ? 'NULL' : 'NO DEFAULT VALUE'}
             aria-label="Default Value"
-            searchPlaceholder="Search functions..."
+            searchPlaceholder="Search..."
             emptyText="Enter a custom default value"
             allowCustomValue
             customValueLabel={(input) => `Use '${input}' as a literal`}

--- a/dashboard/src/features/orgs/projects/database/dataGrid/components/BaseTableForm/ColumnEditorRow/GeneratedBadge.tsx
+++ b/dashboard/src/features/orgs/projects/database/dataGrid/components/BaseTableForm/ColumnEditorRow/GeneratedBadge.tsx
@@ -1,0 +1,29 @@
+import { Sigma } from 'lucide-react';
+import {
+  Tooltip,
+  TooltipContent,
+  TooltipTrigger,
+} from '@/components/ui/v3/tooltip';
+
+export interface GeneratedBadgeProps {
+  generationExpression: string | null | undefined;
+}
+
+export function GeneratedBadge({ generationExpression }: GeneratedBadgeProps) {
+  return (
+    <Tooltip>
+      <TooltipTrigger asChild>
+        <span className="mr-1 flex cursor-help items-center text-muted-foreground">
+          <Sigma width={14} height={14} aria-label="Generated column" />
+        </span>
+      </TooltipTrigger>
+      <TooltipContent sideOffset={8}>
+        <span className="font-semibold">Generated column</span> — value is
+        computed from {generationExpression}. Type and constraints are fixed,
+        but you can rename, edit the comment, or drop the column.
+      </TooltipContent>
+    </Tooltip>
+  );
+}
+
+export default GeneratedBadge;

--- a/dashboard/src/features/orgs/projects/database/dataGrid/components/BaseTableForm/ColumnEditorRow/NameInput.tsx
+++ b/dashboard/src/features/orgs/projects/database/dataGrid/components/BaseTableForm/ColumnEditorRow/NameInput.tsx
@@ -1,0 +1,57 @@
+import { useFormContext, useWatch } from 'react-hook-form';
+import { FormInput } from '@/components/form/FormInput';
+import type { ForeignKeyRelation } from '@/features/orgs/projects/database/dataGrid/types/dataBrowser';
+import type { FieldArrayInputProps } from './ColumnEditorRow';
+import { GeneratedBadge } from './GeneratedBadge';
+
+export function NameInput({ index }: FieldArrayInputProps) {
+  const { control, clearErrors, setValue, getValues } = useFormContext();
+  const originalColumnName = getValues(`columns.${index}.name`);
+  const foreignKeyRelations = getValues(`foreignKeyRelations`);
+  const originalForeignKeyRelationIndex = foreignKeyRelations.findIndex(
+    (relation: ForeignKeyRelation) =>
+      relation.columnName === originalColumnName,
+  );
+
+  const primaryKeyIndices: string[] = useWatch({ name: 'primaryKeyIndices' });
+  const isGenerated = useWatch({ name: `columns.${index}.isGenerated` });
+  const generationExpression = useWatch({
+    name: `columns.${index}.generationExpression`,
+  });
+
+  return (
+    <FormInput
+      control={control}
+      name={`columns.${index}.name`}
+      aria-label="Name"
+      placeholder="Enter name"
+      autoComplete="off"
+      className="border-border"
+      data-testid={`columns.${index}.name`}
+      addonEnd={
+        isGenerated ? (
+          <GeneratedBadge generationExpression={generationExpression} />
+        ) : undefined
+      }
+      onChange={(event) => {
+        if (originalForeignKeyRelationIndex > -1) {
+          setValue(
+            `foreignKeyRelations.${originalForeignKeyRelationIndex}.columnName`,
+            event.target.value,
+          );
+        }
+      }}
+      onBlur={(event) => {
+        clearErrors('columns');
+        if (!event.target.value && primaryKeyIndices.includes(`${index}`)) {
+          setValue(
+            'primaryKeyIndices',
+            primaryKeyIndices.filter((pk) => pk !== `${index}`),
+          );
+        }
+      }}
+    />
+  );
+}
+
+export default NameInput;

--- a/dashboard/src/features/orgs/projects/database/dataGrid/components/BaseTableForm/ColumnEditorRow/TypeAutocomplete.tsx
+++ b/dashboard/src/features/orgs/projects/database/dataGrid/components/BaseTableForm/ColumnEditorRow/TypeAutocomplete.tsx
@@ -1,0 +1,76 @@
+import { useFormContext, useWatch } from 'react-hook-form';
+import {
+  FormAutocomplete,
+  type FormAutocompleteOption,
+} from '@/components/form/FormAutocomplete';
+import { InlineCode } from '@/components/ui/v3/inline-code';
+import {
+  identityTypes,
+  postgresTypeGroups,
+} from '@/features/orgs/projects/database/dataGrid/utils/postgresqlConstants';
+import type { FieldArrayInputProps } from './ColumnEditorRow';
+
+const typeOptions: FormAutocompleteOption[] = postgresTypeGroups.map(
+  ({ group, label, value }) => ({
+    value,
+    group,
+    label,
+    render: (
+      <div className="grid grid-flow-col items-baseline justify-start justify-items-start gap-1.5">
+        <span>{label}</span>
+        <InlineCode>{value}</InlineCode>
+      </div>
+    ),
+  }),
+);
+
+export function TypeAutocomplete({ index }: FieldArrayInputProps) {
+  const { control, setValue } = useFormContext();
+  const identityColumnIndex = useWatch({ name: 'identityColumnIndex' });
+  const isGenerated = useWatch({ name: `columns.${index}.isGenerated` });
+  const type: string | null = useWatch({ name: `columns.${index}.type` });
+
+  if (isGenerated) {
+    return (
+      <div
+        className="flex h-10 w-full cursor-not-allowed items-center rounded-md border bg-background px-4 py-2 text-sm opacity-50"
+        data-testid={`columns.${index}.type`}
+      >
+        <span className="truncate">{type ?? ''}</span>
+      </div>
+    );
+  }
+
+  return (
+    <FormAutocomplete
+      control={control}
+      name={`columns.${index}.type`}
+      placeholder="Select type"
+      aria-label="Type"
+      searchPlaceholder="Search types..."
+      options={typeOptions}
+      filter={(value, search, keywords) => {
+        const haystack = [value, ...(keywords ?? [])].join(' ').toLowerCase();
+        return haystack.includes(search.toLowerCase()) ? 1 : 0;
+      }}
+      allowCustomValue
+      customValueLabel={(input) => `Use type: "${input}"`}
+      data-testid={`columns.${index}.type`}
+      popoverContentClassName="w-80"
+      onChange={(value) => {
+        setValue(`columns.${index}.defaultValue`, null);
+        if (
+          value !== null &&
+          !(identityTypes as readonly string[]).includes(value) &&
+          identityColumnIndex !== null &&
+          identityColumnIndex !== undefined &&
+          identityColumnIndex === index
+        ) {
+          setValue('identityColumnIndex', null);
+        }
+      }}
+    />
+  );
+}
+
+export default TypeAutocomplete;

--- a/dashboard/src/features/orgs/projects/database/dataGrid/components/CreateRecordForm/CreateRecordForm.tsx
+++ b/dashboard/src/features/orgs/projects/database/dataGrid/components/CreateRecordForm/CreateRecordForm.tsx
@@ -8,6 +8,10 @@ import type { BaseRecordFormProps } from '@/features/orgs/projects/database/data
 import { BaseRecordForm } from '@/features/orgs/projects/database/dataGrid/components/BaseRecordForm';
 import { useCreateRecordMutation } from '@/features/orgs/projects/database/dataGrid/hooks/useCreateRecordMutation';
 import type { ColumnInsertOptions } from '@/features/orgs/projects/database/dataGrid/types/dataBrowser';
+import {
+  POSTGRES_DEFAULT_PLACEHOLDER,
+  wrapResolverWithDefaultPlaceholder,
+} from '@/features/orgs/projects/database/dataGrid/utils/postgresDefaultPlaceholder';
 import { createDynamicValidationSchema } from '@/features/orgs/projects/database/dataGrid/utils/validationSchemaHelpers';
 import { triggerToast } from '@/utils/toast';
 
@@ -32,17 +36,23 @@ export default function CreateRecordForm({
 
   const form = useForm({
     defaultValues: props.columns.reduce((defaultValues, column) => {
-      if (column.defaultValue && column.type === 'boolean') {
+      const hasDefault = !!(column.defaultValue || column.isIdentity);
+
+      if (column.type === 'boolean' && column.defaultValue) {
+        return { ...defaultValues, [column.id]: column.defaultValue };
+      }
+
+      if (column.isNullable && hasDefault) {
         return {
           ...defaultValues,
-          [column.id]: column.defaultValue,
+          [column.id]: POSTGRES_DEFAULT_PLACEHOLDER,
         };
       }
 
       return { ...defaultValues, [column.id]: null };
     }, {}),
     reValidateMode: 'onSubmit',
-    resolver: yupResolver(validationSchema),
+    resolver: wrapResolverWithDefaultPlaceholder(yupResolver(validationSchema)),
   });
 
   async function handleSubmit(values: Record<string, ColumnInsertOptions>) {

--- a/dashboard/src/features/orgs/projects/database/dataGrid/components/DataBrowserGrid/DataBrowserGrid.tsx
+++ b/dashboard/src/features/orgs/projects/database/dataGrid/components/DataBrowserGrid/DataBrowserGrid.tsx
@@ -62,8 +62,7 @@ export function extractColumnMetadata(
   column: NormalizedQueryDataRow,
   isEditable: boolean = true,
 ): DataBrowserColumnMetadata {
-  const { normalizedDefaultValue, custom: isDefaultValueCustom } =
-    normalizeDefaultValue(column.column_default);
+  const normalizedDefault = normalizeDefaultValue(column.column_default);
 
   const isGenerated = isGeneratedColumn(column);
 
@@ -75,8 +74,8 @@ export function extractColumnMetadata(
     isIdentity: column.is_identity === 'YES',
     isGenerated,
     generationExpression: column.generation_expression ?? null,
-    defaultValue: normalizedDefaultValue,
-    isDefaultValueCustom,
+    defaultValue: normalizedDefault?.value ?? null,
+    isDefaultValueCustom: normalizedDefault?.custom ?? false,
     isUnique: column.is_unique,
     comment: column.column_comment,
     uniqueConstraints: column.unique_constraints,

--- a/dashboard/src/features/orgs/projects/database/dataGrid/components/DatabaseRecordInputGroup/DatabaseRecordInputGroup.tsx
+++ b/dashboard/src/features/orgs/projects/database/dataGrid/components/DatabaseRecordInputGroup/DatabaseRecordInputGroup.tsx
@@ -9,8 +9,9 @@ import { InlineCode } from '@/components/ui/v3/inline-code';
 import { SelectItem } from '@/components/ui/v3/select';
 import type { DataBrowserColumnMetadata } from '@/features/orgs/projects/database/dataGrid/types/dataBrowser/dataBrowser';
 import { getInputType } from '@/features/orgs/projects/database/dataGrid/utils/inputHelpers';
-import { normalizeDefaultValue } from '@/features/orgs/projects/database/dataGrid/utils/normalizeDefaultValue';
+import { POSTGRESQL_FUNCTION_LABELS } from '@/features/orgs/projects/database/dataGrid/utils/postgresqlConstants';
 import { cn } from '@/lib/utils';
+import NullDefaultToggleField from './NullDefaultToggleField';
 
 export interface DatabaseRecordInputGroupProps {
   /**
@@ -56,37 +57,33 @@ function convertEmptyStringToNull(
   return event.target.value === '' ? null : event.target.value;
 }
 
-function getPlaceholder(
-  defaultValue?: string,
+function getDefaultPlaceholder(
+  defaultValue: string | null | undefined,
+  isDefaultValueCustom: boolean,
   isIdentity?: boolean,
-  isNullable?: boolean,
 ) {
   if (isIdentity) {
     return 'Automatically generated as identity';
   }
 
-  if (!defaultValue && isNullable) {
-    return 'NULL';
+  if (!defaultValue) {
+    return undefined;
   }
 
-  if (!defaultValue) {
-    return '';
+  if (POSTGRESQL_FUNCTION_LABELS[defaultValue]) {
+    return POSTGRESQL_FUNCTION_LABELS[defaultValue];
   }
 
   if (!Number.isNaN(parseInt(defaultValue, 10))) {
     return defaultValue;
   }
 
-  const { normalizedDefaultValue, custom } = normalizeDefaultValue(
-    defaultValue,
-    { removeArgs: true },
-  );
-
-  if (custom) {
-    return normalizedDefaultValue;
+  if (isDefaultValueCustom) {
+    return defaultValue;
   }
 
-  return `Automatically generated value: ${normalizedDefaultValue}`;
+  const display = defaultValue.replace(/\([^)]*\)/g, '()');
+  return `Automatically generated value: ${display}`;
 }
 
 export default function DatabaseRecordInputGroup({
@@ -126,11 +123,14 @@ export default function DatabaseRecordInputGroup({
             type,
             specificType,
             defaultValue,
+            isDefaultValueCustom,
             isPrimary,
             isNullable,
             isIdentity,
             comment,
           } = column;
+
+          const hasDefault = !!(defaultValue || isIdentity);
 
           const isMultiline =
             specificType === 'text' ||
@@ -138,12 +138,6 @@ export default function DatabaseRecordInputGroup({
             specificType?.includes('character varying') ||
             specificType === 'json' ||
             specificType === 'jsonb';
-
-          const placeholder = getPlaceholder(
-            defaultValue,
-            isIdentity,
-            isNullable,
-          );
 
           const inputLabel = (
             <span className="inline-grid grid-flow-col gap-1">
@@ -195,6 +189,34 @@ export default function DatabaseRecordInputGroup({
             );
           }
 
+          if (isNullable && hasDefault) {
+            return (
+              <NullDefaultToggleField
+                ref={getRef(index)}
+                key={columnId}
+                inline
+                name={columnId!}
+                control={control}
+                label={inputLabel}
+                placeholder={getDefaultPlaceholder(
+                  defaultValue,
+                  !!isDefaultValueCustom,
+                  isIdentity,
+                )}
+                helperText={comment}
+                multiline={isMultiline}
+                className={cn({ 'focus-visible:ring-0': isMultiline })}
+                type={getInputType({ type, specificType })}
+              />
+            );
+          }
+
+          const placeholder =
+            getDefaultPlaceholder(
+              defaultValue,
+              !!isDefaultValueCustom,
+              isIdentity,
+            ) ?? (isNullable ? 'NULL' : undefined);
           const InputComponent = isMultiline ? FormTextarea : FormInput;
           return (
             <InputComponent

--- a/dashboard/src/features/orgs/projects/database/dataGrid/components/DatabaseRecordInputGroup/NullDefaultToggleField.test.tsx
+++ b/dashboard/src/features/orgs/projects/database/dataGrid/components/DatabaseRecordInputGroup/NullDefaultToggleField.test.tsx
@@ -1,0 +1,102 @@
+import { FormProvider, useForm, useWatch } from 'react-hook-form';
+import { POSTGRES_DEFAULT_PLACEHOLDER } from '@/features/orgs/projects/database/dataGrid/utils/postgresDefaultPlaceholder';
+import { render, screen, TestUserEvent } from '@/tests/testUtils';
+import NullDefaultToggleField from './NullDefaultToggleField';
+
+function ValueProbe() {
+  const value = useWatch({ name: 'col' });
+  return <div data-testid="value-probe">{JSON.stringify(value ?? null)}</div>;
+}
+
+function Wrapper({
+  defaultValue = POSTGRES_DEFAULT_PLACEHOLDER,
+  placeholder,
+}: {
+  defaultValue?: string | null;
+  placeholder?: string;
+}) {
+  const methods = useForm({ defaultValues: { col: defaultValue } });
+  return (
+    <FormProvider {...methods}>
+      <NullDefaultToggleField
+        control={methods.control}
+        name="col"
+        label="Column"
+        placeholder={placeholder}
+      />
+      <ValueProbe />
+    </FormProvider>
+  );
+}
+
+describe('NullDefaultToggleField', () => {
+  it('always renders both NULL and DEFAULT buttons', () => {
+    render(<Wrapper defaultValue={POSTGRES_DEFAULT_PLACEHOLDER} />);
+    expect(screen.getByRole('button', { name: 'NULL' })).toBeInTheDocument();
+    expect(screen.getByRole('button', { name: 'DEFAULT' })).toBeInTheDocument();
+  });
+
+  it('shows NULL placeholder and empty value after clicking NULL', async () => {
+    render(<Wrapper />);
+    await new TestUserEvent().click(
+      screen.getByRole('button', { name: 'NULL' }),
+    );
+    const input = screen.getByRole('textbox') as HTMLInputElement;
+    expect(input.value).toBe('');
+    expect(input).toHaveAttribute('placeholder', 'NULL');
+    expect(screen.getByTestId('value-probe')).toHaveTextContent('null');
+  });
+
+  it('writes the sentinel after clicking DEFAULT and shows the column default placeholder', async () => {
+    render(<Wrapper defaultValue={null} placeholder="some_default" />);
+    await new TestUserEvent().click(
+      screen.getByRole('button', { name: 'DEFAULT' }),
+    );
+    const input = screen.getByRole('textbox') as HTMLInputElement;
+    expect(input.value).toBe('');
+    expect(input).toHaveAttribute('placeholder', 'some_default');
+    expect(screen.getByTestId('value-probe')).toHaveTextContent(
+      JSON.stringify(POSTGRES_DEFAULT_PLACEHOLDER),
+    );
+  });
+
+  it('writes a literal empty string when the user clears a typed value', async () => {
+    const user = new TestUserEvent();
+    render(<Wrapper defaultValue="hello" />);
+    const input = screen.getByRole('textbox') as HTMLInputElement;
+    await user.clear(input);
+    expect(input.value).toBe('');
+    expect(screen.getByTestId('value-probe')).toHaveTextContent('""');
+  });
+
+  it('writes the typed value verbatim', async () => {
+    const user = new TestUserEvent();
+    render(<Wrapper defaultValue={null} />);
+    await user.type(screen.getByRole('textbox'), 'hello');
+    expect(screen.getByTestId('value-probe')).toHaveTextContent('"hello"');
+  });
+
+  it('marks DEFAULT as pressed when the field holds the sentinel', () => {
+    render(<Wrapper defaultValue={POSTGRES_DEFAULT_PLACEHOLDER} />);
+    expect(screen.getByRole('button', { name: 'DEFAULT' })).toHaveAttribute(
+      'aria-pressed',
+      'true',
+    );
+    expect(screen.getByRole('button', { name: 'NULL' })).toHaveAttribute(
+      'aria-pressed',
+      'false',
+    );
+  });
+
+  it('marks NULL as pressed when the field is null', () => {
+    render(<Wrapper defaultValue={null} />);
+    expect(screen.getByRole('button', { name: 'NULL' })).toHaveAttribute(
+      'aria-pressed',
+      'true',
+    );
+    expect(screen.getByRole('button', { name: 'DEFAULT' })).toHaveAttribute(
+      'aria-pressed',
+      'false',
+    );
+  });
+});

--- a/dashboard/src/features/orgs/projects/database/dataGrid/components/DatabaseRecordInputGroup/NullDefaultToggleField.tsx
+++ b/dashboard/src/features/orgs/projects/database/dataGrid/components/DatabaseRecordInputGroup/NullDefaultToggleField.tsx
@@ -1,0 +1,178 @@
+import {
+  type ChangeEvent,
+  type ForwardedRef,
+  forwardRef,
+  type ReactNode,
+} from 'react';
+import type { Control, FieldPath, FieldValues } from 'react-hook-form';
+import { mergeRefs } from 'react-merge-refs';
+import {
+  FormDescription,
+  FormField,
+  FormItem,
+  FormLabel,
+  FormMessage,
+} from '@/components/ui/v3/form';
+import {
+  InputGroup,
+  InputGroupAddon,
+  InputGroupButton,
+  InputGroupInput,
+  InputGroupTextarea,
+} from '@/components/ui/v3/input-group';
+import { POSTGRES_DEFAULT_PLACEHOLDER } from '@/features/orgs/projects/database/dataGrid/utils/postgresDefaultPlaceholder';
+import { cn } from '@/lib/utils';
+
+interface NullDefaultToggleFieldProps<
+  TFieldValues extends FieldValues = FieldValues,
+  TName extends FieldPath<TFieldValues> = FieldPath<TFieldValues>,
+> {
+  control: Control<TFieldValues>;
+  name: TName;
+  label: ReactNode;
+  placeholder?: string;
+  helperText?: string | null;
+  className?: string;
+  inline?: boolean;
+  type?: string;
+  multiline?: boolean;
+}
+
+function InnerNullDefaultToggleField<
+  TFieldValues extends FieldValues = FieldValues,
+  TName extends FieldPath<TFieldValues> = FieldPath<TFieldValues>,
+>(
+  {
+    control,
+    name,
+    label,
+    placeholder,
+    helperText,
+    className,
+    inline,
+    type = 'text',
+    multiline = false,
+  }: NullDefaultToggleFieldProps<TFieldValues, TName>,
+  ref: ForwardedRef<HTMLInputElement | HTMLTextAreaElement>,
+) {
+  return (
+    <FormField
+      control={control}
+      name={name}
+      render={({ field, fieldState }) => {
+        const isNull = field.value === null;
+        const isDefault = field.value === POSTGRES_DEFAULT_PLACEHOLDER;
+
+        const displayValue = isNull || isDefault ? '' : (field.value ?? '');
+
+        let inputPlaceholder: string | undefined;
+        if (isNull) {
+          inputPlaceholder = 'NULL';
+        } else if (isDefault) {
+          inputPlaceholder = placeholder ?? 'DEFAULT';
+        }
+
+        function handleTextChange(
+          e: ChangeEvent<HTMLInputElement | HTMLTextAreaElement>,
+        ) {
+          field.onChange(e.target.value);
+        }
+
+        function handleSetNull() {
+          field.onChange(null);
+        }
+
+        function handleSetDefault() {
+          field.onChange(POSTGRES_DEFAULT_PLACEHOLDER);
+        }
+
+        return (
+          <FormItem
+            className={cn({ 'flex w-full items-center gap-4 py-3': inline })}
+          >
+            <FormLabel
+              htmlFor={name as string}
+              className={cn({
+                'mt-2 w-52 max-w-52 flex-shrink-0 self-start': inline,
+              })}
+            >
+              {label}
+            </FormLabel>
+            <div
+              className={cn({
+                'flex w-[calc(100%-13.5rem)] max-w-[calc(100%-13.5rem)] flex-col gap-2':
+                  inline,
+              })}
+            >
+              <InputGroup
+                className={cn('bg-transparent dark:bg-transparent', {
+                  'border-destructive': !!fieldState.error,
+                })}
+              >
+                {multiline ? (
+                  <InputGroupTextarea
+                    id={name as string}
+                    placeholder={inputPlaceholder}
+                    value={displayValue as string}
+                    onChange={handleTextChange}
+                    ref={mergeRefs([
+                      field.ref,
+                      ref as ForwardedRef<HTMLTextAreaElement>,
+                    ])}
+                    className={cn('resize-none', className)}
+                  />
+                ) : (
+                  <InputGroupInput
+                    id={name as string}
+                    type={type}
+                    placeholder={inputPlaceholder}
+                    value={displayValue as string}
+                    onChange={handleTextChange}
+                    ref={mergeRefs([
+                      field.ref,
+                      ref as ForwardedRef<HTMLInputElement>,
+                    ])}
+                    className={className}
+                  />
+                )}
+                <InputGroupAddon align="inline-end">
+                  <InputGroupButton
+                    type="button"
+                    onClick={handleSetNull}
+                    aria-pressed={isNull}
+                  >
+                    NULL
+                  </InputGroupButton>
+                  <InputGroupButton
+                    type="button"
+                    onClick={handleSetDefault}
+                    aria-pressed={isDefault}
+                  >
+                    DEFAULT
+                  </InputGroupButton>
+                </InputGroupAddon>
+              </InputGroup>
+              {!!helperText && (
+                <FormDescription className="break-all px-[1px]">
+                  {helperText}
+                </FormDescription>
+              )}
+              <FormMessage />
+            </div>
+          </FormItem>
+        );
+      }}
+    />
+  );
+}
+
+const NullDefaultToggleField = forwardRef(InnerNullDefaultToggleField) as <
+  TFieldValues extends FieldValues = FieldValues,
+  TName extends FieldPath<TFieldValues> = FieldPath<TFieldValues>,
+>(
+  props: NullDefaultToggleFieldProps<TFieldValues, TName> & {
+    ref?: ForwardedRef<HTMLInputElement | HTMLTextAreaElement>;
+  },
+) => ReturnType<typeof InnerNullDefaultToggleField>;
+
+export default NullDefaultToggleField;

--- a/dashboard/src/features/orgs/projects/database/dataGrid/hooks/useCreateColumnMutation/prepareCreateColumnQuery.test.ts
+++ b/dashboard/src/features/orgs/projects/database/dataGrid/hooks/useCreateColumnMutation/prepareCreateColumnQuery.test.ts
@@ -1,8 +1,7 @@
-import { expect, test } from 'vitest';
 import type { DatabaseColumn } from '@/features/orgs/projects/database/dataGrid/types/dataBrowser';
 import prepareCreateColumnQuery from './prepareCreateColumnQuery';
 
-test('should prepare one query for a simple column', () => {
+it('should prepare one query for a simple column', () => {
   const column: DatabaseColumn = {
     name: 'test_column',
     type: 'text',
@@ -21,7 +20,30 @@ test('should prepare one query for a simple column', () => {
   );
 });
 
-test('should prepare a minimum of two queries for a column with a comment', () => {
+it(`should produce DEFAULT ''::text in the SQL for an empty-string default`, () => {
+  const column: DatabaseColumn = {
+    name: 'test_column',
+    type: 'text',
+    defaultValue: {
+      value: "''::text",
+      custom: false,
+    },
+  };
+
+  const transaction = prepareCreateColumnQuery({
+    dataSource: 'default',
+    schema: 'public',
+    table: 'test_table',
+    column,
+  });
+
+  expect(transaction).toHaveLength(1);
+  expect(transaction[0].args.sql).toBe(
+    "ALTER TABLE public.test_table ADD test_column text DEFAULT ''::text NOT NULL;",
+  );
+});
+
+it('should prepare a minimum of two queries for a column with a comment', () => {
   const column: DatabaseColumn = {
     name: 'test_column',
     type: 'text',
@@ -44,7 +66,7 @@ test('should prepare a minimum of two queries for a column with a comment', () =
   );
 });
 
-test('should not prepare an identity query if column is not of the right type', () => {
+it('should not prepare an identity query if column is not of the right type', () => {
   // Note that `text` columns can't be identity columns.
   const column: DatabaseColumn = {
     name: 'test_column',
@@ -65,7 +87,7 @@ test('should not prepare an identity query if column is not of the right type', 
   );
 });
 
-test('should prepare a minimum of two queries for an identity column', () => {
+it('should prepare a minimum of two queries for an identity column', () => {
   const column: DatabaseColumn = {
     name: 'test_column',
     type: 'int4',
@@ -88,7 +110,7 @@ test('should prepare a minimum of two queries for an identity column', () => {
   );
 });
 
-test('should prepare a minimum of two queries for a column that has a foreign key relation', () => {
+it('should prepare a minimum of two queries for a column that has a foreign key relation', () => {
   const column: DatabaseColumn = {
     name: 'test_column',
     type: 'int4',
@@ -119,7 +141,7 @@ test('should prepare a minimum of two queries for a column that has a foreign ke
   );
 });
 
-test(`should not prepare a query for the foreign key relation if generator is disabled`, () => {
+it(`should not prepare a query for the foreign key relation if generator is disabled`, () => {
   const column: DatabaseColumn = {
     name: 'test_column',
     type: 'int4',

--- a/dashboard/src/features/orgs/projects/database/dataGrid/hooks/useCreateTableMutation/prepareCreateTableQuery.test.ts
+++ b/dashboard/src/features/orgs/projects/database/dataGrid/hooks/useCreateTableMutation/prepareCreateTableQuery.test.ts
@@ -1,9 +1,8 @@
-import { expect, test } from 'vitest';
 import type { DatabaseTable } from '@/features/orgs/projects/database/dataGrid/types/dataBrowser';
 import prepareCreateTableQuery from './prepareCreateTableQuery';
 
 describe('prepareCreateTableQuery', () => {
-  test('should prepare a simple query', () => {
+  it('should prepare a simple query', () => {
     const table: DatabaseTable = {
       name: 'test_table',
       columns: [
@@ -31,7 +30,7 @@ describe('prepareCreateTableQuery', () => {
     );
   });
 
-  test('should prepare a query with foreign keys', () => {
+  it('should prepare a query with foreign keys', () => {
     const table: DatabaseTable = {
       name: 'test_table',
       columns: [
@@ -73,7 +72,7 @@ describe('prepareCreateTableQuery', () => {
     );
   });
 
-  test('should prepare a query with unique keys', () => {
+  it('should prepare a query with unique keys', () => {
     const table: DatabaseTable = {
       name: 'test_table',
       columns: [
@@ -102,7 +101,7 @@ describe('prepareCreateTableQuery', () => {
     );
   });
 
-  test('should prepare a query with nullable columns', () => {
+  it('should prepare a query with nullable columns', () => {
     const table: DatabaseTable = {
       name: 'test_table',
       columns: [
@@ -136,7 +135,7 @@ describe('prepareCreateTableQuery', () => {
     );
   });
 
-  test('should prepare a query with default values', () => {
+  it('should prepare a query with default values', () => {
     const table: DatabaseTable = {
       name: 'test_table',
       columns: [
@@ -203,7 +202,46 @@ describe('prepareCreateTableQuery', () => {
     );
   });
 
-  test('should prepare a query with an identity column', () => {
+  it('should prepare a query with an empty-string default for text columns', () => {
+    const table: DatabaseTable = {
+      name: 'test_table',
+      columns: [
+        {
+          name: 'id',
+          type: 'uuid',
+        },
+        {
+          name: 'name',
+          type: 'text',
+          defaultValue: {
+            value: "''::text",
+            custom: false,
+          },
+        },
+        {
+          name: 'nickname',
+          type: 'character varying',
+          defaultValue: {
+            value: "''::character varying",
+            custom: false,
+          },
+        },
+      ],
+      primaryKey: ['id'],
+    };
+
+    const transaction = prepareCreateTableQuery({
+      dataSource: 'default',
+      schema: 'public',
+      table,
+    });
+
+    expect(transaction).toHaveLength(1);
+    expect(transaction[0].args.sql).toBe(
+      "CREATE TABLE public.test_table (id uuid NOT NULL, name text DEFAULT ''::text NOT NULL, nickname character varying DEFAULT ''::character varying NOT NULL, PRIMARY KEY (id));",
+    );
+  });
+  it('should prepare a query with an identity column', () => {
     const table: DatabaseTable = {
       name: 'test_table',
       columns: [
@@ -238,7 +276,7 @@ describe('prepareCreateTableQuery', () => {
       "CREATE TABLE public.test_table (id int4 GENERATED ALWAYS AS IDENTITY, name text, is_active bool DEFAULT 'true', PRIMARY KEY (id));",
     );
   });
-  test('should prepare a query with no primary key', () => {
+  it('should prepare a query with no primary key', () => {
     const table: DatabaseTable = {
       name: 'test_table',
       primaryKey: [],
@@ -267,7 +305,7 @@ describe('prepareCreateTableQuery', () => {
     );
   });
 
-  test('should add comments to columns', () => {
+  it('should add comments to columns', () => {
     const table: DatabaseTable = {
       name: 'test_table',
       columns: [

--- a/dashboard/src/features/orgs/projects/database/dataGrid/hooks/useUpdateColumnMutation/prepareUpdateColumnQuery.test.ts
+++ b/dashboard/src/features/orgs/projects/database/dataGrid/hooks/useUpdateColumnMutation/prepareUpdateColumnQuery.test.ts
@@ -1,8 +1,7 @@
-import { expect, test } from 'vitest';
 import prepareUpdateColumnQuery from './prepareUpdateColumnQuery';
 
 describe('prepareUpdateColumnQuery', () => {
-  test('should not contain any queries if the updated column does not have any changes', () => {
+  it('should not contain any queries if the updated column does not have any changes', () => {
     const transaction = prepareUpdateColumnQuery({
       dataSource: 'test_datasource',
       schema: 'test_schema',
@@ -28,7 +27,7 @@ describe('prepareUpdateColumnQuery', () => {
     expect(transaction).toHaveLength(0);
   });
 
-  test("should contain a query to rename the column if the updated column's name has changed", () => {
+  it("should contain a query to rename the column if the updated column's name has changed", () => {
     const transaction = prepareUpdateColumnQuery({
       dataSource: 'test_datasource',
       schema: 'test_schema',
@@ -51,7 +50,7 @@ describe('prepareUpdateColumnQuery', () => {
     );
   });
 
-  test("should contain queries to drop the default value and to change the type if the updated column's type has changed", () => {
+  it("should contain queries to drop the default value and to change the type if the updated column's type has changed", () => {
     const transaction = prepareUpdateColumnQuery({
       dataSource: 'test_datasource',
       schema: 'test_schema',
@@ -77,7 +76,7 @@ describe('prepareUpdateColumnQuery', () => {
     );
   });
 
-  test('should contain a query to drop the default value if the updated column has no default value', () => {
+  it('should contain a query to drop the default value if the updated column has no default value', () => {
     const transaction = prepareUpdateColumnQuery({
       dataSource: 'test_datasource',
       schema: 'test_schema',
@@ -102,7 +101,51 @@ describe('prepareUpdateColumnQuery', () => {
     );
   });
 
-  test("should contain a query to set the default value to the updated column's literal default value", () => {
+  it('should not contain any default-value query when neither column has a default', () => {
+    const transaction = prepareUpdateColumnQuery({
+      dataSource: 'test_datasource',
+      schema: 'test_schema',
+      table: 'test_table',
+      originalColumn: {
+        id: 'name',
+        name: 'name',
+        type: 'text',
+      },
+      column: {
+        id: 'name',
+        name: 'name',
+        type: 'text',
+      },
+    });
+
+    expect(transaction).toHaveLength(0);
+  });
+
+  it('should contain a query to set the default value when the original column has no default', () => {
+    const transaction = prepareUpdateColumnQuery({
+      dataSource: 'test_datasource',
+      schema: 'test_schema',
+      table: 'test_table',
+      originalColumn: {
+        id: 'name',
+        name: 'name',
+        type: 'text',
+      },
+      column: {
+        id: 'name',
+        name: 'name',
+        type: 'text',
+        defaultValue: { value: 'hello', custom: true },
+      },
+    });
+
+    expect(transaction).toHaveLength(1);
+    expect(transaction[0].args.sql).toBe(
+      "ALTER TABLE test_schema.test_table ALTER COLUMN name SET DEFAULT 'hello';",
+    );
+  });
+
+  it("should contain a query to set the default value to the updated column's literal default value", () => {
     const transaction = prepareUpdateColumnQuery({
       dataSource: 'test_datasource',
       schema: 'test_schema',
@@ -127,7 +170,7 @@ describe('prepareUpdateColumnQuery', () => {
     );
   });
 
-  test('should emit SET DEFAULT when only the custom flag flips on a colliding value', () => {
+  it('should emit SET DEFAULT when only the custom flag flips on a colliding value', () => {
     const transaction = prepareUpdateColumnQuery({
       dataSource: 'test_datasource',
       schema: 'test_schema',
@@ -151,8 +194,59 @@ describe('prepareUpdateColumnQuery', () => {
       "ALTER TABLE test_schema.test_table ALTER COLUMN name SET DEFAULT 'version()';",
     );
   });
+  it('should contain a query to set the default value if the type changed from custom to non-custom or vice versa', () => {
+    // change default value from custom (literal) 'version()' to non-custom
+    // (non-literal) 'version()'
+    const customToNonCustomTransaction = prepareUpdateColumnQuery({
+      dataSource: 'test_datasource',
+      schema: 'test_schema',
+      table: 'test_table',
+      originalColumn: {
+        id: 'name',
+        name: 'name',
+        type: 'text',
+        defaultValue: { value: 'version()', custom: true },
+      },
+      column: {
+        id: 'name',
+        name: 'name',
+        type: 'text',
+        defaultValue: { value: 'version()', custom: false },
+      },
+    });
 
-  test('should contain a query to set the comment to null if the updated column has no comments', () => {
+    expect(customToNonCustomTransaction).toHaveLength(1);
+    expect(customToNonCustomTransaction[0].args.sql).toBe(
+      'ALTER TABLE test_schema.test_table ALTER COLUMN name SET DEFAULT version();',
+    );
+
+    // change default value from non-custom (non-literal) version() to custom
+    // (literal) version()
+    const nonCustomToCustomTransaction = prepareUpdateColumnQuery({
+      dataSource: 'test_datasource',
+      schema: 'test_schema',
+      table: 'test_table',
+      originalColumn: {
+        id: 'name',
+        name: 'name',
+        type: 'text',
+        defaultValue: { value: 'version()', custom: false },
+      },
+      column: {
+        id: 'name',
+        name: 'name',
+        type: 'text',
+        defaultValue: { value: 'version()', custom: true },
+      },
+    });
+
+    expect(nonCustomToCustomTransaction).toHaveLength(1);
+    expect(nonCustomToCustomTransaction[0].args.sql).toBe(
+      "ALTER TABLE test_schema.test_table ALTER COLUMN name SET DEFAULT 'version()';",
+    );
+  });
+
+  it('should contain a query to set the comment to null if the updated column has no comments', () => {
     const transaction = prepareUpdateColumnQuery({
       dataSource: 'test_datasource',
       schema: 'test_schema',
@@ -176,7 +270,7 @@ describe('prepareUpdateColumnQuery', () => {
     );
   });
 
-  test('should contain a query to set the comment if the updated column any comments', () => {
+  it('should contain a query to set the comment if the updated column any comments', () => {
     const transaction = prepareUpdateColumnQuery({
       dataSource: 'test_datasource',
       schema: 'test_schema',
@@ -200,7 +294,7 @@ describe('prepareUpdateColumnQuery', () => {
     );
   });
 
-  test('should contain a query to set the comment if the update column has a different comment than the original column', () => {
+  it('should contain a query to set the comment if the update column has a different comment than the original column', () => {
     const transaction = prepareUpdateColumnQuery({
       dataSource: 'test_datasource',
       schema: 'test_schema',
@@ -225,7 +319,7 @@ describe('prepareUpdateColumnQuery', () => {
     );
   });
 
-  test('should contain a query to drop "not null" constraint if the updated column is nullable', () => {
+  it('should contain a query to drop "not null" constraint if the updated column is nullable', () => {
     const transaction = prepareUpdateColumnQuery({
       dataSource: 'test_datasource',
       schema: 'test_schema',
@@ -250,7 +344,7 @@ describe('prepareUpdateColumnQuery', () => {
     );
   });
 
-  test('should contain a query to add a "not null" constraint if the updated column is not nullable anymore', () => {
+  it('should contain a query to add a "not null" constraint if the updated column is not nullable anymore', () => {
     const transaction = prepareUpdateColumnQuery({
       dataSource: 'test_datasource',
       schema: 'test_schema',
@@ -275,7 +369,7 @@ describe('prepareUpdateColumnQuery', () => {
     );
   });
 
-  test('should contain a query to add a unique constraint if the updated column should be unique', () => {
+  it('should contain a query to add a unique constraint if the updated column should be unique', () => {
     const transaction = prepareUpdateColumnQuery({
       dataSource: 'test_datasource',
       schema: 'test_schema',
@@ -300,7 +394,7 @@ describe('prepareUpdateColumnQuery', () => {
     );
   });
 
-  test('should contain a query to drop unique constraint if the updated column should not be unique anymore', () => {
+  it('should contain a query to drop unique constraint if the updated column should not be unique anymore', () => {
     const transaction = prepareUpdateColumnQuery({
       dataSource: 'test_datasource',
       schema: 'test_schema',
@@ -326,7 +420,7 @@ describe('prepareUpdateColumnQuery', () => {
     );
   });
 
-  test('should contain a query to generate column as identity if the updated column should be used as identity', () => {
+  it('should contain a query to generate column as identity if the updated column should be used as identity', () => {
     const transaction = prepareUpdateColumnQuery({
       dataSource: 'test_datasource',
       schema: 'test_schema',
@@ -351,7 +445,7 @@ describe('prepareUpdateColumnQuery', () => {
     );
   });
 
-  test('should contain a query to drop identity if the updated column should not be used as identity', () => {
+  it('should contain a query to drop identity if the updated column should not be used as identity', () => {
     const transaction = prepareUpdateColumnQuery({
       dataSource: 'test_datasource',
       schema: 'test_schema',
@@ -376,7 +470,7 @@ describe('prepareUpdateColumnQuery', () => {
     );
   });
 
-  test('should prepare a query when a foreign key should be created', () => {
+  it('should prepare a query when a foreign key should be created', () => {
     const transaction = prepareUpdateColumnQuery({
       dataSource: 'default',
       schema: 'public',
@@ -408,7 +502,7 @@ describe('prepareUpdateColumnQuery', () => {
     );
   });
 
-  test('should prepare a query when the foreign key should be removed', () => {
+  it('should prepare a query when the foreign key should be removed', () => {
     const transaction = prepareUpdateColumnQuery({
       dataSource: 'default',
       schema: 'public',
@@ -441,7 +535,7 @@ describe('prepareUpdateColumnQuery', () => {
     );
   });
 
-  test('should prepare two queries when the foreign key should be updated', () => {
+  it('should prepare two queries when the foreign key should be updated', () => {
     const transaction = prepareUpdateColumnQuery({
       dataSource: 'default',
       schema: 'public',
@@ -485,7 +579,7 @@ describe('prepareUpdateColumnQuery', () => {
     );
   });
 
-  test('should prepare two queries when foreign key is changed but it should be skipped', () => {
+  it('should prepare two queries when foreign key is changed but it should be skipped', () => {
     const transaction = prepareUpdateColumnQuery({
       dataSource: 'default',
       schema: 'public',
@@ -523,7 +617,7 @@ describe('prepareUpdateColumnQuery', () => {
 
     expect(transaction).toHaveLength(0);
   });
-  test('should contain queries to change the type to varchar(10) when column type is updated', () => {
+  it('should contain queries to change the type to varchar(10) when column type is updated', () => {
     const transaction = prepareUpdateColumnQuery({
       dataSource: 'test_datasource',
       schema: 'test_schema',

--- a/dashboard/src/features/orgs/projects/database/dataGrid/hooks/useUpdateRecordMutation/updateRecord.test.ts
+++ b/dashboard/src/features/orgs/projects/database/dataGrid/hooks/useUpdateRecordMutation/updateRecord.test.ts
@@ -100,7 +100,7 @@ describe('updateRecord', () => {
     expect(sql).not.toMatch(/tags = '(\[.*\])'/);
   });
 
-  test('sets a column to NULL when reset is true', async () => {
+  test("sets a column to NULL when reset is 'null'", async () => {
     const row = makeRow([
       { id: 'id', isPrimary: true, specificType: 'integer', value: 1 },
       { id: 'bio', specificType: 'text', value: 'hello' },
@@ -109,11 +109,28 @@ describe('updateRecord', () => {
     await updateRecord({
       ...defaultOptions,
       row,
-      columnsToUpdate: { bio: { value: null, reset: true } },
+      columnsToUpdate: { bio: { reset: 'null' } },
     });
 
     const sql = (capturedBody as CapturedRequest).args[0].args.sql;
     expect(sql).toContain('bio = NULL');
+  });
+
+  test("sets a column to DEFAULT when reset is 'default'", async () => {
+    const row = makeRow([
+      { id: 'id', isPrimary: true, specificType: 'integer', value: 1 },
+      { id: 'created_at', specificType: 'timestamptz', value: '2026-01-01' },
+    ]);
+
+    await updateRecord({
+      ...defaultOptions,
+      row,
+      columnsToUpdate: { created_at: { reset: 'default' } },
+    });
+
+    const sql = (capturedBody as CapturedRequest).args[0].args.sql;
+    expect(sql).toContain('created_at = DEFAULT');
+    expect(sql).not.toContain('created_at = NULL');
   });
 
   test('builds the WHERE clause from primary key columns', async () => {
@@ -158,6 +175,47 @@ describe('updateRecord', () => {
         columnsToUpdate: { tags: { value: '{a,b}' } },
       }),
     ).rejects.toThrow('Invalid array value for column "tags"');
+  });
+
+  it("sets an array column to DEFAULT when reset is 'default' without emitting ARRAY[...] syntax", async () => {
+    const row = makeRow([
+      { id: 'id', isPrimary: true, specificType: 'integer', value: 1 },
+      { id: 'tags', specificType: 'text[]', value: ['a', 'b'] },
+    ]);
+
+    await updateRecord({
+      ...defaultOptions,
+      row,
+      columnsToUpdate: { tags: { reset: 'default' } },
+    });
+
+    const sql = (capturedBody as CapturedRequest).args[0].args.sql;
+    expect(sql).toContain('tags = DEFAULT');
+    expect(sql).not.toContain('ARRAY[');
+  });
+
+  it('combines NULL, DEFAULT, and value updates in a single SET clause', async () => {
+    const row = makeRow([
+      { id: 'id', isPrimary: true, specificType: 'integer', value: 1 },
+      { id: 'name', specificType: 'text', value: 'Alice' },
+      { id: 'age', specificType: 'integer', value: 30 },
+      { id: 'bio', specificType: 'text', value: 'hello' },
+    ]);
+
+    await updateRecord({
+      ...defaultOptions,
+      row,
+      columnsToUpdate: {
+        name: { reset: 'null' },
+        age: { reset: 'default' },
+        bio: { value: 'foo' },
+      },
+    });
+
+    const sql = (capturedBody as CapturedRequest).args[0].args.sql;
+    expect(sql).toContain('name = NULL');
+    expect(sql).toContain('age = DEFAULT');
+    expect(sql).toContain("bio = 'foo'");
   });
 
   test('throws a normalized error when the server returns an error', async () => {

--- a/dashboard/src/features/orgs/projects/database/dataGrid/hooks/useUpdateRecordMutation/updateRecord.ts
+++ b/dashboard/src/features/orgs/projects/database/dataGrid/hooks/useUpdateRecordMutation/updateRecord.ts
@@ -68,7 +68,11 @@ export default async function updateRecord<
     .map((key) => {
       const { value, reset } = columnsToUpdate[key];
 
-      if (reset) {
+      if (reset === 'default') {
+        return format('%I = DEFAULT', key);
+      }
+
+      if (reset === 'null') {
         return format('%I = NULL', key);
       }
 

--- a/dashboard/src/features/orgs/projects/database/dataGrid/types/dataBrowser/dataBrowser.ts
+++ b/dashboard/src/features/orgs/projects/database/dataGrid/types/dataBrowser/dataBrowser.ts
@@ -259,9 +259,10 @@ export interface ColumnUpdateOptions {
   // biome-ignore lint/suspicious/noExplicitAny: TODO
   value?: any;
   /**
-   * Whether to set the column to NULL.
+   * How to reset the column. `'null'` sets it to NULL;
+   * `'default'` sets it to its column DEFAULT.
    */
-  reset?: boolean;
+  reset?: 'null' | 'default';
 }
 
 /**
@@ -551,9 +552,9 @@ export interface DataBrowserColumnMetadata {
    */
   dataType: string;
   /**
-   * Default value of the column.
+   * Default value of the column. `null` when the column has no default.
    */
-  defaultValue?: string;
+  defaultValue?: string | null;
   /**
    * Determines whether or not the column is a primary key of the table.
    */

--- a/dashboard/src/features/orgs/projects/database/dataGrid/utils/getPostgresFunctionsKey/getPostgresFunctionsKey.test.ts
+++ b/dashboard/src/features/orgs/projects/database/dataGrid/utils/getPostgresFunctionsKey/getPostgresFunctionsKey.test.ts
@@ -1,0 +1,40 @@
+import getPostgresFunctionsKey from './getPostgresFunctionsKey';
+
+it('should return an empty string for empty or undefined input', () => {
+  expect(getPostgresFunctionsKey(undefined)).toBe('');
+  expect(getPostgresFunctionsKey('')).toBe('');
+});
+
+it('should pass canonical keys through unchanged', () => {
+  expect(getPostgresFunctionsKey('text')).toBe('text');
+  expect(getPostgresFunctionsKey('character varying')).toBe(
+    'character varying',
+  );
+});
+
+it('should map aliases to their canonical form', () => {
+  expect(getPostgresFunctionsKey('varchar')).toBe('character varying');
+});
+
+it('should strip length modifiers from alias and non-alias forms', () => {
+  expect(getPostgresFunctionsKey('varchar(10)')).toBe('character varying');
+  expect(getPostgresFunctionsKey('character varying(255)')).toBe(
+    'character varying',
+  );
+  expect(getPostgresFunctionsKey('numeric(10, 2)')).toBe('numeric');
+});
+
+it('should tolerate whitespace around parentheses', () => {
+  expect(getPostgresFunctionsKey('varchar (10)')).toBe('character varying');
+  expect(getPostgresFunctionsKey('  numeric(10, 2)  ')).toBe('numeric');
+});
+
+it('should pass unknown types through unchanged', () => {
+  expect(getPostgresFunctionsKey('mytype')).toBe('mytype');
+});
+
+it('should be case-insensitive', () => {
+  expect(getPostgresFunctionsKey('VARCHAR')).toBe('character varying');
+  expect(getPostgresFunctionsKey('Varchar(10)')).toBe('character varying');
+  expect(getPostgresFunctionsKey('TEXT')).toBe('text');
+});

--- a/dashboard/src/features/orgs/projects/database/dataGrid/utils/getPostgresFunctionsKey/getPostgresFunctionsKey.ts
+++ b/dashboard/src/features/orgs/projects/database/dataGrid/utils/getPostgresFunctionsKey/getPostgresFunctionsKey.ts
@@ -1,0 +1,28 @@
+import type { postgresFunctions } from '@/features/orgs/projects/database/dataGrid/utils/postgresqlConstants';
+
+/**
+ * Aliases mapping common type names (or free-typed custom types) to the
+ * canonical key used in `postgresFunctions`. Lets custom-length types like
+ * `varchar(10)` or `character varying(255)` pick up the same default-value
+ * options as their canonical form.
+ */
+const TYPE_ALIASES: Record<string, keyof typeof postgresFunctions> = {
+  varchar: 'character varying',
+};
+
+/**
+ * Returns the key to look up in `postgresFunctions` for a given raw type
+ * value, stripping length modifiers (e.g. `varchar(10)` → `varchar`) and
+ * mapping aliases to their canonical form.
+ */
+export default function getPostgresFunctionsKey(typeValue?: string): string {
+  if (!typeValue) {
+    return '';
+  }
+
+  const base = typeValue
+    .replace(/\s*\(.*\)\s*$/, '')
+    .trim()
+    .toLowerCase();
+  return TYPE_ALIASES[base] ?? base;
+}

--- a/dashboard/src/features/orgs/projects/database/dataGrid/utils/getPostgresFunctionsKey/index.ts
+++ b/dashboard/src/features/orgs/projects/database/dataGrid/utils/getPostgresFunctionsKey/index.ts
@@ -1,0 +1,2 @@
+export * from './getPostgresFunctionsKey';
+export { default as getPostgresFunctionsKey } from './getPostgresFunctionsKey';

--- a/dashboard/src/features/orgs/projects/database/dataGrid/utils/normalizeDatabaseColumn/normalizeDatabaseColumn.test.ts
+++ b/dashboard/src/features/orgs/projects/database/dataGrid/utils/normalizeDatabaseColumn/normalizeDatabaseColumn.test.ts
@@ -58,7 +58,7 @@ const rawColumn: NormalizedQueryDataRow = {
   foreign_key_relation: null,
 };
 
-test('should normalize a raw database column', () => {
+it('should normalize a raw database column', () => {
   const column = normalizeDatabaseColumn(rawColumn);
 
   expect(column).toMatchObject<DatabaseColumn>({
@@ -77,7 +77,7 @@ test('should normalize a raw database column', () => {
   });
 });
 
-test('should set identity to true if the column is an identity column', () => {
+it('should set identity to true if the column is an identity column', () => {
   const rawIdentityColumn: typeof rawColumn = {
     ...rawColumn,
     udt_name: 'int4',
@@ -105,7 +105,7 @@ test('should set identity to true if the column is an identity column', () => {
   });
 });
 
-test('should set isGenerated to true and map generationExpression for generated columns', () => {
+it('should set isGenerated to true and map generationExpression for generated columns', () => {
   const rawGeneratedColumn: typeof rawColumn = {
     ...rawColumn,
     column_name: 'total',
@@ -140,7 +140,23 @@ test('should set isGenerated to true and map generationExpression for generated 
   });
 });
 
-test('should set nullable to true if the column is nullable', () => {
+it('should preserve an empty-string cast default and label it from POSTGRESQL_FUNCTION_LABELS', () => {
+  const rawEmptyStringDefaultColumn: typeof rawColumn = {
+    ...rawColumn,
+    udt_name: 'text',
+    data_type: 'text',
+    full_data_type: 'text',
+    column_default: "''::text",
+  };
+
+  const column = normalizeDatabaseColumn(rawEmptyStringDefaultColumn);
+
+  expect(column.defaultValue).toEqual({
+    value: "''::text",
+    custom: false,
+  });
+});
+it('should set nullable to true if the column is nullable', () => {
   const rawNullableColumn: typeof rawColumn = {
     ...rawColumn,
     is_nullable: 'YES',
@@ -164,7 +180,7 @@ test('should set nullable to true if the column is nullable', () => {
   });
 });
 
-test('should preserve the literal flag when the stored default is a quoted literal that collides with a function name', () => {
+it('should preserve the literal flag when the stored default is a quoted literal that collides with a function name', () => {
   const rawLiteralColumn: typeof rawColumn = {
     ...rawColumn,
     udt_name: 'text',
@@ -178,7 +194,7 @@ test('should preserve the literal flag when the stored default is a quoted liter
   expect(column.defaultValue).toEqual({ value: 'version()', custom: true });
 });
 
-test('should mark a bare function default as non-custom', () => {
+it('should mark a bare function default as non-custom', () => {
   const rawFunctionColumn: typeof rawColumn = {
     ...rawColumn,
     udt_name: 'text',

--- a/dashboard/src/features/orgs/projects/database/dataGrid/utils/normalizeDatabaseColumn/normalizeDatabaseColumn.ts
+++ b/dashboard/src/features/orgs/projects/database/dataGrid/utils/normalizeDatabaseColumn/normalizeDatabaseColumn.ts
@@ -5,6 +5,7 @@ import type {
 import { isGeneratedColumn } from '@/features/orgs/projects/database/dataGrid/utils/isGeneratedColumn';
 import { normalizeColumnType } from '@/features/orgs/projects/database/dataGrid/utils/normalizeColumnType';
 import { normalizeDefaultValue } from '@/features/orgs/projects/database/dataGrid/utils/normalizeDefaultValue';
+
 /**
  * Converts a raw database column to a normalized database column.
  *
@@ -14,10 +15,6 @@ import { normalizeDefaultValue } from '@/features/orgs/projects/database/dataGri
 export default function normalizeDatabaseColumn(
   rawColumn: NormalizedQueryDataRow,
 ): DatabaseColumn {
-  const { normalizedDefaultValue, custom } = normalizeDefaultValue(
-    rawColumn.column_default,
-  );
-
   return {
     id: rawColumn.column_name,
     name: rawColumn.column_name,
@@ -29,9 +26,7 @@ export default function normalizeDatabaseColumn(
     isNullable: rawColumn.is_nullable === 'YES',
     isUnique: rawColumn.is_unique,
     comment: rawColumn.column_comment || null,
-    defaultValue: rawColumn.column_default
-      ? { value: normalizedDefaultValue, custom }
-      : null,
+    defaultValue: normalizeDefaultValue(rawColumn.column_default),
     uniqueConstraints: rawColumn.unique_constraints,
     primaryConstraints: rawColumn.primary_constraints,
     foreignKeyRelation: rawColumn.foreign_key_relation,

--- a/dashboard/src/features/orgs/projects/database/dataGrid/utils/normalizeDefaultValue/normalizeDefaultValue.test.ts
+++ b/dashboard/src/features/orgs/projects/database/dataGrid/utils/normalizeDefaultValue/normalizeDefaultValue.test.ts
@@ -1,65 +1,58 @@
-import { expect, test } from 'vitest';
 import normalizeDefaultValue from './normalizeDefaultValue';
 
-test('should return empty string if no default value', () => {
-  expect(normalizeDefaultValue(null)).toMatchObject({
-    normalizedDefaultValue: '',
-    custom: false,
-  });
-  expect(normalizeDefaultValue('')).toMatchObject({
-    normalizedDefaultValue: '',
-    custom: false,
-  });
+it('should return null if no default value', () => {
+  expect(normalizeDefaultValue(null)).toBeNull();
+  expect(normalizeDefaultValue('')).toBeNull();
 });
 
-test('should not change default value that is a plain string', () => {
-  expect(normalizeDefaultValue('test')).toMatchObject({
-    normalizedDefaultValue: 'test',
+it('should not change default value that is a plain string', () => {
+  expect(normalizeDefaultValue('test')).toEqual({
+    value: 'test',
     custom: false,
   });
 });
 
-test('should remove apostrophes and type definition from default value', () => {
-  expect(normalizeDefaultValue("''::text")).toMatchObject({
-    normalizedDefaultValue: '',
+it('should preserve empty-string casts so the form can pre-select them', () => {
+  expect(normalizeDefaultValue("''::text")).toEqual({
+    value: "''::text",
+    custom: false,
+  });
+
+  expect(normalizeDefaultValue("''::character varying")).toEqual({
+    value: "''::character varying",
+    custom: false,
+  });
+});
+
+it('should remove apostrophes and type definition from default value', () => {
+  expect(normalizeDefaultValue("'Test Value'::text")).toEqual({
+    value: 'Test Value',
     custom: true,
   });
 
-  expect(normalizeDefaultValue("''::character varying")).toMatchObject({
-    normalizedDefaultValue: '',
+  expect(normalizeDefaultValue("'Test Value'::character varying")).toEqual({
+    value: 'Test Value',
     custom: true,
   });
 
-  expect(normalizeDefaultValue("'Test Value'::text")).toMatchObject({
-    normalizedDefaultValue: 'Test Value',
-    custom: true,
-  });
-
-  expect(
-    normalizeDefaultValue("'Test Value'::character varying"),
-  ).toMatchObject({
-    normalizedDefaultValue: 'Test Value',
-    custom: true,
-  });
-
-  expect(normalizeDefaultValue("'3'::int4")).toMatchObject({
-    normalizedDefaultValue: '3',
+  expect(normalizeDefaultValue("'3'::int4")).toEqual({
+    value: '3',
     custom: true,
   });
 });
 
-test('should remove arguments from default value function string if enabled', () => {
+it('should remove arguments from default value function string if enabled', () => {
   expect(
     normalizeDefaultValue("nextval('test_table_seq')", { removeArgs: true }),
-  ).toMatchObject({
-    normalizedDefaultValue: 'nextval()',
+  ).toEqual({
+    value: 'nextval()',
     custom: false,
   });
 
   expect(
     normalizeDefaultValue("function('args', 'args')", { removeArgs: true }),
-  ).toMatchObject({
-    normalizedDefaultValue: 'function()',
+  ).toEqual({
+    value: 'function()',
     custom: false,
   });
 });

--- a/dashboard/src/features/orgs/projects/database/dataGrid/utils/normalizeDefaultValue/normalizeDefaultValue.ts
+++ b/dashboard/src/features/orgs/projects/database/dataGrid/utils/normalizeDefaultValue/normalizeDefaultValue.ts
@@ -1,3 +1,5 @@
+import type { ColumnDefaultValue } from '@/features/orgs/projects/database/dataGrid/types/dataBrowser';
+
 export interface NormalizeDefaultValueOptions {
   /**
    * Determines whether or not arguments should be removed from default value
@@ -16,19 +18,19 @@ export interface NormalizeDefaultValueOptions {
  *
  * @param defaultValue - Default value to normalize
  * @param options - Options for normalizing default value
- * @returns Normalized default value and `true` if there was a match for custom
- * default value, `false` otherwise.
+ * @returns A `ColumnDefaultValue` (`{ value, custom }`) when a default is
+ * present, or `null` when there is none.
  */
 export default function normalizeDefaultValue(
   defaultValue?: string | null,
   { removeArgs }: NormalizeDefaultValueOptions = {},
-) {
+): ColumnDefaultValue | null {
   if (!defaultValue) {
-    return { normalizedDefaultValue: '', custom: false };
+    return null;
   }
 
   if (/^''::(\w|\s)+$/i.test(defaultValue)) {
-    return { normalizedDefaultValue: '', custom: true };
+    return { value: defaultValue, custom: false };
   }
 
   // Note: We are extracting the actual default value from the ambiguous
@@ -44,15 +46,13 @@ export default function normalizeDefaultValue(
 
   if (match) {
     return {
-      normalizedDefaultValue: removeArgs
-        ? match.replace(removeArgsRegExp, '()')
-        : match,
+      value: removeArgs ? match.replace(removeArgsRegExp, '()') : match,
       custom: true,
     };
   }
 
   return {
-    normalizedDefaultValue: removeArgs
+    value: removeArgs
       ? defaultValue.replace(removeArgsRegExp, '()')
       : defaultValue,
     custom: false,

--- a/dashboard/src/features/orgs/projects/database/dataGrid/utils/postgresDefaultPlaceholder/index.ts
+++ b/dashboard/src/features/orgs/projects/database/dataGrid/utils/postgresDefaultPlaceholder/index.ts
@@ -1,0 +1,4 @@
+export {
+  POSTGRES_DEFAULT_PLACEHOLDER,
+  wrapResolverWithDefaultPlaceholder,
+} from './postgresDefaultPlaceholder';

--- a/dashboard/src/features/orgs/projects/database/dataGrid/utils/postgresDefaultPlaceholder/postgresDefaultPlaceholder.test.ts
+++ b/dashboard/src/features/orgs/projects/database/dataGrid/utils/postgresDefaultPlaceholder/postgresDefaultPlaceholder.test.ts
@@ -1,0 +1,108 @@
+import type { Resolver } from 'react-hook-form';
+import { vi } from 'vitest';
+import {
+  POSTGRES_DEFAULT_PLACEHOLDER,
+  wrapResolverWithDefaultPlaceholder,
+} from './postgresDefaultPlaceholder';
+
+type FormValues = Record<string, unknown>;
+
+function makeResolver(impl: Resolver<FormValues>) {
+  return vi.fn(impl);
+}
+
+describe('wrapResolverWithDefaultPlaceholder', () => {
+  it('replaces sentinel values with undefined before delegating to the base resolver', async () => {
+    let receivedValues: FormValues | undefined;
+    const base = makeResolver(async (values) => {
+      receivedValues = { ...values };
+      return { values, errors: {} };
+    });
+    const wrapped = wrapResolverWithDefaultPlaceholder(base);
+
+    await wrapped(
+      { a: POSTGRES_DEFAULT_PLACEHOLDER, b: 'hello', c: null },
+      undefined,
+      // biome-ignore lint/suspicious/noExplicitAny: minimal resolver options shape
+      {} as any,
+    );
+
+    expect(base).toHaveBeenCalledTimes(1);
+    expect(receivedValues).toEqual({
+      a: undefined,
+      b: 'hello',
+      c: null,
+    });
+  });
+
+  it('re-applies the sentinel onto validated values', async () => {
+    const base = makeResolver(async () => ({
+      values: { a: undefined, b: 'hello' },
+      errors: {},
+    }));
+    const wrapped = wrapResolverWithDefaultPlaceholder(base);
+
+    const result = await wrapped(
+      { a: POSTGRES_DEFAULT_PLACEHOLDER, b: 'hello' },
+      undefined,
+      // biome-ignore lint/suspicious/noExplicitAny: minimal resolver options shape
+      {} as any,
+    );
+
+    expect(result.values).toEqual({
+      a: POSTGRES_DEFAULT_PLACEHOLDER,
+      b: 'hello',
+    });
+  });
+
+  it('leaves non-sentinel values untouched on the way out', async () => {
+    const base = makeResolver(async (values) => ({ values, errors: {} }));
+    const wrapped = wrapResolverWithDefaultPlaceholder(base);
+
+    const result = await wrapped(
+      { a: 'foo', b: null, c: '' },
+      undefined,
+      // biome-ignore lint/suspicious/noExplicitAny: minimal resolver options shape
+      {} as any,
+    );
+
+    expect(result.values).toEqual({ a: 'foo', b: null, c: '' });
+  });
+
+  it('passes validation errors through unchanged', async () => {
+    const base = makeResolver(async () => ({
+      values: {},
+      errors: { a: { type: 'required', message: 'required' } },
+    }));
+    const wrapped = wrapResolverWithDefaultPlaceholder(base);
+
+    const result = await wrapped(
+      { a: POSTGRES_DEFAULT_PLACEHOLDER },
+      undefined,
+      // biome-ignore lint/suspicious/noExplicitAny: minimal resolver options shape
+      {} as any,
+    );
+
+    expect(result.errors).toEqual({
+      a: { type: 'required', message: 'required' },
+    });
+  });
+
+  it('does not mutate the input values object', async () => {
+    const base = makeResolver(async (values) => ({ values, errors: {} }));
+    const wrapped = wrapResolverWithDefaultPlaceholder(base);
+
+    const input = { a: POSTGRES_DEFAULT_PLACEHOLDER, b: 'hello' };
+    await wrapped(
+      input,
+      undefined,
+      // biome-ignore lint/suspicious/noExplicitAny: minimal resolver options shape
+      {} as any,
+    );
+
+    expect(input).toEqual({
+      a: POSTGRES_DEFAULT_PLACEHOLDER,
+      b: 'hello',
+    });
+  });
+});

--- a/dashboard/src/features/orgs/projects/database/dataGrid/utils/postgresDefaultPlaceholder/postgresDefaultPlaceholder.ts
+++ b/dashboard/src/features/orgs/projects/database/dataGrid/utils/postgresDefaultPlaceholder/postgresDefaultPlaceholder.ts
@@ -1,0 +1,30 @@
+import type { Resolver } from 'react-hook-form';
+
+// Impossible to type in a normal text input — used to distinguish DEFAULT from NULL in nullable+hasDefault form fields.
+export const POSTGRES_DEFAULT_PLACEHOLDER = '\x00DEFAULT\x00';
+
+export function wrapResolverWithDefaultPlaceholder<
+  T extends Record<string, unknown>,
+>(base: Resolver<T>): Resolver<T> {
+  return async (values, context, options) => {
+    const sanitized = { ...(values as Record<string, unknown>) };
+    for (const key of Object.keys(sanitized)) {
+      if (sanitized[key] === POSTGRES_DEFAULT_PLACEHOLDER) {
+        sanitized[key] = undefined;
+      }
+    }
+    const result = await base(sanitized as T, context, options);
+    if (result.values) {
+      for (const key of Object.keys(values as Record<string, unknown>)) {
+        if (
+          (values as Record<string, unknown>)[key] ===
+          POSTGRES_DEFAULT_PLACEHOLDER
+        ) {
+          (result.values as Record<string, unknown>)[key] =
+            POSTGRES_DEFAULT_PLACEHOLDER;
+        }
+      }
+    }
+    return result;
+  };
+}

--- a/dashboard/src/features/orgs/projects/database/dataGrid/utils/postgresqlConstants/postgresqlConstants.ts
+++ b/dashboard/src/features/orgs/projects/database/dataGrid/utils/postgresqlConstants/postgresqlConstants.ts
@@ -15,6 +15,17 @@ export const POSTGRESQL_ERROR_CODES = {
 };
 
 /**
+ * Human-readable labels for raw PostgreSQL expressions that would otherwise be
+ * confusing in the default-value dropdown. Keys are the exact expressions
+ * stored in form state and emitted as SQL; values are what gets shown to the
+ * user.
+ */
+export const POSTGRESQL_FUNCTION_LABELS: Record<string, string> = {
+  "''::text": 'EMPTY STRING',
+  "''::character varying": 'EMPTY STRING',
+};
+
+/**
  * Numeric data types in PostgreSQL.
  *
  * @docs https://www.postgresql.org/docs/current/datatype-numeric.html
@@ -220,7 +231,8 @@ export const dateFunctions = [
  * Relevant functions for PostgreSQL types.
  */
 export const postgresFunctions = {
-  text: ['version()', 'timeofday()'],
+  text: ["''::text", 'version()', 'timeofday()'],
+  'character varying': ["''::character varying"],
   json: ['json_build_object()', 'json_build_array()'],
   jsonb: ['jsonb_build_object()', 'jsonb_build_array()'],
   date: dateFunctions,

--- a/dashboard/src/features/orgs/projects/database/dataGrid/utils/validationSchemaHelpers/validationSchemaHelpers.ts
+++ b/dashboard/src/features/orgs/projects/database/dataGrid/utils/validationSchemaHelpers/validationSchemaHelpers.ts
@@ -1,5 +1,6 @@
 import * as yup from 'yup';
 import type { DataBrowserColumnMetadata } from '@/features/orgs/projects/database/dataGrid/types/dataBrowser/dataBrowser';
+import { POSTGRES_DEFAULT_PLACEHOLDER } from '@/features/orgs/projects/database/dataGrid/utils/postgresDefaultPlaceholder';
 
 export interface ColumnDetails {
   isNullable: boolean;
@@ -11,7 +12,7 @@ function createGenericValidationSchema<T extends yup.Schema>(
   genericSchema: T,
   { isNullable, hasDefaultValue, isIdentity }: ColumnDetails,
 ): T {
-  const schema = genericSchema.transform((value) => value || null);
+  const schema = genericSchema.transform((value) => value ?? null);
 
   if (hasDefaultValue || isIdentity) {
     return schema.optional().nullable();
@@ -34,8 +35,12 @@ function createJSONValidationSchema(details: ColumnDetails) {
   const jsonSchema = yup
     .string()
     .test('is-json', 'This is not a valid JSON.', (value) => {
+      if (!value || value === POSTGRES_DEFAULT_PLACEHOLDER) {
+        return true;
+      }
+
       try {
-        JSON.parse(value as string);
+        JSON.parse(value);
 
         return true;
       } catch {

--- a/dashboard/src/features/orgs/projects/storage/dataGrid/components/CellResetButtons/CellResetButtons.test.tsx
+++ b/dashboard/src/features/orgs/projects/storage/dataGrid/components/CellResetButtons/CellResetButtons.test.tsx
@@ -1,0 +1,267 @@
+import { vi } from 'vitest';
+import { fireEvent, render, screen, TestUserEvent } from '@/tests/testUtils';
+import CellResetButtons from './CellResetButtons';
+
+const focusNextCell = vi.fn();
+
+vi.mock(
+  '@/features/orgs/projects/storage/dataGrid/components/DataGridCell',
+  () => ({
+    useDataGridCell: () => ({ focusNextCell }),
+  }),
+);
+
+beforeEach(() => {
+  focusNextCell.mockReset();
+});
+
+describe('CellResetButtons', () => {
+  describe('rendering and click behavior', () => {
+    it('renders both NULL and DEFAULT when isNullable and hasDefault are true', () => {
+      render(
+        <CellResetButtons
+          isNullable
+          hasDefault
+          onSetNull={vi.fn()}
+          onSetDefault={vi.fn()}
+        />,
+      );
+
+      expect(screen.getByRole('button', { name: 'NULL' })).toBeInTheDocument();
+      expect(
+        screen.getByRole('button', { name: 'DEFAULT' }),
+      ).toBeInTheDocument();
+    });
+
+    it('renders only NULL when only isNullable is true', () => {
+      render(
+        <CellResetButtons
+          isNullable
+          hasDefault={false}
+          onSetNull={vi.fn()}
+          onSetDefault={vi.fn()}
+        />,
+      );
+
+      expect(screen.getByRole('button', { name: 'NULL' })).toBeInTheDocument();
+      expect(
+        screen.queryByRole('button', { name: 'DEFAULT' }),
+      ).not.toBeInTheDocument();
+    });
+
+    it('renders only DEFAULT when only hasDefault is true', () => {
+      render(
+        <CellResetButtons
+          isNullable={false}
+          hasDefault
+          onSetNull={vi.fn()}
+          onSetDefault={vi.fn()}
+        />,
+      );
+
+      expect(
+        screen.queryByRole('button', { name: 'NULL' }),
+      ).not.toBeInTheDocument();
+      expect(
+        screen.getByRole('button', { name: 'DEFAULT' }),
+      ).toBeInTheDocument();
+    });
+
+    it('does not render NULL when isNullable is undefined', () => {
+      render(
+        <CellResetButtons
+          hasDefault
+          onSetNull={vi.fn()}
+          onSetDefault={vi.fn()}
+        />,
+      );
+
+      expect(
+        screen.queryByRole('button', { name: 'NULL' }),
+      ).not.toBeInTheDocument();
+    });
+
+    it('calls onSetNull once when NULL button is clicked', async () => {
+      const user = new TestUserEvent();
+      const onSetNull = vi.fn();
+
+      render(
+        <CellResetButtons
+          isNullable
+          hasDefault
+          onSetNull={onSetNull}
+          onSetDefault={vi.fn()}
+        />,
+      );
+
+      await user.click(screen.getByRole('button', { name: 'NULL' }));
+
+      expect(onSetNull).toHaveBeenCalledTimes(1);
+    });
+
+    it('calls onSetDefault once when DEFAULT button is clicked', async () => {
+      const user = new TestUserEvent();
+      const onSetDefault = vi.fn();
+
+      render(
+        <CellResetButtons
+          isNullable
+          hasDefault
+          onSetNull={vi.fn()}
+          onSetDefault={onSetDefault}
+        />,
+      );
+
+      await user.click(screen.getByRole('button', { name: 'DEFAULT' }));
+
+      expect(onSetDefault).toHaveBeenCalledTimes(1);
+    });
+
+    it('prevents default on mousedown so the editor input keeps focus', () => {
+      render(
+        <CellResetButtons
+          isNullable
+          hasDefault
+          onSetNull={vi.fn()}
+          onSetDefault={vi.fn()}
+        />,
+      );
+
+      const nullButton = screen.getByRole('button', { name: 'NULL' });
+      const wasNotPrevented = fireEvent.mouseDown(nullButton);
+
+      expect(wasNotPrevented).toBe(false);
+    });
+  });
+
+  describe('keyboard behavior', () => {
+    it('does not advance to the next cell when Tab is pressed on NULL while DEFAULT is also rendered', () => {
+      render(
+        <CellResetButtons
+          isNullable
+          hasDefault
+          onSetNull={vi.fn()}
+          onSetDefault={vi.fn()}
+        />,
+      );
+
+      const nullButton = screen.getByRole('button', { name: 'NULL' });
+      const wasNotPrevented = fireEvent.keyDown(nullButton, { key: 'Tab' });
+
+      expect(focusNextCell).not.toHaveBeenCalled();
+      expect(wasNotPrevented).toBe(true);
+    });
+
+    it('advances to the next cell when Tab is pressed on NULL and DEFAULT is not rendered', () => {
+      render(
+        <CellResetButtons
+          isNullable
+          hasDefault={false}
+          onSetNull={vi.fn()}
+          onSetDefault={vi.fn()}
+        />,
+      );
+
+      const nullButton = screen.getByRole('button', { name: 'NULL' });
+      const wasNotPrevented = fireEvent.keyDown(nullButton, { key: 'Tab' });
+
+      expect(focusNextCell).toHaveBeenCalledTimes(1);
+      expect(wasNotPrevented).toBe(false);
+    });
+
+    it('advances to the next cell when Tab is pressed on DEFAULT', () => {
+      render(
+        <CellResetButtons
+          isNullable
+          hasDefault
+          onSetNull={vi.fn()}
+          onSetDefault={vi.fn()}
+        />,
+      );
+
+      const defaultButton = screen.getByRole('button', { name: 'DEFAULT' });
+      const wasNotPrevented = fireEvent.keyDown(defaultButton, { key: 'Tab' });
+
+      expect(focusNextCell).toHaveBeenCalledTimes(1);
+      expect(wasNotPrevented).toBe(false);
+    });
+
+    it('does not advance to the next cell when Shift+Tab is pressed', () => {
+      render(
+        <CellResetButtons
+          isNullable
+          hasDefault
+          onSetNull={vi.fn()}
+          onSetDefault={vi.fn()}
+        />,
+      );
+
+      const nullButton = screen.getByRole('button', { name: 'NULL' });
+      const defaultButton = screen.getByRole('button', { name: 'DEFAULT' });
+
+      const nullNotPrevented = fireEvent.keyDown(nullButton, {
+        key: 'Tab',
+        shiftKey: true,
+      });
+      const defaultNotPrevented = fireEvent.keyDown(defaultButton, {
+        key: 'Tab',
+        shiftKey: true,
+      });
+
+      expect(focusNextCell).not.toHaveBeenCalled();
+      expect(nullNotPrevented).toBe(true);
+      expect(defaultNotPrevented).toBe(true);
+    });
+
+    it.each([
+      'Enter',
+      'Escape',
+      'ArrowDown',
+    ])('does not advance to the next cell when %s is pressed', (key) => {
+      render(
+        <CellResetButtons
+          isNullable
+          hasDefault
+          onSetNull={vi.fn()}
+          onSetDefault={vi.fn()}
+        />,
+      );
+
+      fireEvent.keyDown(screen.getByRole('button', { name: 'NULL' }), {
+        key,
+      });
+      fireEvent.keyDown(screen.getByRole('button', { name: 'DEFAULT' }), {
+        key,
+      });
+
+      expect(focusNextCell).not.toHaveBeenCalled();
+    });
+
+    it('stops propagation of the Tab keydown so the cell-level handler does not run', () => {
+      const onDocumentKeyDown = vi.fn();
+      document.addEventListener('keydown', onDocumentKeyDown);
+
+      try {
+        render(
+          <CellResetButtons
+            isNullable
+            hasDefault
+            onSetNull={vi.fn()}
+            onSetDefault={vi.fn()}
+          />,
+        );
+
+        fireEvent.keyDown(screen.getByRole('button', { name: 'NULL' }), {
+          key: 'Tab',
+        });
+        fireEvent.keyDown(screen.getByRole('button', { name: 'DEFAULT' }), {
+          key: 'Tab',
+        });
+
+        expect(onDocumentKeyDown).not.toHaveBeenCalled();
+      } finally {
+        document.removeEventListener('keydown', onDocumentKeyDown);
+      }
+    });
+  });
+});

--- a/dashboard/src/features/orgs/projects/storage/dataGrid/components/CellResetButtons/CellResetButtons.tsx
+++ b/dashboard/src/features/orgs/projects/storage/dataGrid/components/CellResetButtons/CellResetButtons.tsx
@@ -1,0 +1,67 @@
+import type { KeyboardEvent } from 'react';
+import { useDataGridCell } from '@/features/orgs/projects/storage/dataGrid/components/DataGridCell';
+import { cn } from '@/lib/utils';
+
+export interface CellResetButtonsProps {
+  isNullable?: boolean;
+  hasDefault: boolean;
+  onSetNull: () => void | Promise<void>;
+  onSetDefault: () => void | Promise<void>;
+  className?: string;
+}
+
+export default function CellResetButtons({
+  isNullable,
+  hasDefault,
+  onSetNull,
+  onSetDefault,
+  className,
+}: CellResetButtonsProps) {
+  const { focusNextCell } = useDataGridCell();
+
+  function handleKeyDown(
+    event: KeyboardEvent<HTMLButtonElement>,
+    isLast: boolean,
+  ) {
+    if (event.key !== 'Tab') {
+      return;
+    }
+    event.stopPropagation();
+    if (!event.shiftKey && isLast) {
+      event.preventDefault();
+      focusNextCell();
+    }
+  }
+
+  return (
+    <div
+      className={cn(
+        'flex gap-px rounded border border-input bg-background shadow-sm',
+        className,
+      )}
+    >
+      {isNullable && (
+        <button
+          type="button"
+          onMouseDown={(event) => event.preventDefault()}
+          onClick={() => onSetNull()}
+          onKeyDown={(event) => handleKeyDown(event, !hasDefault)}
+          className="px-1.5 py-0.5 font-mono text-[10px] text-muted-foreground hover:bg-accent hover:text-accent-foreground"
+        >
+          NULL
+        </button>
+      )}
+      {hasDefault && (
+        <button
+          type="button"
+          onMouseDown={(event) => event.preventDefault()}
+          onClick={() => onSetDefault()}
+          onKeyDown={(event) => handleKeyDown(event, true)}
+          className="px-1.5 py-0.5 font-mono text-[10px] text-muted-foreground hover:bg-accent hover:text-accent-foreground"
+        >
+          DEFAULT
+        </button>
+      )}
+    </div>
+  );
+}

--- a/dashboard/src/features/orgs/projects/storage/dataGrid/components/CellResetButtons/index.ts
+++ b/dashboard/src/features/orgs/projects/storage/dataGrid/components/CellResetButtons/index.ts
@@ -1,0 +1,2 @@
+export type { CellResetButtonsProps } from './CellResetButtons';
+export { default as CellResetButtons } from './CellResetButtons';

--- a/dashboard/src/features/orgs/projects/storage/dataGrid/components/DataGridCell/DataGridCell.tsx
+++ b/dashboard/src/features/orgs/projects/storage/dataGrid/components/DataGridCell/DataGridCell.tsx
@@ -35,7 +35,10 @@ export interface CommonDataGridCellProps<
   /**
    * Function that is called when the cell is saved.
    */
-  onSave?: (value: TValue, options?: { reset: boolean }) => Promise<void>;
+  onSave?: (
+    value: TValue,
+    options?: { reset?: 'null' | 'default' },
+  ) => Promise<void>;
   /**
    * Optimistic value for the cell.
    */
@@ -131,27 +134,33 @@ function DataGridCellContent<
 
   async function handleSave(
     value: DataGridCellValue,
-    options: { reset: boolean } = { reset: false },
+    options: { reset?: 'null' | 'default' } = {},
   ) {
     if (!onCellEdit) {
       return;
     }
 
-    const normalizedValue =
-      value !== null && typeof value === 'object'
-        ? JSON.stringify(value)
-        : String(value);
+    function normalize(v: DataGridCellValue) {
+      if (v === null || v === undefined) {
+        return null;
+      }
+      if (typeof v === 'object') {
+        return JSON.stringify(v);
+      }
+      return String(v);
+    }
 
-    const normalizedOptimisticValue =
-      optimisticValue !== null && typeof optimisticValue === 'object'
-        ? JSON.stringify(optimisticValue)
-        : String(optimisticValue);
+    const normalizedValue = normalize(value);
+    const normalizedOptimisticValue = normalize(optimisticValue);
 
     // We are making sure that optimistic value is not equal to the current
     // value. If it is, we are not going to save the value.
+    const escapeNewlines = (v: string | null) =>
+      v === null ? null : v.replace(/\n/gi, '\\n');
+
     if (
-      normalizedValue.replace(/\n/gi, '\\n') ===
-        normalizedOptimisticValue.replace(/\n/gi, '\\n') &&
+      escapeNewlines(normalizedValue) ===
+        escapeNewlines(normalizedOptimisticValue) &&
       !options.reset
     ) {
       return;
@@ -167,7 +176,7 @@ function DataGridCellContent<
         row,
         columnsToUpdate: {
           [id]: {
-            value: !options.reset ? value : undefined,
+            value: options.reset ? undefined : value,
             reset: options.reset,
           },
         },
@@ -224,7 +233,7 @@ function DataGridCellContent<
         primaryButtonText: 'Set to null',
         primaryButtonColor: 'error',
         onPrimaryAction: async () => {
-          await handleSave(null, { reset: true });
+          await handleSave(null, { reset: 'null' });
           focusCell();
         },
       },

--- a/dashboard/src/features/orgs/projects/storage/dataGrid/components/DataGridNumericCell/DataGridNumericCell.tsx
+++ b/dashboard/src/features/orgs/projects/storage/dataGrid/components/DataGridNumericCell/DataGridNumericCell.tsx
@@ -5,6 +5,7 @@ import {
   useEffect,
 } from 'react';
 import { Input } from '@/components/ui/v3/input';
+import { CellResetButtons } from '@/features/orgs/projects/storage/dataGrid/components/CellResetButtons';
 import type { UnknownDataGridRow } from '@/features/orgs/projects/storage/dataGrid/components/DataGrid';
 import type { CommonDataGridCellProps } from '@/features/orgs/projects/storage/dataGrid/components/DataGridCell';
 import { useDataGridCell } from '@/features/orgs/projects/storage/dataGrid/components/DataGridCell';
@@ -23,6 +24,8 @@ export default function DataGridNumericCell<TData extends UnknownDataGridRow>({
   const { inputRef, isEditing } = useDataGridCell<HTMLInputElement>();
 
   const dataType = column.columnDef.meta?.dataType;
+  const isNullable = column.columnDef.meta?.isNullable;
+  const hasDefault = column.columnDef.meta?.defaultValue != null;
 
   useEffect(() => {
     const controller = new AbortController();
@@ -48,6 +51,11 @@ export default function DataGridNumericCell<TData extends UnknownDataGridRow>({
     ) {
       event.stopPropagation();
     }
+    if (event.key === 'Tab' && !event.shiftKey && (isNullable || hasDefault)) {
+      event.stopPropagation();
+      return;
+    }
+
     if (isNotEmptyValue(onSave) && typeof temporaryValue !== 'undefined') {
       if (event.key === 'Tab') {
         await onSave?.(temporaryValue);
@@ -72,20 +80,31 @@ export default function DataGridNumericCell<TData extends UnknownDataGridRow>({
     const step = dataType === 'integer' ? 1 : 0.1;
 
     return (
-      <Input
-        type="number"
-        ref={inputRef as Ref<HTMLInputElement>}
-        value={
-          temporaryValue !== null && typeof temporaryValue !== 'undefined'
-            ? temporaryValue
-            : ''
-        }
-        onChange={handleChange}
-        onKeyDown={handleKeyDown}
-        wrapperClassName="absolute top-0 z-10 w-full top-0 left-0 h-full"
-        className="!text-xs h-full w-full resize-none rounded-none border-none px-2 py-1.5 outline-none [appearance:textfield] focus-within:rounded-none focus-within:border-transparent focus-within:bg-white focus-within:shadow-[inset_0_0_0_1.5px_rgba(0,82,205,1)] focus:outline-none focus:ring-0 dark:focus-within:bg-theme-grey-200 [&::-webkit-inner-spin-button]:appearance-none [&::-webkit-outer-spin-button]:appearance-none"
-        step={step}
-      />
+      <div className="absolute top-0 left-0 z-10 h-full w-full">
+        <Input
+          type="number"
+          ref={inputRef as Ref<HTMLInputElement>}
+          value={
+            temporaryValue !== null && typeof temporaryValue !== 'undefined'
+              ? temporaryValue
+              : ''
+          }
+          onChange={handleChange}
+          onKeyDown={handleKeyDown}
+          wrapperClassName="h-full w-full"
+          className="!text-xs h-full w-full resize-none rounded-none border-none px-2 py-1.5 outline-none [appearance:textfield] focus-within:rounded-none focus-within:border-transparent focus-within:bg-white focus-within:shadow-[inset_0_0_0_1.5px_rgba(0,82,205,1)] focus:outline-none focus:ring-0 dark:focus-within:bg-theme-grey-200 [&::-webkit-inner-spin-button]:appearance-none [&::-webkit-outer-spin-button]:appearance-none"
+          step={step}
+        />
+        {(isNullable || hasDefault) && (
+          <CellResetButtons
+            isNullable={isNullable}
+            hasDefault={hasDefault}
+            onSetNull={() => onSave?.(null, { reset: 'null' })}
+            onSetDefault={() => onSave?.(null, { reset: 'default' })}
+            className="absolute right-1 bottom-1"
+          />
+        )}
+      </div>
     );
   }
 

--- a/dashboard/src/features/orgs/projects/storage/dataGrid/components/DataGridTextCell/DataGridTextCell.tsx
+++ b/dashboard/src/features/orgs/projects/storage/dataGrid/components/DataGridTextCell/DataGridTextCell.tsx
@@ -2,6 +2,7 @@ import type { ChangeEvent, KeyboardEvent, Ref } from 'react';
 import { useEffect } from 'react';
 import { Input } from '@/components/ui/v3/input';
 import { Textarea } from '@/components/ui/v3/textarea';
+import { CellResetButtons } from '@/features/orgs/projects/storage/dataGrid/components/CellResetButtons';
 import type { UnknownDataGridRow } from '@/features/orgs/projects/storage/dataGrid/components/DataGrid';
 import {
   type CommonDataGridCellProps,
@@ -22,6 +23,8 @@ export default function DataGridTextCell<
   cell: { column },
 }: DataGridTextCellProps<TData>) {
   const specificType = column.columnDef.meta?.specificType;
+  const isNullable = column.columnDef.meta?.isNullable;
+  const hasDefault = column.columnDef.meta?.defaultValue != null;
 
   const isMultiline =
     specificType === 'text' ||
@@ -69,6 +72,11 @@ export default function DataGridTextCell<
       event.stopPropagation();
     }
 
+    if (event.key === 'Tab' && !event.shiftKey && (isNullable || hasDefault)) {
+      event.stopPropagation();
+      return;
+    }
+
     if (event.key === 'Tab') {
       await handleSave();
     }
@@ -106,6 +114,11 @@ export default function DataGridTextCell<
       cancelEditCell();
     }
 
+    if (event.key === 'Tab' && !event.shiftKey && (isNullable || hasDefault)) {
+      event.stopPropagation();
+      return;
+    }
+
     if (event.key === 'Tab') {
       await handleSave();
     }
@@ -121,26 +134,48 @@ export default function DataGridTextCell<
 
   if (isEditing && isMultiline) {
     return (
-      <Textarea
-        ref={inputRef as Ref<HTMLTextAreaElement>}
-        value={(normalizedTemporaryValue || '').replace(/\\n/gi, `\n`)}
-        onChange={handleChange}
-        onKeyDown={handleTextAreaKeyDown}
-        className="!text-xs absolute top-0 left-0 z-10 h-25 min-h-25 w-full resize-none rounded-none outline-none focus-within:rounded-none focus-within:border-transparent focus-within:bg-white focus-within:shadow-[inset_0_0_0_1.5px_rgba(0,82,205,1)] focus:outline-none focus:ring-0 dark:focus-within:bg-theme-grey-200"
-      />
+      <div className="absolute top-0 left-0 z-10 h-25 min-h-25 w-full">
+        <Textarea
+          ref={inputRef as Ref<HTMLTextAreaElement>}
+          value={(normalizedTemporaryValue || '').replace(/\\n/gi, `\n`)}
+          onChange={handleChange}
+          onKeyDown={handleTextAreaKeyDown}
+          className="!text-xs h-full w-full resize-none rounded-none outline-none focus-within:rounded-none focus-within:border-transparent focus-within:bg-white focus-within:shadow-[inset_0_0_0_1.5px_rgba(0,82,205,1)] focus:outline-none focus:ring-0 dark:focus-within:bg-theme-grey-200"
+        />
+        {(isNullable || hasDefault) && (
+          <CellResetButtons
+            isNullable={isNullable}
+            hasDefault={hasDefault}
+            onSetNull={() => onSave?.(null, { reset: 'null' })}
+            onSetDefault={() => onSave?.(null, { reset: 'default' })}
+            className="absolute right-1 bottom-1"
+          />
+        )}
+      </div>
     );
   }
 
   if (isEditing) {
     return (
-      <Input
-        ref={inputRef as Ref<HTMLInputElement>}
-        value={(normalizedTemporaryValue || '').replace(/\\n/gi, `\n`)}
-        onChange={handleChange}
-        onKeyDown={handleInputKeyDown}
-        wrapperClassName="absolute top-0 z-10 w-full top-0 left-0 h-full"
-        className="!text-xs h-full w-full resize-none rounded-none border-none px-2 py-1.5 outline-none focus-within:rounded-none focus-within:border-transparent focus-within:bg-white focus-within:shadow-[inset_0_0_0_1.5px_rgba(0,82,205,1)] focus:outline-none focus:ring-0 dark:focus-within:bg-theme-grey-200"
-      />
+      <div className="absolute top-0 left-0 z-10 h-full w-full">
+        <Input
+          ref={inputRef as Ref<HTMLInputElement>}
+          value={(normalizedTemporaryValue || '').replace(/\\n/gi, `\n`)}
+          onChange={handleChange}
+          onKeyDown={handleInputKeyDown}
+          wrapperClassName="h-full w-full"
+          className="!text-xs h-full w-full resize-none rounded-none border-none px-2 py-1.5 outline-none focus-within:rounded-none focus-within:border-transparent focus-within:bg-white focus-within:shadow-[inset_0_0_0_1.5px_rgba(0,82,205,1)] focus:outline-none focus:ring-0 dark:focus-within:bg-theme-grey-200"
+        />
+        {(isNullable || hasDefault) && (
+          <CellResetButtons
+            isNullable={isNullable}
+            hasDefault={hasDefault}
+            onSetNull={() => onSave?.(null, { reset: 'null' })}
+            onSetDefault={() => onSave?.(null, { reset: 'default' })}
+            className="absolute right-1 bottom-1"
+          />
+        )}
+      </div>
     );
   }
 


### PR DESCRIPTION
Fixes #2925

### Checklist

- [x] No breaking changes
- [x] Tests pass
- [x] New features have new tests
- [ ] Documentation is updated (if applicable)
- [x] Title of the PR is in the correct format (see below)

<!-- nhost-reviewer:start -->
### **PR Type**
Enhancement

___

### **Description**
- Allow `''::text` / `''::character varying` as a selectable column default; the default-value dropdown now surfaces it as `EMPTY STRING` and round-trips through `normalizeDefaultValue` and `prepareCreate/UpdateColumnQuery` without being collapsed to the empty string.
- For nullable columns that also have a DEFAULT, introduce a new `NullDefaultToggleField` in the create-record form that lets the user explicitly choose between `NULL` and column `DEFAULT` (previously empty input was ambiguous). Uses a sentinel `POSTGRES_DEFAULT_PLACEHOLDER` (`\x00DEFAULT\x00`) in form state, hidden from yup via a resolver wrapper.
- Extend the storage data-grid cell editors (text, date, numeric) with inline `NULL` / `DEFAULT` reset buttons, and split the row-update `reset` flag into a `'null' | 'default'` discriminator so updates emit `col = NULL` or `col = DEFAULT` distinctly.
- Refactor `InputGroupAddon` to a non-button `role="group"` with `onMouseDown`-based focus delegation, and convert `InputGroupTextarea` to `forwardRef` so the new toggle field can attach refs.
- Add a `getPostgresFunctionsKey` helper that normalises free-typed custom types (e.g. `varchar(10)` → `character varying`) so they pick up the same default-value options, and surface friendly labels through `POSTGRESQL_FUNCTION_LABELS`.
- Split `ColumnEditorRow` into per-concern files (`NameInput`, `TypeAutocomplete`, `Checkbox`, `GeneratedBadge`) and migrate touched test files from `test(` to `it(`, dropping redundant `vitest` imports.

___

### Diagram Walkthrough

```mermaid
flowchart LR
  A["Column metadata<br/>(isNullable, defaultValue)"] --> B["CreateRecordForm<br/>defaultValues"]
  B -->|nullable + hasDefault| P["POSTGRES_DEFAULT_PLACEHOLDER"]
  P --> N["NullDefaultToggleField"]
  N --> R["wrapResolverWithDefaultPlaceholder<br/>(yup sanitiser)"]
  R --> H["BaseRecordForm.handleSubmit"]
  H -->|PLACEHOLDER| D1["fallbackValue: DEFAULT"]
  H -->|null + nullable| D2["fallbackValue: NULL"]
  S["Storage DataGridCell editor"] --> C["CellResetButtons"]
  C -->|reset='null'| U["updateRecord<br/>col = NULL"]
  C -->|reset='default'| V["updateRecord<br/>col = DEFAULT"]
```

<details> <summary><h3> File Walkthrough</h3></summary>

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody>
<tr><td><strong>Record form (database)</strong></td><td><details><summary>5 files</summary><table>
<tr>
  <td><strong>BaseRecordForm.tsx</strong><dd><code>Branch on POSTGRES_DEFAULT_PLACEHOLDER and split nullable vs. required default handling.</code></dd></td>
  <td><a href="https://github.com/nhost/nhost/pull/4210/files#diff-b6bf356211ea3f56b05941761c63104cbfdea0588e986413ec33f9afff58bcdd">+15/-9</a></td>
</tr>
<tr>
  <td><strong>BaseRecordForm.test.tsx</strong><dd><code>Add handleSubmit cases for sentinel/nullable/required-with-default.</code></dd></td>
  <td><a href="https://github.com/nhost/nhost/pull/4210/files#diff-14f015e82f9ea8e15fe72e3b8c15fbb93087f9d94313ca48f1166b59b7124905">+108/-8</a></td>
</tr>
<tr>
  <td><strong>CreateRecordForm.tsx</strong><dd><code>Seed defaultValues with sentinel and wrap resolver.</code></dd></td>
  <td><a href="https://github.com/nhost/nhost/pull/4210/files#diff-b63315826377a8bdcefc6929e557c8dbdb8599961112802bfb30cd2a4f1c684a">+13/-3</a></td>
</tr>
<tr>
  <td><strong>NullDefaultToggleField.tsx</strong><dd><code>New input-group field with NULL/DEFAULT toggle and ref forwarding.</code></dd></td>
  <td><a href="https://github.com/nhost/nhost/pull/4210/files#diff-c52b179fb7e7f91fa0d8edb3f5f7b5cb2e42894953a7ff1cee542cb591be3967">+168/-0</a></td>
</tr>
<tr>
  <td><strong>NullDefaultToggleField.test.tsx</strong><dd><code>Render/toggle smoke tests for the new field.</code></dd></td>
  <td><a href="https://github.com/nhost/nhost/pull/4210/files#diff-58967eb343c0d2a94bf76310cdfde87e2d85d4cadf4e1921bfbc7e9c72622a74">+47/-0</a></td>
</tr>
</table></details></td></tr>

<tr><td><strong>Column editor split &amp; default-value autocomplete</strong></td><td><details><summary>7 files</summary><table>
<tr>
  <td><strong>ColumnEditorRow.tsx</strong><dd><code>Extract NameInput/TypeAutocomplete/Checkbox/GeneratedBadge to own files; align row heights.</code></dd></td>
  <td><a href="https://github.com/nhost/nhost/pull/4210/files#diff-264f067037cfa5d08dbb97964a9ddb8f6296129441682b78f6984c37051ea3f8">+8/-184</a></td>
</tr>
<tr>
  <td><strong>NameInput.tsx</strong><dd><code>Extracted column-name input.</code></dd></td>
  <td><a href="https://github.com/nhost/nhost/pull/4210/files#diff-d297350a19c37479150e5ad62aab2b67fb368534d4a965e7300723d2fce02f4d">+57/-0</a></td>
</tr>
<tr>
  <td><strong>TypeAutocomplete.tsx</strong><dd><code>Extracted column-type autocomplete.</code></dd></td>
  <td><a href="https://github.com/nhost/nhost/pull/4210/files#diff-6a402fb6c8abb09d8a944d03e48f01fecd7dac15d6f7e8440ddb0acca415a889">+76/-0</a></td>
</tr>
<tr>
  <td><strong>Checkbox.tsx</strong><dd><code>Extracted nullable/unique checkbox wrapper.</code></dd></td>
  <td><a href="https://github.com/nhost/nhost/pull/4210/files#diff-4385f282ec9dcae2d7f4749489dbd0430cc7eadb9291dbda595cca384cc42f8b">+31/-0</a></td>
</tr>
<tr>
  <td><strong>GeneratedBadge.tsx</strong><dd><code>Extracted Sigma badge with tooltip.</code></dd></td>
  <td><a href="https://github.com/nhost/nhost/pull/4210/files#diff-400e62e07ec0f37cc85e46c9c1a26633a9c3f24b88032cd7a13c6c39efe81f5f">+29/-0</a></td>
</tr>
<tr>
  <td><strong>DefaultValueAutocomplete.tsx</strong><dd><code>Add NULL/NO-DEFAULT clear option, use POSTGRESQL_FUNCTION_LABELS and normalised type key.</code></dd></td>
  <td><a href="https://github.com/nhost/nhost/pull/4210/files#diff-2c764e2890fa341ae55ea7a1c91e3118f33717decc7bde2dd12d9bcab53fd950">+36/-16</a></td>
</tr>
<tr>
  <td><strong>DefaultValueAutocomplete.test.tsx</strong><dd><code>New tests for trigger/labels/dropdown/selection paths.</code></dd></td>
  <td><a href="https://github.com/nhost/nhost/pull/4210/files#diff-32a8a7bbb0213dada361915922a46722c3f7457839d435345a30d5ea053fef91">+220/-0</a></td>
</tr>
</table></details></td></tr>

<tr><td><strong>Storage data-grid cells</strong></td><td><details><summary>6 files</summary><table>
<tr>
  <td><strong>CellResetButtons.tsx</strong><dd><code>New inline NULL/DEFAULT reset buttons with Tab handling.</code></dd></td>
  <td><a href="https://github.com/nhost/nhost/pull/4210/files#diff-b1ce5700358014b16ef290764f84ef36113941b64989c305271a4ce7ceaf6e59">+67/-0</a></td>
</tr>
<tr>
  <td><strong>CellResetButtons.test.tsx</strong><dd><code>Render/click/keyboard tests for reset buttons.</code></dd></td>
  <td><a href="https://github.com/nhost/nhost/pull/4210/files#diff-7edd094397af4266277c3bb82725e81a53d2d8f55aa13cb0a8b5f221a31029a0">+267/-0</a></td>
</tr>
<tr>
  <td><strong>DataGridCell.tsx</strong><dd><code>Switch reset flag to 'null' | 'default'; normalise null/undefined values.</code></dd></td>
  <td><a href="https://github.com/nhost/nhost/pull/4210/files#diff-0049e6acaddf9f9b60fe43a1fbb2657564bd019e690d0361aae39f44a03adaa2">+23/-14</a></td>
</tr>
<tr>
  <td><strong>DataGridDateCell.tsx</strong><dd><code>Wrap input and render CellResetButtons; stop Tab propagation when reset buttons present.</code></dd></td>
  <td><a href="https://github.com/nhost/nhost/pull/4210/files#diff-95e5b8780946ddb0c020be73a0646e7627c90ea7cc63a408346a434d1f12938e">+31/-12</a></td>
</tr>
<tr>
  <td><strong>DataGridNumericCell.tsx</strong><dd><code>Wrap input and render CellResetButtons.</code></dd></td>
  <td><a href="https://github.com/nhost/nhost/pull/4210/files#diff-74641aa58316603aab327be5bed95f592db80e17509defc303e8d108c366a915">+33/-14</a></td>
</tr>
<tr>
  <td><strong>DataGridTextCell.tsx</strong><dd><code>Wrap text/textarea editors and render CellResetButtons.</code></dd></td>
  <td><a href="https://github.com/nhost/nhost/pull/4210/files#diff-d1ed74fe8eb7a61053dfe908966311e13915ad2127ee107b62f725d6c5282492">+50/-15</a></td>
</tr>
</table></details></td></tr>

<tr><td><strong>Update/insert query helpers &amp; tests</strong></td><td><details><summary>6 files</summary><table>
<tr>
  <td><strong>updateRecord.ts</strong><dd><code>Emit col = NULL or col = DEFAULT based on the new reset discriminator.</code></dd></td>
  <td><a href="https://github.com/nhost/nhost/pull/4210/files#diff-d55f2716d5999af410e357f4d7ee06afaa93f6b185bbeffecbe2917c16a5e3f0">+5/-1</a></td>
</tr>
<tr>
  <td><strong>updateRecord.test.ts</strong><dd><code>Tests for null/default/array-default/mixed reset paths.</code></dd></td>
  <td><a href="https://github.com/nhost/nhost/pull/4210/files#diff-e3d275736970f64c5408b98667076120f76ba75d4bcf9c85113859b74ec43837">+60/-2</a></td>
</tr>
<tr>
  <td><strong>prepareCreateColumnQuery.test.ts</strong><dd><code>Empty-string default + test→it migration.</code></dd></td>
  <td><a href="https://github.com/nhost/nhost/pull/4210/files#diff-044da1c4657773170b3b538cb2d0baa035114cfcf98f89b93b4793e390f019d8">+29/-7</a></td>
</tr>
<tr>
  <td><strong>prepareCreateTableQuery.test.ts</strong><dd><code>Empty-string default for text/varchar.</code></dd></td>
  <td><a href="https://github.com/nhost/nhost/pull/4210/files#diff-348ba7ca6fc037a9d0de76a24efc36846c634d82755bbf33dd5062a7face06ec">+47/-9</a></td>
</tr>
<tr>
  <td><strong>prepareUpdateColumnQuery.test.ts</strong><dd><code>No-default cases and custom↔non-custom flip tests.</code></dd></td>
  <td><a href="https://github.com/nhost/nhost/pull/4210/files#diff-65420c7003a95c03b31fc4b0e45f6a22387f81c1ce8e41a2d7cb89cc44dbda26">+115/-21</a></td>
</tr>
<tr>
  <td><strong>BaseTableForm.test.tsx</strong><dd><code>End-to-end EMPTY STRING selection test.</code></dd></td>
  <td><a href="https://github.com/nhost/nhost/pull/4210/files#diff-76c87617e7921fd6eb4bf7bb18f98a702dbc95e7b6d9342a9c1befa88c7f8fb6">+28/-1</a></td>
</tr>
</table></details></td></tr>

<tr><td><strong>Normalisation utilities</strong></td><td><details><summary>10 files</summary><table>
<tr>
  <td><strong>normalizeDefaultValue.ts</strong><dd><code>Return null when no default; keep ''::text literal intact.</code></dd></td>
  <td><a href="https://github.com/nhost/nhost/pull/4210/files#diff-53542e68f97c2e568cffadfc4ff977c7f4fbc2ac344e40d046c67b083ac3f9ed">+9/-9</a></td>
</tr>
<tr>
  <td><strong>normalizeDefaultValue.test.ts</strong><dd><code>Updated expectations for the new ColumnDefaultValue | null shape.</code></dd></td>
  <td><a href="https://github.com/nhost/nhost/pull/4210/files#diff-94ee9654581ad6c23372bebfee79b4fb9333f2c03804e0bc44ecc7b90b63402a">+26/-33</a></td>
</tr>
<tr>
  <td><strong>normalizeDatabaseColumn.ts</strong><dd><code>Forward the new normalizeDefaultValue result directly.</code></dd></td>
  <td><a href="https://github.com/nhost/nhost/pull/4210/files#diff-e00d1c71fcbc63286896b597ce820388987e0a7edb005bda8a13bb0c0813434b">+2/-7</a></td>
</tr>
<tr>
  <td><strong>normalizeDatabaseColumn.test.ts</strong><dd><code>Empty-string cast preserved as non-custom default.</code></dd></td>
  <td><a href="https://github.com/nhost/nhost/pull/4210/files#diff-a451c29ffa35243d4dbb462e3a048088c514f8056effedf782fcc57d5235e338">+22/-6</a></td>
</tr>
<tr>
  <td><strong>postgresDefaultPlaceholder.ts</strong><dd><code>New sentinel + yup resolver wrapper.</code></dd></td>
  <td><a href="https://github.com/nhost/nhost/pull/4210/files#diff-aa91ab03e7f9a2aeb32858503d88589f0f4ca49d0f0a90f59101c3963e32756a">+30/-0</a></td>
</tr>
<tr>
  <td><strong>postgresDefaultPlaceholder.test.ts</strong><dd><code>Tests covering sanitise/restore/error paths.</code></dd></td>
  <td><a href="https://github.com/nhost/nhost/pull/4210/files#diff-315058fe41dba9147caa5b7a6612346a38cea98e68c0ccc3cd68efd72a190917">+108/-0</a></td>
</tr>
<tr>
  <td><strong>getPostgresFunctionsKey.ts</strong><dd><code>Strip length modifier and alias varchar → character varying.</code></dd></td>
  <td><a href="https://github.com/nhost/nhost/pull/4210/files#diff-21c73e5b90d7d83e2e18389724b6a1e3020719b835c25ebc0f2351c84cb10da0">+28/-0</a></td>
</tr>
<tr>
  <td><strong>getPostgresFunctionsKey.test.ts</strong><dd><code>Alias/strip/case/empty tests.</code></dd></td>
  <td><a href="https://github.com/nhost/nhost/pull/4210/files#diff-6d0d968a91529fdaaf92f2e3f71432ba7fae804d94b5fc6051e93528d8f1fe1c">+40/-0</a></td>
</tr>
<tr>
  <td><strong>postgresqlConstants.ts</strong><dd><code>Add POSTGRESQL_FUNCTION_LABELS and empty-string entries for text/varchar.</code></dd></td>
  <td><a href="https://github.com/nhost/nhost/pull/4210/files#diff-b497da90feca5bff94b0d38b69e519d171d43acc292098054d672a73a89b4717">+13/-1</a></td>
</tr>
<tr>
  <td><strong>validationSchemaHelpers.ts</strong><dd><code>Bypass JSON validation when value is empty or sentinel.</code></dd></td>
  <td><a href="https://github.com/nhost/nhost/pull/4210/files#diff-a3931fcdf04499b324adf30c2aaa1687683ef92aa4e0f6de134a1a5bb076431c">+6/-1</a></td>
</tr>
</table></details></td></tr>

<tr><td><strong>Shared UI / misc</strong></td><td><details><summary>5 files</summary><table>
<tr>
  <td><strong>input-group.tsx</strong><dd><code>Addon becomes role="group" with onMouseDown focus delegation; Textarea gains forwardRef.</code></dd></td>
  <td><a href="https://github.com/nhost/nhost/pull/4210/files#diff-9a2d8f0f3a2ee2a82b8e365ce9cc775c04fed7130c5a9fb3d18db6222b980395">+10/-14</a></td>
</tr>
<tr>
  <td><strong>DatabaseRecordInputGroup.tsx</strong><dd><code>Pick NullDefaultToggleField for nullable+hasDefault columns; rework placeholder helper.</code></dd></td>
  <td><a href="https://github.com/nhost/nhost/pull/4210/files#diff-52b5499e9afc3c5e4929046b487de649d421dda3250a4131462ec710575abc12">+44/-22</a></td>
</tr>
<tr>
  <td><strong>DataBrowserGrid.tsx</strong><dd><code>Adopt the new normalizeDefaultValue shape.</code></dd></td>
  <td><a href="https://github.com/nhost/nhost/pull/4210/files#diff-5910fd8730fbe65c60aa5f54031989a7868e944d5958f69535e5684b72ca1396">+3/-4</a></td>
</tr>
<tr>
  <td><strong>dataBrowser.ts</strong><dd><code>Type updates: defaultValue?: string | null; reset?: 'null' | 'default'.</code></dd></td>
  <td><a href="https://github.com/nhost/nhost/pull/4210/files#diff-33c6810dbd7e2910c86a15009467a348f064380b0e1dd787ef320b4e7543403b">+5/-4</a></td>
</tr>
<tr>
  <td><strong>postgresDefaultPlaceholder/index.ts</strong><dd><code>Barrel re-exports.</code></dd></td>
  <td><a href="https://github.com/nhost/nhost/pull/4210/files#diff-c1b35522a8b485742f1216ae8a156daaa9210694b353041615d6c36728d51100">+4/-0</a></td>
</tr>
</table></details></td></tr>

</tbody></table>

</details>

___

<!-- nhost-reviewer:end -->
