### PR TITLE
feat(functions): reuse esbuild context to lower memory usage

### DIFF
--- a/cli/cmd/dev/up.go
+++ b/cli/cmd/dev/up.go
@@ -41,6 +41,7 @@ const (
 	flagsHasuraPort        = "hasura-port"
 	flagsHasuraConsolePort = "hasura-console-port"
 	flagDashboardVersion   = "dashboard-version"
+	flagFunctionsVersion   = "functions-version"
 	flagConfigserverImage  = "configserver-image"
 	flagRunService         = "run-service"
 	flagRunServiceVolume   = "run-service-volume"
@@ -49,8 +50,9 @@ const (
 )
 
 const (
-	defaultHTTPPort     = 443
-	defaultPostgresPort = 5432
+	defaultHTTPPort         = 443
+	defaultPostgresPort     = 5432
+	defaultFunctionsVersion = "2.0.0-rc2"
 )
 
 func CommandUp() *cli.Command { //nolint:funlen
@@ -114,6 +116,12 @@ func CommandUp() *cli.Command { //nolint:funlen
 				Usage:   "Dashboard version to use",
 				Value:   "nhost/dashboard:2.60.0",
 				Sources: cli.EnvVars("NHOST_DASHBOARD_VERSION"),
+			},
+			&cli.StringFlag{ //nolint:exhaustruct
+				Name:    flagFunctionsVersion,
+				Usage:   "Functions version to use",
+				Value:   defaultFunctionsVersion,
+				Sources: cli.EnvVars("NHOST_FUNCTIONS_VERSION"),
 			},
 			&cli.StringFlag{ //nolint:exhaustruct
 				Name:    flagConfigserverImage,
@@ -188,6 +196,7 @@ func commandUp(ctx context.Context, cmd *cli.Command) error {
 			Functions: cmd.Uint(flagsFunctionsPort),
 		},
 		cmd.String(flagDashboardVersion),
+		cmd.String(flagFunctionsVersion),
 		configserverImage,
 		cmd.String(flagCACertificates),
 		cmd.StringSlice(flagRunService),
@@ -402,6 +411,7 @@ func up( //nolint:funlen,cyclop
 	applySeeds bool,
 	ports dockercompose.ExposePorts,
 	dashboardVersion string,
+	functionsVersion string,
 	configserverImage string,
 	caCertificatesPath string,
 	runServices []string,
@@ -461,6 +471,7 @@ func up( //nolint:funlen,cyclop
 		ports,
 		ce.Branch(),
 		dashboardVersion,
+		functionsVersion,
 		configserverImage,
 		clienv.PathExists(ce.Path.Functions()),
 		caCertificatesPath,
@@ -620,6 +631,7 @@ func Up(
 	applySeeds bool,
 	ports dockercompose.ExposePorts,
 	dashboardVersion string,
+	functionsVersion string,
 	configserverImage string,
 	caCertificatesPath string,
 	runServices []string,
@@ -639,6 +651,7 @@ func Up(
 		applySeeds,
 		ports,
 		dashboardVersion,
+		functionsVersion,
 		configserverImage,
 		caCertificatesPath,
 		runServices,

--- a/cli/dockercompose/compose.go
+++ b/cli/dockercompose/compose.go
@@ -412,6 +412,7 @@ func functions( //nolint:funlen
 	jwtSecret string,
 	port uint,
 	branch string,
+	functionsVersion string,
 ) (*Service, error) {
 	jwtSecret, err := stripJWTSecretToPublic(jwtSecret)
 	if err != nil {
@@ -441,8 +442,9 @@ func functions( //nolint:funlen
 
 	return &Service{
 		Image: fmt.Sprintf(
-			"nhost/functions:%d-2.0.0-rc2",
+			"nhost/functions:%d-%s",
 			*cfg.GetFunctions().GetNode().Version,
+			functionsVersion,
 		),
 		DependsOn:   nil,
 		EntryPoint:  nil,
@@ -573,6 +575,7 @@ func getServices( //nolint: funlen,cyclop
 	ports ExposePorts,
 	branch string,
 	dashboardVersion string,
+	functionsVersion string,
 	configserviceImage string,
 	startFunctions bool,
 	runServices ...*RunService,
@@ -647,6 +650,7 @@ func getServices( //nolint: funlen,cyclop
 			jwtSecret,
 			ports.Functions,
 			branch,
+			functionsVersion,
 		)
 		if err != nil {
 			return nil, err
@@ -714,6 +718,7 @@ func ComposeFileFromConfig(
 	ports ExposePorts,
 	branch string,
 	dashboardVersion string,
+	functionsVersion string,
 	configserverImage string,
 	startFunctions bool,
 	caCertificatesPath string,
@@ -732,6 +737,7 @@ func ComposeFileFromConfig(
 		ports,
 		branch,
 		dashboardVersion,
+		functionsVersion,
 		configserverImage,
 		startFunctions,
 		runServices...,

--- a/docs/src/content/docs/reference/cli/commands.mdx
+++ b/docs/src/content/docs/reference/cli/commands.mdx
@@ -262,6 +262,8 @@ Start local development environment
 
 **--functions-port**="": If specified, expose functions on this port. Not recommended (default: 0)
 
+**--functions-version**="": Functions version to use (default: "2.0.0-rc2") [$NHOST_FUNCTIONS_VERSION]
+
 **--hasura-console-port**="": If specified, expose hasura console on this port. Not recommended (default: 0)
 
 **--hasura-port**="": If specified, expose hasura on this port. Not recommended (default: 0)

--- a/services/functions/CLAUDE.md
+++ b/services/functions/CLAUDE.md
@@ -31,7 +31,7 @@ services/functions/
 
 ## Key Concepts
 
-- **server.js**: Discovers functions via glob, creates an esbuild context per function, watches for changes. Routes are derived from file paths (e.g., `hello.ts` -> `/hello`). Index files map to parent directories. Builds are output to `.nhost-build/dist/`.
+- **server.js**: Discovers functions via glob, then creates a single shared esbuild context with one entry point per function (shares the parsed dependency graph across functions to keep memory bounded). Watches for changes via `ctx.watch()`; polls every 1s to detect added/removed files and recreates the context when the entry set changes. Routes are derived from file paths (e.g., `hello.ts` -> `/hello`). Index files map to parent directories. Builds are output to `/tmp/nhost-build/dist/<safeName>.js`, with generated wrappers in `/tmp/nhost-build/wrappers/`.
 - **local-wrapper.js**: Template that wraps each user function in an Express mini-app with JSON/URL-encoded body parsing (6MB limit), raw body preservation, invocation ID tracking, and error handling. The placeholder `%FUNCTION_PATH%` is replaced at build time.
 - **start.sh**: Docker entrypoint that detects whether `package.json` is at `./functions/` or `./`, validates a lock file exists, copies default `tsconfig.json`, installs dependencies via `nci` (@antfu/ni), and starts the server.
 - **Routing**: `functions/hello.ts` -> `/hello`, `functions/sub/index.ts` -> `/sub/`, `functions/_utils/` -> ignored. Route lookup is flexible: tries exact match, then without trailing slash, then with trailing slash.

--- a/services/functions/Makefile
+++ b/services/functions/Makefile
@@ -4,6 +4,9 @@ include $(ROOT_DIR)/build/makefiles/general.makefile
 NODE_VERSION?=22
 DOCKER_DEV_ENV_PATH=build/dev/docker
 
+# Capture base version (without Node prefix) for changelog-bump-refs
+BUMP_VERSION:=$(VERSION)
+
 # Prepend Node version to VERSION if not already prefixed
 ifneq ($(NODE_VERSION)-,$(firstword $(subst -, ,$(VERSION)))-)
 VERSION:=$(NODE_VERSION)-$(VERSION)
@@ -33,3 +36,8 @@ _dev-env-up:
 .PHONY: _dev-env-down
 _dev-env-down:
 	docker compose -f ${DOCKER_DEV_ENV_PATH}/docker-compose.yaml down --volumes
+
+
+.PHONY: changelog-bump-refs
+changelog-bump-refs:  ## Bump functions version ref in CLI source
+	@sed -i 's|defaultFunctionsVersion = "[^"]*"|defaultFunctionsVersion = "$(BUMP_VERSION)"|' $(ROOT_DIR)/cli/cmd/dev/up.go

--- a/services/functions/server.js
+++ b/services/functions/server.js
@@ -36,6 +36,18 @@ const functionMeta = new Map();
 // bundle per function — matching the per-Lambda artifact layout in prod.
 let buildContext = null;
 
+// setInterval does not await its async callback, so two polls can overlap if a
+// rebuild runs longer than the polling interval — exactly the case for big
+// projects. Serialize all rebuilds behind a single in-flight promise so dispose
+// and create are strictly sequential and no context is leaked.
+let rebuildInFlight = Promise.resolve();
+function scheduleRebuild(functionsPath) {
+  rebuildInFlight = rebuildInFlight
+    .catch(() => {})
+    .then(() => rebuildContext(functionsPath));
+  return rebuildInFlight;
+}
+
 const wrapperTemplate = fs.readFileSync(
   path.join(__dirname, 'local-wrapper.js'),
   'utf-8',
@@ -243,7 +255,7 @@ const main = async () => {
   }
 
   try {
-    await rebuildContext(functionsPath);
+    await scheduleRebuild(functionsPath);
   } catch (err) {
     serverLog('ERROR', '', 'Failed initial build:', err);
   }
@@ -266,7 +278,7 @@ const main = async () => {
     for (const file of discoverFunctions(functionsPath)) {
       prepareFunctionEntry(functionsPath, file);
     }
-    await rebuildContext(functionsPath);
+    await scheduleRebuild(functionsPath);
   }
 
   // Poll for new/deleted function files. Filesystem events (chokidar/inotify)
@@ -300,7 +312,7 @@ const main = async () => {
 
     if (changed) {
       try {
-        await rebuildContext(functionsPath);
+        await scheduleRebuild(functionsPath);
       } catch (err) {
         serverLog('ERROR', '', 'Failed to rebuild context:', err);
       }

--- a/services/functions/server.js
+++ b/services/functions/server.js
@@ -9,6 +9,8 @@ const util = require('node:util');
 
 const PORT = 3000;
 const BUILD_DIR = '/tmp/nhost-build';
+const DIST_DIR = path.join(BUILD_DIR, 'dist');
+const WRAPPER_DIR = path.join(BUILD_DIR, 'wrappers');
 
 function logJSON(obj) {
   process.stdout.write(`${JSON.stringify(obj)}\n`);
@@ -21,11 +23,18 @@ function serverLog(level, route, ...args) {
 // Map of route -> Express app (loaded from esbuild bundles)
 const functionHandlers = new Map();
 
-// Map of file path -> esbuild context (for disposing on delete)
-const esbuildContexts = new Map();
+// Map of file path -> { wrapperPath, outfile, route, safeName }
+const functionEntries = new Map();
 
 // Track discovered functions for metadata endpoint
 const functionMeta = new Map();
+
+// Single esbuild context covering every function's wrapper as an entry point.
+// Per-function contexts retained the parsed dep graph (express, aws-sdk, ...)
+// once per function, multiplying memory by N. A single context shares one
+// module graph across all entry points while still emitting an independent
+// bundle per function — matching the per-Lambda artifact layout in prod.
+let buildContext = null;
 
 const wrapperTemplate = fs.readFileSync(
   path.join(__dirname, 'local-wrapper.js'),
@@ -64,63 +73,16 @@ function generateWrapper(relativeFunctionPath) {
   return wrapperTemplate.replace('%FUNCTION_PATH%', relativeFunctionPath);
 }
 
-async function buildFunction(functionsPath, file) {
+function prepareFunctionEntry(functionsPath, file) {
   const safeName = fileToSafeName(file);
-
-  // Write wrapper under BUILD_DIR to avoid polluting the user's functions directory.
-  // Use the absolute path to the function so require() resolution still works.
-  const wrapperDir = path.join(BUILD_DIR, 'wrappers');
-  fs.mkdirSync(wrapperDir, { recursive: true });
-  const wrapperPath = path.join(wrapperDir, `.wrapper-${safeName}.js`);
+  const wrapperPath = path.join(WRAPPER_DIR, `.wrapper-${safeName}.js`);
   const absoluteFuncPath = path.join(functionsPath, file);
-  const wrapperContent = generateWrapper(absoluteFuncPath);
-  fs.writeFileSync(wrapperPath, wrapperContent);
+  fs.writeFileSync(wrapperPath, generateWrapper(absoluteFuncPath));
 
-  const distDir = path.join(BUILD_DIR, 'dist', safeName);
-  fs.mkdirSync(distDir, { recursive: true });
-
-  const outfile = path.join(distDir, 'bundle.js');
+  const outfile = path.join(DIST_DIR, `${safeName}.js`);
   const route = fileToRoute(file);
 
-  // Resolve global node_modules (NODE_PATH) so esbuild can find express, etc.
-  const nodePaths = process.env.NODE_PATH
-    ? process.env.NODE_PATH.split(path.delimiter)
-    : [];
-
-  const ctx = await esbuild.context({
-    entryPoints: [wrapperPath],
-    bundle: true,
-    minify: true,
-    platform: 'node',
-    target: getNodeTarget(),
-    sourcemap: true,
-    outfile,
-    nodePaths,
-    logLevel: 'warning',
-    plugins: [
-      {
-        name: 'reload-notifier',
-        setup(build) {
-          build.onEnd((result) => {
-            if (result.errors.length > 0) return;
-            if (!fs.existsSync(path.join(functionsPath, file))) return;
-            loadBundle(route, outfile, safeName);
-            serverLog('INFO', route, `Rebuilt from ${file}`);
-          });
-        },
-      },
-    ],
-  });
-
-  // Initial build
-  await ctx.rebuild();
-
-  // Start watching for changes
-  await ctx.watch();
-
-  esbuildContexts.set(file, { ctx, wrapperPath });
-
-  // Store metadata
+  functionEntries.set(file, { wrapperPath, outfile, route, safeName });
   functionMeta.set(file, {
     path: path.join('functions', file),
     route,
@@ -130,11 +92,26 @@ async function buildFunction(functionsPath, file) {
     functionName: '',
     createdWithCommitSha: 'localdev',
   });
-
-  serverLog('INFO', route, `Loaded from ${file}`);
 }
 
-function loadBundle(route, bundlePath, _safeName) {
+function disposeFunctionEntry(file) {
+  const entry = functionEntries.get(file);
+  if (!entry) return;
+
+  try {
+    fs.unlinkSync(entry.wrapperPath);
+  } catch {}
+  try {
+    fs.unlinkSync(entry.outfile);
+    fs.unlinkSync(`${entry.outfile}.map`);
+  } catch {}
+
+  functionEntries.delete(file);
+  functionMeta.delete(file);
+  functionHandlers.delete(entry.route);
+}
+
+function loadBundle(route, bundlePath) {
   // Clear require cache so re-requiring gets fresh code
   const resolved = require.resolve(bundlePath);
   delete require.cache[resolved];
@@ -150,27 +127,64 @@ function loadBundle(route, bundlePath, _safeName) {
   }
 }
 
-async function removeFunction(_functionsPath, file) {
-  const entry = esbuildContexts.get(file);
-  if (entry) {
-    await entry.ctx.dispose();
-    // Clean up wrapper file
-    try {
-      fs.unlinkSync(entry.wrapperPath);
-    } catch {}
-    esbuildContexts.delete(file);
+async function rebuildContext(functionsPath) {
+  if (buildContext) {
+    await buildContext.dispose();
+    buildContext = null;
   }
 
-  const route = fileToRoute(file);
-  functionHandlers.delete(route);
-  functionMeta.delete(file);
+  if (functionEntries.size === 0) return;
 
-  // Clean up build artifacts
-  const safeName = fileToSafeName(file);
-  const distDir = path.join(BUILD_DIR, 'dist', safeName);
-  fs.rmSync(distDir, { recursive: true, force: true });
+  const nodePaths = process.env.NODE_PATH
+    ? process.env.NODE_PATH.split(path.delimiter)
+    : [];
 
-  serverLog('INFO', route, `Removed (${file} deleted)`);
+  const entryPoints = {};
+  for (const [, entry] of functionEntries) {
+    entryPoints[entry.safeName] = entry.wrapperPath;
+  }
+
+  const ctx = await esbuild.context({
+    entryPoints,
+    bundle: true,
+    minify: true,
+    platform: 'node',
+    target: getNodeTarget(),
+    sourcemap: true,
+    outdir: DIST_DIR,
+    nodePaths,
+    logLevel: 'warning',
+    plugins: [
+      {
+        name: 'reload-notifier',
+        setup(build) {
+          build.onEnd((result) => {
+            for (const err of result.errors) {
+              serverLog(
+                'ERROR',
+                err.location?.file || '',
+                `Build error: ${err.text}`,
+              );
+            }
+            // esbuild writes outputs atomically: on any error, no bundles are
+            // (re)written, so we keep the previously loaded handlers in place.
+            if (result.errors.length > 0) return;
+
+            for (const [file, entry] of functionEntries) {
+              if (!fs.existsSync(path.join(functionsPath, file))) continue;
+              if (!fs.existsSync(entry.outfile)) continue;
+              loadBundle(entry.route, entry.outfile);
+              serverLog('INFO', entry.route, `Rebuilt from ${file}`);
+            }
+          });
+        },
+      },
+    ],
+  });
+
+  await ctx.rebuild();
+  await ctx.watch();
+  buildContext = ctx;
 }
 
 function findRoute(reqPath) {
@@ -220,18 +234,18 @@ const main = async () => {
     res.json({ functions: Array.from(functionMeta.values()) });
   });
 
-  // Discover and build all functions
-  const files = discoverFunctions(functionsPath);
+  fs.mkdirSync(WRAPPER_DIR, { recursive: true });
+  fs.mkdirSync(DIST_DIR, { recursive: true });
 
-  // Ensure build directory exists
-  fs.mkdirSync(path.join(BUILD_DIR, 'dist'), { recursive: true });
+  // Discover and prepare all function entries
+  for (const file of discoverFunctions(functionsPath)) {
+    prepareFunctionEntry(functionsPath, file);
+  }
 
-  for (const file of files) {
-    try {
-      await buildFunction(functionsPath, file);
-    } catch (err) {
-      serverLog('ERROR', fileToRoute(file), `Failed to build ${file}:`, err);
-    }
+  try {
+    await rebuildContext(functionsPath);
+  } catch (err) {
+    serverLog('ERROR', '', 'Failed initial build:', err);
   }
 
   // Catch-all route — looks up handler from map
@@ -244,55 +258,51 @@ const main = async () => {
     }
   });
 
-  // Rebuild all functions (used after dependency changes)
+  // Tear down all entries and rebuild from scratch (used after dependency changes)
   async function rebuildAll() {
-    // Dispose all existing esbuild contexts
-    for (const [_file, entry] of esbuildContexts) {
-      await entry.ctx.dispose();
-      try {
-        fs.unlinkSync(entry.wrapperPath);
-      } catch {}
+    for (const file of [...functionEntries.keys()]) {
+      disposeFunctionEntry(file);
     }
-    esbuildContexts.clear();
-    functionHandlers.clear();
-    functionMeta.clear();
-
-    const files = discoverFunctions(functionsPath);
-    for (const file of files) {
-      try {
-        await buildFunction(functionsPath, file);
-      } catch (err) {
-        serverLog('ERROR', fileToRoute(file), `Failed to build ${file}:`, err);
-      }
+    for (const file of discoverFunctions(functionsPath)) {
+      prepareFunctionEntry(functionsPath, file);
     }
+    await rebuildContext(functionsPath);
   }
 
   // Poll for new/deleted function files. Filesystem events (chokidar/inotify)
   // are unreliable over Docker volume mounts — add/unlink all arrive as
-  // "change", so we periodically re-discover and diff instead.
+  // "change", so we periodically re-discover and diff instead. When the entry
+  // set changes, the esbuild context is recreated with the new entry points;
+  // edits inside existing functions are picked up by ctx.watch() without a
+  // recreate.
   setInterval(async () => {
     const currentFiles = new Set(discoverFunctions(functionsPath));
-    const knownFiles = new Set(esbuildContexts.keys());
+    const knownFiles = new Set(functionEntries.keys());
+
+    let changed = false;
 
     for (const file of currentFiles) {
       if (!knownFiles.has(file)) {
         serverLog('INFO', fileToRoute(file), `New function detected: ${file}`);
-        try {
-          await buildFunction(functionsPath, file);
-        } catch (err) {
-          serverLog(
-            'ERROR',
-            fileToRoute(file),
-            `Failed to build ${file}:`,
-            err,
-          );
-        }
+        prepareFunctionEntry(functionsPath, file);
+        changed = true;
       }
     }
 
     for (const file of knownFiles) {
       if (!currentFiles.has(file)) {
-        await removeFunction(functionsPath, file);
+        const route = fileToRoute(file);
+        disposeFunctionEntry(file);
+        serverLog('INFO', route, `Removed (${file} deleted)`);
+        changed = true;
+      }
+    }
+
+    if (changed) {
+      try {
+        await rebuildContext(functionsPath);
+      } catch (err) {
+        serverLog('ERROR', '', 'Failed to rebuild context:', err);
       }
     }
   }, 1000);

--- a/services/functions/start.sh
+++ b/services/functions/start.sh
@@ -43,6 +43,11 @@ cp -n "$SERVER_PATH/tsconfig.json" "$FUNCTIONS_WORKING_DIR/tsconfig.json"
 
 # * Install dependencies and start the server from the functions working directory
 # * (cwd must be FUNCTIONS_WORKING_DIR so FUNCTIONS_RELATIVE_PATH resolves correctly)
+# * NODE_OPTIONS bumps the V8 heap so esbuild's watch context has headroom for
+# * projects with many functions / heavy deps. Override via env if needed.
+: "${NODE_OPTIONS:=--max-old-space-size=4096}"
+export NODE_OPTIONS
+
 cd "$FUNCTIONS_WORKING_DIR" && nci && \
 FUNCTIONS_RELATIVE_PATH="$FUNCTIONS_RELATIVE_PATH" \
 node "$SERVER_PATH/server.js"


### PR DESCRIPTION
<!-- nhost-reviewer:start -->
### **PR Type**
Enhancement

___

### **Description**
- Refactors the functions dev runtime to share a single esbuild context across all functions (one entry point per function) instead of one context per function — drastically reducing memory by sharing the parsed dependency graph (express, aws-sdk, etc.) across functions while still emitting an independent bundle per function.
- Adds a `--functions-version` CLI flag (env: `NHOST_FUNCTIONS_VERSION`) and threads it through `Up`, `up`, `ComposeFileFromConfig`, `getServices`, and `functions` so users can override the `nhost/functions:<node>-<version>` image tag at runtime.
- Bumps the V8 heap to 4 GB via `NODE_OPTIONS=--max-old-space-size=4096` in `start.sh` (overridable via env) so esbuild's watch context has headroom for projects with many functions or heavy deps.
- Adds a `changelog-bump-refs` Makefile target in `services/functions` that updates `defaultFunctionsVersion` in `cli/cmd/dev/up.go` during release; captures the un-prefixed `BUMP_VERSION` before the Node-version prefix is prepended to `VERSION`.

___

### Diagram Walkthrough

```mermaid
flowchart LR
  A["nhost dev up<br/>--functions-version"] --> B["cli/cmd/dev/up.go<br/>commandUp / Up / up"]
  B --> C["dockercompose.ComposeFileFromConfig"]
  C --> D["functions() service<br/>image: nhost/functions:N-VERSION"]
  E["services/functions/start.sh<br/>NODE_OPTIONS heap bump"] --> F["server.js<br/>single esbuild context"]
  F --> G["per-function bundle<br/>in /tmp/nhost-build/dist/"]
  H["release CI<br/>make changelog-bump-refs"] --> I["sed defaultFunctionsVersion<br/>in cli/cmd/dev/up.go"]
```

<details> <summary><h3> File Walkthrough</h3></summary>

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody>
<tr><td><strong>CLI</strong></td><td><details><summary>2 files</summary><table>
<tr>
  <td><strong>up.go</strong><dd><code>Adds --functions-version flag, defaultFunctionsVersion const, and threads functionsVersion through Up/up/commandUp.</code></dd></td>
  <td><a href="https://github.com/nhost/nhost/pull/XXX/files#diff-92566687c489a1d085a135fa208ff65d6f9b9bd72199b9646b7b8741896b99a5">+15/-2</a></td>
</tr>
<tr>
  <td><strong>compose.go</strong><dd><code>Threads functionsVersion through ComposeFileFromConfig/getServices/functions and uses it in the image tag template.</code></dd></td>
  <td><a href="https://github.com/nhost/nhost/pull/XXX/files#diff-cfe5848f846b5d5bcfeb5bf52e76d2c23c08e4da760f2b85c1dd3ed01d0a635b">+7/-1</a></td>
</tr>
</table></details></td></tr>
<tr><td><strong>Functions runtime</strong></td><td><details><summary>2 files</summary><table>
<tr>
  <td><strong>server.js</strong><dd><code>Replaces per-function esbuild contexts with a single multi-entry context; introduces prepareFunctionEntry/disposeFunctionEntry/rebuildContext; flattens dist layout to dist/&lt;safeName&gt;.js.</code></dd></td>
  <td><a href="https://github.com/nhost/nhost/pull/XXX/files#diff-3e3fa54db1b505851f46932547f48ebe3c042fd140996fef7afeeaefbb5850e7">+124/-114</a></td>
</tr>
<tr>
  <td><strong>start.sh</strong><dd><code>Sets NODE_OPTIONS=--max-old-space-size=4096 (overridable) before launching the server.</code></dd></td>
  <td><a href="https://github.com/nhost/nhost/pull/XXX/files#diff-7059619976b3bcd7d4f52055eb7b7cfc690ddde406c03fdff3d7f32b5516705c">+5/-0</a></td>
</tr>
</table></details></td></tr>
<tr><td><strong>Build / release</strong></td><td><details><summary>1 files</summary><table>
<tr>
  <td><strong>Makefile</strong><dd><code>Captures BUMP_VERSION before Node-version prefixing and adds changelog-bump-refs target that seds defaultFunctionsVersion in cli/cmd/dev/up.go.</code></dd></td>
  <td><a href="https://github.com/nhost/nhost/pull/XXX/files#diff-7d44ca57821eecb9dc499f1f4c70e0738a1e17d1b19aec6602b4086ac4cbe77b">+8/-0</a></td>
</tr>
</table></details></td></tr>
</tbody></table>

</details>

___

<!-- nhost-reviewer:end -->