### PR TITLE
chore(cli): bump references to 1.45.0

### DIFF
--- a/cli/get.sh
+++ b/cli/get.sh
@@ -1,7 +1,7 @@
 #!/usr/bin/env bash
 
 # This pinned version is bumped automatically by the changelog workflow.
-VERSION="1.44.0"
+VERSION="1.45.0"
 
 # helper functions
 yell() { echo -e "${RED}FAILED> $* ${NC}" >&2; }


### PR DESCRIPTION
Bumps version references after release of `cli` to `1.45.0`.

Generated by `make changelog-bump-refs VER=1.45.0` in `cli`.