### PR TITLE
release(cli): 1.46.0

### DIFF
--- a/cli/CHANGELOG.md
+++ b/cli/CHANGELOG.md
@@ -1,3 +1,25 @@
+## [cli@1.46.0] - 2026-05-19
+
+### 🚀 Features
+
+- *(cli)* Embed email templates instead of fetching at runtime (#4273)
+- *(cli)* Harden local configserver against cross-origin and exfil access (#4302)
+
+
+### 🐛 Bug Fixes
+
+- *(ci)* Make build and check work on NixOS (#4234)
+- *(ci)* Use the environment NHOST_PAT directly (#4246)
+- *(cli)* Create install path if it doesn't exist (#4256)
+- *(cli)* Use `$$` when `$` is in an env var for Docker Compose (#4160)
+
+
+### ⚙️ Miscellaneous Tasks
+
+- *(cli)* Bump references to 1.45.0 (#4219)
+- *(cli)* Update schema (#4288)
+- *(dashboard)* Bump references to 2.63.0
+
 ## [cli@1.45.0] - 2026-04-30
 
 ### 🚀 Features


### PR DESCRIPTION
Automated release preparation for cli version 1.46.0.

Version references in dependent files (CLI sources, docs, etc.) are bumped in a follow-up PR after the release publishes — see `wf_bump_refs.yaml`.