### PR TITLE
chore(ci): extract check permissions actions and include helper bot

### DIFF
--- a/.github/actions/check-permissions/action.yml
+++ b/.github/actions/check-permissions/action.yml
@@ -1,0 +1,15 @@
+name: 'Check Permissions'
+description: "Fail if the PR author lacks write permissions and the 'safe_to_test' label is not present"
+
+runs:
+  using: 'composite'
+  steps:
+    - shell: bash
+      run: |
+        echo "github.event_name: ${{ github.event_name }}"
+        echo "github.event.pull_request.author_association: ${{ github.event.pull_request.author_association }}"
+    - name: "This task will run and fail if user has no permissions and label safe_to_test isn't present"
+      if: 'github.event_name == ''pull_request_target'' && ! ( contains(github.event.pull_request.labels.*.name, ''safe_to_test'') || contains(fromJson(''["OWNER", "MEMBER", "COLLABORATOR"]''), github.event.pull_request.author_association) || contains(fromJson(''["nhost-helper-bot[bot]"]''), github.event.pull_request.user.login) )'
+      shell: bash
+      run: |
+        exit 1

--- a/.github/workflows/auth_checks.yaml
+++ b/.github/workflows/auth_checks.yaml
@@ -54,13 +54,8 @@ jobs:
     if: needs.detect-changes.outputs.should_run == 'true'
     runs-on: ubuntu-latest
     steps:
-      - run: |
-          echo "github.event_name: ${{ github.event_name }}"
-          echo "github.event.pull_request.author_association: ${{ github.event.pull_request.author_association }}"
-      - name: "This task will run and fail if user has no permissions and label safe_to_test isn't present"
-        if: 'github.event_name == ''pull_request_target'' && ! ( contains(github.event.pull_request.labels.*.name, ''safe_to_test'') || contains(fromJson(''["OWNER", "MEMBER", "COLLABORATOR"]''), github.event.pull_request.author_association) )'
-        run: |
-          exit 1
+      - uses: actions/checkout@v6
+      - uses: ./.github/actions/check-permissions
 
   tests:
     uses: ./.github/workflows/wf_check.yaml

--- a/.github/workflows/cli_checks.yaml
+++ b/.github/workflows/cli_checks.yaml
@@ -63,13 +63,8 @@ jobs:
     if: needs.detect-changes.outputs.should_run == 'true'
     runs-on: ubuntu-latest
     steps:
-      - run: |
-          echo "github.event_name: ${{ github.event_name }}"
-          echo "github.event.pull_request.author_association: ${{ github.event.pull_request.author_association }}"
-      - name: "This task will run and fail if user has no permissions and label safe_to_test isn't present"
-        if: 'github.event_name == ''pull_request_target'' && ! ( contains(github.event.pull_request.labels.*.name, ''safe_to_test'') || contains(fromJson(''["OWNER", "MEMBER", "COLLABORATOR"]''), github.event.pull_request.author_association) )'
-        run: |
-          exit 1
+      - uses: actions/checkout@v6
+      - uses: ./.github/actions/check-permissions
 
   tests:
     uses: ./.github/workflows/wf_check.yaml

--- a/.github/workflows/codegen_checks.yaml
+++ b/.github/workflows/codegen_checks.yaml
@@ -50,13 +50,8 @@ jobs:
     if: needs.detect-changes.outputs.should_run == 'true'
     runs-on: ubuntu-latest
     steps:
-      - run: |
-          echo "github.event_name: ${{ github.event_name }}"
-          echo "github.event.pull_request.author_association: ${{ github.event.pull_request.author_association }}"
-      - name: "This task will run and fail if user has no permissions and label safe_to_test isn't present"
-        if: 'github.event_name == ''pull_request_target'' && ! ( contains(github.event.pull_request.labels.*.name, ''safe_to_test'') || contains(fromJson(''["OWNER", "MEMBER", "COLLABORATOR"]''), github.event.pull_request.author_association) )'
-        run: |
-          exit 1
+      - uses: actions/checkout@v6
+      - uses: ./.github/actions/check-permissions
 
   tests:
     uses: ./.github/workflows/wf_check.yaml

--- a/.github/workflows/dashboard_checks.yaml
+++ b/.github/workflows/dashboard_checks.yaml
@@ -62,13 +62,8 @@ jobs:
     if: needs.detect-changes.outputs.should_run == 'true'
     runs-on: ubuntu-latest
     steps:
-      - run: |
-          echo "github.event_name: ${{ github.event_name }}"
-          echo "github.event.pull_request.author_association: ${{ github.event.pull_request.author_association }}"
-      - name: "This task will run and fail if user has no permissions and label safe_to_test isn't present"
-        if: 'github.event_name == ''pull_request_target'' && ! ( contains(github.event.pull_request.labels.*.name, ''safe_to_test'') || contains(fromJson(''["OWNER", "MEMBER", "COLLABORATOR"]''), github.event.pull_request.author_association) )'
-        run: |
-          exit 1
+      - uses: actions/checkout@v6
+      - uses: ./.github/actions/check-permissions
 
   deploy-vercel:
     uses: ./.github/workflows/wf_deploy_vercel.yaml

--- a/.github/workflows/docs_checks.yaml
+++ b/.github/workflows/docs_checks.yaml
@@ -69,13 +69,8 @@ jobs:
     if: needs.detect-changes.outputs.should_run == 'true'
     runs-on: ubuntu-latest
     steps:
-      - run: |
-          echo "github.event_name: ${{ github.event_name }}"
-          echo "github.event.pull_request.author_association: ${{ github.event.pull_request.author_association }}"
-      - name: "This task will run and fail if user has no permissions and label safe_to_test isn't present"
-        if: 'github.event_name == ''pull_request_target'' && ! ( contains(github.event.pull_request.labels.*.name, ''safe_to_test'') || contains(fromJson(''["OWNER", "MEMBER", "COLLABORATOR"]''), github.event.pull_request.author_association) )'
-        run: |
-          exit 1
+      - uses: actions/checkout@v6
+      - uses: ./.github/actions/check-permissions
 
   tests:
     uses: ./.github/workflows/wf_check.yaml

--- a/.github/workflows/examples_demos_checks.yaml
+++ b/.github/workflows/examples_demos_checks.yaml
@@ -74,13 +74,8 @@ jobs:
     if: needs.detect-changes.outputs.should_run == 'true'
     runs-on: ubuntu-latest
     steps:
-      - run: |
-          echo "github.event_name: ${{ github.event_name }}"
-          echo "github.event.pull_request.author_association: ${{ github.event.pull_request.author_association }}"
-      - name: "This task will run and fail if user has no permissions and label safe_to_test isn't present"
-        if: 'github.event_name == ''pull_request_target'' && ! ( contains(github.event.pull_request.labels.*.name, ''safe_to_test'') || contains(fromJson(''["OWNER", "MEMBER", "COLLABORATOR"]''), github.event.pull_request.author_association) )'
-        run: |
-          exit 1
+      - uses: actions/checkout@v6
+      - uses: ./.github/actions/check-permissions
 
   tests:
     uses: ./.github/workflows/wf_check.yaml

--- a/.github/workflows/examples_guides_checks.yaml
+++ b/.github/workflows/examples_guides_checks.yaml
@@ -74,13 +74,8 @@ jobs:
     if: needs.detect-changes.outputs.should_run == 'true'
     runs-on: ubuntu-latest
     steps:
-      - run: |
-          echo "github.event_name: ${{ github.event_name }}"
-          echo "github.event.pull_request.author_association: ${{ github.event.pull_request.author_association }}"
-      - name: "This task will run and fail if user has no permissions and label safe_to_test isn't present"
-        if: 'github.event_name == ''pull_request_target'' && ! ( contains(github.event.pull_request.labels.*.name, ''safe_to_test'') || contains(fromJson(''["OWNER", "MEMBER", "COLLABORATOR"]''), github.event.pull_request.author_association) )'
-        run: |
-          exit 1
+      - uses: actions/checkout@v6
+      - uses: ./.github/actions/check-permissions
 
   tests:
     uses: ./.github/workflows/wf_check.yaml

--- a/.github/workflows/examples_tutorials_checks.yaml
+++ b/.github/workflows/examples_tutorials_checks.yaml
@@ -74,13 +74,8 @@ jobs:
     if: needs.detect-changes.outputs.should_run == 'true'
     runs-on: ubuntu-latest
     steps:
-      - run: |
-          echo "github.event_name: ${{ github.event_name }}"
-          echo "github.event.pull_request.author_association: ${{ github.event.pull_request.author_association }}"
-      - name: "This task will run and fail if user has no permissions and label safe_to_test isn't present"
-        if: 'github.event_name == ''pull_request_target'' && ! ( contains(github.event.pull_request.labels.*.name, ''safe_to_test'') || contains(fromJson(''["OWNER", "MEMBER", "COLLABORATOR"]''), github.event.pull_request.author_association) )'
-        run: |
-          exit 1
+      - uses: actions/checkout@v6
+      - uses: ./.github/actions/check-permissions
 
   tests:
     uses: ./.github/workflows/wf_check.yaml

--- a/.github/workflows/functions_checks.yaml
+++ b/.github/workflows/functions_checks.yaml
@@ -44,13 +44,8 @@ jobs:
     if: needs.detect-changes.outputs.should_run == 'true'
     runs-on: ubuntu-latest
     steps:
-      - run: |
-          echo "github.event_name: ${{ github.event_name }}"
-          echo "github.event.pull_request.author_association: ${{ github.event.pull_request.author_association }}"
-      - name: "This task will run and fail if user has no permissions and label safe_to_test isn't present"
-        if: 'github.event_name == ''pull_request_target'' && ! ( contains(github.event.pull_request.labels.*.name, ''safe_to_test'') || contains(fromJson(''["OWNER", "MEMBER", "COLLABORATOR"]''), github.event.pull_request.author_association) )'
-        run: |
-          exit 1
+      - uses: actions/checkout@v6
+      - uses: ./.github/actions/check-permissions
 
   build_artifacts:
     strategy:

--- a/.github/workflows/govulncheck-wrapper_checks.yaml
+++ b/.github/workflows/govulncheck-wrapper_checks.yaml
@@ -50,13 +50,8 @@ jobs:
     if: needs.detect-changes.outputs.should_run == 'true'
     runs-on: ubuntu-latest
     steps:
-      - run: |
-          echo "github.event_name: ${{ github.event_name }}"
-          echo "github.event.pull_request.author_association: ${{ github.event.pull_request.author_association }}"
-      - name: "This task will run and fail if user has no permissions and label safe_to_test isn't present"
-        if: 'github.event_name == ''pull_request_target'' && ! ( contains(github.event.pull_request.labels.*.name, ''safe_to_test'') || contains(fromJson(''["OWNER", "MEMBER", "COLLABORATOR"]''), github.event.pull_request.author_association) )'
-        run: |
-          exit 1
+      - uses: actions/checkout@v6
+      - uses: ./.github/actions/check-permissions
 
   tests:
     uses: ./.github/workflows/wf_check.yaml

--- a/.github/workflows/mcp_checks.yaml
+++ b/.github/workflows/mcp_checks.yaml
@@ -54,13 +54,8 @@ jobs:
     if: needs.detect-changes.outputs.should_run == 'true'
     runs-on: ubuntu-latest
     steps:
-      - run: |
-          echo "github.event_name: ${{ github.event_name }}"
-          echo "github.event.pull_request.author_association: ${{ github.event.pull_request.author_association }}"
-      - name: "This task will run and fail if user has no permissions and label safe_to_test isn't present"
-        if: 'github.event_name == ''pull_request_target'' && ! ( contains(github.event.pull_request.labels.*.name, ''safe_to_test'') || contains(fromJson(''["OWNER", "MEMBER", "COLLABORATOR"]''), github.event.pull_request.author_association) )'
-        run: |
-          exit 1
+      - uses: actions/checkout@v6
+      - uses: ./.github/actions/check-permissions
 
   tests:
     uses: ./.github/workflows/wf_check.yaml

--- a/.github/workflows/nhost-js_checks.yaml
+++ b/.github/workflows/nhost-js_checks.yaml
@@ -76,13 +76,8 @@ jobs:
     if: needs.detect-changes.outputs.should_run == 'true'
     runs-on: ubuntu-latest
     steps:
-      - run: |
-          echo "github.event_name: ${{ github.event_name }}"
-          echo "github.event.pull_request.author_association: ${{ github.event.pull_request.author_association }}"
-      - name: "This task will run and fail if user has no permissions and label safe_to_test isn't present"
-        if: 'github.event_name == ''pull_request_target'' && ! ( contains(github.event.pull_request.labels.*.name, ''safe_to_test'') || contains(fromJson(''["OWNER", "MEMBER", "COLLABORATOR"]''), github.event.pull_request.author_association) )'
-        run: |
-          exit 1
+      - uses: actions/checkout@v6
+      - uses: ./.github/actions/check-permissions
 
   tests:
     uses: ./.github/workflows/wf_check.yaml

--- a/.github/workflows/nhostclient_checks.yaml
+++ b/.github/workflows/nhostclient_checks.yaml
@@ -54,13 +54,8 @@ jobs:
     if: needs.detect-changes.outputs.should_run == 'true'
     runs-on: ubuntu-latest
     steps:
-      - run: |
-          echo "github.event_name: ${{ github.event_name }}"
-          echo "github.event.pull_request.author_association: ${{ github.event.pull_request.author_association }}"
-      - name: "This task will run and fail if user has no permissions and label safe_to_test isn't present"
-        if: 'github.event_name == ''pull_request_target'' && ! ( contains(github.event.pull_request.labels.*.name, ''safe_to_test'') || contains(fromJson(''["OWNER", "MEMBER", "COLLABORATOR"]''), github.event.pull_request.author_association) )'
-        run: |
-          exit 1
+      - uses: actions/checkout@v6
+      - uses: ./.github/actions/check-permissions
 
   tests:
     uses: ./.github/workflows/wf_check.yaml

--- a/.github/workflows/nixops_checks.yaml
+++ b/.github/workflows/nixops_checks.yaml
@@ -34,13 +34,8 @@ jobs:
     if: needs.detect-changes.outputs.should_run == 'true'
     runs-on: ubuntu-latest
     steps:
-      - run: |
-          echo "github.event_name: ${{ github.event_name }}"
-          echo "github.event.pull_request.author_association: ${{ github.event.pull_request.author_association }}"
-      - name: "This task will run and fail if user has no permissions and label safe_to_test isn't present"
-        if: 'github.event_name == ''pull_request_target'' && ! ( contains(github.event.pull_request.labels.*.name, ''safe_to_test'') || contains(fromJson(''["OWNER", "MEMBER", "COLLABORATOR"]''), github.event.pull_request.author_association) )'
-        run: |
-          exit 1
+      - uses: actions/checkout@v6
+      - uses: ./.github/actions/check-permissions
 
   tests:
     uses: ./.github/workflows/wf_check.yaml

--- a/.github/workflows/postgres_checks.yaml
+++ b/.github/workflows/postgres_checks.yaml
@@ -40,13 +40,8 @@ jobs:
     if: needs.detect-changes.outputs.should_run == 'true'
     runs-on: ubuntu-latest
     steps:
-      - run: |
-          echo "github.event_name: ${{ github.event_name }}"
-          echo "github.event.pull_request.author_association: ${{ github.event.pull_request.author_association }}"
-      - name: "This task will run and fail if user has no permissions and label safe_to_test isn't present"
-        if: 'github.event_name == ''pull_request_target'' && ! ( contains(github.event.pull_request.labels.*.name, ''safe_to_test'') || contains(fromJson(''["OWNER", "MEMBER", "COLLABORATOR"]''), github.event.pull_request.author_association) )'
-        run: |
-          exit 1
+      - uses: actions/checkout@v6
+      - uses: ./.github/actions/check-permissions
 
   build_artifacts:
     strategy:

--- a/.github/workflows/storage_checks.yaml
+++ b/.github/workflows/storage_checks.yaml
@@ -54,13 +54,8 @@ jobs:
     if: needs.detect-changes.outputs.should_run == 'true'
     runs-on: ubuntu-latest
     steps:
-      - run: |
-          echo "github.event_name: ${{ github.event_name }}"
-          echo "github.event.pull_request.author_association: ${{ github.event.pull_request.author_association }}"
-      - name: "This task will run and fail if user has no permissions and label safe_to_test isn't present"
-        if: 'github.event_name == ''pull_request_target'' && ! ( contains(github.event.pull_request.labels.*.name, ''safe_to_test'') || contains(fromJson(''["OWNER", "MEMBER", "COLLABORATOR"]''), github.event.pull_request.author_association) )'
-        run: |
-          exit 1
+      - uses: actions/checkout@v6
+      - uses: ./.github/actions/check-permissions
 
   tests:
     uses: ./.github/workflows/wf_check.yaml

--- a/.github/workflows/stripe-graphql-js_checks.yaml
+++ b/.github/workflows/stripe-graphql-js_checks.yaml
@@ -52,13 +52,8 @@ jobs:
   check-permissions:
     runs-on: ubuntu-latest
     steps:
-      - run: |
-          echo "github.event_name: ${{ github.event_name }}"
-          echo "github.event.pull_request.author_association: ${{ github.event.pull_request.author_association }}"
-      - name: "This task will run and fail if user has no permissions and label safe_to_test isn't present"
-        if: 'github.event_name == ''pull_request_target'' && ! ( contains(github.event.pull_request.labels.*.name, ''safe_to_test'') || contains(fromJson(''["OWNER", "MEMBER", "COLLABORATOR"]''), github.event.pull_request.author_association) )'
-        run: |
-          exit 1
+      - uses: actions/checkout@v6
+      - uses: ./.github/actions/check-permissions
 
   tests:
     uses: ./.github/workflows/wf_check.yaml


### PR DESCRIPTION
<!-- nhost-reviewer:start -->
### **PR Type**
Refactoring

___

### **Description**
- Extracts the inline `check-permissions` step that was duplicated across 17 workflow files into a reusable composite action at `.github/actions/check-permissions/action.yml`.
- Adds `nhost-helper-bot[bot]` to the allowlist (alongside the `OWNER`/`MEMBER`/`COLLABORATOR` author associations and the `safe_to_test` label) so PRs opened by the helper GitHub App bypass the permission gate.
- Updates each affected workflow to `actions/checkout@v6` followed by `uses: ./.github/actions/check-permissions`, replacing the duplicated inline `if: ... exit 1` block.

___

### Diagram Walkthrough

```mermaid
flowchart LR
  WF["17 *_checks.yaml workflows"] -->|checkout base ref| CO["actions/checkout@v6"]
  CO --> CA["./.github/actions/check-permissions"]
  CA --> EV{"event == pull_request_target?"}
  EV -->|no| OK["pass"]
  EV -->|yes| AUTH{"safe_to_test label OR<br/>OWNER/MEMBER/COLLABORATOR OR<br/>nhost-helper-bot[bot]"}
  AUTH -->|yes| OK
  AUTH -->|no| FAIL["exit 1"]
```

<details> <summary><h3> File Walkthrough</h3></summary>

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody>
<tr><td><strong>New composite action</strong></td><td><details><summary>1 files</summary><table>
<tr>
  <td><strong>action.yml</strong><dd><code>New composite action gating PR checks on author association, label, or helper bot login</code></dd></td>
  <td><a href="https://github.com/nhost/nhost/pull/4224/files#diff-bcc54b63be6bfdeceea405d15c417129561d0cfa0705749a270caf673dedf965">+15/-0</a></td>
</tr>
</table></details></td></tr>
<tr><td><strong>Workflow refactors</strong></td><td><details><summary>17 files</summary><table>
<tr>
  <td><strong>auth_checks.yaml</strong><dd><code>Replace inline permissions check with composite action</code></dd></td>
  <td><a href="https://github.com/nhost/nhost/pull/4224/files#diff-e008be4c75d4fd5b9c11517b9507be917f4b28efe68d72a4657b042f2601d8db">+2/-7</a></td>
</tr>
<tr>
  <td><strong>cli_checks.yaml</strong><dd><code>Replace inline permissions check with composite action</code></dd></td>
  <td><a href="https://github.com/nhost/nhost/pull/4224/files#diff-85e94af94a1e00a42e4095f4d62c5c016af01ba3314b74395cbe21bc1dc0b6bf">+2/-7</a></td>
</tr>
<tr>
  <td><strong>codegen_checks.yaml</strong><dd><code>Replace inline permissions check with composite action</code></dd></td>
  <td><a href="https://github.com/nhost/nhost/pull/4224/files#diff-a0832a0d24c56aeff885d0163d2d0a54af9dd042dfbbe0fd5eba7c9997de7089">+2/-7</a></td>
</tr>
<tr>
  <td><strong>dashboard_checks.yaml</strong><dd><code>Replace inline permissions check with composite action</code></dd></td>
  <td><a href="https://github.com/nhost/nhost/pull/4224/files#diff-a8a8acdeffa4fff6d4fabd436cc1c2c377cda640d5028bd3dfcec5ef5df6e33f">+2/-7</a></td>
</tr>
<tr>
  <td><strong>docs_checks.yaml</strong><dd><code>Replace inline permissions check with composite action</code></dd></td>
  <td><a href="https://github.com/nhost/nhost/pull/4224/files#diff-d11d903fdbfbe578bebef818b8a40eec3c1d413342e6feca475028af3ef69857">+2/-7</a></td>
</tr>
<tr>
  <td><strong>examples_demos_checks.yaml</strong><dd><code>Replace inline permissions check with composite action</code></dd></td>
  <td><a href="https://github.com/nhost/nhost/pull/4224/files#diff-48c5a14a5d1da9f35b409ecc95fae8f3a319f97bffbf0020efcb8c360347dc02">+2/-7</a></td>
</tr>
<tr>
  <td><strong>examples_guides_checks.yaml</strong><dd><code>Replace inline permissions check with composite action</code></dd></td>
  <td><a href="https://github.com/nhost/nhost/pull/4224/files#diff-56c96ece925a38bd3e84d3fff001760c68d40744013d2b3458ad445a686a0c36">+2/-7</a></td>
</tr>
<tr>
  <td><strong>examples_tutorials_checks.yaml</strong><dd><code>Replace inline permissions check with composite action</code></dd></td>
  <td><a href="https://github.com/nhost/nhost/pull/4224/files#diff-745712dc409289d30fe4caa74de567df9cc9fac97750ae5566f93a51e48bf539">+2/-7</a></td>
</tr>
<tr>
  <td><strong>functions_checks.yaml</strong><dd><code>Replace inline permissions check with composite action</code></dd></td>
  <td><a href="https://github.com/nhost/nhost/pull/4224/files#diff-52e81492bf3b99da09aa6f23aa86352117ddcabee01f88af8f57e1c65046aa8a">+2/-7</a></td>
</tr>
<tr>
  <td><strong>govulncheck-wrapper_checks.yaml</strong><dd><code>Replace inline permissions check with composite action</code></dd></td>
  <td><a href="https://github.com/nhost/nhost/pull/4224/files#diff-d3ec72de0b7a38d1b9915650c806e0c49b9c8df7193e5d3fd8b2115dd6d81944">+2/-7</a></td>
</tr>
<tr>
  <td><strong>mcp_checks.yaml</strong><dd><code>Replace inline permissions check with composite action</code></dd></td>
  <td><a href="https://github.com/nhost/nhost/pull/4224/files#diff-900bfcab98ad034fbb56d71fced5fb31a4ff568fe4303b3c42bfc64348c0cfae">+2/-7</a></td>
</tr>
<tr>
  <td><strong>nhost-js_checks.yaml</strong><dd><code>Replace inline permissions check with composite action</code></dd></td>
  <td><a href="https://github.com/nhost/nhost/pull/4224/files#diff-4d839ed910ed156389855fb82fc583c1bafccef3691c01ba5170bf4dc4fcc19c">+2/-7</a></td>
</tr>
<tr>
  <td><strong>nhostclient_checks.yaml</strong><dd><code>Replace inline permissions check with composite action</code></dd></td>
  <td><a href="https://github.com/nhost/nhost/pull/4224/files#diff-f79350f1fcb2bb2e569b5b18b3967ae7ad7828d847c7f4e917309a17cc4c1f83">+2/-7</a></td>
</tr>
<tr>
  <td><strong>nixops_checks.yaml</strong><dd><code>Replace inline permissions check with composite action</code></dd></td>
  <td><a href="https://github.com/nhost/nhost/pull/4224/files#diff-5201e3151155366e6bb8b672a9fb68b52ae38b8c20c5f09c44953c040892226f">+2/-7</a></td>
</tr>
<tr>
  <td><strong>postgres_checks.yaml</strong><dd><code>Replace inline permissions check with composite action</code></dd></td>
  <td><a href="https://github.com/nhost/nhost/pull/4224/files#diff-96f56006ce1231f9e7b97209f14a5b8ae8497c05cb3bb3602849a7133507f81b">+2/-7</a></td>
</tr>
<tr>
  <td><strong>storage_checks.yaml</strong><dd><code>Replace inline permissions check with composite action</code></dd></td>
  <td><a href="https://github.com/nhost/nhost/pull/4224/files#diff-c4c7991f3cae655b5afbc8632eac8749c49bc2375821bc61690adac14aba1c1e">+2/-7</a></td>
</tr>
<tr>
  <td><strong>stripe-graphql-js_checks.yaml</strong><dd><code>Replace inline permissions check with composite action</code></dd></td>
  <td><a href="https://github.com/nhost/nhost/pull/4224/files#diff-bdacf1b64bef6766a7dc346095bee3b482dfd21c8db50ce5b6e703d69bdef350">+2/-7</a></td>
</tr>
</table></details></td></tr>
</tbody></table>

</details>

___

<!-- nhost-reviewer:end -->
