### PR TITLE
fix(auth): only invalidate regular refresh tokens

### DIFF
--- a/services/auth/go/controller/workflows.go
+++ b/services/auth/go/controller/workflows.go
@@ -745,8 +745,10 @@ func (wf *Workflows) ChangePassword(
 	}
 
 	// UpdateUserChangePassword atomically rotates the password hash and revokes
-	// all existing refresh tokens (both the regular and OAuth2 tables) within a
-	// single CTE, so a stolen token cannot be reused after a password change.
+	// session refresh tokens (regular rows in auth.refresh_tokens plus all
+	// auth.oauth2_refresh_tokens) within a single CTE. Personal Access Tokens
+	// (type='pat') are intentionally preserved so automation keeps working
+	// across password changes.
 	if _, err := wf.db.UpdateUserChangePassword(
 		ctx,
 		sql.UpdateUserChangePasswordParams{

--- a/services/auth/go/sql/query.sql
+++ b/services/auth/go/sql/query.sql
@@ -321,6 +321,7 @@ WITH updated_user AS (
 revoked_refresh_tokens AS (
     DELETE FROM auth.refresh_tokens
     WHERE user_id = @id::uuid
+    AND type = 'regular'
 ),
 revoked_oauth2_refresh_tokens AS (
     DELETE FROM auth.oauth2_refresh_tokens

--- a/services/auth/go/sql/query.sql.go
+++ b/services/auth/go/sql/query.sql.go
@@ -1720,6 +1720,7 @@ WITH updated_user AS (
 revoked_refresh_tokens AS (
     DELETE FROM auth.refresh_tokens
     WHERE user_id = $2::uuid
+    AND type = 'regular'
 ),
 revoked_oauth2_refresh_tokens AS (
     DELETE FROM auth.oauth2_refresh_tokens


### PR DESCRIPTION
<!-- nhost-reviewer:start -->
### **PR Type**
Bug fix

___

### **Description**
- Narrows the password-change session revocation introduced in #4192 so that only `regular` refresh tokens are deleted, leaving Personal Access Tokens (`pat`) intact.
- Prevents a password change from breaking automations/scripts that authenticate via PATs, while still rotating end-user sessions for security.
- OAuth2 refresh tokens continue to be revoked unconditionally (they have no PAT equivalent).

___

<details> <summary><h3> File Walkthrough</h3></summary>

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody>
<tr><td><strong>Core logic</strong></td><td><details><summary>1 files</summary><table>
<tr>
  <td><strong>query.sql</strong><dd><code>Add `AND type = 'regular'` filter to the refresh_tokens DELETE inside UpdateUserChangePassword so PATs are preserved.</code></dd></td>
  <td><a href="https://github.com/nhost/nhost/pull/4226/files#diff-97f747248104c1546792d48460adc342691cf9541b0f0970a773c5835668d41a">+1/-0</a></td>
</tr>
</table></details></td></tr>
<tr><td><strong>Generated</strong></td><td><details><summary>1 files</summary><table>
<tr>
  <td><strong>query.sql.go</strong><dd><code>Regenerated sqlc output reflecting the SQL filter change.</code></dd></td>
  <td><a href="https://github.com/nhost/nhost/pull/4226/files#diff-a9f5d32f2fd6726736782eda230adec7603a35dbbbecc7537551bf35f5b35a17">+1/-0</a></td>
</tr>
</table></details></td></tr>
</tbody></table>

</details>

___

<!-- nhost-reviewer:end -->
