### PR TITLE
fix(dashboard): Display boolean values in CustomCheckEditor

### DIFF
--- a/dashboard/src/features/orgs/projects/database/dataGrid/components/CustomCheckEditor/ConditionValue.test.tsx
+++ b/dashboard/src/features/orgs/projects/database/dataGrid/components/CustomCheckEditor/ConditionValue.test.tsx
@@ -229,4 +229,32 @@ describe('ConditionValue', () => {
       },
     );
   });
+
+  describe('combobox trigger label', () => {
+    beforeEach(() => {
+      mocks.useGetRolesPermissionsQuery.mockImplementation(() => ({
+        data: mockPermissionsData,
+        loading: false,
+      }));
+    });
+
+    it.each([
+      { value: true, expected: 'true' },
+      { value: false, expected: 'false' },
+      { value: 'X-Hasura-User-Id', expected: 'X-Hasura-User-Id' },
+      { value: null, expected: 'Select variable...' },
+      { value: undefined, expected: 'Select variable...' },
+    ])('renders $value as "$expected" in the trigger', ({
+      value,
+      expected,
+    }) => {
+      render(
+        <TestWrapper defaultValues={{ operator: '_eq', value }}>
+          <ConditionValue name="test" selectedTablePath="public.users" />
+        </TestWrapper>,
+      );
+
+      expect(screen.getByRole('combobox')).toHaveTextContent(expected);
+    });
+  });
 });

--- a/dashboard/src/features/orgs/projects/database/dataGrid/components/CustomCheckEditor/ConditionValue.tsx
+++ b/dashboard/src/features/orgs/projects/database/dataGrid/components/CustomCheckEditor/ConditionValue.tsx
@@ -233,11 +233,23 @@ function ConditionValue({
     );
   }
 
+  function getDisplayValue(value: unknown): string {
+    if (typeof value === 'string') {
+      return value;
+    }
+    if (value === null || value === undefined) {
+      return '';
+    }
+    return String(value);
+  }
+
   const selectedVariable = availableHasuraPermissionVariables.find(
     (variable) => variable.value === comboboxValue,
   );
   const comboboxLabel =
-    selectedVariable?.label || comboboxValue || 'Select variable...';
+    selectedVariable?.label ||
+    getDisplayValue(comboboxValue) ||
+    'Select variable...';
 
   return (
     <Popover open={open} onOpenChange={setOpen}>


### PR DESCRIPTION
### Checklist

- [x] No breaking changes
- [x] Tests pass
- [x] New features have new tests
- [ ] Documentation is updated (if applicable)
- [x] Title of the PR is in the correct format (see below)

<!-- nhost-reviewer:start -->
### **PR Type**
Bug fix

___

### **Description**
- Fixes the variable-combobox trigger label in `CustomCheckEditor` so non-string `comboboxValue`s (e.g. boolean `true`/`false`) render as readable text instead of falling back to the placeholder or breaking the trigger.
- Introduces a small `getDisplayValue` helper that returns strings as-is, treats `null`/`undefined` as empty so the `'Select variable...'` placeholder still wins, and `String()`-coerces other primitives.
- Adds a parametrized vitest case covering boolean, string, `null`, and `undefined` values to lock in the trigger label rendering.

___

<details> <summary><h3> File Walkthrough</h3></summary>

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody>
<tr><td><strong>Core logic</strong></td><td><details><summary>1 files</summary><table>
<tr>
  <td><strong>ConditionValue.tsx</strong><dd><code>Add getDisplayValue helper to safely stringify non-string combobox values for the trigger label.</code></dd></td>
  <td><a href="https://github.com/nhost/nhost/pull/4228/files#diff-810657158af1493e2b841f61a1dfa02c99077838c527e860607fd0c5ca311f08">+13/-1</a></td>
</tr>
</table></details></td></tr>
<tr><td><strong>Tests</strong></td><td><details><summary>1 files</summary><table>
<tr>
  <td><strong>ConditionValue.test.tsx</strong><dd><code>Add parametrized trigger-label test covering boolean, string, null, and undefined values.</code></dd></td>
  <td><a href="https://github.com/nhost/nhost/pull/4228/files#diff-19fa3f88d3784d5a287e92b6b48ca0e9542916589235e0a00372d75f79abd5a4">+25/-0</a></td>
</tr>
</table></details></td></tr>
</tbody></table>

</details>

___

<!-- nhost-reviewer:end -->
