### PR TITLE
fix(functions): load bundles lazily to fix OOM on large projects

### DIFF
--- a/services/functions/local-wrapper.js
+++ b/services/functions/local-wrapper.js
@@ -1,45 +1,16 @@
 const crypto = require('node:crypto');
-const { AsyncLocalStorage } = require('node:async_hooks');
-const util = require('node:util');
 const express = require('express');
 const app = express();
 
-const asyncLocalStorage = new AsyncLocalStorage();
+// AsyncLocalStorage and console patching live in the parent runtime so that
+// reloading this bundle does not leak. A per-bundle ALS plus per-bundle
+// console wrappers chained across reloads — each new wrapper closed over the
+// previous one and pinned the prior bundle's full module graph in memory.
+const asyncLocalStorage = global.__nhost_als__;
 
 function logJSON(obj) {
   process.stdout.write(`${JSON.stringify(obj)}\n`);
 }
-
-// Intercept console methods to emit structured JSON during request handling.
-// Outside of a request context (e.g. at module load time), the original
-// console methods are used unchanged.
-const originalConsole = {
-  log: console.log,
-  info: console.info,
-  warn: console.warn,
-  error: console.error,
-};
-
-function wrapConsoleMethod(original, level) {
-  return (...args) => {
-    const store = asyncLocalStorage.getStore();
-    if (store) {
-      logJSON({
-        log: util.format(...args),
-        path: store.path,
-        invocationId: store.invocationId,
-        level,
-      });
-    } else {
-      original.apply(console, args);
-    }
-  };
-}
-
-console.log = wrapConsoleMethod(originalConsole.log, 'INFO');
-console.info = wrapConsoleMethod(originalConsole.info, 'INFO');
-console.warn = wrapConsoleMethod(originalConsole.warn, 'WARN');
-console.error = wrapConsoleMethod(originalConsole.error, 'ERROR');
 
 const rawBodySaver = (req, _res, buf) => {
   req.rawBody = buf.toString();

--- a/services/functions/server.js
+++ b/services/functions/server.js
@@ -1,6 +1,7 @@
 const path = require('node:path');
 const fs = require('node:fs');
 const { execSync } = require('node:child_process');
+const { AsyncLocalStorage } = require('node:async_hooks');
 const express = require('express');
 const glob = require('glob');
 const esbuild = require('esbuild');
@@ -19,6 +20,43 @@ function logJSON(obj) {
 function serverLog(level, route, ...args) {
   logJSON({ log: util.format(...args), path: route, level });
 }
+
+// Per-request async context, shared across every bundle. Bundles read it via
+// global.__nhost_als__ instead of creating their own. A per-bundle instance
+// was pinned across reloads through the console wrappers below — each new
+// bundle wrapped the previous wrapper, building a closure chain that retained
+// every prior bundle's entire module graph (express, user code, all deps).
+const requestAsyncLocalStorage = new AsyncLocalStorage();
+global.__nhost_als__ = requestAsyncLocalStorage;
+
+// Patch console once in the parent so user code's console.log/info/warn/error
+// emits structured JSON tagged with the current request. Outside a request
+// context (server startup, dep watcher, ...) we fall back to the original.
+const originalConsole = {
+  log: console.log,
+  info: console.info,
+  warn: console.warn,
+  error: console.error,
+};
+function wrapConsoleMethod(original, level) {
+  return (...args) => {
+    const store = requestAsyncLocalStorage.getStore();
+    if (store) {
+      logJSON({
+        log: util.format(...args),
+        path: store.path,
+        invocationId: store.invocationId,
+        level,
+      });
+    } else {
+      original.apply(console, args);
+    }
+  };
+}
+console.log = wrapConsoleMethod(originalConsole.log, 'INFO');
+console.info = wrapConsoleMethod(originalConsole.info, 'INFO');
+console.warn = wrapConsoleMethod(originalConsole.warn, 'WARN');
+console.error = wrapConsoleMethod(originalConsole.error, 'ERROR');
 
 // Map of route -> Express app (loaded from esbuild bundles)
 const functionHandlers = new Map();
@@ -110,6 +148,13 @@ function disposeFunctionEntry(file) {
   const entry = functionEntries.get(file);
   if (!entry) return;
 
+  // Evict from require.cache before unlink — once the file is gone,
+  // require.resolve throws and we'd lose the cache key, leaving the prior
+  // module pinned in the V8 heap with no way to reach it.
+  try {
+    delete require.cache[require.resolve(entry.outfile)];
+  } catch {}
+
   try {
     fs.unlinkSync(entry.wrapperPath);
   } catch {}
@@ -142,6 +187,14 @@ function loadBundle(route, bundlePath) {
 // bundles out of the V8 heap until they are actually needed — only bundles that
 // receive traffic are ever resident in memory at the same time.
 function deferBundleLoad(route, bundlePath) {
+  // Evict any previously cached version eagerly so the prior module graph
+  // becomes GC-eligible at rebuild time rather than waiting for traffic to
+  // re-run loadBundle (which would otherwise keep the old bundle pinned via
+  // require.cache for any route that doesn't receive a request).
+  try {
+    delete require.cache[require.resolve(bundlePath)];
+  } catch {}
+
   functionHandlers.set(route, function lazyLoad(req, res, next) {
     loadBundle(route, bundlePath);
     const handler = functionHandlers.get(route);

--- a/services/functions/server.js
+++ b/services/functions/server.js
@@ -124,19 +124,33 @@ function disposeFunctionEntry(file) {
 }
 
 function loadBundle(route, bundlePath) {
-  // Clear require cache so re-requiring gets fresh code
   const resolved = require.resolve(bundlePath);
   delete require.cache[resolved];
 
   try {
     const bundled = require(bundlePath);
-    // The bundle exports an Express app (or app.default)
     const app = bundled.default || bundled;
     functionHandlers.set(route, app);
   } catch (err) {
     serverLog('ERROR', route, `Failed to load bundle:`, err);
     functionHandlers.delete(route);
   }
+}
+
+// Install a one-shot lazy handler so the bundle is loaded on the first request
+// that hits the route rather than immediately after a build. This keeps all N
+// bundles out of the V8 heap until they are actually needed — only bundles that
+// receive traffic are ever resident in memory at the same time.
+function deferBundleLoad(route, bundlePath) {
+  functionHandlers.set(route, function lazyLoad(req, res, next) {
+    loadBundle(route, bundlePath);
+    const handler = functionHandlers.get(route);
+    if (handler) {
+      handler(req, res, next);
+    } else {
+      next(new Error('Function failed to load'));
+    }
+  });
 }
 
 async function rebuildContext(functionsPath) {
@@ -185,7 +199,7 @@ async function rebuildContext(functionsPath) {
             for (const [file, entry] of functionEntries) {
               if (!fs.existsSync(path.join(functionsPath, file))) continue;
               if (!fs.existsSync(entry.outfile)) continue;
-              loadBundle(entry.route, entry.outfile);
+              deferBundleLoad(entry.route, entry.outfile);
               serverLog('INFO', entry.route, `Rebuilt from ${file}`);
             }
           });


### PR DESCRIPTION
### **Description**
- Defer per-function bundle `require()` until the first request to each route, so only bundles receiving traffic occupy the V8 heap.
- Move `AsyncLocalStorage` and `console.log/info/warn/error` patching from each per-bundle `local-wrapper.js` into the parent `server.js`; bundles read the shared ALS via `global.__nhost_als__`, breaking the closure chain that pinned every prior bundle's module graph across reloads.
- Evict `require.cache` eagerly in `disposeFunctionEntry` (before the bundle file is unlinked) and in `deferBundleLoad` (at rebuild time) so prior module graphs become GC-eligible immediately.
- Restore the `next(err)` failure path for the lazy handler, matching the existing `loadBundle` behaviour on bundle load errors.

___

### Diagram Walkthrough

```mermaid
flowchart LR
  Build["esbuild onEnd"] -->|"per route"| Defer["deferBundleLoad()"]
  Defer -->|"evict require.cache"| Cache["require.cache"]
  Defer -->|"set lazy stub"| Map["functionHandlers"]
  Req["First request"] --> Map
  Map -->|"lazy stub"| Load["loadBundle()"]
  Load -->|"require()"| Bundle["function bundle"]
  Bundle -->|"reads global.__nhost_als__"| ALS["parent AsyncLocalStorage"]
  Load -->|"replace stub"| Map
```

<details> <summary><h3> File Walkthrough</h3></summary>

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody>
<tr><td><strong>Core fix</strong></td><td><details><summary>2 files</summary><table>
<tr>
  <td><strong>server.js</strong><dd><code>Add lazy bundle loading, parent-process ALS+console patching, and require.cache eviction in dispose.</code></dd></td>
  <td><a href="https://github.com/nhost/nhost/pull/4230/files#diff-3e3fa54db1b505851f46932547f48ebe3c042fd140996fef7afeeaefbb5850e7">+70/-3</a></td>
</tr>
<tr>
  <td><strong>local-wrapper.js</strong><dd><code>Drop per-bundle ALS and console wrappers; read shared ALS from global.__nhost_als__.</code></dd></td>
  <td><a href="https://github.com/nhost/nhost/pull/4230/files#diff-d76e5132bd5d3080a242c743342e5dcc91457ae322af2c5607a20305b4bfaa6c">+5/-34</a></td>
</tr>
</table></details></td></tr>
<tr><td><strong>Examples</strong></td><td><details><summary>1 file</summary><table>
<tr>
  <td><strong>echo.ts</strong><dd><code>Switch import quotes to single quotes and add an unused asd field to the response body.</code></dd></td>
  <td><a href="https://github.com/nhost/nhost/pull/4230/files#diff-f9e1d3805333715edb98b4b76e5979bb8d839cfebdd18bf1a58c584c7ac33434">+3/-2</a></td>
</tr>
</table></details></td></tr>
</tbody></table>

</details>

___

<!-- nhost-reviewer:end -->