### PR TITLE
fix(ci): use the environment NHOST_PAT directly

### DIFF
--- a/build/makefiles/general.makefile
+++ b/build/makefiles/general.makefile
@@ -63,10 +63,13 @@ develop:  ## Start a nix develop shell
 _check-pre:  ## Pre-checks before running nix flake check
 
 
+NIX_CHECK_EXTRA_ARGS?=
+
 .PHONY: check
 check: _check-pre ## Run nix flake check
 	nix build \
 		--print-build-logs \
+		$(NIX_CHECK_EXTRA_ARGS) \
 		.\#checks.$(ARCH)-$(OS).$(NAME)
 
 
@@ -75,6 +78,7 @@ check-dry-run:  ## Returns the derivation of the check
 	@nix build \
 		--dry-run \
 		--json \
+		$(NIX_CHECK_EXTRA_ARGS) \
 		.\#checks.$(ARCH)-$(OS).$(NAME) | jq -r '.[].outputs.out'
 
 

--- a/cli/Makefile
+++ b/cli/Makefile
@@ -1,10 +1,6 @@
 ROOT_DIR?=$(abspath ../)
+NIX_CHECK_EXTRA_ARGS=--impure
 include $(ROOT_DIR)/build/makefiles/general.makefile
-
-
-.PHONY: _check-pre
-_check-pre:
-	@sed -i 's/$$NHOST_PAT/$(NHOST_PAT)/' get_access_token.sh
 
 
 .PHONY: _dev-env-up

--- a/cli/project.nix
+++ b/cli/project.nix
@@ -79,7 +79,16 @@ rec {
       checkDeps
       ;
 
+    impureEnvVars = {
+      NHOST_PAT = builtins.getEnv "NHOST_PAT";
+    };
+
     preCheck = ''
+      if [ -z "''${NHOST_PAT:-}" ]; then
+        echo "ERROR: NHOST_PAT environment variable is not set"
+        exit 1
+      fi
+
       echo "➜ Getting access token"
       export NHOST_ACCESS_TOKEN=$(bash ${src}/cli/get_access_token.sh)
     '';

--- a/nixops/lib/go/go.nix
+++ b/nixops/lib/go/go.nix
@@ -99,12 +99,16 @@ in
       preCheck ? "",
       extraCheck ? "",
       goTestFlags ? "",
+      impureEnvVars ? { },
     }:
     pkgs.runCommand "gotests"
-      {
-        __noChroot = true;
-        nativeBuildInputs = goCheckDeps ++ checkDeps ++ buildInputs ++ nativeBuildInputs;
-      }
+      (
+        {
+          __noChroot = true;
+          nativeBuildInputs = goCheckDeps ++ checkDeps ++ buildInputs ++ nativeBuildInputs;
+        }
+        // impureEnvVars
+      )
       ''
         export HOME=$(mktemp -d)
 

--- a/nixops/lib/nix/nix.nix
+++ b/nixops/lib/nix/nix.nix
@@ -23,7 +23,7 @@ in
         ];
       }
       ''
-        nixfmt --check ${src}/*
+        find ${src} -name '*.nix' -exec nixfmt --check {} +
 
         mkdir $out
       '';


### PR DESCRIPTION
### Checklist

- [X] No breaking changes
- [X] Tests pass
- [X] New features have new tests
- [X] Documentation is updated (if applicable)
- [X] Title of the PR is in the correct format (see below)

### Description

This avoids dirtying the tree when running `make check` for `cli`, the derivation was already impure since the `Makefile` was editing the script generating the access token.