### PR TITLE
fix(dashboard): update create user e2e test

### DIFF
--- a/dashboard/e2e/auth/create-user.test.ts
+++ b/dashboard/e2e/auth/create-user.test.ts
@@ -35,6 +35,6 @@ test('should not be able to create a user with an existing email', async ({
   await createUser({ page, email, password });
 
   await expect(
-    page.getByRole('dialog').getByText(/email already in use/i),
+    page.getByRole('dialog').getByText(/user already exists/i),
   ).toBeVisible();
 });

--- a/package.json
+++ b/package.json
@@ -21,7 +21,7 @@
     "workspace:list": "pnpm ls --depth=-1 -r",
     "clean:all": "pnpm clean && rm -rf ./{{packages,examples/**,templates/**}/*,docs,dashboard}/{.nhost,node_modules} node_modules",
     "clean": "rm -rf ./{{packages,examples/**}/*,docs,dashboard}/{dist,umd,.next,.turbo,coverage}",
-    "clean:install": "pnpm clean:all && pnpm install",
+    "clean:install": "pnpm clean:all && pnpm install --frozen-lockfile",
     "clean:build": "pnpm clean:install && pnpm build:nhost-js",
     "dev:dashboard": "turbo run dev --filter=@nhost/dashboard"
   },


### PR DESCRIPTION
### Checklist

- [x] No breaking changes
- [x] Tests pass
- [ ] New features have new tests
- [ ] Documentation is updated (if applicable)
- [ ] Title of the PR is in the correct format (see below)

<!-- nhost-reviewer:start -->
### **PR Type**
Bug fix

___

### **Description**
- Update the create-user e2e test assertion to match the current backend error copy ("user already exists" instead of "email already in use").
- Make `clean:install` use `pnpm install --frozen-lockfile` so the local clean/rebuild flow installs exactly what the lockfile pins, matching CI and avoiding silent lockfile drift.

___

<details> <summary><h3> File Walkthrough</h3></summary>

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody>
<tr><td><strong>Tests</strong></td><td><details><summary>1 files</summary><table>
<tr>
  <td><strong>create-user.test.ts</strong><dd><code>Update duplicate-user assertion to new error copy</code></dd></td>
  <td><a href="https://github.com/nhost/nhost/pull/4251/files#diff-b5d83f9ceb9d621a5fe72789a6c961773548d7f459c72fad953b2a09694ff0a7">+1/-1</a></td>
</tr>
</table></details></td></tr>
<tr><td><strong>Configuration changes</strong></td><td><details><summary>1 files</summary><table>
<tr>
  <td><strong>package.json</strong><dd><code>Use --frozen-lockfile in clean:install</code></dd></td>
  <td><a href="https://github.com/nhost/nhost/pull/4251/files#diff-7ae45ad102eab3b6d7e7896acd08c427a9b25b346470d7bc6507b6481575d519">+1/-1</a></td>
</tr>
</table></details></td></tr>
</tbody></table>

</details>

___

<!-- nhost-reviewer:end -->
