### PR TITLE
chore(ci): use the non-aliased package for nixfmt

### DIFF
--- a/nixops/lib/go/go.nix
+++ b/nixops/lib/go/go.nix
@@ -72,7 +72,7 @@ in
         with pkgs;
         [
           gnumake
-          nixfmt-rfc-style
+          nixfmt
         ]
         ++ goCheckDeps
         ++ buildInputs;

--- a/nixops/lib/nix/nix.nix
+++ b/nixops/lib/nix/nix.nix
@@ -19,7 +19,7 @@ in
       {
         __noChroot = true;
         nativeBuildInputs = with pkgs; [
-          nixfmt-rfc-style
+          nixfmt
         ];
       }
       ''


### PR DESCRIPTION
### Checklist

- [x] No breaking changes
- [x] Tests pass
- [x] New features have new tests
- [x] Documentation is updated (if applicable)
- [x] Title of the PR is in the correct format (see below)

### Description

Makes the possible warning of the package alias being deprecated disappear.