### PR TITLE
fix(cli): create install path if it doesn't exist

### DIFF
--- a/cli/get.sh
+++ b/cli/get.sh
@@ -112,6 +112,10 @@ log "${GREEN}Download complete!${NC}"
 echo
 
 if [[ "$platform" != 'windows' ]]; then
+    if [ ! -d "${INSTALL_PATH}" ]; then
+        log "${YELLOW}Install path '${INSTALL_PATH}' does not exist. Creating it...${NC}"
+        try sudo mkdir -p "${INSTALL_PATH}"
+    fi
     try sudo mv ./cli ${INSTALL_PATH}/nhost
     nhost --version
     echo


### PR DESCRIPTION
### Description

This fix ensures that the CLI installation script creates the install directory if it doesn't already exist before attempting to move the binary into it. Previously, the script would fail if the `INSTALL_PATH` directory was not present on the system.

The change adds a check that:
1. Verifies if the install path directory exists
2. Creates the directory (with parent directories as needed) if it doesn't exist
3. Proceeds with the binary installation

This makes the installation process more robust and prevents failures on fresh system setups where the install path may not have been pre-created.

### Checklist

- [x] No breaking changes
- [x] Tests pass
- [ ] New features have new tests (N/A - bug fix)
- [ ] Documentation is updated (N/A - internal script improvement)
- [x] Title of the PR is in the correct format