### PR TITLE
feat(functions): remove nodejs 20 support and add nodejs 24

### DIFF
--- a/.github/workflows/functions_checks.yaml
+++ b/.github/workflows/functions_checks.yaml
@@ -50,7 +50,7 @@ jobs:
   build_artifacts:
     strategy:
       matrix:
-        node: ["20", "22"]
+        node: ["22", "24"]
       fail-fast: true
     uses: ./.github/workflows/wf_build_artifacts.yaml
     needs:

--- a/.github/workflows/functions_wf_release.yaml
+++ b/.github/workflows/functions_wf_release.yaml
@@ -33,7 +33,7 @@ jobs:
   build_artifacts:
     strategy:
       matrix:
-        node: ["20", "22"]
+        node: ["22", "24"]
       fail-fast: true
     uses: ./.github/workflows/wf_build_artifacts.yaml
     with:
@@ -52,7 +52,7 @@ jobs:
   push-docker-hub:
     strategy:
       matrix:
-        node: ["20", "22"]
+        node: ["22", "24"]
       fail-fast: true
     uses: ./.github/workflows/wf_docker_push_image.yaml
     needs:

--- a/flake.nix
+++ b/flake.nix
@@ -339,7 +339,6 @@
           functions = functionsf.package;
           functions-node22-docker-image = functionsf.node22DockerImage;
           functions-node24-docker-image = functionsf.node24DockerImage;
-          # functions-node26-docker-image = functionsf.node26DockerImage;
           guides = guidesf.package;
           nhost-js = nhost-jsf.package;
           stripe-graphql-js = stripe-graphql-jsf.package;

--- a/flake.nix
+++ b/flake.nix
@@ -265,6 +265,9 @@
               # docs
               vale
 
+              # nix
+              nixfmt
+
               # internal packages
               self.packages.${system}.codegen
               self.packages.${system}.govulncheck-wrapper
@@ -334,8 +337,9 @@
           dashboard-docker-image = dashboardf.dockerImage;
           demos = demosf.package;
           functions = functionsf.package;
-          functions-node22-docker-image = functionsf.dockerImage;
-          functions-node20-docker-image = functionsf.node20DockerImage;
+          functions-node22-docker-image = functionsf.node22DockerImage;
+          functions-node24-docker-image = functionsf.node24DockerImage;
+          # functions-node26-docker-image = functionsf.node26DockerImage;
           guides = guidesf.package;
           nhost-js = nhost-jsf.package;
           stripe-graphql-js = stripe-graphql-jsf.package;

--- a/services/functions/CLAUDE.md
+++ b/services/functions/CLAUDE.md
@@ -21,7 +21,7 @@ services/functions/
 ├── jest.config.cjs        # Jest test configuration
 ├── CHANGELOG.md           # Auto-generated changelog via git-cliff
 ├── build/dev/docker/
-│   └── docker-compose.yaml  # Dev environment: 4 containers (node20, node22, npm, yarn)
+│   └── docker-compose.yaml  # Dev environment: 4 containers (node22, node24, npm, yarn)
 ├── example-pnpm/          # Example project using pnpm
 ├── example-npm/           # Example project using npm
 ├── example-yarn/          # Example project using yarn
@@ -35,7 +35,7 @@ services/functions/
 - **local-wrapper.js**: Template that wraps each user function in an Express mini-app with JSON/URL-encoded body parsing (6MB limit), raw body preservation, invocation ID tracking, and error handling. The placeholder `%FUNCTION_PATH%` is replaced at build time.
 - **start.sh**: Docker entrypoint that detects whether `package.json` is at `./functions/` or `./`, validates a lock file exists, copies default `tsconfig.json`, installs dependencies via `nci` (@antfu/ni), and starts the server.
 - **Routing**: `functions/hello.ts` -> `/hello`, `functions/sub/index.ts` -> `/sub/`, `functions/_utils/` -> ignored. Route lookup is flexible: tries exact match, then without trailing slash, then with trailing slash.
-- **Docker images**: Built with nix2container. Two variants: Node 22 (default) and Node 20. Images include Node.js, pnpm, git, python3, make, and g++ for native dependency compilation.
+- **Docker images**: Built with nix2container. Two variants: Node 22 (default) and Node 24. Images include Node.js, pnpm, git, python3, make, and g++ for native dependency compilation.
 
 ## Development
 
@@ -44,7 +44,7 @@ make develop             # Enter nix develop shell
 make check               # Run biome linting via nix
 make build               # Build the nix package (server files)
 make build-docker-image  # Build Docker image (Node 22, default)
-NODE_VERSION=20 make build-docker-image  # Build Node 20 variant
+NODE_VERSION=24 make build-docker-image  # Build Node 24 variant
 ```
 
 ## Testing

--- a/services/functions/Makefile
+++ b/services/functions/Makefile
@@ -26,7 +26,6 @@ build-docker-image:  ## Build docker container for native architecture
 _dev-env-build:
 	$(MAKE) build-docker-image NODE_VERSION=22
 	$(MAKE) build-docker-image NODE_VERSION=24
-	# $(MAKE) build-docker-image NODE_VERSION=26
 
 
 .PHONY: _dev-env-up

--- a/services/functions/Makefile
+++ b/services/functions/Makefile
@@ -25,7 +25,8 @@ build-docker-image:  ## Build docker container for native architecture
 .PHONY: _dev-env-build
 _dev-env-build:
 	$(MAKE) build-docker-image NODE_VERSION=22
-	$(MAKE) build-docker-image NODE_VERSION=20
+	$(MAKE) build-docker-image NODE_VERSION=24
+	# $(MAKE) build-docker-image NODE_VERSION=26
 
 
 .PHONY: _dev-env-up

--- a/services/functions/README.md
+++ b/services/functions/README.md
@@ -39,8 +39,8 @@ make develop
 make help              # Show all available targets
 make check             # Run linting via nix
 make build             # Build the server package
-make build-docker-image                    # Build Docker image (Node 22)
-NODE_VERSION=20 make build-docker-image    # Build Docker image (Node 20)
+make build-docker-image                    # Build Docker image (Node 22, default)
+NODE_VERSION=24 make build-docker-image    # Build Docker image (Node 24)
 ```
 
 ### Testing locally with examples
@@ -51,10 +51,10 @@ There are three example projects (`example-pnpm/`, `example-npm/`, `example-yarn
 # Build both Docker image variants and run all examples
 make dev-env-up
 # Functions available at:
-#   http://localhost:3001 (Node 20, pnpm)
-#   http://localhost:3002 (Node 22, pnpm)
-#   http://localhost:3003 (Node 22, npm)
-#   http://localhost:3004 (Node 22, yarn)
+#   http://localhost:3001 (Node 22, pnpm)
+#   http://localhost:3002 (Node 24, pnpm)
+#   http://localhost:3003 (Node 24, npm)
+#   http://localhost:3004 (Node 24, yarn)
 
 # Or test a single example manually:
 make build-docker-image
@@ -77,9 +77,9 @@ Tests verify routing, metadata, 404 handling, utility imports (`_utils/`), npm d
 
 ## Release
 
-Releases are managed through the monorepo CI pipeline. Creating a GitHub release with tag `functions@X.Y.Z` triggers the release workflow, which builds and pushes Docker images for both Node 20 and Node 22 to Docker Hub and ECR.
+Releases are managed through the monorepo CI pipeline. Creating a GitHub release with tag `functions@X.Y.Z` triggers the release workflow, which builds and pushes Docker images for both Node 22 and Node 24 to Docker Hub and ECR.
 
 ### Docker image variants
 
 - `nhost/functions:X.Y.Z` - Node 22 (default)
-- `nhost/functions-node20:X.Y.Z` - Node 20
+- `nhost/functions-node24:X.Y.Z` - Node 24

--- a/services/functions/build/dev/docker/docker-compose.yaml
+++ b/services/functions/build/dev/docker/docker-compose.yaml
@@ -1,25 +1,9 @@
 services:
-  functions-node20:
-    image: functions:20-0.0.0-dev
-    container_name: functions-node20
-    ports:
-      - "3001:3000"
-    volumes:
-      - ../../../example-pnpm:/opt/project
-      - node20_project_node_modules:/opt/project/node_modules
-    healthcheck:
-      test: ["CMD", "wget", "--spider", "-S", "http://localhost:3000/healthz"]
-      interval: 5s
-      timeout: 10s
-      retries: 20
-      start_period: 30s
-    restart: unless-stopped
-
   functions-node22:
     image: functions:22-0.0.0-dev
     container_name: functions-node22
     ports:
-      - "3002:3000"
+      - "3001:3000"
     volumes:
       - ../../../example-pnpm:/opt/project
       - node22_project_node_modules:/opt/project/node_modules
@@ -31,8 +15,40 @@ services:
       start_period: 30s
     restart: unless-stopped
 
+  functions-node24:
+    image: functions:24-0.0.0-dev
+    container_name: functions-node24
+    ports:
+      - "3002:3000"
+    volumes:
+      - ../../../example-pnpm:/opt/project
+      - node24_project_node_modules:/opt/project/node_modules
+    healthcheck:
+      test: ["CMD", "wget", "--spider", "-S", "http://localhost:3000/healthz"]
+      interval: 5s
+      timeout: 10s
+      retries: 20
+      start_period: 30s
+    restart: unless-stopped
+
+  # functions-node26:
+  #   image: functions:26-0.0.0-dev
+  #   container_name: functions-node22
+  #   ports:
+  #     - "3002:3000"
+  #   volumes:
+  #     - ../../../example-pnpm:/opt/project
+  #     - node26_project_node_modules:/opt/project/node_modules
+  #   healthcheck:
+  #     test: ["CMD", "wget", "--spider", "-S", "http://localhost:3000/healthz"]
+  #     interval: 5s
+  #     timeout: 10s
+  #     retries: 20
+  #     start_period: 30s
+  #   restart: unless-stopped
+
   functions-npm:
-    image: functions:22-0.0.0-dev
+    image: functions:24-0.0.0-dev
     container_name: functions-npm
     ports:
       - "3003:3000"
@@ -48,7 +64,7 @@ services:
     restart: unless-stopped
 
   functions-yarn:
-    image: functions:22-0.0.0-dev
+    image: functions:24-0.0.0-dev
     container_name: functions-yarn
     ports:
       - "3004:3000"
@@ -65,6 +81,7 @@ services:
 
 volumes:
   node22_project_node_modules:
-  node20_project_node_modules:
+  node24_project_node_modules:
+  node26_project_node_modules:
   npm_project_node_modules:
   yarn_project_node_modules:

--- a/services/functions/build/dev/docker/docker-compose.yaml
+++ b/services/functions/build/dev/docker/docker-compose.yaml
@@ -31,22 +31,6 @@ services:
       start_period: 30s
     restart: unless-stopped
 
-  # functions-node26:
-  #   image: functions:26-0.0.0-dev
-  #   container_name: functions-node22
-  #   ports:
-  #     - "3002:3000"
-  #   volumes:
-  #     - ../../../example-pnpm:/opt/project
-  #     - node26_project_node_modules:/opt/project/node_modules
-  #   healthcheck:
-  #     test: ["CMD", "wget", "--spider", "-S", "http://localhost:3000/healthz"]
-  #     interval: 5s
-  #     timeout: 10s
-  #     retries: 20
-  #     start_period: 30s
-  #   restart: unless-stopped
-
   functions-npm:
     image: functions:24-0.0.0-dev
     container_name: functions-npm
@@ -82,6 +66,5 @@ services:
 volumes:
   node22_project_node_modules:
   node24_project_node_modules:
-  node26_project_node_modules:
   npm_project_node_modules:
   yarn_project_node_modules:

--- a/services/functions/example-pnpm/pnpm-workspace.yaml
+++ b/services/functions/example-pnpm/pnpm-workspace.yaml
@@ -1,0 +1,4 @@
+allowBuilds:
+  sharp: set this to true or false
+onlyBuiltDependencies:
+  - sharp

--- a/services/functions/example-pnpm/pnpm-workspace.yaml
+++ b/services/functions/example-pnpm/pnpm-workspace.yaml
@@ -1,4 +1,2 @@
 allowBuilds:
-  sharp: set this to true or false
-onlyBuiltDependencies:
-  - sharp
+  sharp: true

--- a/services/functions/package.json
+++ b/services/functions/package.json
@@ -10,7 +10,7 @@
     "generate": "echo 'nothing to generate'",
     "test": "biome check . && jest --testTimeout=120000",
     "lint": "biome check .",
-    "lint:fix": "biome check --write . && echo hi"
+    "lint:fix": "biome check --write ."
   },
   "repository": {
     "type": "git",

--- a/services/functions/package.json
+++ b/services/functions/package.json
@@ -10,7 +10,7 @@
     "generate": "echo 'nothing to generate'",
     "test": "biome check . && jest --testTimeout=120000",
     "lint": "biome check .",
-    "lint:fix": "biome check --write ."
+    "lint:fix": "biome check --write . && echo hi"
   },
   "repository": {
     "type": "git",

--- a/services/functions/project.nix
+++ b/services/functions/project.nix
@@ -171,7 +171,7 @@ in
 
   package = serverFiles;
 
-  dockerImage = mkDockerImage { nodejs = pkgs.nodejs_22; };
-
-  node20DockerImage = mkDockerImage { nodejs = pkgs.nodejs_20; };
+  node22DockerImage = mkDockerImage { nodejs = pkgs.nodejs_22; };
+  node24DockerImage = mkDockerImage { nodejs = pkgs.nodejs_24; };
+  # node26DockerImage = mkDockerImage { nodejs = pkgs.nodejs_26; };
 }

--- a/services/functions/project.nix
+++ b/services/functions/project.nix
@@ -173,5 +173,4 @@ in
 
   node22DockerImage = mkDockerImage { nodejs = pkgs.nodejs_22; };
   node24DockerImage = mkDockerImage { nodejs = pkgs.nodejs_24; };
-  # node26DockerImage = mkDockerImage { nodejs = pkgs.nodejs_26; };
 }

--- a/services/functions/test/integration.test.js
+++ b/services/functions/test/integration.test.js
@@ -1,8 +1,8 @@
 const { describe, it, expect, beforeAll } = require('@jest/globals');
 
 const PORTS = {
-  node22: 3002,
-  node20: 3001,
+  node22: 3001,
+  node24: 3002,
   npm: 3003,
   yarn: 3004,
 };
@@ -32,9 +32,9 @@ async function waitForHealthy(port, label, maxAttempts = 60) {
 
 describe.each([
   ['node22 (pnpm)', PORTS.node22, 'nodejs22.x'],
-  ['node20 (pnpm)', PORTS.node20, 'nodejs20.x'],
-  ['node22 (npm)', PORTS.npm, 'nodejs22.x'],
-  ['node22 (yarn)', PORTS.yarn, 'nodejs22.x'],
+  ['node24 (pnpm)', PORTS.node24, 'nodejs24.x'],
+  ['node24 (npm)', PORTS.npm, 'nodejs24.x'],
+  ['node24 (yarn)', PORTS.yarn, 'nodejs24.x'],
 ])('functions runtime (%s)', (label, port, expectedRuntime) => {
   const base = `http://127.0.0.1:${port}`;
 


### PR DESCRIPTION
Node.js 20 is EOL.

<!-- nhost-reviewer:start -->
### **PR Type**
Enhancement

___

### **Description**
- Drop Node.js 20 from the functions service build matrix (EOL) and add Node.js 24 as the new secondary variant alongside Node.js 22 (default).
- Update CI workflows (`functions_checks.yaml`, `functions_wf_release.yaml`) to build/release for the new `[22, 24]` matrix.
- Rename Nix outputs (`functions-node22-docker-image`, `functions-node24-docker-image`) and replace `node20DockerImage` with `node24DockerImage` in `services/functions/project.nix`.
- Rewire the dev environment: rename the `functions-node20` Compose service to `functions-node24` (port 3002), shift `functions-node22` to port 3001, and bump the `functions-npm` / `functions-yarn` images to the Node 24 build.
- Update integration tests to expect `nodejs22.x` on port 3001 and `nodejs24.x` on 3002/3003/3004.
- Add `services/functions/example-pnpm/pnpm-workspace.yaml` declaring `allowBuilds: { sharp: true }` so pnpm 10's strict-build default permits sharp's postinstall.
- Add `nixfmt` to the default dev shell.

___

### Diagram Walkthrough

```mermaid
flowchart LR
  A["CI matrix<br/>node: 22, 24"] --> B["wf_build_artifacts<br/>NODE_VERSION"]
  B --> C["flake.nix packages<br/>functions-node22/24-docker-image"]
  C --> D["project.nix<br/>mkDockerImage { nodejs_22 | nodejs_24 }"]
  D --> E["docker-compose<br/>node22:3001, node24:3002, npm:3003, yarn:3004"]
  E --> F["integration.test.js<br/>asserts nodejs22.x / nodejs24.x"]
```

<details> <summary><h3> File Walkthrough</h3></summary>

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody>
<tr><td><strong>CI / Workflows</strong></td><td><details><summary>2 files</summary><table>
<tr>
  <td><strong>functions_checks.yaml</strong><dd><code>Bump build matrix from [20, 22] to [22, 24]</code></dd></td>
  <td><a href="https://github.com/nhost/nhost/pull/4266/files#diff-52e81492bf3b99da09aa6f23aa86352117ddcabee01f88af8f57e1c65046aa8a">+1/-1</a></td>
</tr>
<tr>
  <td><strong>functions_wf_release.yaml</strong><dd><code>Bump release build + docker-push matrix from [20, 22] to [22, 24]</code></dd></td>
  <td><a href="https://github.com/nhost/nhost/pull/4266/files#diff-9b12bc6d333475a91c890b4d1301af485b5dfe0e398cf1617114c22eb722aa01">+2/-2</a></td>
</tr>
</table></details></td></tr>
<tr><td><strong>Nix build</strong></td><td><details><summary>2 files</summary><table>
<tr>
  <td><strong>flake.nix</strong><dd><code>Rename functions-node20-docker-image to functions-node24-docker-image; add nixfmt to dev shell</code></dd></td>
  <td><a href="https://github.com/nhost/nhost/pull/4266/files#diff-206b9ce276ab5971a2489d75eb1b12999d4bf3843b7988cbe8d687cfde61dea0">+5/-2</a></td>
</tr>
<tr>
  <td><strong>project.nix</strong><dd><code>Replace dockerImage/node20DockerImage with node22DockerImage/node24DockerImage</code></dd></td>
  <td><a href="https://github.com/nhost/nhost/pull/4266/files#diff-478ae77cf85885988b637453974d32f4bf4840bd557c0d71da2e2620ababdf0a">+2/-3</a></td>
</tr>
</table></details></td></tr>
<tr><td><strong>Dev environment</strong></td><td><details><summary>2 files</summary><table>
<tr>
  <td><strong>Makefile</strong><dd><code>_dev-env-build now builds NODE_VERSION 22 + 24</code></dd></td>
  <td><a href="https://github.com/nhost/nhost/pull/4266/files#diff-7d44ca57821eecb9dc499f1f4c70e0738a1e17d1b19aec6602b4086ac4cbe77b">+1/-1</a></td>
</tr>
<tr>
  <td><strong>docker-compose.yaml</strong><dd><code>Rename node20 service/volume to node24; npm and yarn services now use the Node 24 image</code></dd></td>
  <td><a href="https://github.com/nhost/nhost/pull/4266/files#diff-b6cfbb3f44eb65d4174b999ae1e9596899a36281d83a7974149e8a9e6e2e1af5">+11/-11</a></td>
</tr>
</table></details></td></tr>
<tr><td><strong>Tests</strong></td><td><details><summary>1 file</summary><table>
<tr>
  <td><strong>integration.test.js</strong><dd><code>Update PORTS map and describe matrix to assert nodejs22.x / nodejs24.x</code></dd></td>
  <td><a href="https://github.com/nhost/nhost/pull/4266/files#diff-ceb6cbd64208432d103ee0ab22065cd63b62742f974fb2d61be2df269adc6094">+5/-5</a></td>
</tr>
</table></details></td></tr>
<tr><td><strong>Examples</strong></td><td><details><summary>1 file</summary><table>
<tr>
  <td><strong>pnpm-workspace.yaml</strong><dd><code>New file: allowBuilds.sharp = true so pnpm 10's strictDepBuilds default permits sharp's postinstall</code></dd></td>
  <td><a href="https://github.com/nhost/nhost/pull/4266/files#diff-2c8a6d477c864f0dc8781876d870a8558ee57d93ec144f3a20ddf5b537465eb1">+2/-0</a></td>
</tr>
</table></details></td></tr>
<tr><td><strong>Documentation</strong></td><td><details><summary>1 file</summary><table>
<tr>
  <td><strong>CLAUDE.md</strong><dd><code>Update project notes to describe Node 22 / Node 24 variants</code></dd></td>
  <td><a href="https://github.com/nhost/nhost/pull/4266/files#diff-583d98308d30ae33722543fc3b01769156023ef06aececf7219713bd945f38b4">+3/-3</a></td>
</tr>
</table></details></td></tr>
</tbody></table>

</details>

___

<!-- nhost-reviewer:end -->