### PR TITLE
fix(deps): update biome to 2.4.15

### DIFF
--- a/biome.json
+++ b/biome.json
@@ -1,5 +1,5 @@
 {
-  "$schema": "https://biomejs.dev/schemas/2.4.2/schema.json",
+  "$schema": "https://biomejs.dev/schemas/2.4.15/schema.json",
   "root": true,
   "javascript": { "formatter": { "quoteStyle": "single" }, "globals": [] },
   "vcs": { "enabled": true, "clientKind": "git", "useIgnoreFile": true },

--- a/dashboard/src/components/presentational/CodeBlock/index.ts
+++ b/dashboard/src/components/presentational/CodeBlock/index.ts
@@ -4,5 +4,5 @@ import {
   type CodeBlockPropsBase,
 } from './CodeBlock';
 
-export { CodeBlock };
 export type { CodeBlockProps, CodeBlockPropsBase };
+export { CodeBlock };

--- a/dashboard/src/components/ui/v3/button.tsx
+++ b/dashboard/src/components/ui/v3/button.tsx
@@ -67,4 +67,4 @@ const ButtonWithLoading = React.forwardRef<
   );
 });
 
-export { Button, buttonVariants, ButtonWithLoading };
+export { Button, ButtonWithLoading, buttonVariants };

--- a/dashboard/src/features/orgs/projects/database/common/hooks/useTableSchemaQuery/useTableSchemaQuery.ts
+++ b/dashboard/src/features/orgs/projects/database/common/hooks/useTableSchemaQuery/useTableSchemaQuery.ts
@@ -57,9 +57,7 @@ export default function useTableSchemaQuery(
     name: table,
     queryOptions: {
       enabled:
-        isNotEmptyValue(project) &&
-        !!project?.config?.hasura.adminSecret &&
-        isReady
+        isNotEmptyValue(project?.config?.hasura.adminSecret) && isReady
           ? queryOptions?.enabled
           : false,
     },

--- a/dashboard/src/features/orgs/projects/database/dataGrid/components/FunctionDefinitionView/FunctionDefinitionView.tsx
+++ b/dashboard/src/features/orgs/projects/database/dataGrid/components/FunctionDefinitionView/FunctionDefinitionView.tsx
@@ -249,6 +249,7 @@ export default function FunctionDefinitionView() {
             <div className="space-y-2">
               {functionMetadata.parameters.map((param, index) => (
                 <div
+                  // biome-ignore lint/suspicious/noArrayIndexKey: function parameters are positional and the list never reorders
                   key={`param-${param.name || index}-${index}`}
                   className="flex items-center gap-3 text-sm"
                 >

--- a/dashboard/src/features/orgs/projects/database/dataGrid/hooks/useFunctionQuery/useFunctionQuery.ts
+++ b/dashboard/src/features/orgs/projects/database/dataGrid/hooks/useFunctionQuery/useFunctionQuery.ts
@@ -53,10 +53,9 @@ export default function useFunctionQuery(
     keepPreviousData: true,
     ...queryOptions,
     enabled:
-      isNotEmptyValue(project) &&
-      project?.config?.hasura.adminSecret &&
+      isNotEmptyValue(project?.config?.hasura.adminSecret) &&
       isReady &&
-      !!functionOID
+      functionOID
         ? queryOptions?.enabled
         : false,
   });

--- a/dashboard/src/features/orgs/projects/database/dataGrid/hooks/useTableQuery/useTableQuery.ts
+++ b/dashboard/src/features/orgs/projects/database/dataGrid/hooks/useTableQuery/useTableQuery.ts
@@ -55,9 +55,7 @@ export default function useTableQuery(
     name: table,
     queryOptions: {
       enabled:
-        isNotEmptyValue(project) &&
-        !!project?.config?.hasura.adminSecret &&
-        isReady
+        isNotEmptyValue(project?.config?.hasura.adminSecret) && isReady
           ? queryOptions?.enabled
           : false,
     },

--- a/dashboard/src/features/orgs/projects/database/dataGrid/hooks/useTableRelatedObjectsQuery/useTableRelatedObjectsQuery.ts
+++ b/dashboard/src/features/orgs/projects/database/dataGrid/hooks/useTableRelatedObjectsQuery/useTableRelatedObjectsQuery.ts
@@ -64,7 +64,7 @@ export default function useTableRelatedObjectsQuery(
     },
     ...queryOptions,
     enabled:
-      project?.config?.hasura.adminSecret && isReady && !!schema && !!table
+      project?.config?.hasura.adminSecret && isReady && schema && table
         ? (queryOptions?.enabled ?? true)
         : false,
   });

--- a/dashboard/src/features/orgs/projects/deployments/components/DeploymentDetails/DeploymentDetails.tsx
+++ b/dashboard/src/features/orgs/projects/deployments/components/DeploymentDetails/DeploymentDetails.tsx
@@ -128,6 +128,7 @@ function TaskLogList({ logs }: { logs: DeploymentLog[] }) {
       className="max-h-64 overflow-x-auto overflow-y-scroll"
     >
       {logs.map((log, index) => (
+        // biome-ignore lint/suspicious/noArrayIndexKey: logs are append-only and timestamps can collide, so index disambiguates
         <div key={`${log.timestamp}-${index}`} className="flex font-mono">
           <div className="mr-2 flex-shrink-0 text-white/60">
             {format(parseISO(log.timestamp), 'HH:mm:ss')}

--- a/dashboard/src/features/orgs/projects/graphql/metadata/components/MetadataInconsistentStatus/MetadataInconsistentStatus.tsx
+++ b/dashboard/src/features/orgs/projects/graphql/metadata/components/MetadataInconsistentStatus/MetadataInconsistentStatus.tsx
@@ -106,6 +106,7 @@ export default function MetadataInconsistentStatus({
                     </TableHeader>
                     <TableBody>
                       {inconsistentObjects.map((obj, index) => (
+                        // biome-ignore lint/suspicious/noArrayIndexKey: Hasura's get_inconsistent_metadata API does not guarantee type+name uniqueness; index is a safe tiebreaker
                         <TableRow key={`${obj.type}-${obj.name}-${index}`}>
                           <TableCell className="font-medium">
                             {obj.name}

--- a/dashboard/src/features/orgs/projects/remote-schemas/components/EditRemoteSchemaPermissionsForm/RemoteSchemaRolePermissionsEditorForm.tsx
+++ b/dashboard/src/features/orgs/projects/remote-schemas/components/EditRemoteSchemaPermissionsForm/RemoteSchemaRolePermissionsEditorForm.tsx
@@ -188,7 +188,7 @@ export default function RemoteSchemaRolePermissionsEditorForm({
       setRemoteSchemaFields((prev) => {
         const newFields = [...prev];
         const schemaType = newFields[schemaTypeIndex];
-        if (!schemaType || !schemaType.children) {
+        if (!schemaType?.children) {
           return prev;
         }
         if (fieldIndex < 0 || fieldIndex >= schemaType.children.length) {

--- a/dashboard/src/pages/support/ticket.tsx
+++ b/dashboard/src/pages/support/ticket.tsx
@@ -90,7 +90,7 @@ function TicketPage() {
   const canSetPriority = typeof slaLevel === 'string' && slaLevel !== 'none';
 
   useEffect(() => {
-    if (!!selectedOrganization && !canSetPriority && priority !== 'low') {
+    if (selectedOrganization && !canSetPriority && priority !== 'low') {
       setValue('priority', 'low', { shouldValidate: true });
     }
   }, [selectedOrganization, canSetPriority, priority, setValue]);
@@ -261,7 +261,7 @@ function TicketPage() {
                     }}
                     error={!!errors.priority}
                     helperText={
-                      !!selectedOrganization && !canSetPriority ? (
+                      selectedOrganization && !canSetPriority ? (
                         <>
                           To set a higher priority, upgrade to a plan with an
                           SLA.{' '}

--- a/dashboard/src/styles/globals.css
+++ b/dashboard/src/styles/globals.css
@@ -1,4 +1,5 @@
 /** biome-ignore-all lint/complexity/noImportantStyles: we need to override some third party CSS */
+/** biome-ignore-all lint/style/noDescendingSpecificity: selectors are grouped by topic, not specificity */
 @tailwind base;
 @tailwind components;
 @tailwind utilities;

--- a/docs/src/styles/custom.css
+++ b/docs/src/styles/custom.css
@@ -1,3 +1,5 @@
+/** biome-ignore-all lint/style/noDescendingSpecificity: selectors are grouped by topic, not specificity */
+
 /* ==============================================
    NHOST BRAND THEME
    ============================================== */

--- a/nixops/overlays/js.nix
+++ b/nixops/overlays/js.nix
@@ -1,23 +1,23 @@
 (
   final: prev:
   let
-    biome_version = "2.4.2";
+    biome_version = "2.4.15";
     biome_dist = {
       aarch64-darwin = {
         url = "https://github.com/biomejs/biome/releases/download/%40biomejs%2Fbiome%40${biome_version}/biome-darwin-arm64";
-        sha256 = "1qjmbnw0v000d6qgfa8rgicra9sq737w555s2l0n4phkp465yyqw";
+        sha256 = "0ym19wd6yzpzpj6inydsfc5xzakl6w7g4lj1dihd1z5hnc0mdimj";
       };
       x86_64-darwin = {
         url = "https://github.com/biomejs/biome/releases/download/%40biomejs%2Fbiome%40${biome_version}/biome-darwin-x64";
-        sha256 = "05jjj2nw0fziiagcahw29lr6km3dlcpjjl5rnv2y16r067288srl";
+        sha256 = "0zd0508kdx6bs4cly6jhny1k96g8wy07ybwmn8hghf2aqnfs7f7s";
       };
       aarch64-linux = {
         url = "https://github.com/biomejs/biome/releases/download/%40biomejs%2Fbiome%40${biome_version}/biome-linux-arm64";
-        sha256 = "116mddjdy8m23mc0i7g51qv2g0lcfhwzg13g189gnqwg3isb99qy";
+        sha256 = "1bp2adhhszz38p6izszhbxk9w54vq9lm8m007yj91f9nva9dbf3y";
       };
       x86_64-linux = {
         url = "https://github.com/biomejs/biome/releases/download/%40biomejs%2Fbiome%40${biome_version}/biome-linux-x64";
-        sha256 = "10pr2ymh7846karlswy9xnd24pfv6p4bjcm2azmii3pczv2shnh2";
+        sha256 = "001m5xy2riy2yj3mjf5bq4ywydm0i8dbxlqvx8q35l5gkrry5bwd";
       };
     };
   in

--- a/packages/nhost-js/src/session/refreshSession.ts
+++ b/packages/nhost-js/src/session/refreshSession.ts
@@ -147,7 +147,7 @@ const _needsRefresh = (storage: SessionStorage, marginSeconds = 60) => {
     return { session: null, needsRefresh: false, sessionExpired: false };
   }
 
-  if (!session.decodedToken || !session.decodedToken.exp) {
+  if (!session.decodedToken?.exp) {
     // if the session does not have a valid decoded token, treat it as expired
     // as we can't determine its validity
     return { session, needsRefresh: true, sessionExpired: true };


### PR DESCRIPTION
### Checklist

- [ ] No breaking changes
- [ ] Tests pass
- [ ] New features have new tests
- [ ] Documentation is updated (if applicable)
- [ ] Title of the PR is in the correct format (see below)

<!-- nhost-reviewer:start -->
### **PR Type**
Configuration

___

### **Description**
- Upgrade Biome from 2.4.2 to 2.4.15, updating `biome.json` schema ref and Nix overlay hashes for all four platforms
- Fix import export order violations surfaced by the new Biome version in `CodeBlock/index.ts` and `button.tsx`
- Simplify redundant double-negation (`!!x`) and null-guard patterns across several dashboard hooks and pages to pass the stricter linter
- Add `biome-ignore` comments with justifications where array-index keys are intentional (function parameters, append-only deployment logs, inconsistent metadata objects)
- Suppress `noDescendingSpecificity` for CSS files that group selectors by topic rather than specificity

___

<details> <summary><h3> File Walkthrough</h3></summary>

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody>
<tr><td><strong>Tooling / configuration</strong></td><td><details><summary>2 files</summary><table>
<tr>
  <td><strong>biome.json</strong><dd><code>Bump schema URL to Biome 2.4.15</code></dd></td>
  <td><a href="https://github.com/nhost/nhost/pull/4270/files#diff-2bc8a1f5e9380d5a187a4e90f11b4dd36c3abad6aea44c84be354a4f44cdec55">+1/-1</a></td>
</tr>
<tr>
  <td><strong>js.nix</strong><dd><code>Update biome version string and all four platform SHA256 hashes</code></dd></td>
  <td><a href="https://github.com/nhost/nhost/pull/4270/files#diff-97e4512702da292a4600b31097cf187d98b18c9af1a9b8a2f6af742b00664c06">+5/-5</a></td>
</tr>
</table></details></td></tr>
<tr><td><strong>Import / export order fixes</strong></td><td><details><summary>2 files</summary><table>
<tr>
  <td><strong>index.ts</strong><dd><code>Move type exports before value exports to satisfy Biome's ordering rule</code></dd></td>
  <td><a href="https://github.com/nhost/nhost/pull/4270/files#diff-4f4871a11cede46630a94c78b8a9f9132e7ca794fd4919677f5b8dcc679486d8">+1/-1</a></td>
</tr>
<tr>
  <td><strong>button.tsx</strong><dd><code>Reorder named exports alphabetically</code></dd></td>
  <td><a href="https://github.com/nhost/nhost/pull/4270/files#diff-3128c8a9c83cc7319d992e31c2cba551cde0d85037f42a5a74a47464d7e80f82">+1/-1</a></td>
</tr>
</table></details></td></tr>
<tr><td><strong>Linter fixes – dashboard hooks & pages</strong></td><td><details><summary>6 files</summary><table>
<tr>
  <td><strong>useTableSchemaQuery.ts</strong><dd><code>Collapse redundant isNotEmptyValue + !! guard into a single isNotEmptyValue call</code></dd></td>
  <td><a href="https://github.com/nhost/nhost/pull/4270/files#diff-0403e5b459d55b1bca5053708c2132df97fa1f582cbd4097c41efd635e2b4835">+1/-3</a></td>
</tr>
<tr>
  <td><strong>useFunctionQuery.ts</strong><dd><code>Remove double negation and redundant null guard on project</code></dd></td>
  <td><a href="https://github.com/nhost/nhost/pull/4270/files#diff-115b37b789d0cf670fc1706774fa7099cf4a93a95bbaa2dd871c04621c3fd3ac">+2/-3</a></td>
</tr>
<tr>
  <td><strong>useTableQuery.ts</strong><dd><code>Same pattern simplification as useTableSchemaQuery</code></dd></td>
  <td><a href="https://github.com/nhost/nhost/pull/4270/files#diff-13ce245133be3c4bbcd9fe302cacd42e3e8472dc57d8ce27371e59818240d942">+1/-3</a></td>
</tr>
<tr>
  <td><strong>useTableRelatedObjectsQuery.ts</strong><dd><code>Drop !! on schema and table string guards</code></dd></td>
  <td><a href="https://github.com/nhost/nhost/pull/4270/files#diff-7bcc8005e9b05340f3d5c498686562fba2a30d0941c7a1d300c19cdc40e69f8c">+1/-1</a></td>
</tr>
<tr>
  <td><strong>RemoteSchemaRolePermissionsEditorForm.tsx</strong><dd><code>Replace redundant !schemaType || !schemaType.children with optional chaining</code></dd></td>
  <td><a href="https://github.com/nhost/nhost/pull/4270/files#diff-504fbff10f5a955dbafda0274374ff0af04b583510b589b0e1d73c996d5b4e0f">+1/-1</a></td>
</tr>
<tr>
  <td><strong>ticket.tsx</strong><dd><code>Remove double negation on selectedOrganization truthiness checks</code></dd></td>
  <td><a href="https://github.com/nhost/nhost/pull/4270/files#diff-a66cba186d2014b03f1a0e005147ae7b48e88933700fe065d235cd819a949a97">+2/-2</a></td>
</tr>
</table></details></td></tr>
<tr><td><strong>biome-ignore annotations</strong></td><td><details><summary>5 files</summary><table>
<tr>
  <td><strong>FunctionDefinitionView.tsx</strong><dd><code>Suppress noArrayIndexKey: parameters are positional and never reorder</code></dd></td>
  <td><a href="https://github.com/nhost/nhost/pull/4270/files#diff-6dd6c35e2bf85c39495bef4c6afe505c73f8034502f439204f7913e3f7d7f99b">+1/-0</a></td>
</tr>
<tr>
  <td><strong>DeploymentDetails.tsx</strong><dd><code>Suppress noArrayIndexKey: logs are append-only and timestamps can collide</code></dd></td>
  <td><a href="https://github.com/nhost/nhost/pull/4270/files#diff-e95736b80d6545cd9bab82a81263adef8e9c39f8428eae50420e4b65349b774b">+1/-0</a></td>
</tr>
<tr>
  <td><strong>MetadataInconsistentStatus.tsx</strong><dd><code>Restore index tiebreaker in React key; suppress noArrayIndexKey with justification that type+name uniqueness is not guaranteed by the API</code></dd></td>
  <td><a href="https://github.com/nhost/nhost/pull/4270/files#diff-74053e177e9b4f50d7f0023da9ae476d0f4b5dec2d5e6effb88688f015cee35b">+2/-2</a></td>
</tr>
<tr>
  <td><strong>globals.css</strong><dd><code>Add file-level suppress for noDescendingSpecificity</code></dd></td>
  <td><a href="https://github.com/nhost/nhost/pull/4270/files#diff-fe5e1172304066de64ab9008cce8cb7ac09661fbc93feb37d0ba69091f7f4311">+1/-0</a></td>
</tr>
<tr>
  <td><strong>custom.css</strong><dd><code>Add file-level suppress for noDescendingSpecificity</code></dd></td>
  <td><a href="https://github.com/nhost/nhost/pull/4270/files#diff-e246a661203299ae44d3562a2b6c98e785b0878e825598eb24178bc018215447">+2/-0</a></td>
</tr>
</table></details></td></tr>
<tr><td><strong>SDK</strong></td><td><details><summary>1 file</summary><table>
<tr>
  <td><strong>refreshSession.ts</strong><dd><code>Simplify double null guard using optional chaining</code></dd></td>
  <td><a href="https://github.com/nhost/nhost/pull/4270/files#diff-578cd1f069f1742b4a1aeabaaed852562659c6a830a4b51df0c26d52af478051">+1/-1</a></td>
</tr>
</table></details></td></tr>
</tbody></table>

</details>

___

<!-- nhost-reviewer:end -->