### PR TITLE
feat(cli): embed email templates instead of fetching at runtime

### DIFF
--- a/.github/workflows/cli_checks.yaml
+++ b/.github/workflows/cli_checks.yaml
@@ -28,6 +28,9 @@ on:
       - "internal/lib/clidocs/**"
       - "internal/lib/nhostclient/**"
 
+      # auth email templates (embedded into the CLI by `nhost init`)
+      - "services/auth/email-templates/**"
+
       # docs
       - "docs/**"
   merge_group:
@@ -56,6 +59,7 @@ jobs:
         vendor/**
         cli/**
         internal/lib/clidocs/**
+        services/auth/email-templates/**
         docs/**
 
   check-permissions:

--- a/cli/cmd/project/init.go
+++ b/cli/cmd/project/init.go
@@ -9,11 +9,11 @@ import (
 	"os"
 	"path/filepath"
 
-	"github.com/hashicorp/go-getter/v2"
 	"github.com/nhost/be/services/mimir/model"
 	"github.com/nhost/nhost/cli/clienv"
 	"github.com/nhost/nhost/cli/cmd/config"
 	"github.com/nhost/nhost/cli/dockercompose"
+	emailtemplates "github.com/nhost/nhost/services/auth/email-templates"
 	"github.com/urfave/cli/v3"
 	"gopkg.in/yaml.v3"
 )
@@ -25,41 +25,37 @@ const (
 //go:embed templates/init/*
 var embeddedFS embed.FS
 
-func writeFiles(ps *clienv.PathStructure, root, relPath string) error {
-	dirEntries, err := embeddedFS.ReadDir(filepath.Join(root, relPath))
-	if err != nil {
-		return fmt.Errorf("failed to read dir: %w", err)
-	}
-
-	for _, entry := range dirEntries {
-		if entry.IsDir() {
-			return writeFiles(ps, root, filepath.Join(relPath, entry.Name()))
-		}
-
-		src := filepath.Join(root, relPath, entry.Name())
-
-		fileData, err := fs.ReadFile(embeddedFS, src)
+func writeFS(srcFS fs.FS, srcRoot, dstRoot string) error {
+	return fs.WalkDir(srcFS, srcRoot, func(p string, d fs.DirEntry, err error) error {
 		if err != nil {
-			return fmt.Errorf("failed to read file %s: %w", src, err)
+			return fmt.Errorf("failed to walk %s: %w", p, err)
 		}
 
-		dst := filepath.Join(ps.Root(), relPath, entry.Name())
-
-		f, err := os.OpenFile(
-			filepath.Join(ps.Root(), dst),
-			os.O_RDWR|os.O_CREATE|os.O_TRUNC, 0o600, //nolint:mnd
-		)
+		rel, err := filepath.Rel(srcRoot, p)
 		if err != nil {
-			return fmt.Errorf("failed to open file %s: %w", dst, err)
+			return fmt.Errorf("failed to compute relative path for %s: %w", p, err)
 		}
-		defer f.Close()
 
-		if _, err := f.Write(fileData); err != nil {
+		dst := filepath.Join(dstRoot, rel)
+
+		if d.IsDir() {
+			if err := os.MkdirAll(dst, 0o755); err != nil { //nolint:mnd
+				return fmt.Errorf("failed to create dir %s: %w", dst, err)
+			}
+			return nil
+		}
+
+		data, err := fs.ReadFile(srcFS, p)
+		if err != nil {
+			return fmt.Errorf("failed to read file %s: %w", p, err)
+		}
+
+		if err := os.WriteFile(dst, data, 0o600); err != nil { //nolint:mnd
 			return fmt.Errorf("failed to write file %s: %w", dst, err)
 		}
-	}
 
-	return nil
+		return nil
+	})
 }
 
 const hasuraMetadataVersion = 3
@@ -103,7 +99,7 @@ func commandInit(ctx context.Context, cmd *cli.Command) error {
 			return fmt.Errorf("failed to initialize remote project: %w", err)
 		}
 	} else {
-		if err := initInit(ctx, ce.Path); err != nil {
+		if err := initInit(ce.Path); err != nil {
 			return fmt.Errorf("failed to initialize project: %w", err)
 		}
 	}
@@ -113,9 +109,7 @@ func commandInit(ctx context.Context, cmd *cli.Command) error {
 	return nil
 }
 
-func initInit(
-	ctx context.Context, ps *clienv.PathStructure,
-) error {
+func initInit(ps *clienv.PathStructure) error {
 	hasuraConf := map[string]any{"version": hasuraMetadataVersion}
 	if err := clienv.MarshalFile(hasuraConf, ps.HasuraConfig(), yaml.Marshal); err != nil {
 		return fmt.Errorf("failed to save hasura config: %w", err)
@@ -125,17 +119,12 @@ func initInit(
 		return err
 	}
 
-	if err := writeFiles(ps, "templates/init", ""); err != nil {
-		return err
+	if err := writeFS(embeddedFS, "templates/init", ps.Root()); err != nil {
+		return fmt.Errorf("failed to write project files: %w", err)
 	}
 
-	getclient := &getter.Client{}                    //nolint:exhaustruct
-	if _, err := getclient.Get(ctx, &getter.Request{ //nolint:exhaustruct
-		Src:             "git::https://github.com/nhost/nhost.git//services/auth/email-templates",
-		Dst:             "nhost/emails",
-		DisableSymlinks: true,
-	}); err != nil {
-		return fmt.Errorf("failed to download email templates: %w", err)
+	if err := writeFS(emailtemplates.FS, ".", filepath.Join(ps.NhostFolder(), "emails")); err != nil {
+		return fmt.Errorf("failed to write email templates: %w", err)
 	}
 
 	return nil
@@ -173,7 +162,7 @@ func InitRemote(
 		return fmt.Errorf("failed to pull config: %w", err)
 	}
 
-	if err := initInit(ctx, ce.Path); err != nil {
+	if err := initInit(ce.Path); err != nil {
 		return err
 	}
 

--- a/cli/project.nix
+++ b/cli/project.nix
@@ -43,6 +43,9 @@ let
       (inDirectory "${submodule}/cmd/mcp/testdata")
       (inDirectory "${submodule}/mcp/graphql/testdata")
 
+      # auth email templates (embedded into the CLI binary by `nhost init`)
+      (inDirectory "services/auth/email-templates")
+
       # docs
       ../docs/embed.go
       (and (inDirectory ../docs/src/content/docs) (matchExt "mdx"))

--- a/services/auth/email-templates/embed.go
+++ b/services/auth/email-templates/embed.go
@@ -1,0 +1,9 @@
+// Package emailtemplates exposes the default Nhost Auth email templates as an
+// embedded filesystem so consumers (e.g. the CLI) can bundle them at build
+// time instead of fetching them from a remote source at runtime.
+package emailtemplates
+
+import "embed"
+
+//go:embed all:bg all:cs all:en all:es all:fr
+var FS embed.FS


### PR DESCRIPTION
```
$ time ./nhost-dev init
Initializing Nhost project
Successfully initialized Nhost project, run `nhost up` to start development
./nhost-dev init  0.02s user 0.02s system 110% cpu 0.036 total
```

<!-- nhost-reviewer:start -->
### **PR Type**
Enhancement

___

### **Description**
- Expose the default Nhost Auth email templates as a Go `embed.FS` so consumers can bundle them at build time.
- Refactor `nhost init` to copy email templates from the embedded filesystem instead of fetching them from `github.com/nhost/nhost` at runtime via `go-getter`.
- Replace the hand-rolled recursive `writeFiles` with a generic `writeFS` helper built on `fs.WalkDir`, fixing a latent bug where directory siblings could be skipped after recursing into a subdirectory.
- Drop the `ctx` parameter from `initInit` since no remote call is made anymore.
- Update the `cli` Nix build filter and the `cli_checks` CI workflow so the CLI is rebuilt and re-tested whenever the embedded email templates change.

___

### Diagram Walkthrough

```mermaid
flowchart LR
  A["services/auth/email-templates<br/>(bg, cs, en, es, fr)"] -->|"//go:embed"| B["emailtemplates.FS"]
  B -->|"writeFS"| C["nhost init"]
  C --> D["<project>/nhost/emails/"]
  E["templates/init/*<br/>(CLI scaffolding)"] -->|"//go:embed"| F["embeddedFS"]
  F -->|"writeFS"| C
```

<details> <summary><h3> File Walkthrough</h3></summary>

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody>
<tr><td><strong>Core logic</strong></td><td><details><summary>2 files</summary><table>
<tr>
  <td><strong>embed.go</strong><dd><code>New package exposing auth email templates as an embed.FS</code></dd></td>
  <td><a href="https://github.com/nhost/nhost/pull/XXX/files#diff-2042e66604c08d085dde8edd1379b022f357fa0079dcc3fb2ab3cf2df0299c57">+9/-0</a></td>
</tr>
<tr>
  <td><strong>init.go</strong><dd><code>Switch nhost init to embedded templates, refactor file copy via fs.WalkDir</code></dd></td>
  <td><a href="https://github.com/nhost/nhost/pull/XXX/files#diff-d4b6da7fca9111a6b232f4cabd76e1ea567fa80593a397d4fe458c0b3c25bb6e">+27/-38</a></td>
</tr>
</table></details></td></tr>
<tr><td><strong>Infrastructure</strong></td><td><details><summary>2 files</summary><table>
<tr>
  <td><strong>project.nix</strong><dd><code>Include services/auth/email-templates in the CLI Nix build source filter</code></dd></td>
  <td><a href="https://github.com/nhost/nhost/pull/XXX/files#diff-02e27e8c362889995fcb502cc7802ce44664dedbaffc546095431a050374c927">+3/-0</a></td>
</tr>
<tr>
  <td><strong>cli_checks.yaml</strong><dd><code>Trigger CLI checks when auth email templates change</code></dd></td>
  <td><a href="https://github.com/nhost/nhost/pull/XXX/files#diff-85e94af94a1e00a42e4095f4d62c5c016af01ba3314b74395cbe21bc1dc0b6bf">+4/-0</a></td>
</tr>
</table></details></td></tr>
</tbody></table>

</details>

___

<!-- nhost-reviewer:end -->