### PR TITLE
fix(dashboard): route useGetRolesPermissionsQuery through localMimirClient in ColumnPresetsSection

### DIFF
--- a/dashboard/src/features/orgs/projects/database/dataGrid/components/EditPermissionsForm/sections/ColumnPresetsSection.tsx
+++ b/dashboard/src/features/orgs/projects/database/dataGrid/components/EditPermissionsForm/sections/ColumnPresetsSection.tsx
@@ -15,12 +15,15 @@ import {
 } from '@/components/ui/v3/select';
 import { useTableSchemaQuery } from '@/features/orgs/projects/database/common/hooks/useTableSchemaQuery';
 import type { RolePermissionEditorFormValues } from '@/features/orgs/projects/database/dataGrid/components/EditPermissionsForm/RolePermissionEditorForm';
+import { useIsPlatform } from '@/features/orgs/projects/common/hooks/useIsPlatform';
+import { useLocalMimirClient } from '@/features/orgs/projects/hooks/useLocalMimirClient';
 import { useProject } from '@/features/orgs/projects/hooks/useProject';
 import { getAllPermissionVariables } from '@/features/orgs/projects/permissions/settings/utils/getAllPermissionVariables';
 import { cn } from '@/lib/utils';
 import { useGetRolesPermissionsQuery } from '@/utils/__generated__/graphql';
 import ColumnPresetValueCombobox from './ColumnPresetValueCombobox';
 import PermissionSettingsSection from './PermissionSettingsSection';
+
 
 export interface ColumnPreset {
   column: string;
@@ -42,11 +45,16 @@ export default function ColumnPresetsSection({
   );
 
   const { project } = useProject();
+  const isPlatform = useIsPlatform();
+  const localMimirClient = useLocalMimirClient();
 
   const { data: permissionVariablesData } = useGetRolesPermissionsQuery({
     variables: { appId: project?.id },
     skip: !project?.id,
+    ...(!isPlatform ? { client: localMimirClient } : {}),
   });
+
+  
   const {
     control,
     formState: { errors },

--- a/dashboard/src/features/orgs/projects/database/dataGrid/components/EditPermissionsForm/sections/ColumnPresetsSection.tsx
+++ b/dashboard/src/features/orgs/projects/database/dataGrid/components/EditPermissionsForm/sections/ColumnPresetsSection.tsx
@@ -13,9 +13,9 @@ import {
   SelectTrigger,
   SelectValue,
 } from '@/components/ui/v3/select';
+import { useIsPlatform } from '@/features/orgs/projects/common/hooks/useIsPlatform';
 import { useTableSchemaQuery } from '@/features/orgs/projects/database/common/hooks/useTableSchemaQuery';
 import type { RolePermissionEditorFormValues } from '@/features/orgs/projects/database/dataGrid/components/EditPermissionsForm/RolePermissionEditorForm';
-import { useIsPlatform } from '@/features/orgs/projects/common/hooks/useIsPlatform';
 import { useLocalMimirClient } from '@/features/orgs/projects/hooks/useLocalMimirClient';
 import { useProject } from '@/features/orgs/projects/hooks/useProject';
 import { getAllPermissionVariables } from '@/features/orgs/projects/permissions/settings/utils/getAllPermissionVariables';
@@ -23,7 +23,6 @@ import { cn } from '@/lib/utils';
 import { useGetRolesPermissionsQuery } from '@/utils/__generated__/graphql';
 import ColumnPresetValueCombobox from './ColumnPresetValueCombobox';
 import PermissionSettingsSection from './PermissionSettingsSection';
-
 
 export interface ColumnPreset {
   column: string;
@@ -53,8 +52,6 @@ export default function ColumnPresetsSection({
     skip: !project?.id,
     ...(!isPlatform ? { client: localMimirClient } : {}),
   });
-
-  
   const {
     control,
     formState: { errors },


### PR DESCRIPTION
## Problem
In the Column presets section of the table permissions editor, the value combobox was not showing custom session variables (e.g. `X-Hasura-Org-Id`) when the dashboard runs locally (`!isPlatform`). Only the default `X-Hasura-User-Id` was listed.

## Cause
`useGetRolesPermissionsQuery` in `ColumnPresetsSection.tsx` was not routing through `localMimirClient` when `!isPlatform`, so it queried the wrong config source locally.

## Fix
Added `useIsPlatform` and `useLocalMimirClient` hooks and passed `client: localMimirClient` when `!isPlatform` — the same pattern already used in `CustomCheckEditor/ConditionValue.tsx`.

Fixes #4279