### PR TITLE
fix(dashboard): Migrate overview and storage page icons

### DIFF
--- a/dashboard/src/components/ui/v2/icons/MIGRATION.md
+++ b/dashboard/src/components/ui/v2/icons/MIGRATION.md
@@ -20,8 +20,35 @@ Disposition values and the import the codemod should write:
 ## JSX prop translation (apply to every replaced site)
 
 - `color="primary"` → `className="text-primary"` (merge with existing class)
-- `sx={...}` → equivalent Tailwind classes
 - `fontSize="small"` → `size={20}` (lucide/simple-icons take a numeric `size` prop). Verify at the call site rather than relying on a global default.
+- `sx={...}` → equivalent Tailwind classes (`className`), merge with existing. Concrete mappings below.
+
+### `sx={{ color: '<token>' }}` → Tailwind class
+
+Encountered MUI palette tokens and their replacements in this project. Map to the existing token if one exists; for unknown tokens, fall back to the literal hex from the MUI default palette and verify visually.
+
+| MUI token       | Tailwind class           | Notes |
+| ---             | ---                      | --- |
+| `primary.main`  | `text-primary-main`      | MUI-compat shim in `tailwind.config.js`; not the same as `text-primary` (shadcn token). |
+| `error.main`    | `text-error-main`        | MUI-compat shim (`#f13154`). |
+| `text.primary`  | `text-foreground`        | Default body text color. |
+| `text.secondary`| `text-muted-foreground`  | |
+| `text.disabled` | `text-disabled`          | |
+
+### `sx={{ color: (theme) => theme.palette.mode === 'dark' ? 'X' : 'Y' }}`
+
+Dynamic theme callbacks become `dark:`-prefixed Tailwind classes. There is no shadcn equivalent for MUI `grey.*` tokens — translate to the literal MUI hex.
+
+| MUI grey | Hex      |
+| ---      | ---      |
+| 100      | #F5F5F5  |
+| 200      | #21262D  | (this project's `--theme-grey-200` dark-mode override, not MUI's #EEEEEE) |
+| 600      | #757575  |
+| 900      | #212121  |
+
+Example: `sx={{ color: (theme) => theme.palette.mode === 'dark' ? 'grey.200' : 'grey.100' }}` → `className="text-[#F5F5F5] dark:text-[#21262D]"`.
+
+For filled MUI icons replaced by outline-only lucide ones (e.g. `ExclamationFilledIcon` → `CircleAlert`): lucide ships these as line drawings made of strokes, so `fill-current` blacks out the glyph rather than filling a single shape. Don't add it. If the call site renders inside a colored container (e.g. `<Badge variant="standard">`), the container already provides the filled disc — leave the icon stroked. If a true filled glyph is required and there's no colored container, wrap the icon in a `bg-current rounded-full` element instead.
 - Existing `className="h-4 w-4"` (16×16) → bump to `h-5 w-5` (20×20) where layout allows; keep 16×16 only where unavoidable
 - Drop `aria-label` from the icon when the wrapping element already has text or its own `aria-label`; keep it only for standalone state-conveying icons
 
@@ -38,7 +65,7 @@ Disposition values and the import the codemod should write:
 | `ArrowSquareOutIcon` | lucide | `ExternalLink` | `lucide-react` | |
 | `ArrowUpIcon` | lucide | `ArrowUp` | `lucide-react` | |
 | `CalendarIcon` | lucide | `Calendar` | `lucide-react` | |
-| `CheckIcon` | lucide | `Check` | `lucide-react` | |
+| `CheckIcon` | lucide | `Check` | `lucide-react` | For Project Health-specific usages (the small status badge inside `ProjectHealthBadge` / `AccordionHealthBadge`), use the scope-restricted v3 port `ProjectHealthCheckIcon` from `@/components/ui/v3/icons/ProjectHealthCheckIcon` instead. **Why ported instead of replaced:** lucide `Check` renders as thin strokes inside a 24×24 viewBox, which looks washed out at the badge sizes used in Project Health (8–10 px). The v3 port preserves the v2 16×16 viewBox and stroke proportions so the glyph stays legible at small sizes. |
 | `ChevronDownIcon` | lucide | `ChevronDown` | `lucide-react` | |
 | `ChevronLeftIcon` | lucide | `ChevronLeft` | `lucide-react` | |
 | `ChevronRightIcon` | lucide | `ChevronRight` | `lucide-react` | |
@@ -53,7 +80,7 @@ Disposition values and the import the codemod should write:
 | `DotsHorizontalIcon` | lucide | `Ellipsis` | `lucide-react` | |
 | `DotsVerticalIcon` | lucide | `EllipsisVertical` | `lucide-react` | |
 | `EmbeddingsIcon` | already-v3 | `EmbeddingsIcon` | `@/components/ui/v3/icons/EmbeddingsIcon` | Done — ported and call sites migrated in #4202. |
-| `ExclamationFilledIcon` | lucide | `CircleAlert` | `lucide-react` | Lucide is outline-only; if filled appearance is needed, add `className="fill-current"` (or a specific `fill-*` color) at the call site. |
+| `ExclamationFilledIcon` | lucide | `CircleAlert` | `lucide-react` | Lucide is outline-only (see the prop-translation section for why `fill-current` is *not* a safe shortcut here). For Project Health-specific usages (the version-mismatch badge in `ProjectHealthBadge`), use the scope-restricted v3 port `ProjectHealthExclamationIcon` from `@/components/ui/v3/icons/ProjectHealthExclamationIcon` instead. **Why ported instead of replaced:** lucide `CircleAlert` is a stroked outline that doesn't render the original's filled-disc-with-cutout-`!` look, and at badge sizes (≤10 px) the outline glyph is illegible. The v3 port keeps the v2 7×7 filled SVG so the indicator stays readable. |
 | `ExclamationIcon` | lucide | `CircleAlert` | `lucide-react` | |
 | `EyeIcon` | lucide | `Eye` | `lucide-react` | |
 | `EyeOffIcon` | lucide | `EyeOff` | `lucide-react` | |

--- a/dashboard/src/components/ui/v3/icons/ProjectHealthCheckIcon.tsx
+++ b/dashboard/src/components/ui/v3/icons/ProjectHealthCheckIcon.tsx
@@ -1,0 +1,22 @@
+import type { SVGProps } from 'react';
+
+export function ProjectHealthCheckIcon(props: SVGProps<SVGSVGElement>) {
+  return (
+    <svg
+      xmlns="http://www.w3.org/2000/svg"
+      width="16"
+      height="16"
+      viewBox="0 0 16 16"
+      fill="none"
+      aria-hidden="true"
+      {...props}
+    >
+      <path
+        d="m13.5 4.5-7 7L3 8"
+        stroke="currentColor"
+        strokeWidth="2"
+        strokeLinejoin="round"
+      />
+    </svg>
+  );
+}

--- a/dashboard/src/components/ui/v3/icons/ProjectHealthExclamationIcon.tsx
+++ b/dashboard/src/components/ui/v3/icons/ProjectHealthExclamationIcon.tsx
@@ -1,0 +1,22 @@
+import type { SVGProps } from 'react';
+
+export function ProjectHealthExclamationIcon(props: SVGProps<SVGSVGElement>) {
+  return (
+    <svg
+      xmlns="http://www.w3.org/2000/svg"
+      width="7"
+      height="7"
+      viewBox="0 0 7 7"
+      fill="none"
+      aria-hidden="true"
+      {...props}
+    >
+      <path
+        fillRule="evenodd"
+        clipRule="evenodd"
+        d="M7 3.5C7 5.433 5.433 7 3.5 7C1.567 7 0 5.433 0 3.5C0 1.567 1.567 0 3.5 0C5.433 0 7 1.567 7 3.5ZM3.96667 5.36667C3.96667 5.6244 3.75773 5.83333 3.5 5.83333C3.24227 5.83333 3.03333 5.6244 3.03333 5.36667C3.03333 5.10893 3.24227 4.9 3.5 4.9C3.75773 4.9 3.96667 5.10893 3.96667 5.36667ZM3.5 1.16667C3.20564 1.16667 2.97296 1.41615 2.99345 1.70979L3.16724 4.20075C3.17943 4.37554 3.32478 4.51111 3.5 4.51111C3.67522 4.51111 3.82057 4.37554 3.83276 4.20075L4.00655 1.70979C4.02704 1.41615 3.79436 1.16667 3.5 1.16667Z"
+        fill="currentColor"
+      />
+    </svg>
+  );
+}

--- a/dashboard/src/features/orgs/projects/overview/components/AccordionHealthBadge/AccordionHealthBadge.tsx
+++ b/dashboard/src/features/orgs/projects/overview/components/AccordionHealthBadge/AccordionHealthBadge.tsx
@@ -1,5 +1,5 @@
 import { Box } from '@/components/ui/v2/Box';
-import { CheckIcon } from '@/components/ui/v2/icons/CheckIcon';
+import { ProjectHealthCheckIcon } from '@/components/ui/v3/icons/ProjectHealthCheckIcon';
 import { QuestionMarkIcon } from '@/components/ui/v3/icons/QuestionMarkIcon';
 import { serviceStateToThemeColor } from '@/features/orgs/projects/overview/health';
 import { ServiceState } from '@/utils/__generated__/graphql';
@@ -39,13 +39,7 @@ export default function AccordionHealthBadge({
         }}
         className="flex h-2.5 w-2.5 items-center justify-center rounded-full"
       >
-        <CheckIcon
-          sx={{
-            color: (theme) =>
-              theme.palette.mode === 'dark' ? 'grey.200' : 'grey.100',
-          }}
-          className="h-3/4 w-3/4 stroke-2"
-        />
+        <ProjectHealthCheckIcon className="h-3/4 w-3/4 text-[#F5F5F5] dark:text-[#21262D]" />
       </Box>
     );
   }

--- a/dashboard/src/features/orgs/projects/overview/components/InfoCard/InfoCard.tsx
+++ b/dashboard/src/features/orgs/projects/overview/components/InfoCard/InfoCard.tsx
@@ -1,8 +1,8 @@
+import { CopyIcon } from 'lucide-react';
 import type { ReactNode } from 'react';
 import type { BoxProps } from '@/components/ui/v2/Box';
 import { Box } from '@/components/ui/v2/Box';
 import { IconButton } from '@/components/ui/v2/IconButton';
-import { CopyIcon } from '@/components/ui/v2/icons/CopyIcon';
 import { Text } from '@/components/ui/v2/Text';
 import { copy } from '@/utils/copy';
 

--- a/dashboard/src/features/orgs/projects/overview/components/MetricsCard/MetricsCard.tsx
+++ b/dashboard/src/features/orgs/projects/overview/components/MetricsCard/MetricsCard.tsx
@@ -1,7 +1,7 @@
+import { InfoIcon } from 'lucide-react';
 import { twMerge } from 'tailwind-merge';
 import type { BoxProps } from '@/components/ui/v2/Box';
 import { Box } from '@/components/ui/v2/Box';
-import { InfoIcon } from '@/components/ui/v2/icons/InfoIcon';
 import { Text } from '@/components/ui/v2/Text';
 import { Tooltip } from '@/components/ui/v2/Tooltip';
 

--- a/dashboard/src/features/orgs/projects/overview/components/OverviewCard/OverviewCard.tsx
+++ b/dashboard/src/features/orgs/projects/overview/components/OverviewCard/OverviewCard.tsx
@@ -1,9 +1,9 @@
+import { ArrowRightIcon } from 'lucide-react';
 import type { ImageProps } from 'next/image';
 import Image from 'next/image';
 import { twMerge } from 'tailwind-merge';
 import type { BoxProps } from '@/components/ui/v2/Box';
 import { Box } from '@/components/ui/v2/Box';
-import { ArrowRightIcon } from '@/components/ui/v2/icons/ArrowRightIcon';
 import { Link } from '@/components/ui/v2/Link';
 import { Text } from '@/components/ui/v2/Text';
 import type { CardProps } from '@/features/orgs/projects/overview/types/cards';

--- a/dashboard/src/features/orgs/projects/overview/components/OverviewDeployments/OverviewDeployments.tsx
+++ b/dashboard/src/features/orgs/projects/overview/components/OverviewDeployments/OverviewDeployments.tsx
@@ -1,12 +1,11 @@
+import { SiGithub as GitHubIcon } from '@icons-pack/react-simple-icons';
+import { ChevronRightIcon, RocketIcon } from 'lucide-react';
 import { Fragment } from 'react';
 import { NavLink } from '@/components/common/NavLink';
 import { ActivityIndicator } from '@/components/ui/v2/ActivityIndicator';
 import { Box } from '@/components/ui/v2/Box';
 import { Button } from '@/components/ui/v2/Button';
 import { Divider } from '@/components/ui/v2/Divider';
-import { ChevronRightIcon } from '@/components/ui/v2/icons/ChevronRightIcon';
-import { GitHubIcon } from '@/components/ui/v2/icons/GitHubIcon';
-import { RocketIcon } from '@/components/ui/v2/icons/RocketIcon';
 import { List } from '@/components/ui/v2/List';
 import { Text } from '@/components/ui/v2/Text';
 import { DeploymentListItem } from '@/features/orgs/projects/deployments/components/DeploymentListItem';
@@ -82,11 +81,7 @@ function OverviewDeploymentList() {
   if (!deployments.length) {
     return (
       <Box className="grid grid-flow-row items-center justify-items-center gap-5 overflow-hidden rounded-lg border-1 px-4 py-12 shadow-sm">
-        <RocketIcon
-          strokeWidth={1}
-          className="h-10 w-10"
-          sx={{ color: 'text.primary' }}
-        />
+        <RocketIcon strokeWidth={1} className="h-10 w-10 text-foreground" />
         <div className="grid grid-flow-row gap-2">
           <Text className="text-center font-medium" variant="h3">
             No Deployments
@@ -96,7 +91,6 @@ function OverviewDeploymentList() {
             deployment branch in your connected GitHub repository
           </Text>
         </div>
-
         <Box
           className="mt-6 flex w-full max-w-sm flex-row place-content-between rounded-lg px-2 py-2"
           sx={{ backgroundColor: 'grey.200' }}

--- a/dashboard/src/features/orgs/projects/overview/components/OverviewProjectHealth/OverviewProjectHealth.tsx
+++ b/dashboard/src/features/orgs/projects/overview/components/OverviewProjectHealth/OverviewProjectHealth.tsx
@@ -1,20 +1,20 @@
+import { SiHasura as HasuraIcon } from '@icons-pack/react-simple-icons';
+import {
+  Sparkles as AIIcon,
+  DatabaseIcon,
+  HardDrive as StorageIcon,
+  UserIcon,
+} from 'lucide-react';
 import { useDialog } from '@/components/common/DialogProvider';
-import { AIIcon } from '@/components/ui/v2/icons/AIIcon';
-import { DatabaseIcon } from '@/components/ui/v2/icons/DatabaseIcon';
-import { HasuraIcon } from '@/components/ui/v2/icons/HasuraIcon';
-import { StorageIcon } from '@/components/ui/v2/icons/StorageIcon';
-import { UserIcon } from '@/components/ui/v2/icons/UserIcon';
 import { Text } from '@/components/ui/v2/Text';
 import { ServicesOutlinedIcon } from '@/components/ui/v3/icons/ServicesOutlinedIcon';
 import { useServiceStatus } from '@/features/orgs/projects/common/hooks/useServiceStatus';
 import { useSoftwareVersionsInfo } from '@/features/orgs/projects/common/hooks/useSoftwareVersionsInfo';
 import { useProject } from '@/features/orgs/projects/hooks/useProject';
-
 import { OverviewProjectHealthModal } from '@/features/orgs/projects/overview/components/OverviewProjectHealthModal';
 import { ProjectHealthCard } from '@/features/orgs/projects/overview/components/ProjectHealthCard';
 import { RunStatusTooltip } from '@/features/orgs/projects/overview/components/RunStatusTooltip';
 import { ServiceVersionTooltip } from '@/features/orgs/projects/overview/components/ServiceVersionTooltip';
-
 import {
   baseServices,
   findHighestImportanceState,

--- a/dashboard/src/features/orgs/projects/overview/components/OverviewProjectHealthModal/OverviewProjectHealthModal.tsx
+++ b/dashboard/src/features/orgs/projects/overview/components/OverviewProjectHealthModal/OverviewProjectHealthModal.tsx
@@ -1,11 +1,13 @@
+import { SiHasura as HasuraIcon } from '@icons-pack/react-simple-icons';
+import {
+  Sparkles as AIIcon,
+  DatabaseIcon,
+  HardDrive as StorageIcon,
+  UserIcon,
+} from 'lucide-react';
 import { twMerge } from 'tailwind-merge';
 import { Box } from '@/components/ui/v2/Box';
 import { Divider } from '@/components/ui/v2/Divider';
-import { AIIcon } from '@/components/ui/v2/icons/AIIcon';
-import { DatabaseIcon } from '@/components/ui/v2/icons/DatabaseIcon';
-import { HasuraIcon } from '@/components/ui/v2/icons/HasuraIcon';
-import { StorageIcon } from '@/components/ui/v2/icons/StorageIcon';
-import { UserIcon } from '@/components/ui/v2/icons/UserIcon';
 import { ServicesOutlinedIcon } from '@/components/ui/v3/icons/ServicesOutlinedIcon';
 import { useServiceStatus } from '@/features/orgs/projects/common/hooks/useServiceStatus';
 import { ServiceAccordion } from '@/features/orgs/projects/overview/components/ServiceAccordion';

--- a/dashboard/src/features/orgs/projects/overview/components/OverviewRepository/OverviewRepository.tsx
+++ b/dashboard/src/features/orgs/projects/overview/components/OverviewRepository/OverviewRepository.tsx
@@ -1,6 +1,6 @@
+import { SiGithub as GitHubIcon } from '@icons-pack/react-simple-icons';
 import { NavLink } from '@/components/common/NavLink';
 import { Box } from '@/components/ui/v2/Box';
-import { GitHubIcon } from '@/components/ui/v2/icons/GitHubIcon';
 import { Text } from '@/components/ui/v2/Text';
 import { useCurrentOrg } from '@/features/orgs/projects/hooks/useCurrentOrg';
 import { useProject } from '@/features/orgs/projects/hooks/useProject';
@@ -24,7 +24,7 @@ export default function OverviewRepository() {
             variant="outline"
             className="h-9 w-full gap-2"
           >
-            <GitHubIcon />
+            <GitHubIcon className="h-4 w-4" />
             Connect to GitHub
           </NavLink>
         </div>

--- a/dashboard/src/features/orgs/projects/overview/components/OverviewTopBar/OverviewTopBar.tsx
+++ b/dashboard/src/features/orgs/projects/overview/components/OverviewTopBar/OverviewTopBar.tsx
@@ -1,7 +1,7 @@
 import { formatDistanceToNowStrict, parseISO } from 'date-fns';
+import { Settings as CogIcon } from 'lucide-react';
 import Image from 'next/image';
 import { NavLink } from '@/components/common/NavLink';
-import { CogIcon } from '@/components/ui/v2/icons/CogIcon';
 import { Text } from '@/components/ui/v2/Text';
 import { useIsPlatform } from '@/features/orgs/projects/common/hooks/useIsPlatform';
 import { useCurrentOrg } from '@/features/orgs/projects/hooks/useCurrentOrg';

--- a/dashboard/src/features/orgs/projects/overview/components/ProjectHealthBadge/ProjectHealthBadge.tsx
+++ b/dashboard/src/features/orgs/projects/overview/components/ProjectHealthBadge/ProjectHealthBadge.tsx
@@ -1,7 +1,7 @@
 import type { ReactNode } from 'react';
 import { Badge, type BadgeProps } from '@/components/ui/v2/Badge';
-import { CheckIcon } from '@/components/ui/v2/icons/CheckIcon';
-import { ExclamationFilledIcon } from '@/components/ui/v2/icons/ExclamationFilledIcon';
+import { ProjectHealthCheckIcon } from '@/components/ui/v3/icons/ProjectHealthCheckIcon';
+import { ProjectHealthExclamationIcon } from '@/components/ui/v3/icons/ProjectHealthExclamationIcon';
 import { QuestionMarkIcon } from '@/components/ui/v3/icons/QuestionMarkIcon';
 
 export interface ProjectHealthBadgeProps extends BadgeProps {
@@ -31,13 +31,7 @@ export default function ProjectHealthBadge({
     );
   } else if (showCheckIcon) {
     innerBadgeContent = (
-      <CheckIcon
-        sx={{
-          color: (theme) =>
-            theme.palette.mode === 'dark' ? 'grey.200' : 'grey.100',
-        }}
-        className="h-2 w-2 stroke-2"
-      />
+      <ProjectHealthCheckIcon className="h-2 w-2 text-[#F5F5F5] dark:text-[#21262D]" />
     );
   }
 
@@ -54,13 +48,7 @@ export default function ProjectHealthBadge({
           horizontal: 'right',
         }}
         badgeContent={
-          <ExclamationFilledIcon
-            sx={{
-              color: (theme) =>
-                theme.palette.mode === 'dark' ? 'grey.900' : 'grey.600',
-            }}
-            className="h-2.5 w-2.5"
-          />
+          <ProjectHealthExclamationIcon className="h-2.5 w-2.5 text-foreground" />
         }
       >
         <Badge
@@ -83,7 +71,6 @@ export default function ProjectHealthBadge({
       </Badge>
     );
   }
-
   return (
     <Badge
       color={badgeColor}

--- a/dashboard/src/features/orgs/projects/overview/components/ServiceAccordion/ServiceAccordion.tsx
+++ b/dashboard/src/features/orgs/projects/overview/components/ServiceAccordion/ServiceAccordion.tsx
@@ -1,8 +1,8 @@
+import { ChevronDownIcon } from 'lucide-react';
 import Image from 'next/image';
 import type { ReactElement } from 'react';
 import { CodeBlock } from '@/components/presentational/CodeBlock';
 import { Accordion } from '@/components/ui/v2/Accordion';
-import { ChevronDownIcon } from '@/components/ui/v2/icons/ChevronDownIcon';
 import { Text } from '@/components/ui/v2/Text';
 import { AccordionHealthBadge } from '@/features/orgs/projects/overview/components/AccordionHealthBadge';
 import { ServiceState } from '@/utils/__generated__/graphql';
@@ -43,13 +43,7 @@ export default function ServiceAccordion({
   return (
     <Accordion.Root defaultExpanded={defaultExpanded}>
       <Accordion.Summary
-        expandIcon={
-          <ChevronDownIcon
-            sx={{
-              color: 'text.primary',
-            }}
-          />
-        }
+        expandIcon={<ChevronDownIcon className="text-foreground" />}
         aria-controls="panel1-content"
         id="panel1-header"
         className="px-6"

--- a/dashboard/src/features/orgs/projects/overview/features/features.tsx
+++ b/dashboard/src/features/orgs/projects/overview/features/features.tsx
@@ -1,35 +1,38 @@
-import { DatabaseIcon } from '@/components/ui/v2/icons/DatabaseIcon';
-import { GraphQLIcon } from '@/components/ui/v2/icons/GraphQLIcon';
-import { StorageIcon } from '@/components/ui/v2/icons/StorageIcon';
-import { UserIcon } from '@/components/ui/v2/icons/UserIcon';
+import { SiGraphql as GraphQLIcon } from '@icons-pack/react-simple-icons';
+
+import {
+  Database as DatabaseIcon,
+  HardDrive as StorageIcon,
+  User as UserIcon,
+} from 'lucide-react';
 import type { CardProps } from '@/features/orgs/projects/overview/types/cards';
 
 const features: CardProps[] = [
   {
     title: 'Database',
     description: 'Learn how to use Postgres with Nhost',
-    icon: <DatabaseIcon className="h-8 w-8" sx={{ color: 'text.secondary' }} />,
+    icon: <DatabaseIcon className="h-8 w-8 text-muted-foreground" />,
     disableIconBackground: true,
     link: 'https://docs.nhost.io/products/database',
   },
   {
     title: 'GraphQL API',
     description: 'Learn how to interact with the GraphQL API',
-    icon: <GraphQLIcon className="h-8 w-8" sx={{ color: 'text.secondary' }} />,
+    icon: <GraphQLIcon className="h-8 w-8 text-muted-foreground" />,
     disableIconBackground: true,
     link: 'https://docs.nhost.io/products/graphql',
   },
   {
     title: 'Authentication',
     description: 'Learn how to authenticate users with Nhost',
-    icon: <UserIcon className="h-8 w-8" sx={{ color: 'text.secondary' }} />,
+    icon: <UserIcon className="h-8 w-8 text-muted-foreground" />,
     disableIconBackground: true,
     link: 'https://docs.nhost.io/products/auth',
   },
   {
     title: 'Storage',
     description: 'Learn how to use Storage with Nhost',
-    icon: <StorageIcon className="h-8 w-8" sx={{ color: 'text.secondary' }} />,
+    icon: <StorageIcon className="h-8 w-8 text-muted-foreground" />,
     disableIconBackground: true,
     link: 'https://docs.nhost.io/products/storage',
   },

--- a/dashboard/src/features/orgs/projects/storage/dataGrid/components/FileUploadButton/FileUploadButton.tsx
+++ b/dashboard/src/features/orgs/projects/storage/dataGrid/components/FileUploadButton/FileUploadButton.tsx
@@ -1,9 +1,9 @@
 import clsx from 'clsx';
+import { UploadIcon } from 'lucide-react';
 import type { DetailedHTMLProps, HTMLProps } from 'react';
 import { useRef } from 'react';
 import type { ButtonProps } from '@/components/ui/v2/Button';
 import { Button } from '@/components/ui/v2/Button';
-import { UploadIcon } from '@/components/ui/v2/icons/UploadIcon';
 
 export type FileUploadButtonProps = Omit<
   ButtonProps,


### PR DESCRIPTION
### Checklist

- [x] No breaking changes
- [ ] Tests pass
- [ ] New features have new tests
- [ ] Documentation is updated (if applicable)
- [x] Title of the PR is in the correct format (see below)


<!-- nhost-reviewer:start -->
### **PR Type**
Refactoring

___

### **Description**
- Migrate icon usage in the Overview and Storage pages from the legacy `ui/v2/icons` set to `lucide-react` / `@icons-pack/react-simple-icons`, replacing `sx={{ color: ... }}` callbacks with Tailwind classes.
- Add two scope-restricted v3 icon ports (`ProjectHealthCheckIcon`, `ProjectHealthExclamationIcon`) so the small status badges in Project Health stay legible at 8–10 px — lucide's stroked equivalents are too thin/illegible at that size.
- Expand `ui/v2/icons/MIGRATION.md` with explicit `sx` → Tailwind token mappings, dynamic `theme.palette.mode` → `dark:` guidance, and a note about why `fill-current` is not a safe shortcut for outline lucide icons.

___

### Diagram Walkthrough

```mermaid
flowchart LR
  V2["ui/v2/icons (MUI)"] -->|most icons| LUC["lucide-react / simple-icons"]
  V2 -->|Check / ExclamationFilled in Project Health| V3PORT["v3 ports: ProjectHealthCheckIcon / ProjectHealthExclamationIcon"]
  LUC --> OV["Overview components"]
  LUC --> ST["Storage FileUploadButton"]
  V3PORT --> PHB["ProjectHealthBadge / AccordionHealthBadge"]
  DOC["MIGRATION.md"] -.->|guides| LUC
  DOC -.->|guides| V3PORT
```

<details> <summary><h3> File Walkthrough</h3></summary>

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody>
<tr><td><strong>Documentation</strong></td><td><details><summary>1 file</summary><table>
<tr>
  <td><strong>MIGRATION.md</strong><dd><code>Expand sx → Tailwind mapping; document the Project Health icon ports</code></dd></td>
  <td><a href="https://github.com/nhost/nhost/pull/4281/files#diff-12d17e861f2cab3213a06e702f7f6dbabb215feb8cf0ace214511b2b586eefe1">+30/-3</a></td>
</tr>
</table></details></td></tr>
<tr><td><strong>New v3 icon ports</strong></td><td><details><summary>2 files</summary><table>
<tr>
  <td><strong>ProjectHealthCheckIcon.tsx</strong><dd><code>16×16 stroked check, scoped to Project Health badges</code></dd></td>
  <td><a href="https://github.com/nhost/nhost/pull/4281/files#diff-153cd269fbf5de2f7ac7555d2932c96818693985968fcde65a3bd40f263d0c02">+22/-0</a></td>
</tr>
<tr>
  <td><strong>ProjectHealthExclamationIcon.tsx</strong><dd><code>7×7 filled exclamation disc, scoped to version-mismatch badge</code></dd></td>
  <td><a href="https://github.com/nhost/nhost/pull/4281/files#diff-44a36b95892bc1b12f4582f612e6aed322c57063cfc2584e67e38f0d26f0dc75">+22/-0</a></td>
</tr>
</table></details></td></tr>
<tr><td><strong>Overview components</strong></td><td><details><summary>11 files</summary><table>
<tr>
  <td><strong>AccordionHealthBadge.tsx</strong><dd><code>CheckIcon → ProjectHealthCheckIcon, theme callback → dark: class</code></dd></td>
  <td><a href="https://github.com/nhost/nhost/pull/4281/files#diff-d06c2c032603364fa13472f17e52b5ce4f31d51f0ea1abc92c89773b785ed4ee">+2/-8</a></td>
</tr>
<tr>
  <td><strong>InfoCard.tsx</strong><dd><code>v2 CopyIcon → lucide CopyIcon</code></dd></td>
  <td><a href="https://github.com/nhost/nhost/pull/4281/files#diff-8448771766a0ca481141ad17b3db3caf4bfc335575be755cd3808046b224d049">+1/-1</a></td>
</tr>
<tr>
  <td><strong>MetricsCard.tsx</strong><dd><code>v2 InfoIcon → lucide InfoIcon</code></dd></td>
  <td><a href="https://github.com/nhost/nhost/pull/4281/files#diff-eae12fc5e2962acf0566dab98876b4c59788105ddb93d33760278d6a582cff99">+1/-1</a></td>
</tr>
<tr>
  <td><strong>OverviewCard.tsx</strong><dd><code>v2 ArrowRightIcon → lucide ArrowRightIcon</code></dd></td>
  <td><a href="https://github.com/nhost/nhost/pull/4281/files#diff-09736c13b5db303025a40485a45728c0566d75e460f9e79a0b98ee778a2f242c">+1/-1</a></td>
</tr>
<tr>
  <td><strong>OverviewDeployments.tsx</strong><dd><code>Rocket/Chevron/GitHub → lucide & simple-icons; sx → Tailwind</code></dd></td>
  <td><a href="https://github.com/nhost/nhost/pull/4281/files#diff-973fc11a37ae6a96523a29d0f780bf01939cb093a87b7b46d4920486866c7783">+3/-9</a></td>
</tr>
<tr>
  <td><strong>OverviewProjectHealth.tsx</strong><dd><code>Service icons → lucide / simple-icons (Hasura)</code></dd></td>
  <td><a href="https://github.com/nhost/nhost/pull/4281/files#diff-26e03b1860b74f6c512e4bbbf854b8f6380e2a48d060f5a34973f8106da2d95e">+7/-7</a></td>
</tr>
<tr>
  <td><strong>OverviewProjectHealthModal.tsx</strong><dd><code>Service icons → lucide / simple-icons</code></dd></td>
  <td><a href="https://github.com/nhost/nhost/pull/4281/files#diff-ea0364ed396c5764b42bb46cd11a3e3c47f770dba9ce72b59c4b363a31734cc9">+7/-5</a></td>
</tr>
<tr>
  <td><strong>OverviewRepository.tsx</strong><dd><code>v2 GitHubIcon → simple-icons GitHubIcon, explicit sizing</code></dd></td>
  <td><a href="https://github.com/nhost/nhost/pull/4281/files#diff-0aa399e71cbdc92dc5ad0ede36b096f8cc07f963f696aa6103d41e11ee2aa725">+2/-2</a></td>
</tr>
<tr>
  <td><strong>OverviewTopBar.tsx</strong><dd><code>v2 CogIcon → lucide Settings (aliased)</code></dd></td>
  <td><a href="https://github.com/nhost/nhost/pull/4281/files#diff-560ae107ed8e458fa4b4a226b9f5c24e24b042b5f9bcea9317c78e75929faa4b">+1/-1</a></td>
</tr>
<tr>
  <td><strong>ProjectHealthBadge.tsx</strong><dd><code>Check / ExclamationFilled → v3 ports; drop sx callbacks</code></dd></td>
  <td><a href="https://github.com/nhost/nhost/pull/4281/files#diff-e38173a08ac105f600de49c7b3b6898d5bf4212d5a1f5c1dcc91634cdf79e76c">+4/-17</a></td>
</tr>
<tr>
  <td><strong>ServiceAccordion.tsx</strong><dd><code>v2 ChevronDownIcon → lucide, sx → text-foreground</code></dd></td>
  <td><a href="https://github.com/nhost/nhost/pull/4281/files#diff-b359476e4d4f6b57b7108bb668614e2aa7312cbd97a1e9d084b5ead943a36677">+2/-8</a></td>
</tr>
<tr>
  <td><strong>features.tsx</strong><dd><code>Service feature-card icons → lucide / simple-icons, text-muted-foreground</code></dd></td>
  <td><a href="https://github.com/nhost/nhost/pull/4281/files#diff-036778e07a1cdf33b7d90d8110f75338f8cd6870cc68bb75cff0c880318cd92d">+11/-8</a></td>
</tr>
</table></details></td></tr>
<tr><td><strong>Storage</strong></td><td><details><summary>1 file</summary><table>
<tr>
  <td><strong>FileUploadButton.tsx</strong><dd><code>v2 UploadIcon → lucide UploadIcon</code></dd></td>
  <td><a href="https://github.com/nhost/nhost/pull/4281/files#diff-5f33f07dee1c730c61e7a8c7c03b725ad01a899854b808052892a4610a3c4c73">+1/-1</a></td>
</tr>
</table></details></td></tr>
</tbody></table>

</details>

___

<!-- nhost-reviewer:end -->
