### PR TITLE
fix(dashboard): Migrate database page icons

### DIFF
--- a/dashboard/src/features/orgs/projects/database/dataGrid/components/DataBrowserSidebar/DatabaseObjectActions.tsx
+++ b/dashboard/src/features/orgs/projects/database/dataGrid/components/DataBrowserSidebar/DatabaseObjectActions.tsx
@@ -1,6 +1,6 @@
+import { SiGraphql as GraphQLIcon } from '@icons-pack/react-simple-icons';
 import { Anchor, Ellipsis, SquarePen, Trash2, Users } from 'lucide-react';
 import type { ReactNode } from 'react';
-import { GraphQLIcon } from '@/components/ui/v2/icons/GraphQLIcon';
 import { Button } from '@/components/ui/v3/button';
 import {
   DropdownMenu,

--- a/dashboard/src/features/orgs/projects/database/dataGrid/components/EditFunctionPermissionsForm/EditFunctionPermissionsForm.tsx
+++ b/dashboard/src/features/orgs/projects/database/dataGrid/components/EditFunctionPermissionsForm/EditFunctionPermissionsForm.tsx
@@ -2,9 +2,6 @@ import NavLink from 'next/link';
 import { useRouter } from 'next/router';
 import { useState } from 'react';
 import { useDialog } from '@/components/common/DialogProvider';
-import { FullPermissionIcon } from '@/components/ui/v2/icons/FullPermissionIcon';
-import { NoPermissionIcon } from '@/components/ui/v2/icons/NoPermissionIcon';
-import { PartialPermissionIcon } from '@/components/ui/v2/icons/PartialPermissionIcon';
 import { Alert, AlertDescription } from '@/components/ui/v3/alert';
 import { Button } from '@/components/ui/v3/button';
 import {
@@ -12,6 +9,9 @@ import {
   CollapsibleContent,
   CollapsibleTrigger,
 } from '@/components/ui/v3/collapsible';
+import { FullPermissionIcon } from '@/components/ui/v3/icons/FullPermissionIcon';
+import { NoPermissionIcon } from '@/components/ui/v3/icons/NoPermissionIcon';
+import { PartialPermissionIcon } from '@/components/ui/v3/icons/PartialPermissionIcon';
 import { Spinner } from '@/components/ui/v3/spinner';
 import { useGetMetadataResourceVersion } from '@/features/orgs/projects/common/hooks/useGetMetadataResourceVersion';
 import { useIsPlatform } from '@/features/orgs/projects/common/hooks/useIsPlatform';

--- a/dashboard/src/features/orgs/projects/database/dataGrid/components/PermissionsLegend/PermissionsLegend.tsx
+++ b/dashboard/src/features/orgs/projects/database/dataGrid/components/PermissionsLegend/PermissionsLegend.tsx
@@ -1,6 +1,6 @@
-import { FullPermissionIcon } from '@/components/ui/v2/icons/FullPermissionIcon';
-import { NoPermissionIcon } from '@/components/ui/v2/icons/NoPermissionIcon';
-import { PartialPermissionIcon } from '@/components/ui/v2/icons/PartialPermissionIcon';
+import { FullPermissionIcon } from '@/components/ui/v3/icons/FullPermissionIcon';
+import { NoPermissionIcon } from '@/components/ui/v3/icons/NoPermissionIcon';
+import { PartialPermissionIcon } from '@/components/ui/v3/icons/PartialPermissionIcon';
 
 export default function PermissionsLegend() {
   return (

--- a/dashboard/src/features/orgs/projects/database/dataGrid/components/SQLEditor/SQLEditor.tsx
+++ b/dashboard/src/features/orgs/projects/database/dataGrid/components/SQLEditor/SQLEditor.tsx
@@ -4,6 +4,7 @@ import { PostgreSQL, sql } from '@codemirror/lang-sql';
 import { useTheme } from '@mui/material';
 import { githubDark, githubLight } from '@uiw/codemirror-theme-github';
 import CodeMirror from '@uiw/react-codemirror';
+import { InfoIcon, PlayIcon } from 'lucide-react';
 import { useCallback, useState } from 'react';
 import { useResizable } from 'react-resizable-layout';
 import { ActivityIndicator } from '@/components/ui/v2/ActivityIndicator';
@@ -11,8 +12,6 @@ import { Alert } from '@/components/ui/v2/Alert';
 import { Box } from '@/components/ui/v2/Box';
 import { Button } from '@/components/ui/v2/Button';
 import { Input } from '@/components/ui/v2/Input';
-import { InfoIcon } from '@/components/ui/v2/icons/InfoIcon';
-import { PlayIcon } from '@/components/ui/v2/icons/PlayIcon';
 import { Switch } from '@/components/ui/v2/Switch';
 import { Table } from '@/components/ui/v2/Table';
 import { TableBody } from '@/components/ui/v2/TableBody';
@@ -74,11 +73,7 @@ export default function SQLEditor({ initialSQL }: SQLEditorProps) {
                 onChange={(event) => setTrack(event.currentTarget.checked)}
               />
               <Tooltip title="If you are creating tables, views or functions, checking this will also expose them over the GraphQL API as top level fields. Functions only intended to be used as computed fields should not be tracked.">
-                <InfoIcon
-                  aria-label="Info"
-                  className="h-4 w-4"
-                  color="primary"
-                />
+                <InfoIcon aria-label="Info" className="h-4 w-4 text-primary" />
               </Tooltip>
             </Box>
 
@@ -94,11 +89,7 @@ export default function SQLEditor({ initialSQL }: SQLEditorProps) {
               />
 
               <Tooltip title="Cascade actions on all dependent metadata references, like relationships and permissions">
-                <InfoIcon
-                  aria-label="Info"
-                  className="h-4 w-4"
-                  color="primary"
-                />
+                <InfoIcon aria-label="Info" className="h-4 w-4 text-primary" />
               </Tooltip>
             </Box>
 
@@ -114,11 +105,7 @@ export default function SQLEditor({ initialSQL }: SQLEditorProps) {
               />
 
               <Tooltip title="When set to true, the request will be run in READ ONLY transaction access mode which means only select queries will be successful. This flag ensures that the GraphQL schema is not modified and is hence highly performant.">
-                <InfoIcon
-                  aria-label="Info"
-                  className="h-4 w-4"
-                  color="primary"
-                />
+                <InfoIcon aria-label="Info" className="h-4 w-4 text-primary" />
               </Tooltip>
             </Box>
 
@@ -137,8 +124,7 @@ export default function SQLEditor({ initialSQL }: SQLEditorProps) {
                   <Tooltip title="Create a migration file with the SQL statement">
                     <InfoIcon
                       aria-label="Info"
-                      className="h-4 w-4"
-                      color="primary"
+                      className="h-4 w-4 text-primary"
                     />
                   </Tooltip>
                 </Box>
@@ -161,7 +147,7 @@ export default function SQLEditor({ initialSQL }: SQLEditorProps) {
             disabled={loading || !sqlCode.trim()}
             variant="contained"
             className="self-start"
-            startIcon={<PlayIcon />}
+            startIcon={<PlayIcon className="h-4 w-4" />}
             onClick={runSQL}
           >
             Run

--- a/dashboard/src/features/orgs/projects/database/settings/components/DatabaseConnectionInfo/DatabaseConnectionInfo.tsx
+++ b/dashboard/src/features/orgs/projects/database/settings/components/DatabaseConnectionInfo/DatabaseConnectionInfo.tsx
@@ -1,4 +1,5 @@
 import { yupResolver } from '@hookform/resolvers/yup';
+import { CopyIcon } from 'lucide-react';
 import { FormProvider, useForm } from 'react-hook-form';
 import * as Yup from 'yup';
 import { ApplyLocalSettingsDialog } from '@/components/common/ApplyLocalSettingsDialog';
@@ -11,7 +12,6 @@ import { Button } from '@/components/ui/v2/Button';
 import type { InputProps } from '@/components/ui/v2/Input';
 import { Input } from '@/components/ui/v2/Input';
 import { InputAdornment } from '@/components/ui/v2/InputAdornment';
-import { CopyIcon } from '@/components/ui/v2/icons/CopyIcon';
 import { useIsPlatform } from '@/features/orgs/projects/common/hooks/useIsPlatform';
 import { generateAppServiceUrl } from '@/features/orgs/projects/common/utils/generateAppServiceUrl';
 import { useLocalMimirClient } from '@/features/orgs/projects/hooks/useLocalMimirClient';

--- a/dashboard/src/features/orgs/projects/database/settings/components/DatabaseMigrateDisabledError/DatabaseMigrateDisabledError.tsx
+++ b/dashboard/src/features/orgs/projects/database/settings/components/DatabaseMigrateDisabledError/DatabaseMigrateDisabledError.tsx
@@ -1,5 +1,5 @@
+import { XIcon } from 'lucide-react';
 import { Alert } from '@/components/ui/v2/Alert';
-import { XIcon } from '@/components/ui/v2/icons/XIcon';
 import { Text } from '@/components/ui/v2/Text';
 import { useAppState } from '@/features/orgs/projects/common/hooks/useAppState';
 import { ApplicationStatus } from '@/types/application';

--- a/dashboard/src/features/orgs/projects/database/settings/components/DatabaseServiceVersionSettings/DatabaseServiceVersionSettings.tsx
+++ b/dashboard/src/features/orgs/projects/database/settings/components/DatabaseServiceVersionSettings/DatabaseServiceVersionSettings.tsx
@@ -1,4 +1,5 @@
 import { yupResolver } from '@hookform/resolvers/yup';
+import { RepeatIcon } from 'lucide-react';
 import { useEffect, useMemo } from 'react';
 import { FormProvider, useForm } from 'react-hook-form';
 import * as Yup from 'yup';
@@ -13,7 +14,6 @@ import { SettingsContainer } from '@/components/layout/SettingsContainer';
 import { ActivityIndicator } from '@/components/ui/v2/ActivityIndicator';
 import { Box } from '@/components/ui/v2/Box';
 import { Button } from '@/components/ui/v2/Button';
-import { RepeatIcon } from '@/components/ui/v2/icons/RepeatIcon';
 import { useAppState } from '@/features/orgs/projects/common/hooks/useAppState';
 import { useIsPlatform } from '@/features/orgs/projects/common/hooks/useIsPlatform';
 import { useGetPostgresVersion } from '@/features/orgs/projects/database/common/hooks/useGetPostgresVersion';

--- a/dashboard/src/features/orgs/projects/database/settings/components/ResetDatabasePasswordSettings/ResetDatabasePasswordSettings.tsx
+++ b/dashboard/src/features/orgs/projects/database/settings/components/ResetDatabasePasswordSettings/ResetDatabasePasswordSettings.tsx
@@ -1,5 +1,6 @@
 import { yupResolver } from '@hookform/resolvers/yup';
 import { alpha } from '@mui/system';
+import { CopyIcon } from 'lucide-react';
 import { FormProvider, useForm } from 'react-hook-form';
 import { twMerge } from 'tailwind-merge';
 import { useDialog } from '@/components/common/DialogProvider';
@@ -8,7 +9,6 @@ import { SettingsContainer } from '@/components/layout/SettingsContainer';
 import { Button } from '@/components/ui/v2/Button';
 import { Input } from '@/components/ui/v2/Input';
 import { InputAdornment } from '@/components/ui/v2/InputAdornment';
-import { CopyIcon } from '@/components/ui/v2/icons/CopyIcon';
 import { generateRandomDatabasePassword } from '@/features/orgs/projects/database/common/utils/generateRandomDatabasePassword';
 import type { ResetDatabasePasswordFormValues } from '@/features/orgs/projects/database/settings/utils/resetDatabasePasswordValidationSchema';
 import { resetDatabasePasswordValidationSchema } from '@/features/orgs/projects/database/settings/utils/resetDatabasePasswordValidationSchema';

--- a/dashboard/src/features/orgs/projects/database/settings/components/UpgradeNotification/UpgradeNotification.tsx
+++ b/dashboard/src/features/orgs/projects/database/settings/components/UpgradeNotification/UpgradeNotification.tsx
@@ -1,8 +1,8 @@
+import { ExternalLink as ArrowSquareOutIcon } from 'lucide-react';
 import { useState } from 'react';
 import { OpenTransferDialogButton } from '@/components/common/OpenTransferDialogButton';
 import { NhostIcon } from '@/components/presentational/NhostIcon';
 import { Alert } from '@/components/ui/v2/Alert';
-import { ArrowSquareOutIcon } from '@/components/ui/v2/icons/ArrowSquareOutIcon';
 import { Link } from '@/components/ui/v2/Link';
 import { Text } from '@/components/ui/v2/Text';
 import { TransferProjectDialog } from '@/features/orgs/components/common/TransferProjectDialog';


### PR DESCRIPTION
### Checklist

- [ ] No breaking changes
- [ ] Tests pass
- [ ] New features have new tests
- [ ] Documentation is updated (if applicable)
- [ ] Title of the PR is in the correct format (see below)

<!-- nhost-reviewer:start -->
### **PR Type**
Refactoring

___

### **Description**
- Migrate database page icons away from the deprecated `@/components/ui/v2/icons/*` set to `lucide-react`, `@icons-pack/react-simple-icons`, and the new `@/components/ui/v3/icons/*` permission icons.
- Replace MUI-style `color="primary"` prop on `InfoIcon` with the Tailwind `text-primary` class to match the lucide API.
- Add explicit `h-4 w-4` sizing on lucide icons (which default to 24px) so visual sizing matches the previous v2 icons.
- Continues the icon-migration series following overview/storage, authentication, and remote-schemas pages.

___

<details> <summary><h3> File Walkthrough</h3></summary>

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody>
<tr><td><strong>Data grid components</strong></td><td><details><summary>4 files</summary><table>
<tr>
  <td><strong>DatabaseObjectActions.tsx</strong><dd><code>Swap v2 GraphQLIcon for SiGraphql aliased from react-simple-icons.</code></dd></td>
  <td><a href="https://github.com/nhost/nhost/pull/4285/files#diff-d9b3d469e71dcc60c958dc6dca4581f2dbc9246ab72cea6129f5c9e2b7665fb1">+1/-1</a></td>
</tr>
<tr>
  <td><strong>EditFunctionPermissionsForm.tsx</strong><dd><code>Move Full/No/Partial permission icons from v2 to v3 icon set.</code></dd></td>
  <td><a href="https://github.com/nhost/nhost/pull/4285/files#diff-f859d1d9f373ae0d0faf90af82c0a70b391d8083ba06fee6a4e4909bb9e672af">+3/-3</a></td>
</tr>
<tr>
  <td><strong>PermissionsLegend.tsx</strong><dd><code>Move Full/No/Partial permission icons from v2 to v3 icon set.</code></dd></td>
  <td><a href="https://github.com/nhost/nhost/pull/4285/files#diff-ccfb2f4ca383a1ee1691552732557a740ae49d5c0636acc06d26398b4fd364c3">+3/-3</a></td>
</tr>
<tr>
  <td><strong>SQLEditor.tsx</strong><dd><code>Replace v2 InfoIcon/PlayIcon with lucide; convert color="primary" to text-primary class.</code></dd></td>
  <td><a href="https://github.com/nhost/nhost/pull/4285/files#diff-492c0b030e0b54dd005c897addc5dbb76d94207f6284d136f5f4087912ce713f">+6/-20</a></td>
</tr>
</table></details></td></tr>
<tr><td><strong>Settings components</strong></td><td><details><summary>5 files</summary><table>
<tr>
  <td><strong>DatabaseConnectionInfo.tsx</strong><dd><code>Swap v2 CopyIcon for lucide CopyIcon.</code></dd></td>
  <td><a href="https://github.com/nhost/nhost/pull/4285/files#diff-b89287fb76d3112b8bc2b0f04181993512fbb537e618abd228d14b18ce6deb59">+1/-1</a></td>
</tr>
<tr>
  <td><strong>DatabaseMigrateDisabledError.tsx</strong><dd><code>Swap v2 XIcon for lucide XIcon.</code></dd></td>
  <td><a href="https://github.com/nhost/nhost/pull/4285/files#diff-219cee10be46589547ff1966812d2c83cbaf361478e96826ca95f6f4d16d4092">+1/-1</a></td>
</tr>
<tr>
  <td><strong>DatabaseServiceVersionSettings.tsx</strong><dd><code>Swap v2 RepeatIcon for lucide RepeatIcon.</code></dd></td>
  <td><a href="https://github.com/nhost/nhost/pull/4285/files#diff-a982b817513fc173371f7468ad642f99ee0c914e5990a48992fc1fa5e230765f">+1/-1</a></td>
</tr>
<tr>
  <td><strong>ResetDatabasePasswordSettings.tsx</strong><dd><code>Swap v2 CopyIcon for lucide CopyIcon.</code></dd></td>
  <td><a href="https://github.com/nhost/nhost/pull/4285/files#diff-46fc60a26a2de3efb98e9778b1c6e82d62823ae5c7534037eb120728cba26288">+1/-1</a></td>
</tr>
<tr>
  <td><strong>UpgradeNotification.tsx</strong><dd><code>Replace v2 ArrowSquareOutIcon with lucide ExternalLink aliased as ArrowSquareOutIcon.</code></dd></td>
  <td><a href="https://github.com/nhost/nhost/pull/4285/files#diff-f712e65a6e88f2731fc5597117f716594311087f8090e3e8f5f76e1a67c95188">+1/-1</a></td>
</tr>
</table></details></td></tr>
</tbody></table>

</details>

___

<!-- nhost-reviewer:end -->
