### PR TITLE
fix(dashboard): Migrate AI page icons

### DIFF
--- a/dashboard/src/features/orgs/projects/ai/AssistantForm/AssistantForm.tsx
+++ b/dashboard/src/features/orgs/projects/ai/AssistantForm/AssistantForm.tsx
@@ -1,5 +1,5 @@
 import { yupResolver } from '@hookform/resolvers/yup';
-import { RefreshCwIcon } from 'lucide-react';
+import { InfoIcon, PlusIcon, RefreshCwIcon } from 'lucide-react';
 import { useEffect } from 'react';
 import { FormProvider, useForm } from 'react-hook-form';
 import * as Yup from 'yup';
@@ -9,8 +9,6 @@ import { Form } from '@/components/form/Form';
 import { Box } from '@/components/ui/v2/Box';
 import { Button } from '@/components/ui/v2/Button';
 import { Input } from '@/components/ui/v2/Input';
-import { InfoIcon } from '@/components/ui/v2/icons/InfoIcon';
-import { PlusIcon } from '@/components/ui/v2/icons/PlusIcon';
 import { Option } from '@/components/ui/v2/Option';
 import { Text } from '@/components/ui/v2/Text';
 import { Tooltip } from '@/components/ui/v2/Tooltip';
@@ -234,8 +232,7 @@ export default function AssistantForm({
                 <Tooltip title="Name of the assistant">
                   <InfoIcon
                     aria-label="Info"
-                    className="h-4 w-4"
-                    color="primary"
+                    className="h-4 w-4 text-primary"
                   />
                 </Tooltip>
               </Box>
@@ -258,8 +255,7 @@ export default function AssistantForm({
                 <Tooltip title={<span>Description of the assistant</span>}>
                   <InfoIcon
                     aria-label="Info"
-                    className="h-4 w-4"
-                    color="primary"
+                    className="h-4 w-4 text-primary"
                   />
                 </Tooltip>
               </Box>
@@ -285,8 +281,7 @@ export default function AssistantForm({
                 <Tooltip title="Instructions for the assistant. This is used to instruct the AI assistant on how to behave and respond to the user">
                   <InfoIcon
                     aria-label="Info"
-                    className="h-4 w-4"
-                    color="primary"
+                    className="h-4 w-4 text-primary"
                   />
                 </Tooltip>
               </Box>
@@ -312,8 +307,7 @@ export default function AssistantForm({
                 <Tooltip title="Model to use for the assistant.">
                   <InfoIcon
                     aria-label="Info"
-                    className="h-4 w-4"
-                    color="primary"
+                    className="h-4 w-4 text-primary"
                   />
                 </Tooltip>
               </Box>
@@ -340,8 +334,7 @@ export default function AssistantForm({
                 <Tooltip title={fileStoreTooltip}>
                   <InfoIcon
                     aria-label="Info"
-                    className="h-4 w-4"
-                    color="primary"
+                    className="h-4 w-4 text-primary"
                   />
                 </Tooltip>
               </Box>
@@ -369,9 +362,9 @@ export default function AssistantForm({
             disabled={isSubmitting}
             startIcon={
               assistantId ? (
-                <RefreshCwIcon width={16} height={16} />
+                <RefreshCwIcon className="h-4 w-4" />
               ) : (
-                <PlusIcon />
+                <PlusIcon className="h-4 w-4" />
               )
             }
           >

--- a/dashboard/src/features/orgs/projects/ai/AssistantForm/components/ArgumentsFormSection/ArgumentsFormSection.tsx
+++ b/dashboard/src/features/orgs/projects/ai/AssistantForm/components/ArgumentsFormSection/ArgumentsFormSection.tsx
@@ -1,12 +1,10 @@
+import { InfoIcon, PlusIcon, Trash2 as TrashIcon } from 'lucide-react';
 import { type Path, useFieldArray, useFormContext } from 'react-hook-form';
 import { ControlledSelect } from '@/components/form/ControlledSelect';
 import { ControlledSwitch } from '@/components/form/ControlledSwitch';
 import { Box } from '@/components/ui/v2/Box';
 import { Button } from '@/components/ui/v2/Button';
 import { Input } from '@/components/ui/v2/Input';
-import { InfoIcon } from '@/components/ui/v2/icons/InfoIcon';
-import { PlusIcon } from '@/components/ui/v2/icons/PlusIcon';
-import { TrashIcon } from '@/components/ui/v2/icons/TrashIcon';
 import { Option } from '@/components/ui/v2/Option';
 import { Text } from '@/components/ui/v2/Text';
 import { Tooltip } from '@/components/ui/v2/Tooltip';
@@ -47,7 +45,7 @@ export default function ArgumentsFormSection({
             Arguments
           </Text>
           <Tooltip title={<span>Arguments</span>}>
-            <InfoIcon aria-label="Info" className="h-4 w-4" color="primary" />
+            <InfoIcon aria-label="Info" className="h-4 w-4 text-primary" />
           </Tooltip>
         </div>
         <Button variant="borderless" onClick={() => append({})}>

--- a/dashboard/src/features/orgs/projects/ai/AssistantForm/components/GraphqlDataSourcesFormSection/GraphqlDataSourcesFormSection.tsx
+++ b/dashboard/src/features/orgs/projects/ai/AssistantForm/components/GraphqlDataSourcesFormSection/GraphqlDataSourcesFormSection.tsx
@@ -1,11 +1,9 @@
+import { InfoIcon, PlusIcon, Trash2 as TrashIcon } from 'lucide-react';
 import { useFieldArray, useFormContext } from 'react-hook-form';
 import { Box } from '@/components/ui/v2/Box';
 import { Button } from '@/components/ui/v2/Button';
 import { Divider } from '@/components/ui/v2/Divider';
 import { Input } from '@/components/ui/v2/Input';
-import { InfoIcon } from '@/components/ui/v2/icons/InfoIcon';
-import { PlusIcon } from '@/components/ui/v2/icons/PlusIcon';
-import { TrashIcon } from '@/components/ui/v2/icons/TrashIcon';
 import { Text } from '@/components/ui/v2/Text';
 import { Tooltip } from '@/components/ui/v2/Tooltip';
 import type { AssistantFormValues } from '@/features/orgs/projects/ai/AssistantForm/AssistantForm';
@@ -31,7 +29,7 @@ export default function GraphqlDataSourcesFormSection() {
             GraphQL
           </Text>
           <Tooltip title="GraphQL data sources and tools. Run against the project's GraphQL API">
-            <InfoIcon aria-label="Info" className="h-4 w-4" color="primary" />
+            <InfoIcon aria-label="Info" className="h-4 w-4 text-primary" />
           </Tooltip>
         </Box>
         <Button

--- a/dashboard/src/features/orgs/projects/ai/AssistantForm/components/WebhooksDataSourcesFormSection/WebhooksDataSourcesFormSection.tsx
+++ b/dashboard/src/features/orgs/projects/ai/AssistantForm/components/WebhooksDataSourcesFormSection/WebhooksDataSourcesFormSection.tsx
@@ -1,11 +1,9 @@
+import { InfoIcon, PlusIcon, Trash2 as TrashIcon } from 'lucide-react';
 import { useFieldArray, useFormContext } from 'react-hook-form';
 import { Box } from '@/components/ui/v2/Box';
 import { Button } from '@/components/ui/v2/Button';
 import { Divider } from '@/components/ui/v2/Divider';
 import { Input } from '@/components/ui/v2/Input';
-import { InfoIcon } from '@/components/ui/v2/icons/InfoIcon';
-import { PlusIcon } from '@/components/ui/v2/icons/PlusIcon';
-import { TrashIcon } from '@/components/ui/v2/icons/TrashIcon';
 import { Text } from '@/components/ui/v2/Text';
 import { Tooltip } from '@/components/ui/v2/Tooltip';
 import type { AssistantFormValues } from '@/features/orgs/projects/ai/AssistantForm/AssistantForm';
@@ -31,7 +29,7 @@ export default function WebhooksDataSourcesFormSection() {
             Webhooks
           </Text>
           <Tooltip title="Webhook data sources and tools">
-            <InfoIcon aria-label="Info" className="h-4 w-4" color="primary" />
+            <InfoIcon aria-label="Info" className="h-4 w-4 text-primary" />
           </Tooltip>
         </Box>
         <Button

--- a/dashboard/src/features/orgs/projects/ai/AssistantsList/AssistantsList.tsx
+++ b/dashboard/src/features/orgs/projects/ai/AssistantsList/AssistantsList.tsx
@@ -1,12 +1,14 @@
+import {
+  CopyIcon,
+  Ellipsis as DotsHorizontalIcon,
+  EyeIcon,
+  Trash2 as TrashIcon,
+} from 'lucide-react';
 import { useDialog } from '@/components/common/DialogProvider';
 import { Box } from '@/components/ui/v2/Box';
 import { Divider } from '@/components/ui/v2/Divider';
 import { Dropdown } from '@/components/ui/v2/Dropdown';
 import { IconButton } from '@/components/ui/v2/IconButton';
-import { CopyIcon } from '@/components/ui/v2/icons/CopyIcon';
-import { DotsHorizontalIcon } from '@/components/ui/v2/icons/DotsHorizontalIcon';
-import { TrashIcon } from '@/components/ui/v2/icons/TrashIcon';
-import { UserIcon } from '@/components/ui/v2/icons/UserIcon';
 import { Text } from '@/components/ui/v2/Text';
 import {
   AssistantForm,
@@ -144,7 +146,7 @@ export default function AssistantsList({
                 onClick={() => viewAssistant(assistant)}
                 className="z-50 grid grid-flow-col items-center gap-2 p-2 font-medium text-sm+"
               >
-                <UserIcon className="h-4 w-4" />
+                <EyeIcon className="h-4 w-4" />
                 <Text className="font-medium">View {assistant?.name}</Text>
               </Dropdown.Item>
               <Divider component="li" />

--- a/dashboard/src/features/orgs/projects/ai/AutoEmbeddingsForm/AutoEmbeddingsForm.tsx
+++ b/dashboard/src/features/orgs/projects/ai/AutoEmbeddingsForm/AutoEmbeddingsForm.tsx
@@ -1,5 +1,5 @@
 import { yupResolver } from '@hookform/resolvers/yup';
-import { RefreshCwIcon } from 'lucide-react';
+import { InfoIcon, PlusIcon, RefreshCwIcon } from 'lucide-react';
 import { useEffect } from 'react';
 import { FormProvider, useForm } from 'react-hook-form';
 import * as Yup from 'yup';
@@ -9,8 +9,6 @@ import { Form } from '@/components/form/Form';
 import { Box } from '@/components/ui/v2/Box';
 import { Button } from '@/components/ui/v2/Button';
 import { Input } from '@/components/ui/v2/Input';
-import { InfoIcon } from '@/components/ui/v2/icons/InfoIcon';
-import { PlusIcon } from '@/components/ui/v2/icons/PlusIcon';
 import { Option } from '@/components/ui/v2/Option';
 import { Text } from '@/components/ui/v2/Text';
 import { Tooltip } from '@/components/ui/v2/Tooltip';
@@ -159,8 +157,7 @@ export default function AutoEmbeddingsForm({
                 <Tooltip title="Name of the Auto-Embeddings">
                   <InfoIcon
                     aria-label="Info"
-                    className="h-4 w-4"
-                    color="primary"
+                    className="h-4 w-4 text-primary"
                   />
                 </Tooltip>
               </Box>
@@ -186,8 +183,7 @@ export default function AutoEmbeddingsForm({
                 <Tooltip title="Auto-Embeddings Model">
                   <InfoIcon
                     aria-label="Info"
-                    className="h-4 w-4"
-                    color="primary"
+                    className="h-4 w-4 text-primary"
                   />
                 </Tooltip>
               </Box>
@@ -212,8 +208,7 @@ export default function AutoEmbeddingsForm({
                 <Tooltip title={<span>Schema where the table belongs to</span>}>
                   <InfoIcon
                     aria-label="Info"
-                    className="h-4 w-4"
-                    color="primary"
+                    className="h-4 w-4 text-primary"
                   />
                 </Tooltip>
               </Box>
@@ -234,8 +229,7 @@ export default function AutoEmbeddingsForm({
                 <Tooltip title="Table Name">
                   <InfoIcon
                     aria-label="Info"
-                    className="h-4 w-4"
-                    color="primary"
+                    className="h-4 w-4 text-primary"
                   />
                 </Tooltip>
               </Box>
@@ -256,8 +250,7 @@ export default function AutoEmbeddingsForm({
                 <Tooltip title="Column name">
                   <InfoIcon
                     aria-label="Info"
-                    className="h-4 w-4"
-                    color="primary"
+                    className="h-4 w-4 text-primary"
                   />
                 </Tooltip>
               </Box>
@@ -278,8 +271,7 @@ export default function AutoEmbeddingsForm({
                 <Tooltip title="Query">
                   <InfoIcon
                     aria-label="Info"
-                    className="h-4 w-4"
-                    color="primary"
+                    className="h-4 w-4 text-primary"
                   />
                 </Tooltip>
               </Box>
@@ -302,8 +294,7 @@ export default function AutoEmbeddingsForm({
                 <Tooltip title="Mutation">
                   <InfoIcon
                     aria-label="Info"
-                    className="h-4 w-4"
-                    color="primary"
+                    className="h-4 w-4 text-primary"
                   />
                 </Tooltip>
               </Box>
@@ -328,9 +319,9 @@ export default function AutoEmbeddingsForm({
             disabled={isSubmitting}
             startIcon={
               autoEmbeddingsId ? (
-                <RefreshCwIcon width={16} height={16} />
+                <RefreshCwIcon className="h-4 w-4" />
               ) : (
-                <PlusIcon />
+                <PlusIcon className="h-4 w-4" />
               )
             }
           >

--- a/dashboard/src/features/orgs/projects/ai/AutoEmbeddingsList/AutoEmbeddingsList.tsx
+++ b/dashboard/src/features/orgs/projects/ai/AutoEmbeddingsList/AutoEmbeddingsList.tsx
@@ -1,13 +1,15 @@
 import { formatDistanceToNow } from 'date-fns';
-import { BoxIcon } from 'lucide-react';
+import {
+  BoxIcon,
+  Ellipsis as DotsHorizontalIcon,
+  EyeIcon,
+  Trash2 as TrashIcon,
+} from 'lucide-react';
 import { useDialog } from '@/components/common/DialogProvider';
 import { Box } from '@/components/ui/v2/Box';
 import { Divider } from '@/components/ui/v2/Divider';
 import { Dropdown } from '@/components/ui/v2/Dropdown';
 import { IconButton } from '@/components/ui/v2/IconButton';
-import { DotsHorizontalIcon } from '@/components/ui/v2/icons/DotsHorizontalIcon';
-import { TrashIcon } from '@/components/ui/v2/icons/TrashIcon';
-import { UserIcon } from '@/components/ui/v2/icons/UserIcon';
 import { Text } from '@/components/ui/v2/Text';
 import { Tooltip } from '@/components/ui/v2/Tooltip';
 import { EmbeddingsIcon } from '@/components/ui/v3/icons/EmbeddingsIcon';
@@ -144,7 +146,7 @@ export default function AutoEmbeddingsList({
                 }
                 className="z-50 grid grid-flow-col items-center gap-2 p-2 font-medium text-sm+"
               >
-                <UserIcon className="h-4 w-4" />
+                <EyeIcon className="h-4 w-4" />
                 <Text className="font-medium">
                   View {autoEmbeddingsConfiguration?.name}
                 </Text>

--- a/dashboard/src/features/orgs/projects/ai/FileStoreForm/FileStoreForm.tsx
+++ b/dashboard/src/features/orgs/projects/ai/FileStoreForm/FileStoreForm.tsx
@@ -1,5 +1,5 @@
 import { yupResolver } from '@hookform/resolvers/yup';
-import { RefreshCwIcon } from 'lucide-react';
+import { InfoIcon, PlusIcon, RefreshCwIcon } from 'lucide-react';
 import { useEffect } from 'react';
 import { FormProvider, useForm } from 'react-hook-form';
 import * as Yup from 'yup';
@@ -9,8 +9,6 @@ import { Form } from '@/components/form/Form';
 import { Box } from '@/components/ui/v2/Box';
 import { Button } from '@/components/ui/v2/Button';
 import { Input } from '@/components/ui/v2/Input';
-import { InfoIcon } from '@/components/ui/v2/icons/InfoIcon';
-import { PlusIcon } from '@/components/ui/v2/icons/PlusIcon';
 import { Text } from '@/components/ui/v2/Text';
 import { Tooltip } from '@/components/ui/v2/Tooltip';
 import { useRemoteApplicationGQLClient } from '@/features/orgs/hooks/useRemoteApplicationGQLClient';
@@ -163,8 +161,7 @@ export default function FileStoreForm({
                 <Tooltip title="Name of the file store">
                   <InfoIcon
                     aria-label="Info"
-                    className="h-4 w-4"
-                    color="primary"
+                    className="h-4 w-4 text-primary"
                   />
                 </Tooltip>
               </Box>
@@ -187,8 +184,7 @@ export default function FileStoreForm({
                 <Tooltip title="One or more buckets from storage from which documents can be used by Assistants">
                   <InfoIcon
                     aria-label="Info"
-                    className="h-4 w-4"
-                    color="primary"
+                    className="h-4 w-4 text-primary"
                   />
                 </Tooltip>
               </Box>
@@ -210,7 +206,11 @@ export default function FileStoreForm({
             type="submit"
             disabled={isSubmitting}
             startIcon={
-              id ? <RefreshCwIcon width={16} height={16} /> : <PlusIcon />
+              id ? (
+                <RefreshCwIcon className="h-4 w-4" />
+              ) : (
+                <PlusIcon className="h-4 w-4" />
+              )
             }
           >
             {id ? 'Update' : 'Create'}

--- a/dashboard/src/features/orgs/projects/ai/FileStoresList/FileStoresList.tsx
+++ b/dashboard/src/features/orgs/projects/ai/FileStoresList/FileStoresList.tsx
@@ -1,12 +1,14 @@
+import {
+  CopyIcon,
+  Ellipsis as DotsHorizontalIcon,
+  EyeIcon,
+  Trash2 as TrashIcon,
+} from 'lucide-react';
 import { useDialog } from '@/components/common/DialogProvider';
 import { Box } from '@/components/ui/v2/Box';
 import { Divider } from '@/components/ui/v2/Divider';
 import { Dropdown } from '@/components/ui/v2/Dropdown';
 import { IconButton } from '@/components/ui/v2/IconButton';
-import { CopyIcon } from '@/components/ui/v2/icons/CopyIcon';
-import { DotsHorizontalIcon } from '@/components/ui/v2/icons/DotsHorizontalIcon';
-import { TrashIcon } from '@/components/ui/v2/icons/TrashIcon';
-import { UserIcon } from '@/components/ui/v2/icons/UserIcon';
 import { Text } from '@/components/ui/v2/Text';
 import { FileStoresIcon } from '@/components/ui/v3/icons/FileStoresIcon';
 import { DeleteFileStoreModal } from '@/features/orgs/projects/ai/DeleteFileStoreModal';
@@ -134,7 +136,7 @@ export default function FileStoresList({
                 onClick={() => viewFileStore(fileStore)}
                 className="z-50 grid grid-flow-col items-center gap-2 p-2 font-medium text-sm+"
               >
-                <UserIcon className="h-4 w-4" />
+                <EyeIcon className="h-4 w-4" />
                 <Text className="font-medium">View {fileStore?.name}</Text>
               </Dropdown.Item>
               <Divider component="li" />

--- a/dashboard/src/features/orgs/projects/ai/settings/components/AISettings.tsx
+++ b/dashboard/src/features/orgs/projects/ai/settings/components/AISettings.tsx
@@ -1,4 +1,5 @@
 import { yupResolver } from '@hookform/resolvers/yup';
+import { InfoIcon } from 'lucide-react';
 import { useEffect, useState } from 'react';
 import { FormProvider, useForm } from 'react-hook-form';
 import { toast } from 'react-hot-toast';
@@ -15,7 +16,6 @@ import { ActivityIndicator } from '@/components/ui/v2/ActivityIndicator';
 import { Alert } from '@/components/ui/v2/Alert';
 import { Box } from '@/components/ui/v2/Box';
 import { Input } from '@/components/ui/v2/Input';
-import { InfoIcon } from '@/components/ui/v2/icons/InfoIcon';
 import { Switch } from '@/components/ui/v2/Switch';
 import { Text } from '@/components/ui/v2/Text';
 import { Tooltip } from '@/components/ui/v2/Tooltip';
@@ -303,8 +303,7 @@ export default function AISettings() {
                     <Tooltip title="Version of the service to use.">
                       <InfoIcon
                         aria-label="Info"
-                        className="h-4 w-4"
-                        color="primary"
+                        className="h-4 w-4 text-primary"
                       />
                     </Tooltip>
                   </Box>
@@ -340,8 +339,7 @@ export default function AISettings() {
                     <Tooltip title="Used to validate requests between postgres and the AI service. The AI service will also include the header X-Graphite-Webhook-Secret with this value set when calling external webhooks so the source of the request can be validated.">
                       <InfoIcon
                         aria-label="Info"
-                        className="h-4 w-4"
-                        color="primary"
+                        className="h-4 w-4 text-primary"
                       />
                     </Tooltip>
                   </Box>
@@ -364,8 +362,7 @@ export default function AISettings() {
                     <Tooltip title="Dedicated resources allocated for the service.">
                       <InfoIcon
                         aria-label="Info"
-                        className="h-4 w-4"
-                        color="primary"
+                        className="h-4 w-4 text-primary"
                       />
                     </Tooltip>
                   </Box>
@@ -404,8 +401,7 @@ export default function AISettings() {
                         <Tooltip title="Key to use for authenticating API requests to OpenAI">
                           <InfoIcon
                             aria-label="Info"
-                            className="h-4 w-4"
-                            color="primary"
+                            className="h-4 w-4 text-primary"
                           />
                         </Tooltip>
                       </Box>
@@ -427,8 +423,7 @@ export default function AISettings() {
                         <Tooltip title="Optional. OpenAI organization to use.">
                           <InfoIcon
                             aria-label="Info"
-                            className="h-4 w-4"
-                            color="primary"
+                            className="h-4 w-4 text-primary"
                           />
                         </Tooltip>
                       </Box>
@@ -455,8 +450,7 @@ export default function AISettings() {
                         <Tooltip title="How often to run the job that keeps embeddings up to date.">
                           <InfoIcon
                             aria-label="Info"
-                            className="h-4 w-4"
-                            color="primary"
+                            className="h-4 w-4 text-primary"
                           />
                         </Tooltip>
                       </Box>

--- a/dashboard/src/pages/orgs/[orgSlug]/projects/[appSubdomain]/ai/assistants/index.tsx
+++ b/dashboard/src/pages/orgs/[orgSlug]/projects/[appSubdomain]/ai/assistants/index.tsx
@@ -1,3 +1,4 @@
+import { PlusIcon } from 'lucide-react';
 import { type ReactElement, useMemo } from 'react';
 import { useDialog } from '@/components/common/DialogProvider';
 import { UpgradeToProBanner } from '@/components/common/UpgradeToProBanner';
@@ -7,7 +8,6 @@ import { ActivityIndicator } from '@/components/ui/v2/ActivityIndicator';
 import { Alert } from '@/components/ui/v2/Alert';
 import { Box } from '@/components/ui/v2/Box';
 import { Button } from '@/components/ui/v2/Button';
-import { PlusIcon } from '@/components/ui/v2/icons/PlusIcon';
 import { Link } from '@/components/ui/v2/Link';
 import { Text } from '@/components/ui/v2/Text';
 import { AISidebar } from '@/features/orgs/layout/AISidebar';

--- a/dashboard/src/pages/orgs/[orgSlug]/projects/[appSubdomain]/ai/auto-embeddings/index.tsx
+++ b/dashboard/src/pages/orgs/[orgSlug]/projects/[appSubdomain]/ai/auto-embeddings/index.tsx
@@ -1,3 +1,4 @@
+import { PlusIcon } from 'lucide-react';
 import { useRouter } from 'next/router';
 import { type ReactElement, useEffect, useMemo, useRef, useState } from 'react';
 import { useDialog } from '@/components/common/DialogProvider';
@@ -8,7 +9,6 @@ import { RetryableErrorBoundary } from '@/components/presentational/RetryableErr
 import { Alert } from '@/components/ui/v2/Alert';
 import { Box } from '@/components/ui/v2/Box';
 import { Button } from '@/components/ui/v2/Button';
-import { PlusIcon } from '@/components/ui/v2/icons/PlusIcon';
 import { Link } from '@/components/ui/v2/Link';
 import { Text } from '@/components/ui/v2/Text';
 import { EmbeddingsIcon } from '@/components/ui/v3/icons/EmbeddingsIcon';

--- a/dashboard/src/pages/orgs/[orgSlug]/projects/[appSubdomain]/ai/file-stores/index.tsx
+++ b/dashboard/src/pages/orgs/[orgSlug]/projects/[appSubdomain]/ai/file-stores/index.tsx
@@ -1,3 +1,4 @@
+import { PlusIcon } from 'lucide-react';
 import { type ReactElement, useMemo } from 'react';
 import { useDialog } from '@/components/common/DialogProvider';
 import { UpgradeToProBanner } from '@/components/common/UpgradeToProBanner';
@@ -6,7 +7,6 @@ import { ActivityIndicator } from '@/components/ui/v2/ActivityIndicator';
 import { Alert } from '@/components/ui/v2/Alert';
 import { Box } from '@/components/ui/v2/Box';
 import { Button } from '@/components/ui/v2/Button';
-import { PlusIcon } from '@/components/ui/v2/icons/PlusIcon';
 import { Link } from '@/components/ui/v2/Link';
 import { Text } from '@/components/ui/v2/Text';
 import { FileStoresIcon } from '@/components/ui/v3/icons/FileStoresIcon';


### PR DESCRIPTION
### Checklist

- [ ] No breaking changes
- [ ] Tests pass
- [ ] New features have new tests
- [ ] Documentation is updated (if applicable)
- [ ] Title of the PR is in the correct format (see below)

<!-- nhost-reviewer:start -->
### **PR Type**
Refactoring

___

### **Description**
- Migrates icons in the dashboard's AI feature pages (Assistants, Auto-Embeddings, File Stores, AI settings) from the local `@/components/ui/v2/icons/*` set to `lucide-react`, continuing the repo-wide icon migration.
- Replaces the legacy `color="primary"` prop with the Tailwind utility `text-primary` on `InfoIcon` instances, and standardizes the `h-4 w-4` sizing class for `PlusIcon` / `RefreshCwIcon` (since lucide icons no longer inherit the v2 sizing defaults).
- Swaps the `UserIcon` used inside "View …" dropdown items for the more semantically-appropriate `EyeIcon` across the three AI list components.
- Aliases `Trash2 as TrashIcon` and `Ellipsis as DotsHorizontalIcon` on import to keep call-sites unchanged.

___

<details> <summary><h3> File Walkthrough</h3></summary>

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody>
<tr><td><strong>Forms</strong></td><td><details><summary>4 files</summary><table>
<tr>
  <td><strong>AssistantForm.tsx</strong><dd><code>Switch InfoIcon/PlusIcon/RefreshCwIcon to lucide-react; replace color prop with text-primary.</code></dd></td>
  <td><a href="https://github.com/nhost/nhost/pull/4287/files#diff-50db3e48f3d8798600ac6a6bb9f24b0f76c660e6f5afb048c303e9bf7212978b">+8/-15</a></td>
</tr>
<tr>
  <td><strong>AutoEmbeddingsForm.tsx</strong><dd><code>Same icon migration applied across all tooltip fields and the submit button.</code></dd></td>
  <td><a href="https://github.com/nhost/nhost/pull/4287/files#diff-021330b973de35f7029804ba4eca0a7c25c62f60b6447d91d9b507c6d9c6f96d">+10/-19</a></td>
</tr>
<tr>
  <td><strong>FileStoreForm.tsx</strong><dd><code>Migrate InfoIcon/PlusIcon/RefreshCwIcon; add explicit h-4 w-4 sizing.</code></dd></td>
  <td><a href="https://github.com/nhost/nhost/pull/4287/files#diff-ea208a619f7375475d05b8a64bed8d530592e2eef8ad64ff664e1a921723bc43">+8/-8</a></td>
</tr>
<tr>
  <td><strong>AISettings.tsx</strong><dd><code>Migrate InfoIcon tooltips on version, secret, resources, OpenAI key/org, and synch interval fields.</code></dd></td>
  <td><a href="https://github.com/nhost/nhost/pull/4287/files#diff-6ec092fc4af4c9acd11edb4ae69ff6ad6e8e984c761148836c9fde8daaa6e9a4">+7/-13</a></td>
</tr>
</table></details></td></tr>
<tr><td><strong>Form sections</strong></td><td><details><summary>3 files</summary><table>
<tr>
  <td><strong>ArgumentsFormSection.tsx</strong><dd><code>Use lucide InfoIcon/PlusIcon/Trash2 (aliased TrashIcon).</code></dd></td>
  <td><a href="https://github.com/nhost/nhost/pull/4287/files#diff-8847ce02f6c3083961ded0a46df1482d8280f84535751480f7ee8e7cc9b0c7e7">+2/-4</a></td>
</tr>
<tr>
  <td><strong>GraphqlDataSourcesFormSection.tsx</strong><dd><code>Same icon set migrated.</code></dd></td>
  <td><a href="https://github.com/nhost/nhost/pull/4287/files#diff-dda7c58809b854354f7f611b948fcb3e29624521e9ed788c0aded18b1fa72e3b">+2/-4</a></td>
</tr>
<tr>
  <td><strong>WebhooksDataSourcesFormSection.tsx</strong><dd><code>Same icon set migrated.</code></dd></td>
  <td><a href="https://github.com/nhost/nhost/pull/4287/files#diff-50a666a4313f4b6befb706b606bbc8250eadb53ee4f7e68e8a3f6b7d461ff0ec">+2/-4</a></td>
</tr>
</table></details></td></tr>
<tr><td><strong>List components</strong></td><td><details><summary>3 files</summary><table>
<tr>
  <td><strong>AssistantsList.tsx</strong><dd><code>Migrate Copy/Trash/Dots icons; replace UserIcon with EyeIcon in the View action.</code></dd></td>
  <td><a href="https://github.com/nhost/nhost/pull/4287/files#diff-6d4f7f768bd50808fb9bdbb4aafbe75d0fbef75a0a3cb915729512bc508d764d">+7/-5</a></td>
</tr>
<tr>
  <td><strong>AutoEmbeddingsList.tsx</strong><dd><code>Migrate icons and swap UserIcon -> EyeIcon for the View action.</code></dd></td>
  <td><a href="https://github.com/nhost/nhost/pull/4287/files#diff-3a7b16bf4360ad5a244afe3853733eb3e656afd36a95b932ae283babe586a2dd">+7/-5</a></td>
</tr>
<tr>
  <td><strong>FileStoresList.tsx</strong><dd><code>Migrate icons and swap UserIcon -> EyeIcon for the View action.</code></dd></td>
  <td><a href="https://github.com/nhost/nhost/pull/4287/files#diff-1df1e8c4c34837a464afa69a2b9d1bfed416843f30a6b9a34e406a94fb5e4b0e">+7/-5</a></td>
</tr>
</table></details></td></tr>
<tr><td><strong>Pages</strong></td><td><details><summary>3 files</summary><table>
<tr>
  <td><strong>assistants/index.tsx</strong><dd><code>Switch PlusIcon import to lucide-react.</code></dd></td>
  <td><a href="https://github.com/nhost/nhost/pull/4287/files#diff-7899d8d55f092651c722e063ffbab70ebfc9bbd845e349f3d4c88942fc723ecc">+1/-1</a></td>
</tr>
<tr>
  <td><strong>auto-embeddings/index.tsx</strong><dd><code>Switch PlusIcon import to lucide-react.</code></dd></td>
  <td><a href="https://github.com/nhost/nhost/pull/4287/files#diff-23be5f3d94bedf6332a72e290abd05516ee515793e097178323d6e42e27b0172">+1/-1</a></td>
</tr>
<tr>
  <td><strong>file-stores/index.tsx</strong><dd><code>Switch PlusIcon import to lucide-react.</code></dd></td>
  <td><a href="https://github.com/nhost/nhost/pull/4287/files#diff-67ed2c588a335e53f8e4dc5b8af947c218f7a2fd35a239a3ab548606d6d90dbd">+1/-1</a></td>
</tr>
</table></details></td></tr>
</tbody></table>

</details>

___

<!-- nhost-reviewer:end -->
