### PR TITLE
fix(dashboard): Migrate metrics page icons

### DIFF
--- a/dashboard/src/features/orgs/projects/metrics/settings/components/DiscordFormSection/DiscordFormSection.tsx
+++ b/dashboard/src/features/orgs/projects/metrics/settings/components/DiscordFormSection/DiscordFormSection.tsx
@@ -1,10 +1,8 @@
+import { InfoIcon, PlusIcon, Trash2 as TrashIcon } from 'lucide-react';
 import { useFieldArray, useFormContext } from 'react-hook-form';
 import { Box } from '@/components/ui/v2/Box';
 import { Button } from '@/components/ui/v2/Button';
 import { Input } from '@/components/ui/v2/Input';
-import { InfoIcon } from '@/components/ui/v2/icons/InfoIcon';
-import { PlusIcon } from '@/components/ui/v2/icons/PlusIcon';
-import { TrashIcon } from '@/components/ui/v2/icons/TrashIcon';
 import { Text } from '@/components/ui/v2/Text';
 import { Tooltip } from '@/components/ui/v2/Tooltip';
 import type { ContactPointsFormValues } from '@/features/orgs/projects/metrics/settings/components/ContactPointsSettings/ContactPointsSettingsTypes';
@@ -35,7 +33,7 @@ export default function DiscordFormSection() {
               </span>
             }
           >
-            <InfoIcon aria-label="Info" className="h-4 w-4" color="primary" />
+            <InfoIcon aria-label="Info" className="h-4 w-4 text-primary" />
           </Tooltip>
         </Box>
         <Button

--- a/dashboard/src/features/orgs/projects/metrics/settings/components/EmailsFormSection/EmailsFormSection.tsx
+++ b/dashboard/src/features/orgs/projects/metrics/settings/components/EmailsFormSection/EmailsFormSection.tsx
@@ -1,10 +1,8 @@
+import { InfoIcon, PlusIcon, Trash2 as TrashIcon } from 'lucide-react';
 import { useFieldArray, useFormContext } from 'react-hook-form';
 import { Box } from '@/components/ui/v2/Box';
 import { Button } from '@/components/ui/v2/Button';
 import { Input } from '@/components/ui/v2/Input';
-import { InfoIcon } from '@/components/ui/v2/icons/InfoIcon';
-import { PlusIcon } from '@/components/ui/v2/icons/PlusIcon';
-import { TrashIcon } from '@/components/ui/v2/icons/TrashIcon';
 import { Text } from '@/components/ui/v2/Text';
 import { Tooltip } from '@/components/ui/v2/Tooltip';
 import type { ContactPointsFormValues } from '@/features/orgs/projects/metrics/settings/components/ContactPointsSettings/ContactPointsSettingsTypes';
@@ -35,7 +33,7 @@ export default function EmailsFormSection() {
               </span>
             }
           >
-            <InfoIcon aria-label="Info" className="h-4 w-4" color="primary" />
+            <InfoIcon aria-label="Info" className="h-4 w-4 text-primary" />
           </Tooltip>
         </Box>
         <Button variant="borderless" onClick={() => append({ email: '' })}>

--- a/dashboard/src/features/orgs/projects/metrics/settings/components/PagerdutyFormSection/PagerdutyFormSection.tsx
+++ b/dashboard/src/features/orgs/projects/metrics/settings/components/PagerdutyFormSection/PagerdutyFormSection.tsx
@@ -1,10 +1,8 @@
+import { InfoIcon, PlusIcon, Trash2 as TrashIcon } from 'lucide-react';
 import { useFieldArray, useFormContext, useWatch } from 'react-hook-form';
 import { Box } from '@/components/ui/v2/Box';
 import { Button } from '@/components/ui/v2/Button';
 import { Input } from '@/components/ui/v2/Input';
-import { InfoIcon } from '@/components/ui/v2/icons/InfoIcon';
-import { PlusIcon } from '@/components/ui/v2/icons/PlusIcon';
-import { TrashIcon } from '@/components/ui/v2/icons/TrashIcon';
 import { Option } from '@/components/ui/v2/Option';
 import { Select } from '@/components/ui/v2/Select';
 import { Text } from '@/components/ui/v2/Text';
@@ -43,7 +41,7 @@ export default function PagerdutyFormSection() {
               </span>
             }
           >
-            <InfoIcon aria-label="Info" className="h-4 w-4" color="primary" />
+            <InfoIcon aria-label="Info" className="h-4 w-4 text-primary" />
           </Tooltip>
         </Box>
         <Button

--- a/dashboard/src/features/orgs/projects/metrics/settings/components/SlackFormSection/SlackFormSection.tsx
+++ b/dashboard/src/features/orgs/projects/metrics/settings/components/SlackFormSection/SlackFormSection.tsx
@@ -1,11 +1,9 @@
+import { InfoIcon, PlusIcon, Trash2 as TrashIcon } from 'lucide-react';
 import { useFieldArray, useFormContext } from 'react-hook-form';
 import { Alert } from '@/components/ui/v2/Alert';
 import { Box } from '@/components/ui/v2/Box';
 import { Button } from '@/components/ui/v2/Button';
 import { Input } from '@/components/ui/v2/Input';
-import { InfoIcon } from '@/components/ui/v2/icons/InfoIcon';
-import { PlusIcon } from '@/components/ui/v2/icons/PlusIcon';
-import { TrashIcon } from '@/components/ui/v2/icons/TrashIcon';
 import { Text } from '@/components/ui/v2/Text';
 import { Tooltip } from '@/components/ui/v2/Tooltip';
 import type { ContactPointsFormValues } from '@/features/orgs/projects/metrics/settings/components/ContactPointsSettings/ContactPointsSettingsTypes';
@@ -43,7 +41,7 @@ export default function SlackFormSection() {
               </span>
             }
           >
-            <InfoIcon aria-label="Info" className="h-4 w-4" color="primary" />
+            <InfoIcon aria-label="Info" className="h-4 w-4 text-primary" />
           </Tooltip>
         </Box>
         <Button

--- a/dashboard/src/features/orgs/projects/metrics/settings/components/WebhookFormSection/WebhookFormSection.tsx
+++ b/dashboard/src/features/orgs/projects/metrics/settings/components/WebhookFormSection/WebhookFormSection.tsx
@@ -1,3 +1,10 @@
+import {
+  EyeIcon,
+  EyeOffIcon,
+  InfoIcon,
+  PlusIcon,
+  Trash2 as TrashIcon,
+} from 'lucide-react';
 import { useState } from 'react';
 import { useFieldArray, useFormContext, useWatch } from 'react-hook-form';
 import { Box } from '@/components/ui/v2/Box';
@@ -5,11 +12,6 @@ import { Button } from '@/components/ui/v2/Button';
 import { IconButton } from '@/components/ui/v2/IconButton';
 import { Input } from '@/components/ui/v2/Input';
 import { InputAdornment } from '@/components/ui/v2/InputAdornment';
-import { EyeIcon } from '@/components/ui/v2/icons/EyeIcon';
-import { EyeOffIcon } from '@/components/ui/v2/icons/EyeOffIcon';
-import { InfoIcon } from '@/components/ui/v2/icons/InfoIcon';
-import { PlusIcon } from '@/components/ui/v2/icons/PlusIcon';
-import { TrashIcon } from '@/components/ui/v2/icons/TrashIcon';
 import { Option } from '@/components/ui/v2/Option';
 import { Select } from '@/components/ui/v2/Select';
 import { Text } from '@/components/ui/v2/Text';
@@ -50,7 +52,7 @@ export default function WebhookFormSection() {
               </span>
             }
           >
-            <InfoIcon aria-label="Info" className="h-4 w-4" color="primary" />
+            <InfoIcon aria-label="Info" className="h-4 w-4 text-primary" />
           </Tooltip>
         </Box>
         <Button


### PR DESCRIPTION
### Checklist

- [ ] No breaking changes
- [ ] Tests pass
- [ ] New features have new tests
- [ ] Documentation is updated (if applicable)
- [ ] Title of the PR is in the correct format (see below)


<!-- nhost-reviewer:start -->
### **PR Type**
Refactoring

___

### **Description**
- Migrates icon imports in the metrics settings contact-point form sections from the local `@/components/ui/v2/icons/*` set to `lucide-react`.
- Aliases `Trash2` to `TrashIcon` to keep the existing identifier and JSX usage stable across the migrated files.
- Replaces the v2 `<InfoIcon color="primary" />` prop with the Tailwind `text-primary` class to match lucide's color API.

___

<details> <summary><h3> File Walkthrough</h3></summary>

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody>
<tr><td><strong>Refactoring</strong></td><td><details><summary>5 files</summary><table>
<tr>
  <td><strong>DiscordFormSection.tsx</strong><dd><code>Swap v2 icons for lucide-react; use text-primary class on InfoIcon</code></dd></td>
  <td><a href="https://github.com/nhost/nhost/pull/4289/files#diff-0fd5ee2276f07a5127c6835daa61969536adca5aae7c42815388d5bbff20db8b">+2/-4</a></td>
</tr>
<tr>
  <td><strong>EmailsFormSection.tsx</strong><dd><code>Swap v2 icons for lucide-react; use text-primary class on InfoIcon</code></dd></td>
  <td><a href="https://github.com/nhost/nhost/pull/4289/files#diff-352c52f85482ac341bad6d54d505eab6d3760a287092adcb7ea4743a571bddb6">+2/-4</a></td>
</tr>
<tr>
  <td><strong>PagerdutyFormSection.tsx</strong><dd><code>Swap v2 icons for lucide-react; use text-primary class on InfoIcon</code></dd></td>
  <td><a href="https://github.com/nhost/nhost/pull/4289/files#diff-e3d636fafec638ecab2c0fcdd6450d54189c46b43402102ed2e085248cdb2cc0">+2/-4</a></td>
</tr>
<tr>
  <td><strong>SlackFormSection.tsx</strong><dd><code>Swap v2 icons for lucide-react; use text-primary class on InfoIcon</code></dd></td>
  <td><a href="https://github.com/nhost/nhost/pull/4289/files#diff-8f524100d160a1f95571e2ef3df8a08da649b84a02f70c072cd85ef7f21231e1">+2/-4</a></td>
</tr>
<tr>
  <td><strong>WebhookFormSection.tsx</strong><dd><code>Swap v2 icons (incl. EyeIcon/EyeOffIcon) for lucide-react; use text-primary class on InfoIcon</code></dd></td>
  <td><a href="https://github.com/nhost/nhost/pull/4289/files#diff-656d0927cf2d72eaa00cb8e56e22087213b50e6e7148bad7a3313489f2537569">+8/-6</a></td>
</tr>
</table></details></td></tr>
</tbody></table>

</details>

___

<!-- nhost-reviewer:end -->
