### PR TITLE
fix(dashboard): remove useEffect URL→state sync in header comboboxes

### DIFF
--- a/dashboard/src/components/layout/Header/OrgPagesComboBox.tsx
+++ b/dashboard/src/components/layout/Header/OrgPagesComboBox.tsx
@@ -1,6 +1,6 @@
 import { Check, ChevronsUpDown } from 'lucide-react';
 import { useRouter } from 'next/router';
-import { useEffect, useMemo, useState } from 'react';
+import { useMemo, useState } from 'react';
 import { Button } from '@/components/ui/v3/button';
 import {
   Command,
@@ -42,17 +42,9 @@ export default function OrgPagesComboBox() {
   const pathSegments = useMemo(() => asPath.split('/'), [asPath]);
   const orgPageFromUrl = pathSegments[3] || null;
 
-  const selectedOrgPageFromUrl = orgPages.find(
+  const selectedOrgPage = orgPages.find(
     (item) => item.value === orgPageFromUrl,
   );
-
-  const [selectedOrgPage, setSelectedOrgPage] = useState<Option | null>(null);
-
-  useEffect(() => {
-    if (selectedOrgPageFromUrl) {
-      setSelectedOrgPage(selectedOrgPageFromUrl);
-    }
-  }, [selectedOrgPageFromUrl]);
 
   const options: Option[] = orgPages.map((page) => ({
     label: page.label,
@@ -88,7 +80,6 @@ export default function OrgPagesComboBox() {
                   key={option.value}
                   value={option.label}
                   onSelect={() => {
-                    setSelectedOrgPage(option);
                     setOpen(false);
                     push(`/orgs/${orgSlug}/${option.value}`);
                   }}

--- a/dashboard/src/components/layout/Header/OrgsComboBox.tsx
+++ b/dashboard/src/components/layout/Header/OrgsComboBox.tsx
@@ -1,6 +1,6 @@
 import { Check, ChevronsUpDown } from 'lucide-react';
 import { useRouter } from 'next/router';
-import { useEffect, useState } from 'react';
+import { useState } from 'react';
 import { Badge } from '@/components/ui/v3/badge';
 import { Button } from '@/components/ui/v3/button';
 import {
@@ -37,22 +37,17 @@ export default function OrgsComboBox() {
     push,
   } = useRouter();
 
-  const selectedOrgFromUrl =
-    Boolean(orgSlug) && orgs.find((item) => item.slug === orgSlug);
+  const selectedOrgFromUrl = orgSlug
+    ? orgs.find((item) => item.slug === orgSlug)
+    : undefined;
 
-  const [selectedItem, setSelectedItem] = useState<Option | null>(null);
-
-  useEffect(() => {
-    const selectedItemFromUrl = selectedOrgFromUrl;
-
-    if (selectedItemFromUrl) {
-      setSelectedItem({
-        label: selectedItemFromUrl.name,
-        value: selectedItemFromUrl.slug,
-        plan: selectedOrgFromUrl ? selectedOrgFromUrl.plan.name : 'Legacy',
-      });
-    }
-  }, [selectedOrgFromUrl]);
+  const selectedItem: Option | null = selectedOrgFromUrl
+    ? {
+        label: selectedOrgFromUrl.name,
+        value: selectedOrgFromUrl.slug,
+        plan: selectedOrgFromUrl.plan?.name ?? 'Legacy',
+      }
+    : null;
 
   const orgsOptions: Option[] = orgs.map((org) => ({
     label: org.name,
@@ -115,7 +110,6 @@ export default function OrgsComboBox() {
                   value={option.value}
                   className="flex items-center text-foreground dark:hover:bg-muted"
                   onSelect={() => {
-                    setSelectedItem(option);
                     setOpen(false);
 
                     // persist last slug in local storage

--- a/dashboard/src/components/layout/Header/ProjectAuthPagesComboBox.tsx
+++ b/dashboard/src/components/layout/Header/ProjectAuthPagesComboBox.tsx
@@ -1,6 +1,6 @@
 import { Check, ChevronsUpDown } from 'lucide-react';
 import { useRouter } from 'next/router';
-import { useEffect, useMemo, useState } from 'react';
+import { useMemo, useState } from 'react';
 import { Button } from '@/components/ui/v3/button';
 import {
   Command,
@@ -69,20 +69,9 @@ export default function ProjectAuthPagesComboBox() {
   const isAuthPage = pathSegments.includes('auth');
   const authPageFromUrl = isAuthPage ? pathSegments[6] || 'users' : null;
 
-  const selectedAuthPageFromUrl = projectAuthPages.find(
+  const selectedAuthPage = projectAuthPages.find(
     (item) => item.value === authPageFromUrl,
   );
-  const [selectedAuthPage, setSelectedAuthPage] = useState<Option | null>(null);
-
-  useEffect(() => {
-    if (selectedAuthPageFromUrl) {
-      setSelectedAuthPage({
-        label: selectedAuthPageFromUrl.label,
-        value: selectedAuthPageFromUrl.value,
-        route: selectedAuthPageFromUrl.route,
-      });
-    }
-  }, [selectedAuthPageFromUrl]);
 
   const options: Option[] = projectAuthPages.map((page) => ({
     label: page.label,
@@ -119,7 +108,6 @@ export default function ProjectAuthPagesComboBox() {
                   key={option.value}
                   value={option.label}
                   onSelect={() => {
-                    setSelectedAuthPage(option);
                     setOpen(false);
                     push(
                       `/orgs/${orgSlug}/projects/${appSubdomain}/auth/${option.route}/`,

--- a/dashboard/src/components/layout/Header/ProjectEventsPagesComboBox.tsx
+++ b/dashboard/src/components/layout/Header/ProjectEventsPagesComboBox.tsx
@@ -1,6 +1,6 @@
 import { Check, ChevronsUpDown } from 'lucide-react';
 import { useRouter } from 'next/router';
-import { useEffect, useMemo, useState } from 'react';
+import { useMemo, useState } from 'react';
 import { Button } from '@/components/ui/v3/button';
 import {
   Command,
@@ -58,22 +58,9 @@ export default function ProjectEventsPagesComboBox() {
     ? pathSegments[6] || 'event-triggers'
     : null;
 
-  const selectedEventsPageFromUrl = projectEventsPages.find(
+  const selectedEventsPage = projectEventsPages.find(
     (item) => item.value === eventsPageFromUrl,
   );
-  const [selectedEventsPage, setSelectedEventsPage] = useState<Option | null>(
-    null,
-  );
-
-  useEffect(() => {
-    if (selectedEventsPageFromUrl) {
-      setSelectedEventsPage({
-        label: selectedEventsPageFromUrl.label,
-        value: selectedEventsPageFromUrl.value,
-        route: selectedEventsPageFromUrl.route,
-      });
-    }
-  }, [selectedEventsPageFromUrl]);
 
   const options: Option[] = projectEventsPages.map((page) => ({
     label: page.label,
@@ -110,7 +97,6 @@ export default function ProjectEventsPagesComboBox() {
                   key={option.value}
                   value={option.label}
                   onSelect={() => {
-                    setSelectedEventsPage(option);
                     setOpen(false);
                     push(
                       `/orgs/${orgSlug}/projects/${appSubdomain}/events/${option.route}/`,

--- a/dashboard/src/components/layout/Header/ProjectGraphQLPagesComboBox.tsx
+++ b/dashboard/src/components/layout/Header/ProjectGraphQLPagesComboBox.tsx
@@ -1,6 +1,6 @@
 import { Check, ChevronsUpDown } from 'lucide-react';
 import { useRouter } from 'next/router';
-import { useEffect, useMemo, useState } from 'react';
+import { useMemo, useState } from 'react';
 import { Button } from '@/components/ui/v3/button';
 import {
   Command,
@@ -58,22 +58,9 @@ export default function ProjectGraphQLPagesComboBox() {
     ? pathSegments[6] || 'playground'
     : null;
 
-  const selectedGraphQLPageFromUrl = projectGraphQLPages.find(
+  const selectedGraphQLPage = projectGraphQLPages.find(
     (item) => item.value === graphQLPageFromUrl,
   );
-  const [selectedGraphQLPage, setSelectedGraphQLPage] = useState<Option | null>(
-    null,
-  );
-
-  useEffect(() => {
-    if (selectedGraphQLPageFromUrl) {
-      setSelectedGraphQLPage({
-        label: selectedGraphQLPageFromUrl.label,
-        value: selectedGraphQLPageFromUrl.value,
-        route: selectedGraphQLPageFromUrl.route,
-      });
-    }
-  }, [selectedGraphQLPageFromUrl]);
 
   const options: Option[] = projectGraphQLPages.map((page) => ({
     label: page.label,
@@ -110,7 +97,6 @@ export default function ProjectGraphQLPagesComboBox() {
                   key={option.value}
                   value={option.label}
                   onSelect={() => {
-                    setSelectedGraphQLPage(option);
                     setOpen(false);
                     push(
                       `/orgs/${orgSlug}/projects/${appSubdomain}/graphql/${option.route}/`,

--- a/dashboard/src/components/layout/Header/ProjectPagesComboBox.tsx
+++ b/dashboard/src/components/layout/Header/ProjectPagesComboBox.tsx
@@ -13,7 +13,7 @@ import {
   Zap,
 } from 'lucide-react';
 import { useRouter } from 'next/router';
-import { type ReactElement, useEffect, useMemo, useState } from 'react';
+import { type ReactElement, useMemo, useState } from 'react';
 
 import { AIIcon } from '@/components/ui/v2/icons/AIIcon';
 import { GraphQLIcon } from '@/components/ui/v2/icons/GraphQLIcon';
@@ -176,18 +176,13 @@ export default function ProjectPagesComboBox() {
   const selectedProjectPageFromUrl = projectPages.find(
     (item) => item.value === projectPageFromUrl,
   );
-  const [selectedProjectPage, setSelectedProjectPage] =
-    useState<SelectedOption | null>(null);
-
-  useEffect(() => {
-    if (selectedProjectPageFromUrl) {
-      setSelectedProjectPage({
+  const selectedProjectPage: SelectedOption | null = selectedProjectPageFromUrl
+    ? {
         label: selectedProjectPageFromUrl.label,
         value: selectedProjectPageFromUrl.slug,
         icon: selectedProjectPageFromUrl.icon,
-      });
-    }
-  }, [selectedProjectPageFromUrl]);
+      }
+    : null;
 
   const options: Option[] = projectPages.map((app) => ({
     label: app.label,
@@ -229,7 +224,6 @@ export default function ProjectPagesComboBox() {
                   value={option.label}
                   disabled={option.disabled}
                   onSelect={() => {
-                    setSelectedProjectPage(option);
                     setOpen(false);
                     push(
                       `/orgs/${orgSlug}/projects/${appSubdomain}/${option.value}`,

--- a/dashboard/src/components/layout/Header/ProjectSettingsPagesComboBox.tsx
+++ b/dashboard/src/components/layout/Header/ProjectSettingsPagesComboBox.tsx
@@ -1,6 +1,6 @@
 import { Check, ChevronsUpDown } from 'lucide-react';
 import { useRouter } from 'next/router';
-import { useEffect, useMemo, useState } from 'react';
+import { useMemo, useState } from 'react';
 import { Button } from '@/components/ui/v3/button';
 import {
   Command,
@@ -116,21 +116,9 @@ export default function ProjectSettingsPagesComboBox() {
     ? pathSegments[6] || 'general'
     : null;
 
-  const selectedSettingsPageFromUrl = projectSettingsPages.find(
+  const selectedSettingsPage = projectSettingsPages.find(
     (item) => item.value === settingsPageFromUrl,
   );
-  const [selectedSettingsPage, setSelectedSettingsPage] =
-    useState<Option | null>(null);
-
-  useEffect(() => {
-    if (selectedSettingsPageFromUrl) {
-      setSelectedSettingsPage({
-        label: selectedSettingsPageFromUrl.label,
-        value: selectedSettingsPageFromUrl.value,
-        route: selectedSettingsPageFromUrl.route,
-      });
-    }
-  }, [selectedSettingsPageFromUrl]);
 
   const options: Option[] = projectSettingsPages.map((page) => ({
     label: page.label,
@@ -167,7 +155,6 @@ export default function ProjectSettingsPagesComboBox() {
                   key={option.value}
                   value={option.label}
                   onSelect={() => {
-                    setSelectedSettingsPage(option);
                     setOpen(false);
                     push(
                       `/orgs/${orgSlug}/projects/${appSubdomain}/settings/${option.route}/`,

--- a/dashboard/src/components/layout/Header/ProjectsComboBox.tsx
+++ b/dashboard/src/components/layout/Header/ProjectsComboBox.tsx
@@ -1,7 +1,7 @@
 import { SiGithub } from '@icons-pack/react-simple-icons';
 import { Box, Check, ChevronsUpDown } from 'lucide-react';
 import { useRouter } from 'next/router';
-import { useEffect, useState } from 'react';
+import { useState } from 'react';
 import ProjectStatus from '@/components/layout/Header/ProjectStatus';
 import { Button } from '@/components/ui/v3/button';
 import {
@@ -47,7 +47,6 @@ export default function ProjectsComboBox() {
   const { project } = useProject();
   const isGitHubConnected = !!project?.githubRepository;
 
-  const [selectedProject, setSelectedProject] = useState<Option | null>(null);
   const [open, setOpen] = useState(false);
 
   const options: Option[] = apps.map((app) => ({
@@ -60,18 +59,15 @@ export default function ProjectsComboBox() {
     (app) => app.subdomain === appSubdomain,
   );
 
-  useEffect(() => {
-    if (selectedProjectFromUrl) {
-      setSelectedProject({
+  const selectedProject: Option | null = selectedProjectFromUrl
+    ? {
         label: selectedProjectFromUrl.name,
         value: selectedProjectFromUrl.subdomain,
         hasGitHubRepo: !!selectedProjectFromUrl.githubRepository,
-      });
-    }
-  }, [selectedProjectFromUrl]);
+      }
+    : null;
 
   const handleProjectSelect = (option: Option) => {
-    setSelectedProject(option);
     setOpen(false);
     const featurePath = getProjectFeaturePagePath(pathname);
     push(`/orgs/${orgSlug}/projects/${option.value}${featurePath}`);


### PR DESCRIPTION
### Checklist

- [ ] No breaking changes
- [ ] Tests pass
- [ ] New features have new tests
- [ ] Documentation is updated (if applicable)
- [ ] Title of the PR is in the correct format (see below)

<!-- nhost-reviewer:start -->
### **PR Type**
Refactoring

___

### **Description**
- Removes `useEffect`-based URL → local-state syncing across eight header combobox components.
- Derives the currently-selected option directly from the URL (`useRouter`) on every render, eliminating the redundant `useState` mirror.
- Drops `setSelected*` calls inside `onSelect` handlers — navigation via `router.push` is now the single source of truth.
- In `OrgsComboBox`, additionally hardens the plan-name access with optional chaining (`plan?.name ?? 'Legacy'`).

___

<details> <summary><h3> File Walkthrough</h3></summary>

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody>
<tr><td><strong>Header comboboxes</strong></td><td><details><summary>8 files</summary><table>
<tr>
  <td><strong>OrgPagesComboBox.tsx</strong><dd><code>Derive selected org page from URL; drop useEffect/useState mirror</code></dd></td>
  <td><a href="https://github.com/nhost/nhost/pull/4290/files#diff-b70a46a4233201c9a2650c930192b4417f35a27303ff5c78872c05a41a92c8ac">+2/-11</a></td>
</tr>
<tr>
  <td><strong>OrgsComboBox.tsx</strong><dd><code>Derive selected org from URL; harden plan?.name access</code></dd></td>
  <td><a href="https://github.com/nhost/nhost/pull/4290/files#diff-0736dac185f4ed134d5b53be292c9a2ee4f6df65e965b801a2dbbc8a184b3687">+11/-17</a></td>
</tr>
<tr>
  <td><strong>ProjectAuthPagesComboBox.tsx</strong><dd><code>Derive selected auth page from URL; drop sync effect</code></dd></td>
  <td><a href="https://github.com/nhost/nhost/pull/4290/files#diff-49a229005be696b96468e5be0334be3719a749d7de024ef2466eb5bf0f4a2661">+2/-14</a></td>
</tr>
<tr>
  <td><strong>ProjectEventsPagesComboBox.tsx</strong><dd><code>Derive selected events page from URL; drop sync effect</code></dd></td>
  <td><a href="https://github.com/nhost/nhost/pull/4290/files#diff-d15391148edeae8954a91367b9f786e662f37dd756682ba219a9f5e448e9362c">+2/-16</a></td>
</tr>
<tr>
  <td><strong>ProjectGraphQLPagesComboBox.tsx</strong><dd><code>Derive selected GraphQL page from URL; drop sync effect</code></dd></td>
  <td><a href="https://github.com/nhost/nhost/pull/4290/files#diff-9b4cb20a2e6da1215ea1420c5c58c18c8113a7dd966771a002b42e070d1b4716">+2/-16</a></td>
</tr>
<tr>
  <td><strong>ProjectPagesComboBox.tsx</strong><dd><code>Derive selected project page from URL via ternary</code></dd></td>
  <td><a href="https://github.com/nhost/nhost/pull/4290/files#diff-70b3af41358f0a22b83e502409a70a0df15e8946d958dbaee4c32b6ebdb38cf6">+5/-11</a></td>
</tr>
<tr>
  <td><strong>ProjectSettingsPagesComboBox.tsx</strong><dd><code>Derive selected settings page from URL; drop sync effect</code></dd></td>
  <td><a href="https://github.com/nhost/nhost/pull/4290/files#diff-18418239a75256fb02b2c116681d609e12428ee3d91a0208a26b5dc8d5234082">+2/-15</a></td>
</tr>
<tr>
  <td><strong>ProjectsComboBox.tsx</strong><dd><code>Derive selected project from URL; remove setSelected on click</code></dd></td>
  <td><a href="https://github.com/nhost/nhost/pull/4290/files#diff-3cce1319c40c935cc1ff9487f6bf9dff402d1da5087fa93be4a8c699eb5f3313">+5/-9</a></td>
</tr>
</table></details></td></tr>
</tbody></table>

</details>

___

<!-- nhost-reviewer:end -->
