### PR TITLE
fix(dashboard): Migrate git page icons

### DIFF
--- a/dashboard/src/features/orgs/projects/git/common/components/ConnectGitHubModal/ConnectGitHubModal.tsx
+++ b/dashboard/src/features/orgs/projects/git/common/components/ConnectGitHubModal/ConnectGitHubModal.tsx
@@ -1,5 +1,10 @@
+import { SiGithub as GitHubIcon } from '@icons-pack/react-simple-icons';
 import { Divider } from '@mui/material';
 import debounce from 'lodash.debounce';
+import {
+  ExternalLink as ArrowSquareOutIcon,
+  CirclePlus as PlusCircleIcon,
+} from 'lucide-react';
 import type { ChangeEvent } from 'react';
 import { Fragment, useEffect, useMemo, useState } from 'react';
 import toast from 'react-hot-toast';
@@ -10,9 +15,6 @@ import { Avatar } from '@/components/ui/v2/Avatar';
 import { Box } from '@/components/ui/v2/Box';
 import { Button } from '@/components/ui/v2/Button';
 import { Input } from '@/components/ui/v2/Input';
-import { ArrowSquareOutIcon } from '@/components/ui/v2/icons/ArrowSquareOutIcon';
-import { GitHubIcon } from '@/components/ui/v2/icons/GitHubIcon';
-import { PlusCircleIcon } from '@/components/ui/v2/icons/PlusCircleIcon';
 import { Link } from '@/components/ui/v2/Link';
 import { List } from '@/components/ui/v2/List';
 import { ListItem } from '@/components/ui/v2/ListItem';
@@ -277,7 +279,7 @@ export default function ConnectGitHubModal({ close }: ConnectGitHubModalProps) {
             className="flex w-72 max-w-72 gap-2"
             onClick={handleConnectGitHub}
           >
-            <GitHubIcon />
+            <GitHubIcon className="h-4 w-4" />
             Connect to GitHub
           </Button>
         </div>

--- a/dashboard/src/features/orgs/projects/git/common/components/EditRepositoryAndBranchSettings/EditRepositoryAndBranchSettings.tsx
+++ b/dashboard/src/features/orgs/projects/git/common/components/EditRepositoryAndBranchSettings/EditRepositoryAndBranchSettings.tsx
@@ -1,8 +1,8 @@
+import { CircleHelp as QuestionMarkCircleIcon } from 'lucide-react';
 import { useFormContext } from 'react-hook-form';
 import { Box } from '@/components/ui/v2/Box';
 import { Input } from '@/components/ui/v2/Input';
 import { InputLabel } from '@/components/ui/v2/InputLabel';
-import { QuestionMarkCircleIcon } from '@/components/ui/v2/icons/QuestionMarkCircleIcon';
 import { Link } from '@/components/ui/v2/Link';
 import type { EditRepositorySettingsFormData } from '@/features/orgs/projects/git/common/components/EditRepositorySettings';
 
@@ -61,7 +61,7 @@ export default function EditRepositoryAndBranchSettings({
                   underline="none"
                   aria-label="Base Directory Documentation"
                 >
-                  <QuestionMarkCircleIcon />
+                  <QuestionMarkCircleIcon className="h-4 w-4" />
                 </Link>
               </InputLabel>
             }

--- a/dashboard/src/features/orgs/projects/git/common/components/EditRepositorySettingsModal/EditRepositorySettingsModal.tsx
+++ b/dashboard/src/features/orgs/projects/git/common/components/EditRepositorySettingsModal/EditRepositorySettingsModal.tsx
@@ -1,8 +1,8 @@
+import { SiGithub as GitHubIcon } from '@icons-pack/react-simple-icons';
 import { useFormContext } from 'react-hook-form';
 import { useDialog } from '@/components/common/DialogProvider';
 import { RetryableErrorBoundary } from '@/components/presentational/RetryableErrorBoundary';
 import { Button } from '@/components/ui/v2/Button';
-import { GitHubIcon } from '@/components/ui/v2/icons/GitHubIcon';
 import { Link } from '@/components/ui/v2/Link';
 import { Text } from '@/components/ui/v2/Text';
 import { Switch } from '@/components/ui/v3/switch';

--- a/dashboard/src/features/orgs/projects/git/settings/components/GitConnectionSettings/GitConnectionSettings.tsx
+++ b/dashboard/src/features/orgs/projects/git/settings/components/GitConnectionSettings/GitConnectionSettings.tsx
@@ -1,8 +1,8 @@
+import { SiGithub as GitHubIcon } from '@icons-pack/react-simple-icons';
 import { useDialog } from '@/components/common/DialogProvider';
 import { SettingsContainer } from '@/components/layout/SettingsContainer';
 import { Box } from '@/components/ui/v2/Box';
 import { Button } from '@/components/ui/v2/Button';
-import { GitHubIcon } from '@/components/ui/v2/icons/GitHubIcon';
 import { Text } from '@/components/ui/v2/Text';
 import { useGitHubModal } from '@/features/orgs/projects/git/common/hooks/useGitHubModal';
 import { useProject } from '@/features/orgs/projects/hooks/useProject';


### PR DESCRIPTION
### Checklist

- [x] No breaking changes
- [x] Tests pass
- [ ] New features have new tests
- [ ] Documentation is updated (if applicable)
- [x] Title of the PR is in the correct format (see below)

<!-- nhost-reviewer:start -->
### **PR Type**
Refactoring

___

### **Description**
- Migrates icons in the dashboard's git pages off the legacy `@/components/ui/v2/icons/*` set.
- Replaces `GitHubIcon` with `SiGithub` from `@icons-pack/react-simple-icons` (aliased to keep the local name).
- Replaces `ArrowSquareOutIcon`, `PlusCircleIcon`, and `QuestionMarkCircleIcon` with their `lucide-react` equivalents (`ExternalLink`, `CirclePlus`, `CircleHelp`), aliased to preserve existing usage.
- Adds explicit `h-4 w-4` sizing classes where the new icons render at default-sized callsites.

___

<details> <summary><h3> File Walkthrough</h3></summary>

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody>
<tr><td><strong>Icon migration</strong></td><td><details><summary>4 files</summary><table>
<tr>
  <td><strong>ConnectGitHubModal.tsx</strong><dd><code>Swap v2 GitHub/ArrowSquareOut/PlusCircle icons for simple-icons + lucide-react equivalents.</code></dd></td>
  <td><a href="https://github.com/nhost/nhost/pull/4291/files#diff-74dbd284940985bc504b2cac300cea3b121b65f23d1299753f01ca0aea73b819">+6/-4</a></td>
</tr>
<tr>
  <td><strong>EditRepositoryAndBranchSettings.tsx</strong><dd><code>Replace QuestionMarkCircleIcon with lucide-react CircleHelp; add explicit size class.</code></dd></td>
  <td><a href="https://github.com/nhost/nhost/pull/4291/files#diff-e19e36c0830816cdd4d73cd058b91295bbfcbe65c37c36fa9a87e9c1f2e3b7ef">+2/-2</a></td>
</tr>
<tr>
  <td><strong>EditRepositorySettingsModal.tsx</strong><dd><code>Swap v2 GitHubIcon for simple-icons SiGithub (aliased).</code></dd></td>
  <td><a href="https://github.com/nhost/nhost/pull/4291/files#diff-eb88f4f79aa0286c7f1d06ff73908f34009e7e9e8b982f54866f157fd81c5c3a">+1/-1</a></td>
</tr>
<tr>
  <td><strong>GitConnectionSettings.tsx</strong><dd><code>Swap v2 GitHubIcon for simple-icons SiGithub (aliased).</code></dd></td>
  <td><a href="https://github.com/nhost/nhost/pull/4291/files#diff-9e7a97afc3500aa2f4b28bdf4acb135925d92a6a595e16a3808b0b90ecc6be58">+1/-1</a></td>
</tr>
</table></details></td></tr>
</tbody></table>

</details>

___

<!-- nhost-reviewer:end -->

