### PR TITLE
fix(dashboard): hide non-trackable functions from the data browser

### DIFF
--- a/dashboard/src/features/orgs/projects/database/dataGrid/components/DataBrowserSidebar/DatabaseObjectListItem.tsx
+++ b/dashboard/src/features/orgs/projects/database/dataGrid/components/DataBrowserSidebar/DatabaseObjectListItem.tsx
@@ -99,7 +99,14 @@ export default function DatabaseObjectListItem({
         );
 
   return (
-    <li className="group pb-1">
+    <li
+      className="group pb-1"
+      ref={(node) => {
+        if (node && isSelected) {
+          node.scrollIntoView({ block: 'nearest' });
+        }
+      }}
+    >
       <Tooltip open={isUntracked ? undefined : false}>
         <TooltipTrigger asChild>
           <Button

--- a/dashboard/src/features/orgs/projects/database/dataGrid/components/DataBrowserSidebar/DatabaseObjectListItem.tsx
+++ b/dashboard/src/features/orgs/projects/database/dataGrid/components/DataBrowserSidebar/DatabaseObjectListItem.tsx
@@ -99,14 +99,7 @@ export default function DatabaseObjectListItem({
         );
 
   return (
-    <li
-      className="group pb-1"
-      ref={(node) => {
-        if (node && isSelected) {
-          node.scrollIntoView({ block: 'nearest' });
-        }
-      }}
-    >
+    <li className="group pb-1">
       <Tooltip open={isUntracked ? undefined : false}>
         <TooltipTrigger asChild>
           <Button

--- a/dashboard/src/features/orgs/projects/database/dataGrid/components/FunctionDefinitionView/FunctionDefinitionView.test.tsx
+++ b/dashboard/src/features/orgs/projects/database/dataGrid/components/FunctionDefinitionView/FunctionDefinitionView.test.tsx
@@ -121,7 +121,6 @@ describe('FunctionDefinitionView', () => {
 
   it('omits the SETOF prefix when returnsSet is false', () => {
     renderWith({ functionMetadata: meta({ returnsSet: false }) });
-    expect(screen.queryByText(/SETOF mytable/)).not.toBeInTheDocument();
     expect(screen.queryByText(/SETOF public\.mytable/)).not.toBeInTheDocument();
   });
 

--- a/dashboard/src/features/orgs/projects/database/dataGrid/components/FunctionDefinitionView/FunctionDefinitionView.test.tsx
+++ b/dashboard/src/features/orgs/projects/database/dataGrid/components/FunctionDefinitionView/FunctionDefinitionView.test.tsx
@@ -121,7 +121,14 @@ describe('FunctionDefinitionView', () => {
 
   it('omits the SETOF prefix when returnsSet is false', () => {
     renderWith({ functionMetadata: meta({ returnsSet: false }) });
-    expect(screen.queryByText(/SETOF/)).not.toBeInTheDocument();
+    expect(screen.queryByText(/SETOF mytable/)).not.toBeInTheDocument();
+    expect(screen.queryByText(/SETOF public\.mytable/)).not.toBeInTheDocument();
+  });
+
+  it('shows the SETOF alert when the function does not return a set', () => {
+    renderWith({ functionMetadata: meta({ returnsSet: false }) });
+    expect(screen.getByText('Not exposable in GraphQL')).toBeInTheDocument();
+    expect(screen.getByText(/doesn't return a SETOF/)).toBeInTheDocument();
   });
 
   it('renders the source definition panel with an Edit button when a definition is present', () => {

--- a/dashboard/src/features/orgs/projects/database/dataGrid/components/FunctionDefinitionView/FunctionDefinitionView.tsx
+++ b/dashboard/src/features/orgs/projects/database/dataGrid/components/FunctionDefinitionView/FunctionDefinitionView.tsx
@@ -134,17 +134,25 @@ export default function FunctionDefinitionView() {
     functionMetadata.parameters.length - functionMetadata.defaultArgsCount;
 
   const isCompositeReturn = functionMetadata.returnTypeKind === 'c';
-  const isTrackable = isCompositeReturn && !functionMetadata.hasVariadic;
+  const { returnsSet, hasVariadic } = functionMetadata;
+  const isTrackable = isCompositeReturn && returnsSet && !hasVariadic;
 
   const returnTypeDisplay = functionMetadata.returnTableName
     ? `${functionMetadata.returnTableSchema}.${functionMetadata.returnTableName}`
     : functionMetadata.returnTypeName;
 
-  const returnPrefix = functionMetadata.returnsSet ? 'SETOF ' : '';
+  const returnPrefix = returnsSet ? 'SETOF ' : '';
 
-  const nonTrackableReason = !isCompositeReturn
-    ? `This function returns the type "${functionMetadata.returnTypeName}", so it can't be exposed in GraphQL.`
-    : "This function uses VARIADIC arguments, so it can't be exposed in GraphQL.";
+  let nonTrackableReason: string;
+  if (!isCompositeReturn) {
+    nonTrackableReason = `This function returns the type "${functionMetadata.returnTypeName}", so it can't be exposed in GraphQL.`;
+  } else if (!returnsSet) {
+    nonTrackableReason =
+      "This function doesn't return a SETOF, so it can't be exposed in GraphQL.";
+  } else {
+    nonTrackableReason =
+      "This function uses VARIADIC arguments, so it can't be exposed in GraphQL.";
+  }
 
   return (
     <div className="flex h-full flex-col overflow-y-auto">

--- a/dashboard/src/features/orgs/projects/database/dataGrid/components/FunctionDefinitionView/FunctionDefinitionView.tsx
+++ b/dashboard/src/features/orgs/projects/database/dataGrid/components/FunctionDefinitionView/FunctionDefinitionView.tsx
@@ -216,40 +216,29 @@ export default function FunctionDefinitionView() {
                 </>
               )}{' '}
               · Returns{' '}
-              <InlineCode className="bg-opacity-80 px-1 text-xs">
+              <InlineCode className="bg-opacity-80 px-1 text-sm">
                 {returnPrefix}
                 {returnTypeDisplay}
               </InlineCode>
             </p>
           </div>
-          <div className="flex flex-wrap gap-2">
-            {functionMetadata.functionType && (
-              <Badge variant="outline" className="font-medium">
-                {functionMetadata.functionType}
-              </Badge>
-            )}
-            <Badge variant="outline" className="font-medium">
-              {returnPrefix}
-              {functionMetadata.returnTypeName}
-            </Badge>
-            {functionMetadata.returnTableName && (
-              <Badge variant="outline" className="font-medium">
-                Returns table: {functionMetadata.returnTableSchema}.
-                {functionMetadata.returnTableName}
-              </Badge>
-            )}
-            {functionMetadata.hasVariadic && (
-              <Badge variant="outline" className="font-medium">
-                VARIADIC
-              </Badge>
-            )}
-            {functionMetadata.functionType === 'STABLE' ||
-            functionMetadata.functionType === 'IMMUTABLE' ? (
-              <Badge variant="outline" className="font-medium">
-                Query-only
-              </Badge>
-            ) : null}
-          </div>
+          {(hasVariadic ||
+            functionMetadata.functionType === 'STABLE' ||
+            functionMetadata.functionType === 'IMMUTABLE') && (
+            <div className="mt-3 flex flex-wrap gap-2">
+              {hasVariadic && (
+                <Badge variant="outline" className="font-medium">
+                  VARIADIC
+                </Badge>
+              )}
+              {(functionMetadata.functionType === 'STABLE' ||
+                functionMetadata.functionType === 'IMMUTABLE') && (
+                <Badge variant="outline" className="font-medium">
+                  Query-only
+                </Badge>
+              )}
+            </div>
+          )}
         </div>
         {functionMetadata.parameters.length > 0 && (
           <div className="mt-4 rounded-md border bg-muted/20 p-4">
@@ -264,11 +253,11 @@ export default function FunctionDefinitionView() {
                   <span className="w-32 font-medium">
                     {param.name || `arg${index + 1}`}
                   </span>
-                  <InlineCode className="bg-opacity-80 px-1.5 text-xs">
+                  <InlineCode className="bg-opacity-80 px-1.5 text-sm">
                     {param.displayType}
                   </InlineCode>
                   {index >= requiredParamsCount && (
-                    <span className="text-muted-foreground text-xs italic">
+                    <span className="text-muted-foreground text-sm italic">
                       optional
                     </span>
                   )}

--- a/dashboard/src/features/orgs/projects/database/dataGrid/hooks/useDatabaseQuery/fetchDatabase.ts
+++ b/dashboard/src/features/orgs/projects/database/dataGrid/hooks/useDatabaseQuery/fetchDatabase.ts
@@ -77,7 +77,8 @@ export default async function fetchDatabase({
             JOIN pg_type ON p.prorettype = pg_type.oid
             WHERE n.nspname NOT LIKE 'pg_%'
               AND n.nspname != 'information_schema'
-              AND pg_type.typtype ='c'
+              AND pg_type.typtype = 'c'
+              AND p.proretset = true
               AND p.provariadic = 0
             ORDER BY p.proname ASC
           ) func_data`,


### PR DESCRIPTION
### Checklist

- [X] No breaking changes
- [X] Tests pass
- [X] New features have new tests
- [X] Documentation is updated (if applicable)
- [X] Title of the PR is in the correct format (see below)

<!-- nhost-reviewer:start -->
### **PR Type**
Bug fix

___

### **Description**
- Filter the data-browser function list SQL query so it only returns set-returning composite functions (`p.proretset = true`), matching Hasura's GraphQL-trackability rules and hiding entries that can never be tracked.
- Tighten `isTrackable` in `FunctionDefinitionView` to require `returnsSet`, so the "Track function" button no longer appears for non-SETOF composite functions.
- Add a dedicated "doesn't return a SETOF" branch to `nonTrackableReason` so users who reach a non-SETOF function via a direct URL get an accurate explanation instead of the misleading VARIADIC message.
- Consolidate the function-definition header: drop the redundant return-type / return-table / function-type badges (now expressed inline in the description text), keep only the VARIADIC and Query-only badges, and bump inline-code / parameter text from `text-xs` to `text-sm` for legibility.
- Tighten the existing `returnsSet === false` test (the bare `/SETOF/` regex now collides with the alert copy) and add a new test that asserts the SETOF alert renders for non-set-returning functions.

___

### Diagram Walkthrough

```mermaid
flowchart LR
  A["pg_proc query<br/>(fetchDatabase.ts)"] -->|"+ proretset = true"| B["DataBrowserSidebar<br/>function list"]
  C["Direct URL navigation<br/>by function OID"] --> D["useFunctionQuery<br/>(unfiltered)"]
  D --> E["FunctionDefinitionView"]
  E -->|"!returnsSet"| F["'doesn't return a SETOF' alert"]
  E -->|"returnsSet &&<br/>composite &&<br/>!variadic"| G["TrackFunctionButton"]
```

<details> <summary><h3> File Walkthrough</h3></summary>

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody>
<tr><td><strong>Core logic</strong></td><td><details><summary>2 files</summary><table>
<tr>
  <td><strong>fetchDatabase.ts</strong><dd><code>Filter pg_proc query to only set-returning composite functions</code></dd></td>
  <td><a href="https://github.com/nhost/nhost/pull/4294/files#diff-af0053eb0760ab67aec49f66890f35435f7f7696d4c948e953d12ff8f3c57b56">+2/-1</a></td>
</tr>
<tr>
  <td><strong>FunctionDefinitionView.tsx</strong><dd><code>Require returnsSet for trackability, add SETOF alert branch, collapse redundant badges, bump text sizes</code></dd></td>
  <td><a href="https://github.com/nhost/nhost/pull/4294/files#diff-6dd6c35e2bf85c39495bef4c6afe505c73f8034502f439204f7913e3f7d7f99b">+33/-36</a></td>
</tr>
</table></details></td></tr>
<tr><td><strong>Tests</strong></td><td><details><summary>1 file</summary><table>
<tr>
  <td><strong>FunctionDefinitionView.test.tsx</strong><dd><code>Tighten the SETOF-prefix-absence assertion and add a new test for the SETOF non-trackable alert</code></dd></td>
  <td><a href="https://github.com/nhost/nhost/pull/4294/files#diff-81632a69d7dfddf80f10e94609ecdb38c73eaabcde0f982da08f2d4ddce93481">+7/-1</a></td>
</tr>
</table></details></td></tr>
</tbody></table>

</details>

___

<!-- nhost-reviewer:end -->
