### PR TITLE
fix(dashboard): prevent SQL editor from shrinking data browser sidebar

### DIFF
--- a/dashboard/src/pages/orgs/[orgSlug]/projects/[appSubdomain]/database/browser/[dataSourceSlug]/editor.tsx
+++ b/dashboard/src/pages/orgs/[orgSlug]/projects/[appSubdomain]/database/browser/[dataSourceSlug]/editor.tsx
@@ -25,7 +25,7 @@ Editor.getLayout = function getLayout(page: ReactElement) {
     >
       <DataBrowserSidebar />
       <RetryableErrorBoundary>
-        <div className="flex w-full flex-col">{page}</div>
+        <div className="flex w-full flex-col overflow-x-hidden">{page}</div>
       </RetryableErrorBoundary>
     </OrgLayout>
   );


### PR DESCRIPTION
This change prevents the sidebar from shrinking after you type a long line in the SQL editor (screenshot attached as reference)

<img width="1710" height="993" alt="Screenshot 2026-05-16 at 13 41 59" src="https://github.com/user-attachments/assets/45db232b-148b-445d-bc25-e3bf1b1e0810" />

### Checklist

- [X] No breaking changes
- [X] Tests pass
- [X] New features have new tests
- [X] Documentation is updated (if applicable)
- [X] Title of the PR is in the correct format (see below)

<!-- nhost-reviewer:start -->
### **PR Type**
Bug fix

___

### **Description**
- Adds `overflow-x-hidden` to the page-content wrapper of the SQL editor route so that long lines typed in the editor cannot widen the flex container and shrink the sibling `DataBrowserSidebar`.
- Aligns the editor route's layout wrapper with the pattern already used by the sibling database-browser routes (`index.tsx`, `[tableSlug].tsx`, `[functionOID].tsx`), which already include `overflow-x-hidden` on their page wrappers.

___

<details> <summary><h3> File Walkthrough</h3></summary>

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody>
<tr><td><strong>Bug fix</strong></td><td><details><summary>1 files</summary><table>
<tr>
  <td><strong>editor.tsx</strong><dd><code>Add overflow-x-hidden to the SQL editor page wrapper to stop long lines from shrinking the data-browser sidebar.</code></dd></td>
  <td><a href="https://github.com/nhost/nhost/pull/4295/files#diff-3092dd85115f09fb62be31613345bc4d21a1872908c4ffbff5b0c71757207e7d">+1/-1</a></td>
</tr>
</table></details></td></tr>
</tbody></table>

</details>

___

<!-- nhost-reviewer:end -->
