### PR TITLE
fix(dashboard): Do not call onSubmit on cancel in create/edit table forms

### DIFF
--- a/dashboard/src/features/orgs/projects/database/dataGrid/components/BaseTableForm/BaseTableForm.test.tsx
+++ b/dashboard/src/features/orgs/projects/database/dataGrid/components/BaseTableForm/BaseTableForm.test.tsx
@@ -28,6 +28,7 @@ Object.defineProperty(HTMLElement.prototype, 'getBoundingClientRect', {
 
 const mocks = vi.hoisted(() => ({
   onSubmit: vi.fn(),
+  onCancel: vi.fn(),
 }));
 
 const defaultFormValues = {
@@ -60,7 +61,11 @@ function TestTableFormWrapper({ defaultValues = defaultFormValues }: any) {
 
   return (
     <FormProvider {...form}>
-      <BaseTableForm onSubmit={mocks.onSubmit} submitButtonText="Save" />
+      <BaseTableForm
+        onSubmit={mocks.onSubmit}
+        onCancel={mocks.onCancel}
+        submitButtonText="Save"
+      />
     </FormProvider>
   );
 }
@@ -125,6 +130,7 @@ async function fillColumnForm(
 describe('BaseTableForm', () => {
   beforeEach(() => {
     mocks.onSubmit.mockClear();
+    mocks.onCancel.mockClear();
   });
 
   it('should not disable the nullable and unique checkboxes after setting the column name', async () => {
@@ -522,6 +528,53 @@ describe('BaseTableForm', () => {
         type: 'int2',
       },
     ]);
+  });
+
+  it('should not call onSubmit when the Cancel button is clicked, even with a valid form', async () => {
+    render(<TestTableFormWrapper />);
+
+    const user = new TestUserEvent();
+
+    await user.type(screen.getByTestId('tableNameInput'), 'test_table');
+
+    await fillColumnForm(
+      {
+        columnName: 'id',
+        optionName: /^uuid.*uuid/,
+        typeValue: 'uuid',
+        defaultValue: 'gen_random_uuid()',
+        defaultValueKind: 'function',
+      },
+      0,
+      user,
+    );
+
+    const cancelButton = screen.getByRole('button', { name: 'Cancel' });
+    // Without type="button", the button defaults to type="submit" inside the
+    // <form> and clicking Cancel would submit the form.
+    expect(cancelButton).toHaveAttribute('type', 'button');
+
+    await TestUserEvent.fireClickEvent(cancelButton);
+
+    expect(mocks.onSubmit).not.toHaveBeenCalled();
+    expect(mocks.onCancel).toHaveBeenCalledTimes(1);
+  });
+
+  it('should call onCancel without triggering form submission on an untouched form', async () => {
+    render(<TestTableFormWrapper />);
+
+    const cancelButton = screen.getByRole('button', { name: 'Cancel' });
+    // Without type="button", the button defaults to type="submit" inside the
+    // <form> and clicking Cancel would submit the form.
+    expect(cancelButton).toHaveAttribute('type', 'button');
+
+    await TestUserEvent.fireClickEvent(cancelButton);
+
+    expect(mocks.onSubmit).not.toHaveBeenCalled();
+    expect(mocks.onCancel).toHaveBeenCalledTimes(1);
+    expect(
+      screen.queryByText('This field is required.'),
+    ).not.toBeInTheDocument();
   });
 
   it('should submit a colliding default as a literal when the user picks the create item', async () => {

--- a/dashboard/src/features/orgs/projects/database/dataGrid/components/BaseTableForm/BaseTableForm.tsx
+++ b/dashboard/src/features/orgs/projects/database/dataGrid/components/BaseTableForm/BaseTableForm.tsx
@@ -1,4 +1,4 @@
-import { useEffect, useState } from 'react';
+import { type MouseEvent, useEffect, useState } from 'react';
 import { useFormContext, useFormState } from 'react-hook-form';
 import * as Yup from 'yup';
 import { useDialog } from '@/components/common/DialogProvider';
@@ -138,6 +138,8 @@ function NameInput() {
   );
 }
 
+const DIRTY_SOURCE_ID = 'base-table-form';
+
 const ACCORDION_SECTION_VALUES = [
   'columns',
   'foreignKeys',
@@ -149,24 +151,21 @@ const ACCORDION_SECTION_VALUES = [
 function FormFooter({
   onCancel,
   submitButtonText,
-  location,
   onSubmitClick,
-}: Pick<BaseTableFormProps, 'onCancel' | 'submitButtonText'> &
-  Pick<DialogFormProps, 'location'> & { onSubmitClick?: VoidFunction }) {
-  const { onDirtyStateChange } = useDialog();
-  const { isSubmitting, dirtyFields } = useFormState();
+}: Pick<BaseTableFormProps, 'onCancel' | 'submitButtonText'> & {
+  onSubmitClick?: VoidFunction;
+}) {
+  const { closeDrawerWithDirtyGuard } = useDialog();
+  const { isSubmitting } = useFormState();
 
-  // react-hook-form's isDirty gets true even if an input field is focused, then
-  // immediately unfocused - we can't rely on that information
-  const isDirty = Object.keys(dirtyFields).length > 0;
-
-  useEffect(() => {
-    onDirtyStateChange(isDirty, location);
-  }, [isDirty, location, onDirtyStateChange]);
+  const handleCancel = (event: MouseEvent<HTMLButtonElement>) => {
+    onCancel?.();
+    closeDrawerWithDirtyGuard(event);
+  };
 
   return (
     <div className="box grid flex-shrink-0 grid-flow-col justify-between gap-3 border-t-1 p-2">
-      <Button variant="ghost" onClick={onCancel} tabIndex={isDirty ? -1 : 0}>
+      <Button type="button" variant="ghost" onClick={handleCancel}>
         Cancel
       </Button>
 
@@ -197,6 +196,25 @@ export default function BaseTableForm({
     'columns',
     'foreignKeys',
   ]);
+  const { setDirtySource } = useDialog();
+  const form = useFormContext();
+
+  useEffect(() => {
+    const unsubscribe = form.subscribe({
+      formState: { dirtyFields: true },
+      callback: ({ dirtyFields }) => {
+        setDirtySource(
+          DIRTY_SOURCE_ID,
+          Object.keys(dirtyFields ?? {}).length > 0,
+          location,
+        );
+      },
+    });
+    return () => {
+      unsubscribe();
+      setDirtySource(DIRTY_SOURCE_ID, false, location);
+    };
+  }, [form, setDirtySource, location]);
 
   const showSchemaPicker =
     !!onSchemaChange && !!availableSchemas && availableSchemas.length > 0;
@@ -269,7 +287,6 @@ export default function BaseTableForm({
       <FormFooter
         onCancel={onCancel}
         submitButtonText={submitButtonText}
-        location={location}
         onSubmitClick={() => setOpenSections([...ACCORDION_SECTION_VALUES])}
       />
     </Form>


### PR DESCRIPTION
<!-- nhost-reviewer:start -->
### **PR Type**
Enhancement

___

### **Description**
- Migrates `BaseTableForm`'s `FormFooter` from the deprecated `onDirtyStateChange` API to the new `setDirtySource` registry on `DialogProvider`, scoped under the stable id `base-table-form`.
- Replaces the `useFormState({ dirtyFields })` re-render path with a `form.subscribe({ formState: { dirtyFields: true } })` subscription, and clears the source on unmount.
- Hardens the Cancel button by setting `type="button"` (so it never acts as a form submit) and removes the previous `tabIndex={isDirty ? -1 : 0}` workaround.
- Adds a regression test asserting that clicking Cancel does not invoke `onSubmit`.

___

<details> <summary><h3> File Walkthrough</h3></summary>

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody>
<tr><td><strong>Core logic</strong></td><td><details><summary>1 files</summary><table>
<tr>
  <td><strong>BaseTableForm.tsx</strong><dd><code>Switch FormFooter to setDirtySource + form.subscribe; harden Cancel button</code></dd></td>
  <td><a href="https://github.com/nhost/nhost/pull/4296/files#diff-33e0bcf77738162f71af2ab673966d2e61d1e270ad09179c23e2d29d18582f80">+23/-9</a></td>
</tr>
</table></details></td></tr>
<tr><td><strong>Tests</strong></td><td><details><summary>1 files</summary><table>
<tr>
  <td><strong>BaseTableForm.test.tsx</strong><dd><code>Add test that Cancel does not trigger onSubmit</code></dd></td>
  <td><a href="https://github.com/nhost/nhost/pull/4296/files#diff-76c87617e7921fd6eb4bf7bb18f98a702dbc95e7b6d9342a9c1befa88c7f8fb6">+11/-0</a></td>
</tr>
</table></details></td></tr>
</tbody></table>

</details>

___

<!-- nhost-reviewer:end -->
