### PR TITLE
chore(dashboard): migrated remaining baseTableForm v2 to v3 follow-up.

### DIFF
--- a/dashboard/src/components/form/ControlledAutocomplete/ControlledAutocomplete.tsx
+++ b/dashboard/src/components/form/ControlledAutocomplete/ControlledAutocomplete.tsx
@@ -1,117 +1,103 @@
-import type { FilterOptionsState } from '@mui/material';
-import type { ForwardedRef } from 'react';
-import { forwardRef } from 'react';
-import type { FieldValues, UseControllerProps } from 'react-hook-form';
-import { useController, useFormContext } from 'react-hook-form';
-import { mergeRefs } from 'react-merge-refs';
-import type {
-  AutocompleteOption,
-  AutocompleteProps,
-} from '@/components/ui/v2/Autocomplete';
-import { Autocomplete } from '@/components/ui/v2/Autocomplete';
-import { isNotEmptyValue } from '@/lib/utils';
-import type { MakeRequired } from '@/types/common';
-import { callAll } from '@/utils/callAll';
+import type { FilterOptionsState } from '@mui/material'
+import type { ForwardedRef } from 'react'
+import { forwardRef } from 'react'
+import type { FieldValues, UseControllerProps } from 'react-hook-form'
+import { useController, useFormContext } from 'react-hook-form'
+import { mergeRefs } from 'react-merge-refs'
+import type { AutocompleteOption } from '@/components/ui/types'
+import type { AutocompleteProps } from '@/components/ui/v2/Autocomplete'
+import { Autocomplete } from '@/components/ui/v2/Autocomplete'
+import { isNotEmptyValue } from '@/lib/utils'
+import type { MakeRequired } from '@/types/common'
+import { callAll } from '@/utils/callAll'
 
 export interface ControlledAutocompleteProps<
   TOption extends AutocompleteOption = AutocompleteOption,
   // biome-ignore lint/suspicious/noExplicitAny: TODO
-  TFieldValues extends FieldValues = any,
+  TFieldValues extends FieldValues = any
 > extends AutocompleteProps<TOption> {
   /**
    * Props passed to the react-hook-form controller.
    */
-  controllerProps?: UseControllerProps<TFieldValues>;
+  controllerProps?: UseControllerProps<TFieldValues>
   /**
    * Name of the input field.
    */
-  name?: string;
+  name?: string
   /**
    * Control for the input field.
    */
-  control?: UseControllerProps<TFieldValues>['control'];
+  control?: UseControllerProps<TFieldValues>['control']
 }
 
 export function defaultFilterOptions(
   options: AutocompleteOption<string>[],
-  { inputValue }: FilterOptionsState<AutocompleteOption<string>>,
+  { inputValue }: FilterOptionsState<AutocompleteOption<string>>
 ) {
-  const inputValueLower = inputValue.toLowerCase();
-  const matched: AutocompleteOption<string>[] = [];
-  const otherOptions: AutocompleteOption<string>[] = [];
+  const inputValueLower = inputValue.toLowerCase()
+  const matched: AutocompleteOption<string>[] = []
+  const otherOptions: AutocompleteOption<string>[] = []
 
   options.forEach((option) => {
-    const optionLabelLower = option.label.toLowerCase();
+    const optionLabelLower = option.label.toLowerCase()
 
     if (optionLabelLower.startsWith(inputValueLower)) {
-      matched.push(option);
+      matched.push(option)
     } else {
-      otherOptions.push(option);
+      otherOptions.push(option)
     }
-  });
+  })
 
-  const result = [...matched, ...otherOptions];
+  const result = [...matched, ...otherOptions]
 
-  return result;
+  return result
 }
 
 export function defaultFilterGroupedOptions(
   options: AutocompleteOption<string>[],
-  { inputValue }: FilterOptionsState<AutocompleteOption<string>>,
+  { inputValue }: FilterOptionsState<AutocompleteOption<string>>
 ) {
-  const optionsWithGroup = options as MakeRequired<
-    AutocompleteOption<string>,
-    'group'
-  >[];
-  const inputValueLower = inputValue.toLowerCase();
-  const matchedSet = new Set<string>();
-  const otherOptionsSet = new Set<string>();
+  const optionsWithGroup = options as MakeRequired<AutocompleteOption<string>, 'group'>[]
+  const inputValueLower = inputValue.toLowerCase()
+  const matchedSet = new Set<string>()
+  const otherOptionsSet = new Set<string>()
 
   optionsWithGroup.forEach((option) => {
-    const optionLabelLower = option.label.toLowerCase();
+    const optionLabelLower = option.label.toLowerCase()
 
     if (optionLabelLower.includes(inputValueLower)) {
-      matchedSet.add(option.group);
-      otherOptionsSet.delete(option.group);
+      matchedSet.add(option.group)
+      otherOptionsSet.delete(option.group)
     } else if (!matchedSet.has(option.group)) {
-      otherOptionsSet.add(option.group);
+      otherOptionsSet.add(option.group)
     }
-  });
-  const matchedOptions = optionsWithGroup.filter((option) =>
-    matchedSet.has(option.group),
-  );
-  const otherOptions = optionsWithGroup.filter((option) =>
-    otherOptionsSet.has(option.group),
-  );
+  })
+  const matchedOptions = optionsWithGroup.filter((option) => matchedSet.has(option.group))
+  const otherOptions = optionsWithGroup.filter((option) => otherOptionsSet.has(option.group))
 
-  const result = [...matchedOptions, ...otherOptions];
+  const result = [...matchedOptions, ...otherOptions]
 
-  return result;
+  return result
 }
 
 export default forwardRef(
   (
-    {
-      controllerProps,
-      name,
-      control,
-      ...props
-    }: ControlledAutocompleteProps<AutocompleteOption>,
-    ref: ForwardedRef<HTMLInputElement>,
+    { controllerProps, name, control, ...props }: ControlledAutocompleteProps<AutocompleteOption>,
+    ref: ForwardedRef<HTMLInputElement>
   ) => {
-    const form = useFormContext();
-    const nameAttr = controllerProps?.name || name || '';
+    const form = useFormContext()
+    const nameAttr = controllerProps?.name || name || ''
     const { field } = useController({
       ...(controllerProps || {}),
       name: nameAttr,
-      control: controllerProps?.control || control,
-    });
+      control: controllerProps?.control || control
+    })
 
     if (!form) {
-      throw new Error('ControlledAutocomplete must be used in a FormContext.');
+      throw new Error('ControlledAutocomplete must be used in a FormContext.')
     }
 
-    const { setValue } = form || {};
+    const { setValue } = form || {}
 
     return (
       <Autocomplete
@@ -125,18 +111,15 @@ export default forwardRef(
         ref={mergeRefs([field.ref, ref])}
         onChange={(event, options, reason, details) => {
           setValue?.(nameAttr, options, {
-            shouldDirty: true,
-          });
+            shouldDirty: true
+          })
 
           if (props.onChange) {
-            props.onChange(event, options, reason, details);
+            props.onChange(event, options, reason, details)
           }
         }}
-        onBlur={callAll<[React.FocusEvent<HTMLDivElement>]>(
-          field.onBlur,
-          props.onBlur,
-        )}
+        onBlur={callAll<[React.FocusEvent<HTMLDivElement>]>(field.onBlur, props.onBlur)}
       />
-    );
-  },
-);
+    )
+  }
+)

--- a/dashboard/src/components/ui/types.ts
+++ b/dashboard/src/components/ui/types.ts
@@ -1,0 +1,30 @@
+/**
+ * Option type for Autocomplete components.
+ */
+export interface AutocompleteOption<TValue = string> {
+  /**
+   * Label to display.
+   */
+  label: string
+  /**
+   * Label to display in the dropdown.
+   */
+  dropdownLabel?: string
+  /**
+   * Value to be submitted.
+   */
+  value: TValue
+  /**
+   * Determines whether the option is custom.
+   */
+  custom?: boolean
+  /**
+   * Value that can be used to group options.
+   */
+  group?: string
+  /**
+   * Any additional data to be passed to the option.
+   */
+  // biome-ignore lint/suspicious/noExplicitAny: TODO
+  metadata?: any
+}

--- a/dashboard/src/components/ui/v2/Autocomplete/Autocomplete.tsx
+++ b/dashboard/src/components/ui/v2/Autocomplete/Autocomplete.tsx
@@ -1,56 +1,31 @@
-import type { StyledComponent } from '@emotion/styled';
-import { Popper } from '@mui/base';
-import type { UseAutocompleteProps } from '@mui/base/useAutocomplete';
-import { createFilterOptions } from '@mui/base/useAutocomplete';
-import { styled } from '@mui/material';
-import type { AutocompleteProps as MaterialAutocompleteProps } from '@mui/material/Autocomplete';
+import type { StyledComponent } from '@emotion/styled'
+import { Popper } from '@mui/base'
+import type { UseAutocompleteProps } from '@mui/base/useAutocomplete'
+import { createFilterOptions } from '@mui/base/useAutocomplete'
+import { styled } from '@mui/material'
+import type { AutocompleteProps as MaterialAutocompleteProps } from '@mui/material/Autocomplete'
 import MaterialAutocomplete, {
-  autocompleteClasses as materialAutocompleteClasses,
-} from '@mui/material/Autocomplete';
-import clsx from 'clsx';
-import type { DetailedHTMLProps, ForwardedRef, HTMLProps } from 'react';
-import { forwardRef, useEffect, useState } from 'react';
-import { Chip } from '@/components/ui/v2/Chip';
-import type { FormControlProps } from '@/components/ui/v2/FormControl';
-import type { InputProps } from '@/components/ui/v2/Input';
-import { Input, inputClasses } from '@/components/ui/v2/Input';
-import { CheckIcon } from '@/components/ui/v2/icons/CheckIcon';
-import { ChevronDownIcon } from '@/components/ui/v2/icons/ChevronDownIcon';
-import { XIcon } from '@/components/ui/v2/icons/XIcon';
-import { OptionBase } from '@/components/ui/v2/Option';
-import { OptionGroupBase } from '@/components/ui/v2/OptionGroup';
+  autocompleteClasses as materialAutocompleteClasses
+} from '@mui/material/Autocomplete'
+import clsx from 'clsx'
+import type { DetailedHTMLProps, ForwardedRef, HTMLProps } from 'react'
+import { forwardRef, useEffect, useState } from 'react'
+import { Chip } from '@/components/ui/v2/Chip'
+import type { FormControlProps } from '@/components/ui/v2/FormControl'
+import type { InputProps } from '@/components/ui/v2/Input'
+import { Input, inputClasses } from '@/components/ui/v2/Input'
+import { CheckIcon } from '@/components/ui/v2/icons/CheckIcon'
+import { ChevronDownIcon } from '@/components/ui/v2/icons/ChevronDownIcon'
+import { XIcon } from '@/components/ui/v2/icons/XIcon'
+import { OptionBase } from '@/components/ui/v2/Option'
+import { OptionGroupBase } from '@/components/ui/v2/OptionGroup'
+import type { AutocompleteOption } from '@/components/ui/types'
 
-export interface AutocompleteOption<TValue = string> {
-  /**
-   * Label to display.
-   */
-  label: string;
-  /**
-   * Label to display in the dropdown.
-   */
-  dropdownLabel?: string;
-  /**
-   * Value to be submitted.
-   */
-  value: TValue;
-  /**
-   * Determines whether the option is custom.
-   */
-  custom?: boolean;
-  /**
-   * Value that can be used to group options.
-   */
-  group?: string;
-  /**
-   * Any additional data to be passed to the option.
-   */
-  // biome-ignore lint/suspicious/noExplicitAny: TODO
-  metadata?: any;
-}
+export type { AutocompleteOption }
 
-export interface AutocompleteProps<
-  TOption extends AutocompleteOption = AutocompleteOption,
-> extends Omit<
+export interface AutocompleteProps<TOption extends AutocompleteOption = AutocompleteOption>
+  extends
+    Omit<
       MaterialAutocompleteProps<TOption, boolean, boolean, boolean>,
       'renderInput' | 'autoSelect' | 'componentsProps' | 'isOptionEqualToValue'
     >,
@@ -68,94 +43,88 @@ export interface AutocompleteProps<
   /**
    * Props for component slots.
    */
-  slotProps?: MaterialAutocompleteProps<
-    TOption,
-    boolean,
-    boolean,
-    boolean
-  >['componentsProps'] & {
+  slotProps?: MaterialAutocompleteProps<TOption, boolean, boolean, boolean>['componentsProps'] & {
     /**
      * Props passed to the root element.
      */
     // biome-ignore lint/suspicious/noExplicitAny: TODO
-    root?: Partial<UseAutocompleteProps<any, boolean, boolean, boolean>>;
+    root?: Partial<UseAutocompleteProps<any, boolean, boolean, boolean>>
     /**
      * Props passed to the input component.
      */
-    input?: Partial<Omit<InputProps, 'ref'>>;
-    inputRoot?: Partial<
-      DetailedHTMLProps<HTMLProps<HTMLInputElement>, HTMLInputElement>
-    > & { 'data-testid'?: string };
+    input?: Partial<Omit<InputProps, 'ref'>>
+    inputRoot?: Partial<DetailedHTMLProps<HTMLProps<HTMLInputElement>, HTMLInputElement>> & {
+      'data-testid'?: string
+    }
     /**
      * Props passed to the input's `FormControl` component.
      */
-    formControl?: Partial<FormControlProps>;
-  };
+    formControl?: Partial<FormControlProps>
+  }
   /**
    * Name of the input field.
    */
-  name?: string;
+  name?: string
   /**
    * Function to be used to conditionally decide if the highlighted option
    * should automatically be selected on blur.
    */
-  autoSelect?: boolean | ((filteredOptions?: AutocompleteOption[]) => boolean);
+  autoSelect?: boolean | ((filteredOptions?: AutocompleteOption[]) => boolean)
   /**
    * Show custom option at the end of filtered options.
    *
    * @default 'never'
    */
-  showCustomOption?: 'always' | 'never' | 'auto' | 'first';
+  showCustomOption?: 'always' | 'never' | 'auto' | 'first'
   /**
    * Custom option label.
    */
-  customOptionLabel?: string | ((customOptionLabel: string) => string);
+  customOptionLabel?: string | ((customOptionLabel: string) => string)
   isOptionEqualToValue?: (
     option: AutocompleteOption<string>,
-    value: string | AutocompleteOption<string>,
-  ) => boolean;
+    value: string | AutocompleteOption<string>
+  ) => boolean
 
   sortByOptions?: (
     option1: AutocompleteOption<string>,
-    option2: AutocompleteOption<string>,
-  ) => number;
+    option2: AutocompleteOption<string>
+  ) => number
 }
 
 const StyledTag = styled(Chip)(({ theme }) => ({
   fontSize: theme.typography.pxToRem(15),
   lineHeight: theme.typography.pxToRem(22),
   color: theme.palette.text.primary,
-  fontWeight: 400,
-}));
+  fontWeight: 400
+}))
 
 const StyledAutocomplete = styled(MaterialAutocomplete)(({ theme }) => ({
   [`&:not(.${materialAutocompleteClasses.focused})`]: {
     [`& .${inputClasses.root}`]: {
       maxHeight: 40,
-      overflow: 'auto',
-    },
+      overflow: 'auto'
+    }
   },
   [`.${materialAutocompleteClasses.endAdornment}`]: {
-    right: theme.spacing(1.5),
+    right: theme.spacing(1.5)
   },
   [`.${materialAutocompleteClasses.input}`]: {
-    paddingRight: theme.spacing(3),
+    paddingRight: theme.spacing(3)
   },
-  [`.${materialAutocompleteClasses.endAdornment} .${materialAutocompleteClasses.popupIndicator}`]:
-    {
-      color: theme.palette.text.secondary,
-    },
+  [`.${materialAutocompleteClasses.endAdornment} .${materialAutocompleteClasses.popupIndicator}`]: {
+    color: theme.palette.text.secondary
+  }
   // biome-ignore lint/suspicious/noExplicitAny: TODO
 })) as any as StyledComponent<
   MaterialAutocompleteProps<AutocompleteOption, boolean, boolean, boolean>
->;
+>
 
 const StyledOptionBase = styled(OptionBase)(({ theme }) => ({
   display: 'grid !important',
   gridAutoFlow: 'column',
   justifyContent: 'space-between !important',
-  gap: theme.spacing(0.5),
-}));
+  gap: theme.spacing(0.5)
+}))
 
 export const AutocompletePopper = styled(Popper)(({ theme }) => ({
   zIndex: theme.zIndex.modal + 1,
@@ -166,13 +135,10 @@ export const AutocompletePopper = styled(Popper)(({ theme }) => ({
     borderRadius: theme.shape.borderRadius,
     overflow: 'hidden',
     backgroundColor:
-      theme.palette.mode === 'dark'
-        ? theme.palette.secondary[100]
-        : theme.palette.common.white,
+      theme.palette.mode === 'dark' ? theme.palette.secondary[100] : theme.palette.common.white,
     borderWidth: theme.palette.mode === 'dark' ? 1 : 0,
-    borderColor:
-      theme.palette.mode === 'dark' ? theme.palette.grey[400] : 'none',
-    boxShadow: `0px 1px 4px rgba(14, 24, 39, 0.1), 0px 8px 24px rgba(14, 24, 39, 0.1)`,
+    borderColor: theme.palette.mode === 'dark' ? theme.palette.grey[400] : 'none',
+    boxShadow: `0px 1px 4px rgba(14, 24, 39, 0.1), 0px 8px 24px rgba(14, 24, 39, 0.1)`
   },
   [`& .${materialAutocompleteClasses.listbox}`]: {
     overflow: 'auto',
@@ -181,23 +147,21 @@ export const AutocompletePopper = styled(Popper)(({ theme }) => ({
     maxHeight: 400,
     margin: 0,
     backgroundColor:
-      theme.palette.mode === 'dark'
-        ? theme.palette.secondary[100]
-        : theme.palette.common.white,
+      theme.palette.mode === 'dark' ? theme.palette.secondary[100] : theme.palette.common.white,
     padding: 0,
     [`& .${materialAutocompleteClasses.option}`]: {
       padding: theme.spacing(1, 1.5),
       cursor: 'default',
-      minHeight: 'initial',
-    },
+      minHeight: 'initial'
+    }
   },
   [`& .${materialAutocompleteClasses.noOptions}`]: {
     padding: theme.spacing(1, 1.5),
     fontSize: '0.875rem',
     fontWeight: 500,
-    color: theme.palette.text.secondary,
-  },
-}));
+    color: theme.palette.text.secondary
+  }
+}))
 
 /**
  * Function to be used to filter options.
@@ -207,8 +171,8 @@ export const filterOptions = createFilterOptions<AutocompleteOption>({
   ignoreAccents: true,
   ignoreCase: true,
   trim: true,
-  stringify: (option) => `${option.label} (${option.value})`,
-});
+  stringify: (option) => `${option.label} (${option.value})`
+})
 
 const Autocomplete = forwardRef(
   (
@@ -232,47 +196,41 @@ const Autocomplete = forwardRef(
       sortByOptions,
       ...props
     }: AutocompleteProps<AutocompleteOption>,
-    ref: ForwardedRef<HTMLInputElement>,
+    ref: ForwardedRef<HTMLInputElement>
   ) => {
-    const { formControl: formControlSlotProps, ...defaultComponentsProps } =
-      slotProps || {};
+    const { formControl: formControlSlotProps, ...defaultComponentsProps } = slotProps || {}
 
-    const [inputValue, setInputValue] = useState<string>(
-      () => externalInputValue || '',
-    );
+    const [inputValue, setInputValue] = useState<string>(() => externalInputValue || '')
 
     // TODO: Revisit this implementation. We should probably have a better way to
     // make this component controlled.
     useEffect(() => {
-      setInputValue(externalInputValue ?? '');
-    }, [externalInputValue]);
+      setInputValue(externalInputValue ?? '')
+    }, [externalInputValue])
 
-    const filterOptionsFn = externalFilterOptions || filterOptions;
-    const filteredOptions = filterOptionsFn(
-      props.options as AutocompleteOption[],
-      {
-        inputValue: inputValue || '',
-        getOptionLabel: props.getOptionLabel
-          ? props.getOptionLabel
-          : (option: string | number | AutocompleteOption<string>) => {
-              if (typeof option !== 'object') {
-                return option.toString();
-              }
+    const filterOptionsFn = externalFilterOptions || filterOptions
+    const filteredOptions = filterOptionsFn(props.options as AutocompleteOption[], {
+      inputValue: inputValue || '',
+      getOptionLabel: props.getOptionLabel
+        ? props.getOptionLabel
+        : (option: string | number | AutocompleteOption<string>) => {
+            if (typeof option !== 'object') {
+              return option.toString()
+            }
 
-              return option.label ?? option.dropdownLabel;
-            },
-      },
-    );
+            return option.label ?? option.dropdownLabel
+          }
+    })
 
     const autoSelect =
       typeof externalAutoSelect === 'function'
         ? externalAutoSelect(filteredOptions)
-        : externalAutoSelect;
+        : externalAutoSelect
 
     const customOptionLabel =
       typeof externalCustomOptionLabel === 'function'
         ? externalCustomOptionLabel(inputValue)
-        : externalCustomOptionLabel;
+        : externalCustomOptionLabel
 
     return (
       <StyledAutocomplete
@@ -286,80 +244,71 @@ const Autocomplete = forwardRef(
           popper: {
             modifiers: [{ name: 'offset', options: { offset: [0, 10] } }],
             ...defaultComponentsProps.popper,
-            placement: 'bottom-start',
+            placement: 'bottom-start'
           },
           popupIndicator: {
             ...defaultComponentsProps?.popupIndicator,
             disableRipple: true,
             className: clsx(
               materialAutocompleteClasses.popupIndicator,
-              defaultComponentsProps?.popupIndicator?.className,
-            ),
-          },
+              defaultComponentsProps?.popupIndicator?.className
+            )
+          }
         }}
         inputValue={inputValue || ''}
         onInputChange={(event, value, reason) => {
-          setInputValue(value);
+          setInputValue(value)
 
           if (onInputChange) {
-            onInputChange(event, value, reason);
+            onInputChange(event, value, reason)
           }
         }}
         onKeyDown={(event) => {
           if (event.key !== 'Escape') {
-            return;
+            return
           }
 
-          event.stopPropagation();
+          event.stopPropagation()
 
           if (document.activeElement instanceof HTMLElement) {
-            document.activeElement.blur();
+            document.activeElement.blur()
           }
         }}
         PopperComponent={AutocompletePopper}
         popupIcon={<ChevronDownIcon sx={{ width: 12, height: 12 }} />}
-        getOptionLabel={(
-          option: string | number | AutocompleteOption<string>,
-        ) => {
+        getOptionLabel={(option: string | number | AutocompleteOption<string>) => {
           if (!option) {
-            return '';
+            return ''
           }
 
           if (typeof option !== 'object') {
-            return option.toString();
+            return option.toString()
           }
 
-          return option.label ?? option.dropdownLabel;
+          return option.label ?? option.dropdownLabel
         }}
-        isOptionEqualToValue={(
-          option,
-          value: string | AutocompleteOption<string>,
-        ) => {
+        isOptionEqualToValue={(option, value: string | AutocompleteOption<string>) => {
           if (!value) {
-            return false;
+            return false
           }
 
           if (typeof value !== 'object') {
-            return option.value.toString() === value.toString();
+            return option.value.toString() === value.toString()
           }
 
-          return option.value === value.value && option.custom === value.custom;
+          return option.value === value.value && option.custom === value.custom
         }}
         renderTags={(value, getTagProps) =>
-          value.map(
-            (option: string | number | AutocompleteOption<string>, index) => (
-              // biome-ignore lint/correctness/useJsxKeyInIterable: key is added with getTagProps
-              <StyledTag
-                deleteIcon={<XIcon />}
-                size="small"
-                sx={{ fontSize: (theme) => theme.typography.pxToRem(12) }}
-                label={
-                  typeof option !== 'object' ? option.toString() : option.value
-                }
-                {...getTagProps({ index })}
-              />
-            ),
-          )
+          value.map((option: string | number | AutocompleteOption<string>, index) => (
+            // biome-ignore lint/correctness/useJsxKeyInIterable: key is added with getTagProps
+            <StyledTag
+              deleteIcon={<XIcon />}
+              size="small"
+              sx={{ fontSize: (theme) => theme.typography.pxToRem(12) }}
+              label={typeof option !== 'object' ? option.toString() : option.value}
+              {...getTagProps({ index })}
+            />
+          ))
         }
         renderGroup={({ group, key, children }) =>
           group ? (
@@ -372,46 +321,36 @@ const Autocomplete = forwardRef(
             <div key={key}>{children}</div>
           )
         }
-        renderOption={(
-          optionProps,
-          option: string | number | AutocompleteOption<string>,
-        ) => {
-          const selected = optionProps['aria-selected'];
+        renderOption={(optionProps, option: string | number | AutocompleteOption<string>) => {
+          const selected = optionProps['aria-selected']
 
           if (typeof option !== 'object') {
             return (
               <StyledOptionBase {...optionProps} key={option.toString()}>
                 {option.toString()}
-                {selected && props.multiple && (
-                  <CheckIcon sx={{ width: 16, height: 16 }} />
-                )}
+                {selected && props.multiple && <CheckIcon sx={{ width: 16, height: 16 }} />}
               </StyledOptionBase>
-            );
+            )
           }
 
           return (
-            <StyledOptionBase
-              {...optionProps}
-              key={option.dropdownLabel || option.label}
-            >
+            <StyledOptionBase {...optionProps} key={option.dropdownLabel || option.label}>
               <span>{option.dropdownLabel || option.label}</span>
 
-              {selected && props.multiple && (
-                <CheckIcon key="asd" sx={{ width: 16, height: 16 }} />
-              )}
+              {selected && props.multiple && <CheckIcon key="asd" sx={{ width: 16, height: 16 }} />}
             </StyledOptionBase>
-          );
+          )
         }}
         filterOptions={
           showCustomOption !== 'never'
             ? () => {
                 if (!inputValue) {
-                  return filteredOptions;
+                  return filteredOptions
                 }
                 if (showCustomOption === 'first') {
                   const isInputValueInOptions = filteredOptions.some(
-                    (filteredOption) => filteredOption.label === inputValue,
-                  );
+                    (filteredOption) => filteredOption.label === inputValue
+                  )
 
                   return isInputValueInOptions
                     ? filteredOptions
@@ -419,17 +358,16 @@ const Autocomplete = forwardRef(
                         {
                           value: inputValue,
                           label: inputValue,
-                          dropdownLabel:
-                            customOptionLabel || `Select "${inputValue}"`,
-                          custom: Boolean(inputValue),
+                          dropdownLabel: customOptionLabel || `Select "${inputValue}"`,
+                          custom: Boolean(inputValue)
                         },
-                        ...filteredOptions,
-                      ];
+                        ...filteredOptions
+                      ]
                 }
                 if (showCustomOption === 'auto') {
                   const isInputValueInOptions = filteredOptions.some(
-                    (filteredOption) => filteredOption.label === inputValue,
-                  );
+                    (filteredOption) => filteredOption.label === inputValue
+                  )
 
                   return isInputValueInOptions
                     ? filteredOptions
@@ -438,11 +376,10 @@ const Autocomplete = forwardRef(
                         {
                           value: inputValue,
                           label: inputValue,
-                          dropdownLabel:
-                            customOptionLabel || `Select "${inputValue}"`,
-                          custom: Boolean(inputValue),
-                        },
-                      ];
+                          dropdownLabel: customOptionLabel || `Select "${inputValue}"`,
+                          custom: Boolean(inputValue)
+                        }
+                      ]
                 }
 
                 return [
@@ -450,20 +387,15 @@ const Autocomplete = forwardRef(
                   {
                     value: inputValue,
                     label: inputValue,
-                    dropdownLabel:
-                      customOptionLabel || `Select "${inputValue}"`,
-                    custom: Boolean(inputValue),
-                  },
-                ];
+                    dropdownLabel: customOptionLabel || `Select "${inputValue}"`,
+                    custom: Boolean(inputValue)
+                  }
+                ]
               }
             : filterOptionsFn
         }
         autoSelect={autoSelect}
-        renderInput={({
-          InputProps: InternalInputProps,
-          InputLabelProps,
-          ...params
-        }) => (
+        renderInput={({ InputProps: InternalInputProps, InputLabelProps, ...params }) => (
           <Input
             slotProps={{
               input: {
@@ -473,17 +405,17 @@ const Autocomplete = forwardRef(
                       flexWrap: 'wrap',
                       [`& .${inputClasses.input}`]: {
                         minWidth: 30,
-                        width: 0,
-                      },
+                        width: 0
+                      }
                     }
-                  : null,
+                  : null
               },
               inputRoot: {
                 'aria-label': ariaLabel,
-                ...slotProps.inputRoot,
+                ...slotProps.inputRoot
               },
               label: InputLabelProps,
-              formControl: formControlSlotProps,
+              formControl: formControlSlotProps
             }}
             {...InternalInputProps}
             {...params}
@@ -504,10 +436,10 @@ const Autocomplete = forwardRef(
         )}
         {...props}
       />
-    );
-  },
-);
+    )
+  }
+)
 
-Autocomplete.displayName = 'NhostAutocomplete';
+Autocomplete.displayName = 'NhostAutocomplete'
 
-export default Autocomplete;
+export default Autocomplete

--- a/dashboard/src/features/orgs/projects/database/dataGrid/components/ColumnAutocomplete/useAsyncValue.ts
+++ b/dashboard/src/features/orgs/projects/database/dataGrid/components/ColumnAutocomplete/useAsyncValue.ts
@@ -1,45 +1,42 @@
-import { useEffect, useState } from 'react';
-import type { AutocompleteOption } from '@/components/ui/v2/Autocomplete';
-import type { FetchTableSchemaReturnType } from '@/features/orgs/projects/database/common/hooks/useTableSchemaQuery';
-import type { FetchMetadataReturnType } from '@/features/orgs/projects/database/dataGrid/hooks/useMetadataQuery';
-import type { HasuraMetadataTable } from '@/features/orgs/projects/database/dataGrid/types/dataBrowser';
+import { useEffect, useState } from 'react'
+import type { AutocompleteOption } from '@/components/ui/types'
+import type { FetchTableSchemaReturnType } from '@/features/orgs/projects/database/common/hooks/useTableSchemaQuery'
+import type { FetchMetadataReturnType } from '@/features/orgs/projects/database/dataGrid/hooks/useMetadataQuery'
+import type { HasuraMetadataTable } from '@/features/orgs/projects/database/dataGrid/types/dataBrowser'
 
 export interface UseAsyncValueOptions {
   /**
    * Selected schema to be used to determine the initial value.
    */
-  selectedSchema?: string;
+  selectedSchema?: string
   /**
    * Selected table to be used to determine the initial value.
    */
-  selectedTable?: string;
+  selectedTable?: string
   /**
    * Initial value to be used before the async value is loaded.
    */
-  initialValue?: string;
+  initialValue?: string
   /**
    * Determines whether or not the table data is loading.
    */
-  isTableLoading?: boolean;
+  isTableLoading?: boolean
   /**
    * Determines whether or not the metadata is loading.
    */
-  isMetadataLoading?: boolean;
+  isMetadataLoading?: boolean
   /**
    * Table data to be used to determine the initial value.
    */
-  tableData?: FetchTableSchemaReturnType;
+  tableData?: FetchTableSchemaReturnType
   /**
    * Metadata to be used to determine the initial value.
    */
-  metadata?: FetchMetadataReturnType;
+  metadata?: FetchMetadataReturnType
   /**
    * Function to be called when the input is asynchronously initialized.
    */
-  onInitialized?: (value: {
-    value: string;
-    columnMetadata: Record<string, unknown>;
-  }) => void;
+  onInitialized?: (value: { value: string; columnMetadata: Record<string, unknown> }) => void
 }
 
 export default function useAsyncValue({
@@ -50,37 +47,35 @@ export default function useAsyncValue({
   isMetadataLoading,
   tableData,
   metadata,
-  onInitialized,
+  onInitialized
 }: UseAsyncValueOptions) {
-  const currentTablePath = `${selectedSchema}.${selectedTable}`;
-  const [initialized, setInitialized] = useState(false);
+  const currentTablePath = `${selectedSchema}.${selectedTable}`
+  const [initialized, setInitialized] = useState(false)
   // We might not going to have the most up-to-date table data because the
   // relationship is loaded asynchronously, so we need to make sure we don't
   // look for the column in a stale table when initializing
-  const [asyncTablePath, setAsyncTablePath] = useState(currentTablePath);
+  const [asyncTablePath, setAsyncTablePath] = useState(currentTablePath)
   const [remainingColumnPath, setRemainingColumnPath] = useState(
-    initialValue ? initialValue.split('.') : [],
-  );
+    initialValue ? initialValue.split('.') : []
+  )
   const [selectedRelationships, setSelectedRelationships] = useState<
     { schema: string; table: string; name: string }[]
-  >([]);
+  >([])
   const relationshipDotNotation = selectedRelationships
     .map((relationship) => relationship.name)
-    .join('.');
-  const [selectedColumn, setSelectedColumn] =
-    useState<AutocompleteOption | null>(null);
-  const activeRelationship =
-    selectedRelationships[selectedRelationships.length - 1];
+    .join('.')
+  const [selectedColumn, setSelectedColumn] = useState<AutocompleteOption | null>(null)
+  const activeRelationship = selectedRelationships[selectedRelationships.length - 1]
 
   useEffect(() => {
     if (remainingColumnPath?.length > 0 || initialized) {
-      return;
+      return
     }
 
-    setInitialized(true);
+    setInitialized(true)
 
     if (!selectedColumn) {
-      return;
+      return
     }
 
     onInitialized?.({
@@ -88,16 +83,16 @@ export default function useAsyncValue({
         selectedRelationships.length > 0
           ? [relationshipDotNotation, selectedColumn.value].join('.')
           : selectedColumn.value,
-      columnMetadata: selectedColumn.metadata,
-    });
+      columnMetadata: selectedColumn.metadata
+    })
   }, [
     initialized,
     onInitialized,
     relationshipDotNotation,
     remainingColumnPath?.length,
     selectedColumn,
-    selectedRelationships.length,
-  ]);
+    selectedRelationships.length
+  ])
 
   useEffect(() => {
     if (
@@ -106,37 +101,27 @@ export default function useAsyncValue({
       !tableData?.columns ||
       asyncTablePath !== currentTablePath
     ) {
-      return;
+      return
     }
 
-    const [activeColumn] = remainingColumnPath;
+    const [activeColumn] = remainingColumnPath
 
     // If there is a single column in the path, it means that we can look for it
     // in the table columns
-    if (
-      !tableData?.columns.some((column) => column.column_name === activeColumn)
-    ) {
-      setRemainingColumnPath([]);
+    if (!tableData?.columns.some((column) => column.column_name === activeColumn)) {
+      setRemainingColumnPath([])
 
-      return;
+      return
     }
 
     setSelectedColumn({
       value: activeColumn,
       label: activeColumn,
       group: 'columns',
-      metadata: tableData.columns.find(
-        (column) => column.column_name === activeColumn,
-      )!,
-    });
-    setRemainingColumnPath((columnPath) => columnPath.slice(1));
-  }, [
-    remainingColumnPath,
-    isTableLoading,
-    tableData?.columns,
-    asyncTablePath,
-    currentTablePath,
-  ]);
+      metadata: tableData.columns.find((column) => column.column_name === activeColumn)!
+    })
+    setRemainingColumnPath((columnPath) => columnPath.slice(1))
+  }, [remainingColumnPath, isTableLoading, tableData?.columns, asyncTablePath, currentTablePath])
 
   useEffect(() => {
     if (
@@ -146,128 +131,111 @@ export default function useAsyncValue({
       !tableData?.columns ||
       asyncTablePath !== currentTablePath
     ) {
-      return;
+      return
     }
 
     const metadataMap = (metadata?.tables ?? []).reduce(
       (map, metadataTable) =>
-        map.set(
-          `${metadataTable.table.schema}.${metadataTable.table.name}`,
-          metadataTable,
-        ),
-      new Map<string, HasuraMetadataTable>(),
-    );
+        map.set(`${metadataTable.table.schema}.${metadataTable.table.name}`, metadataTable),
+      new Map<string, HasuraMetadataTable>()
+    )
 
-    const [nextPath] = remainingColumnPath.slice(
-      0,
-      remainingColumnPath.length - 1,
-    );
+    const [nextPath] = remainingColumnPath.slice(0, remainingColumnPath.length - 1)
 
-    const tableMetadata = metadataMap.get(`${selectedSchema}.${selectedTable}`);
+    const tableMetadata = metadataMap.get(`${selectedSchema}.${selectedTable}`)
     const currentRelationship = [
       ...(tableMetadata?.object_relationships || []),
-      ...(tableMetadata?.array_relationships || []),
-    ].find(({ name }) => name === nextPath);
+      ...(tableMetadata?.array_relationships || [])
+    ].find(({ name }) => name === nextPath)
 
     if (!currentRelationship) {
-      setRemainingColumnPath([]);
-      return;
+      setRemainingColumnPath([])
+      return
     }
 
     const {
       foreign_key_constraint_on: metadataConstraint,
-      manual_configuration: metadataManualConfiguration,
-    } = currentRelationship.using || {};
+      manual_configuration: metadataManualConfiguration
+    } = currentRelationship.using || {}
 
     if (metadataManualConfiguration) {
       setAsyncTablePath(
-        `${metadataManualConfiguration.remote_table.schema}.${metadataManualConfiguration.remote_table.name}`,
-      );
+        `${metadataManualConfiguration.remote_table.schema}.${metadataManualConfiguration.remote_table.name}`
+      )
 
       setSelectedRelationships((currentRelationships) => [
         ...currentRelationships,
         {
           schema: metadataManualConfiguration.remote_table.schema || 'public',
           table: metadataManualConfiguration.remote_table.name,
-          name: nextPath,
-        },
-      ]);
+          name: nextPath
+        }
+      ])
 
-      setRemainingColumnPath((columnPath) => columnPath.slice(1));
+      setRemainingColumnPath((columnPath) => columnPath.slice(1))
 
-      return;
+      return
     }
 
     // In some cases the metadata already contains the schema and table name
     if (metadataConstraint && typeof metadataConstraint !== 'string') {
       setAsyncTablePath(
-        `${metadataConstraint.table.schema || 'public'}.${
-          metadataConstraint.table.name
-        }`,
-      );
+        `${metadataConstraint.table.schema || 'public'}.${metadataConstraint.table.name}`
+      )
 
       setSelectedRelationships((currentRelationships) => [
         ...currentRelationships,
         {
           schema: metadataConstraint.table.schema || 'public',
           table: metadataConstraint.table.name,
-          name: nextPath,
-        },
-      ]);
+          name: nextPath
+        }
+      ])
 
-      setRemainingColumnPath((columnPath) => columnPath.slice(1));
+      setRemainingColumnPath((columnPath) => columnPath.slice(1))
 
-      return;
+      return
     }
 
-    const foreignKeyRelation = tableData?.foreignKeyRelations?.find(
-      ({ columnName }) => {
-        const normalizedColumnName = columnName.replace(/"/g, '');
-        const { foreign_key_constraint_on, manual_configuration } =
-          currentRelationship.using || {};
+    const foreignKeyRelation = tableData?.foreignKeyRelations?.find(({ columnName }) => {
+      const normalizedColumnName = columnName.replace(/"/g, '')
+      const { foreign_key_constraint_on, manual_configuration } = currentRelationship.using || {}
 
-        if (!foreign_key_constraint_on && !manual_configuration) {
-          return false;
-        }
+      if (!foreign_key_constraint_on && !manual_configuration) {
+        return false
+      }
 
-        if (manual_configuration) {
-          return Object.keys(manual_configuration.column_mapping).includes(
-            normalizedColumnName,
-          );
-        }
+      if (manual_configuration) {
+        return Object.keys(manual_configuration.column_mapping).includes(normalizedColumnName)
+      }
 
-        if (typeof foreign_key_constraint_on === 'string') {
-          return foreign_key_constraint_on === normalizedColumnName;
-        }
+      if (typeof foreign_key_constraint_on === 'string') {
+        return foreign_key_constraint_on === normalizedColumnName
+      }
 
-        return foreign_key_constraint_on?.column === normalizedColumnName;
-      },
-    );
+      return foreign_key_constraint_on?.column === normalizedColumnName
+    })
 
     if (!foreignKeyRelation) {
-      setRemainingColumnPath([]);
-      return;
+      setRemainingColumnPath([])
+      return
     }
 
-    const normalizedSchema = foreignKeyRelation.referencedSchema?.replace(
-      /(\\"|")/g,
-      '',
-    );
-    const normalizedTable =
-      foreignKeyRelation.referencedTable?.replace(/(\\"|")/g, '') ?? '';
+    const normalizedSchema = foreignKeyRelation.referencedSchema?.replace(/(\\"|")/g, '')
+    const normalizedTable = foreignKeyRelation.referencedTable?.replace(/(\\"|")/g, '') ?? ''
 
-    setAsyncTablePath(`${normalizedSchema || 'public'}.${normalizedTable}`);
+    setAsyncTablePath(`${normalizedSchema || 'public'}.${normalizedTable}`)
 
     setSelectedRelationships((currentRelationships) => [
       ...currentRelationships,
       {
         schema: normalizedSchema || 'public',
         table: normalizedTable,
-        name: nextPath,
-      },
-    ]);
+        name: nextPath
+      }
+    ])
 
-    setRemainingColumnPath((columnPath) => columnPath.slice(1));
+    setRemainingColumnPath((columnPath) => columnPath.slice(1))
   }, [
     currentTablePath,
     asyncTablePath,
@@ -278,8 +246,8 @@ export default function useAsyncValue({
     tableData?.foreignKeyRelations,
     remainingColumnPath,
     isTableLoading,
-    isMetadataLoading,
-  ]);
+    isMetadataLoading
+  ])
 
   return {
     initialized,
@@ -289,8 +257,6 @@ export default function useAsyncValue({
     setSelectedRelationships,
     setSelectedColumn,
     relationshipDotNotation:
-      initialized && selectedRelationships?.length > 0
-        ? relationshipDotNotation
-        : '',
-  };
+      initialized && selectedRelationships?.length > 0 ? relationshipDotNotation : ''
+  }
 }

--- a/dashboard/src/features/orgs/projects/database/dataGrid/components/ColumnAutocomplete/useColumnGroups.ts
+++ b/dashboard/src/features/orgs/projects/database/dataGrid/components/ColumnAutocomplete/useColumnGroups.ts
@@ -1,29 +1,29 @@
-import type { AutocompleteOption } from '@/components/ui/v2/Autocomplete';
-import type { FetchTableSchemaReturnType } from '@/features/orgs/projects/database/common/hooks/useTableSchemaQuery';
-import type { FetchMetadataReturnType } from '@/features/orgs/projects/database/dataGrid/hooks/useMetadataQuery';
-import { isNotEmptyValue } from '@/lib/utils';
+import type { AutocompleteOption } from '@/components/ui/types'
+import type { FetchTableSchemaReturnType } from '@/features/orgs/projects/database/common/hooks/useTableSchemaQuery'
+import type { FetchMetadataReturnType } from '@/features/orgs/projects/database/dataGrid/hooks/useMetadataQuery'
+import { isNotEmptyValue } from '@/lib/utils'
 
 export interface UseColumnGroupsOptions {
   /**
    * Selected schema to be used to determines the column groups.
    */
-  selectedSchema?: string;
+  selectedSchema?: string
   /**
    * Selected table to be used to determine the column groups.
    */
-  selectedTable?: string;
+  selectedTable?: string
   /**
    * Table data to be used to determine the column groups.
    */
-  tableData?: FetchTableSchemaReturnType;
+  tableData?: FetchTableSchemaReturnType
   /**
    * Metadata to be used to determine the column groups.
    */
-  metadata?: FetchMetadataReturnType;
+  metadata?: FetchMetadataReturnType
   /**
    * Determines whether or not to disable column groups.
    */
-  disableRelationships?: boolean;
+  disableRelationships?: boolean
 }
 
 export default function useColumnGroups({
@@ -31,59 +31,55 @@ export default function useColumnGroups({
   selectedSchema,
   tableData,
   metadata,
-  disableRelationships,
+  disableRelationships
 }: UseColumnGroupsOptions) {
-  const { columns, foreignKeyRelations } = tableData || {};
+  const { columns, foreignKeyRelations } = tableData || {}
 
   const columnTargetMap = foreignKeyRelations?.reduce(
     (map, currentRelation) =>
       map.set(currentRelation.columnName, {
         schema: currentRelation.referencedSchema || 'public',
-        table: currentRelation.referencedTable,
+        table: currentRelation.referencedTable
       }),
-    new Map<string, { schema: string; table: string }>(),
-  );
+    new Map<string, { schema: string; table: string }>()
+  )
 
   const columnOptions: AutocompleteOption[] =
     columns?.map((column) => ({
       label: column.column_name,
       value: column.column_name,
       group: 'columns',
-      metadata: column,
-    })) || [];
+      metadata: column
+    })) || []
 
   if (disableRelationships) {
-    return columnOptions;
+    return columnOptions
   }
 
   const { object_relationships, array_relationships } =
     metadata?.tables?.find(
       ({ table: metadataTable }) =>
-        metadataTable.name === selectedTable &&
-        metadataTable.schema === selectedSchema,
-    ) || {};
+        metadataTable.name === selectedTable && metadataTable.schema === selectedSchema
+    ) || {}
 
   const objectAndArrayRelationships = [
     ...(object_relationships || []),
-    ...(array_relationships || []),
+    ...(array_relationships || [])
   ].reduce<{ schema: string; table: string; column: string; name: string }[]>(
     (relationships, currentRelationship) => {
       if (isNotEmptyValue(currentRelationship?.using)) {
-        const { foreign_key_constraint_on, manual_configuration } =
-          currentRelationship.using;
+        const { foreign_key_constraint_on, manual_configuration } = currentRelationship.using
 
         if (manual_configuration) {
           return [
             ...relationships,
-            ...Object.keys(manual_configuration.column_mapping).map(
-              (column) => ({
-                schema: manual_configuration.remote_table?.schema || 'public',
-                table: manual_configuration.remote_table?.name,
-                column,
-                name: currentRelationship.name,
-              }),
-            ),
-          ];
+            ...Object.keys(manual_configuration.column_mapping).map((column) => ({
+              schema: manual_configuration.remote_table?.schema || 'public',
+              table: manual_configuration.remote_table?.name,
+              column,
+              name: currentRelationship.name
+            }))
+          ]
         }
 
         if (
@@ -97,9 +93,9 @@ export default function useColumnGroups({
               schema: selectedSchema!,
               table: selectedTable!,
               column: foreign_key_constraint_on,
-              name: currentRelationship.name,
-            },
-          ];
+              name: currentRelationship.name
+            }
+          ]
         }
         if (
           isNotEmptyValue(foreign_key_constraint_on) &&
@@ -111,15 +107,15 @@ export default function useColumnGroups({
               schema: foreign_key_constraint_on.table.schema,
               table: foreign_key_constraint_on.table.name,
               column: foreign_key_constraint_on.column,
-              name: currentRelationship.name,
-            },
-          ];
+              name: currentRelationship.name
+            }
+          ]
         }
       }
-      return relationships;
+      return relationships
     },
-    [] as { schema: string; table: string; column: string; name: string }[],
-  );
+    [] as { schema: string; table: string; column: string; name: string }[]
+  )
 
   return [
     ...columnOptions,
@@ -133,9 +129,9 @@ export default function useColumnGroups({
           table: relationship.table,
           column: relationship.column,
           ...(columnTargetMap?.get(relationship.column) || {}),
-          name: relationship.name,
-        },
-      },
-    })),
-  ];
+          name: relationship.name
+        }
+      }
+    }))
+  ]
 }


### PR DESCRIPTION
Part of #4247 — task 3: ColumnAutocomplete follow-up.

Moves the `AutocompleteOption` type from the v2 Autocomplete component 
to a new shared location at `dashboard/src/components/ui/types.ts`.

Files changed:
- `components/ui/types.ts` — new shared type file
- `components/ui/v2/Autocomplete/Autocomplete.tsx` — removed local type, re-exports from shared
- `components/form/ControlledAutocomplete/ControlledAutocomplete.tsx` — updated import
- `ColumnAutocomplete/useAsyncValue.ts` — updated import
- `ColumnAutocomplete/useColumnGroups.ts` — updated import

No JSX or logic changes — type imports only.

Closes #4247