### PR TITLE
fix(dashboard): hide remote schema permissions table until enabled state loads

### DIFF
--- a/dashboard/src/features/orgs/projects/remote-schemas/components/EditRemoteSchemaPermissionsForm/EditRemoteSchemaPermissionsForm.tsx
+++ b/dashboard/src/features/orgs/projects/remote-schemas/components/EditRemoteSchemaPermissionsForm/EditRemoteSchemaPermissionsForm.tsx
@@ -96,9 +96,18 @@ export default function EditRemoteSchemaPermissionsForm({
   });
 
   if (
-    !remoteSchemaPermissionsEnabled &&
-    !remoteSchemaPermissionsEnabledLoading
+    rolesLoading ||
+    introspectionLoading ||
+    remoteSchemaPermissionsEnabledLoading
   ) {
+    return (
+      <div className="p-6">
+        <ActivityIndicator label="Loading available roles..." />
+      </div>
+    );
+  }
+
+  if (!remoteSchemaPermissionsEnabled) {
     return (
       <Box className="p-4">
         <Alert className="grid w-full grid-flow-col place-content-between items-center gap-2">
@@ -117,14 +126,6 @@ export default function EditRemoteSchemaPermissionsForm({
           </Text>
         </Alert>
       </Box>
-    );
-  }
-
-  if (rolesLoading || introspectionLoading) {
-    return (
-      <div className="p-6">
-        <ActivityIndicator label="Loading available roles..." />
-      </div>
     );
   }
 


### PR DESCRIPTION
### Checklist

- [ ] No breaking changes
- [ ] Tests pass
- [ ] New features have new tests
- [ ] Documentation is updated (if applicable)
- [ ] Title of the PR is in the correct format (see below)

<!-- nhost-reviewer:start -->
### **PR Type**
Bug fix

___

### **Description**
- Gates the remote-schema permissions UI on all three relevant queries (`rolesLoading`, `introspectionLoading`, `remoteSchemaPermissionsEnabledLoading`) instead of only the enabled-flag query, so the table no longer briefly renders before the enabled state is known.
- Splits the previous combined "not enabled + not loading" check into a dedicated loading branch followed by a `!remoteSchemaPermissionsEnabled` branch, removing the now-redundant second loading check further down.

___

<details> <summary><h3> File Walkthrough</h3></summary>

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody>
<tr><td><strong>Core logic</strong></td><td><details><summary>1 files</summary><table>
<tr>
  <td><strong>EditRemoteSchemaPermissionsForm.tsx</strong><dd><code>Reorder render guards so loading spinner shows while any query is pending, then check enabled flag.</code></dd></td>
  <td><a href="https://github.com/nhost/nhost/pull/XXX/files#diff-af3d13327c8c8f448fdd2de58e986049b3278b33fceb2887cfdda4c0fba3a5e5">+11/-10</a></td>
</tr>
</table></details></td></tr>
</tbody></table>

</details>

___

<!-- nhost-reviewer:end -->
