### PR TITLE
fix(dashboard): align serverless function HTTP method colors with schema diagram

### DIFF
--- a/dashboard/src/features/orgs/projects/serverless-functions/components/ExecuteTab/ExecuteTab.tsx
+++ b/dashboard/src/features/orgs/projects/serverless-functions/components/ExecuteTab/ExecuteTab.tsx
@@ -35,9 +35,9 @@ import { buildServerlessFunctionRequestUrl } from '@/features/orgs/projects/serv
 import { cn } from '@/lib/utils';
 
 const METHOD_COLORS: Record<HttpMethod, string> = {
-  GET: 'text-green-600 dark:text-green-400',
-  POST: 'text-blue-600 dark:text-blue-400',
-  PUT: 'text-orange-600 dark:text-orange-400',
+  GET: 'text-blue-600 dark:text-blue-400',
+  POST: 'text-green-600 dark:text-green-400',
+  PUT: 'text-amber-600 dark:text-amber-400',
   PATCH: 'text-pink-600 dark:text-pink-400',
   DELETE: 'text-red-600 dark:text-red-400',
   OPTIONS: 'text-purple-600 dark:text-purple-400',


### PR DESCRIPTION
Updates the HTTP method dropdown colors in the serverless function Execute tab to mirror the GraphQL operation colors used in the new schema diagram (SELECT=blue, INSERT=green, UPDATE=amber, DELETE=red)

<img width="516" height="690" alt="image" src="https://github.com/user-attachments/assets/f3e8ffa3-3a00-4aa1-b79f-6ad95dd589f7" />

### Checklist

- [X] No breaking changes
- [X] Tests pass
- [X] New features have new tests
- [X] Documentation is updated (if applicable)
- [X] Title of the PR is in the correct format (see below)

<!-- nhost-reviewer:start -->
### **PR Type**
Bug fix

___

### **Description**
- Reassign HTTP method colors in the serverless function Execute tab so they line up with the GraphQL operation colors in the schema diagram.
- `GET` switches from green to blue (mirrors `SELECT`), `POST` from blue to green (mirrors `INSERT`), and `PUT` from orange to amber (mirrors `UPDATE`); `DELETE` stays red.
- `PATCH`, `OPTIONS`, and `HEAD` are unchanged.

___

<details> <summary><h3> File Walkthrough</h3></summary>

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody>
<tr><td><strong>Core logic</strong></td><td><details><summary>1 files</summary><table>
<tr>
  <td><strong>ExecuteTab.tsx</strong><dd><code>Remap METHOD_COLORS for GET/POST/PUT to match schema-diagram operation colors.</code></dd></td>
  <td><a href="https://github.com/nhost/nhost/pull/4322/files#diff-31413ca62f3bed522f7e5ed5240a32d7a157556a3c647dbfc749fa4307ed6e55">+3/-3</a></td>
</tr>
</table></details></td></tr>
</tbody></table>

</details>

___

<!-- nhost-reviewer:end -->
