### PR TITLE
fix(dashboard): remove irrelevant role public header from Apollo Client

### DIFF
--- a/dashboard/src/providers/Apollo/createApolloClient.ts
+++ b/dashboard/src/providers/Apollo/createApolloClient.ts
@@ -53,9 +53,6 @@ export const createApolloClient = ({
     const token = session?.accessToken;
     if (token) {
       resHeaders.authorization = `Bearer ${token}`;
-    } else {
-      // ? Not sure it changes anything for Hasura
-      resHeaders.role = 'public';
     }
 
     return resHeaders;


### PR DESCRIPTION
### Checklist

- [X] No breaking changes
- [X] Tests pass
- [X] New features have new tests
- [X] Documentation is updated (if applicable)
- [X] Title of the PR is in the correct format (see below)

<!-- nhost-reviewer:start -->
### **PR Type**
Bug fix

___

### **Description**
- Removes the `role: 'public'` fallback header set by the Apollo client's `getAuthHeaders` when no access token is available; both Hasura and Constellation (the in-house Hasura-compatible engine used by Nhost) read the role from `X-Hasura-Role`, never the un-prefixed `role` header, so the fallback was a no-op (which the original `// ? Not sure it changes anything for Hasura` comment already hinted at).
- Anonymous requests now arrive at the GraphQL endpoint without any synthetic role hint, which matches Constellation's documented behaviour: a request without credentials is treated as the `public` role automatically (`controller/middleware/session.go`, `docs/developers/architecture.md`).

___

<details> <summary><h3> File Walkthrough</h3></summary>

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody>
<tr><td><strong>Bug fix</strong></td><td><details><summary>1 files</summary><table>
<tr>
  <td><strong>createApolloClient.ts</strong><dd><code>Drop the no-op <code>role: 'public'</code> fallback header from the unauthenticated branch of <code>getAuthHeaders</code>.</code></dd></td>
  <td><a href="https://github.com/nhost/nhost/pull/4351/files#diff-6a34c5ed967837282403b4cfdf06e13e5effb32da891d682580b8174d047a454">+0/-3</a></td>
</tr>
</table></details></td></tr>
</tbody></table>

</details>

___

<!-- nhost-reviewer:end -->
