### PR TITLE
chore(ci): build and cache nixops dev-shell on macOS runners

### DIFF
--- a/.github/actions/cache-nix/action.yml
+++ b/.github/actions/cache-nix/action.yml
@@ -46,7 +46,8 @@ runs:
           local t1=$(date +%s)
           nix nar pack "$store_path" | zstd -q > "$tmp_nar"
           local file_size
-          file_size=$(stat -c%s "$tmp_nar")
+          # `wc -c` is portable across GNU and BSD coreutils (stat flags differ).
+          file_size=$(wc -c < "$tmp_nar" | tr -d '[:space:]')
           local file_hash
           file_hash=$(nix-hash --type sha256 --base32 --flat "$tmp_nar")
           local t2=$(date +%s)
@@ -86,7 +87,12 @@ runs:
 
         # Find locally-built paths (unsigned, non-drv)
         T=$(date +%s)
-        mapfile -t LOCAL_PATHS < <(
+        # `mapfile` requires bash 4+, which macOS doesn't ship. Use a portable
+        # `while read` loop instead.
+        LOCAL_PATHS=()
+        while IFS= read -r line; do
+          LOCAL_PATHS+=("$line")
+        done < <(
           nix path-info --all --json \
             | jq -r 'to_entries[] | select(.key | endswith(".drv") | not) | select(.value.signatures | length == 0) | .key'
         )
@@ -105,7 +111,10 @@ runs:
 
         # Check which paths are missing from S3 (in parallel)
         T=$(date +%s)
-        mapfile -t MISSING_PATHS < <(
+        MISSING_PATHS=()
+        while IFS= read -r line; do
+          MISSING_PATHS+=("$line")
+        done < <(
           printf '%s\n' "${LOCAL_PATHS[@]}" \
             | xargs -P 16 -I{} bash -c \
               'aws s3api head-object --bucket "$S3_BUCKET" --region "$S3_REGION" --key "$(basename "$1" | cut -d- -f1).narinfo" >/dev/null 2>&1 || echo "$1"' _ {}

--- a/.github/actions/setup-nix/action.yml
+++ b/.github/actions/setup-nix/action.yml
@@ -29,6 +29,35 @@ runs:
           keep-outputs = true
           accept-flake-config = true
 
+    - name: "Forward AWS credentials to the Nix daemon"
+      # The Nix daemon runs as root and doesn't inherit AWS_* env vars
+      # from the shell, so the S3 substituter fails with "Access Denied"
+      # and every job rebuilds paths that are already cached. Drop the
+      # short-lived OIDC credentials into root's ~/.aws/credentials so
+      # the AWS SDK picks them up via its standard provider chain, then
+      # bounce the daemon so any cached credential state is reset.
+      shell: bash
+      run: |
+        if [ "$RUNNER_OS" = "macOS" ]; then
+          root_home=/var/root
+        else
+          root_home=/root
+        fi
+        sudo mkdir -p "$root_home/.aws"
+        sudo tee "$root_home/.aws/credentials" > /dev/null <<EOF
+        [default]
+        aws_access_key_id = $AWS_ACCESS_KEY_ID
+        aws_secret_access_key = $AWS_SECRET_ACCESS_KEY
+        aws_session_token = $AWS_SESSION_TOKEN
+        region = $AWS_REGION
+        EOF
+        sudo chmod 600 "$root_home/.aws/credentials"
+        if [ "$RUNNER_OS" = "macOS" ]; then
+          sudo launchctl kickstart -k system/org.nixos.nix-daemon
+        else
+          sudo systemctl restart nix-daemon
+        fi
+
     - name: "Verify nixops is cached"
       if: ${{ inputs.NAME != 'nixops' }}
       shell: bash

--- a/.github/actions/setup-nix/action.yml
+++ b/.github/actions/setup-nix/action.yml
@@ -63,7 +63,8 @@ runs:
       shell: bash
       run: |
         ARCH=$([ "$(uname -m)" = "x86_64" ] && echo "x86_64" || echo "aarch64")
-        output=$(nix build --dry-run .\#packages.$ARCH-linux.nixops 2>&1)
+        SYSTEM=$([ "$RUNNER_OS" = "macOS" ] && echo "$ARCH-darwin" || echo "$ARCH-linux")
+        output=$(nix build --dry-run .\#packages.$SYSTEM.nixops 2>&1)
         if echo "$output" | grep -q "will be built"; then
           echo "$output"
           echo "::error::nixops needs to be rebuilt — build and cache nixops first"

--- a/.github/actions/setup-nix/action.yml
+++ b/.github/actions/setup-nix/action.yml
@@ -1,24 +1,23 @@
-name: 'Setup Nix'
-description: 'Install Nix and setup caching for Nhost projects'
+name: "Setup Nix"
+description: "Install Nix and setup caching for Nhost projects"
 inputs:
   NAME:
-    description: 'Project name for cache key'
+    description: "Project name for cache key"
     required: true
   NIX_CACHE_PUB_KEY:
-    description: 'Nix cache public key'
+    description: "Nix cache public key"
     required: true
   GITHUB_TOKEN:
-    description: 'GitHub token for Nix access'
+    description: "GitHub token for Nix access"
     required: true
 
 runs:
-  using: 'composite'
+  using: "composite"
   steps:
     - name: Install Nix
       uses: cachix/install-nix-action@v31
       with:
         install_url: "https://releases.nixos.org/nix/nix-2.28.5/install"
-        install_options: "--no-daemon"
         extra_nix_config: |
           download-buffer-size = 500000000
           experimental-features = nix-command flakes
@@ -41,4 +40,3 @@ runs:
           echo "::error::nixops needs to be rebuilt — build and cache nixops first"
           exit 1
         fi
-

--- a/.github/workflows/nixops_checks.yaml
+++ b/.github/workflows/nixops_checks.yaml
@@ -71,6 +71,24 @@ jobs:
       NIX_CACHE_PUB_KEY: ${{ secrets.NIX_CACHE_PUB_KEY }}
       NIX_CACHE_PRIV_KEY: ${{ secrets.NIX_CACHE_PRIV_KEY }}
 
+  build_artifacts_macos:
+    uses: ./.github/workflows/wf_build_artifacts.yaml
+    needs:
+      - detect-changes
+      - check-permissions
+    if: needs.detect-changes.outputs.should_run == 'true'
+    with:
+      NAME: nixops
+      PATH: nixops
+      GIT_REF: ${{ github.event_name == 'pull_request_target' && github.event.pull_request.head.sha || github.sha }}
+      VERSION: 0.0.0-dev # we use a fixed version here to avoid unnecessary rebuilds
+      DOCKER: false
+      OS_MATRIX: '["blacksmith-6vcpu-macos-latest"]'
+    secrets:
+      AWS_ACCOUNT_ID: ${{ secrets.AWS_PRODUCTION_CORE_ACCOUNT_ID }}
+      NIX_CACHE_PUB_KEY: ${{ secrets.NIX_CACHE_PUB_KEY }}
+      NIX_CACHE_PRIV_KEY: ${{ secrets.NIX_CACHE_PRIV_KEY }}
+
   remove_label:
     runs-on: ubuntu-latest
     needs:

--- a/.github/workflows/nixops_checks.yaml
+++ b/.github/workflows/nixops_checks.yaml
@@ -1,7 +1,6 @@
 ---
 name: "nixops: check and build"
 on:
-  push:
   pull_request_target:
     paths:
       - ".github/workflows/wf_check.yaml"
@@ -65,7 +64,7 @@ jobs:
       PATH: nixops
       GIT_REF: ${{ github.event_name == 'pull_request_target' && github.event.pull_request.head.sha || github.sha }}
       VERSION: 0.0.0-dev # we use a fixed version here to avoid unnecessary rebuilds
-      DOCKER: true # docker steps are auto-skipped on macOS runners
+      DOCKER: false
       OS_MATRIX: '["blacksmith-32vcpu-ubuntu-2404-arm", "blacksmith-8vcpu-ubuntu-2404", "blacksmith-6vcpu-macos-latest"]'
     secrets:
       AWS_ACCOUNT_ID: ${{ secrets.AWS_PRODUCTION_CORE_ACCOUNT_ID }}

--- a/.github/workflows/nixops_checks.yaml
+++ b/.github/workflows/nixops_checks.yaml
@@ -65,26 +65,8 @@ jobs:
       PATH: nixops
       GIT_REF: ${{ github.event_name == 'pull_request_target' && github.event.pull_request.head.sha || github.sha }}
       VERSION: 0.0.0-dev # we use a fixed version here to avoid unnecessary rebuilds
-      DOCKER: true
-      OS_MATRIX: '["blacksmith-32vcpu-ubuntu-2404-arm", "blacksmith-8vcpu-ubuntu-2404"]'
-    secrets:
-      AWS_ACCOUNT_ID: ${{ secrets.AWS_PRODUCTION_CORE_ACCOUNT_ID }}
-      NIX_CACHE_PUB_KEY: ${{ secrets.NIX_CACHE_PUB_KEY }}
-      NIX_CACHE_PRIV_KEY: ${{ secrets.NIX_CACHE_PRIV_KEY }}
-
-  build_artifacts_macos:
-    uses: ./.github/workflows/wf_build_artifacts.yaml
-    needs:
-      - detect-changes
-      - check-permissions
-    if: needs.detect-changes.outputs.should_run == 'true'
-    with:
-      NAME: nixops
-      PATH: nixops
-      GIT_REF: ${{ github.event_name == 'pull_request_target' && github.event.pull_request.head.sha || github.sha }}
-      VERSION: 0.0.0-dev # we use a fixed version here to avoid unnecessary rebuilds
-      DOCKER: false
-      OS_MATRIX: '["blacksmith-6vcpu-macos-latest"]'
+      DOCKER: true # docker steps are auto-skipped on macOS runners
+      OS_MATRIX: '["blacksmith-32vcpu-ubuntu-2404-arm", "blacksmith-8vcpu-ubuntu-2404", "blacksmith-6vcpu-macos-latest"]'
     secrets:
       AWS_ACCOUNT_ID: ${{ secrets.AWS_PRODUCTION_CORE_ACCOUNT_ID }}
       NIX_CACHE_PUB_KEY: ${{ secrets.NIX_CACHE_PUB_KEY }}

--- a/.github/workflows/nixops_checks.yaml
+++ b/.github/workflows/nixops_checks.yaml
@@ -1,6 +1,7 @@
 ---
 name: "nixops: check and build"
 on:
+  push:
   pull_request_target:
     paths:
       - ".github/workflows/wf_check.yaml"

--- a/.github/workflows/wf_build_artifacts.yaml
+++ b/.github/workflows/wf_build_artifacts.yaml
@@ -91,7 +91,11 @@ jobs:
           # path-info --recursive` only sees the runtime closure, which
           # misses build-time intermediates.
           stderr_log=$(mktemp)
-          make build-dry-run 2>"$stderr_log" >/dev/null
+          if ! make build-dry-run 2>"$stderr_log" >/dev/null; then
+            cat "$stderr_log" >&2
+            rm -f "$stderr_log"
+            exit 1
+          fi
           if grep -q "will be built" "$stderr_log"; then
             export BUILD_NEEDED=yes
           else

--- a/.github/workflows/wf_build_artifacts.yaml
+++ b/.github/workflows/wf_build_artifacts.yaml
@@ -83,7 +83,10 @@ jobs:
         id: verify-build
         run: |
           export drvPath=$(make build-dry-run)
-          nix path-info --store s3://nhost-nix-cache\?region=eu-central-1 $drvPath \
+          # `--recursive` walks the full closure. If any path is missing from
+          # the cache we still need to (re)build and upload, even if the
+          # top-level output happens to be cached.
+          nix path-info --recursive --store s3://nhost-nix-cache\?region=eu-central-1 $drvPath \
             && export BUILD_NEEDED=no \
             || export BUILD_NEEDED=yes
           echo BUILD_NEEDED=$BUILD_NEEDED >> $GITHUB_OUTPUT

--- a/.github/workflows/wf_build_artifacts.yaml
+++ b/.github/workflows/wf_build_artifacts.yaml
@@ -82,13 +82,22 @@ jobs:
       - name: "Verify if we need to build"
         id: verify-build
         run: |
-          export drvPath=$(make build-dry-run)
-          # `--recursive` walks the full closure. If any path is missing from
-          # the cache we still need to (re)build and upload, even if the
-          # top-level output happens to be cached.
-          nix path-info --recursive --store s3://nhost-nix-cache\?region=eu-central-1 $drvPath \
-            && export BUILD_NEEDED=no \
-            || export BUILD_NEEDED=yes
+          # `nix build --dry-run` (inside `make build-dry-run`) walks the
+          # full build graph and reports what would be built locally vs
+          # fetched from configured substituters (cache.nixos.org + our
+          # S3 cache). If any derivation would be built we have new paths
+          # worth uploading. This catches the case where the top-level
+          # output is cached but transitive build deps aren't — `nix
+          # path-info --recursive` only sees the runtime closure, which
+          # misses build-time intermediates.
+          stderr_log=$(mktemp)
+          make build-dry-run 2>"$stderr_log" >/dev/null
+          if grep -q "will be built" "$stderr_log"; then
+            export BUILD_NEEDED=yes
+          else
+            export BUILD_NEEDED=no
+          fi
+          rm -f "$stderr_log"
           echo BUILD_NEEDED=$BUILD_NEEDED >> $GITHUB_OUTPUT
 
       - name: Compute common env vars

--- a/.github/workflows/wf_build_artifacts.yaml
+++ b/.github/workflows/wf_build_artifacts.yaml
@@ -117,7 +117,7 @@ jobs:
           sudo mkdir -p "/run/containers/$(id -u runner)"
           sudo chown runner: "/run/containers/$(id -u runner)"
           make build-docker-image
-        if: ${{ ( inputs.DOCKER ) }}
+        if: ${{ inputs.DOCKER && runner.os != 'macOS' }}
 
       - name: "Push docker image to artifact repository"
         uses: actions/upload-artifact@v7
@@ -125,7 +125,7 @@ jobs:
           name: ${{ inputs.NAME }}-docker-image${{ inputs.ARTIFACT_SUFFIX }}-${{ steps.vars.outputs.ARCH }}-${{ steps.vars.outputs.VERSION }}
           path: ${{ inputs.PATH }}/result
           retention-days: 7
-        if: ${{ ( inputs.DOCKER ) }}
+        if: ${{ inputs.DOCKER && runner.os != 'macOS' }}
 
       - name: "Store Nix cache"
         uses: ./.github/actions/cache-nix

--- a/.github/workflows/wf_check.yaml
+++ b/.github/workflows/wf_check.yaml
@@ -76,7 +76,10 @@ jobs:
       run: |
         export drvPath=$(make check-dry-run)
         echo "Derivation path: $drvPath"
-        nix path-info --store s3://nhost-nix-cache\?region=eu-central-1 $drvPath \
+        # `--recursive` walks the full closure. If any path is missing from
+        # the cache we still need to (re)build and upload, even if the
+        # top-level output happens to be cached.
+        nix path-info --recursive --store s3://nhost-nix-cache\?region=eu-central-1 $drvPath \
           && export BUILD_NEEDED=no \
           || export BUILD_NEEDED=yes
         echo BUILD_NEEDED=$BUILD_NEEDED >> $GITHUB_OUTPUT

--- a/.github/workflows/wf_check.yaml
+++ b/.github/workflows/wf_check.yaml
@@ -74,14 +74,23 @@ jobs:
     - name: "Verify if we need to build"
       id: verify-build
       run: |
-        export drvPath=$(make check-dry-run)
+        # `nix build --dry-run` (inside `make check-dry-run`) walks the
+        # full build graph and reports what would be built locally vs
+        # fetched from configured substituters (cache.nixos.org + our
+        # S3 cache). If any derivation would be built we have new paths
+        # worth uploading. This catches the case where the top-level
+        # output is cached but transitive build deps aren't — `nix
+        # path-info --recursive` only sees the runtime closure, which
+        # misses build-time intermediates.
+        stderr_log=$(mktemp)
+        export drvPath=$(make check-dry-run 2>"$stderr_log")
         echo "Derivation path: $drvPath"
-        # `--recursive` walks the full closure. If any path is missing from
-        # the cache we still need to (re)build and upload, even if the
-        # top-level output happens to be cached.
-        nix path-info --recursive --store s3://nhost-nix-cache\?region=eu-central-1 $drvPath \
-          && export BUILD_NEEDED=no \
-          || export BUILD_NEEDED=yes
+        if grep -q "will be built" "$stderr_log"; then
+          export BUILD_NEEDED=yes
+        else
+          export BUILD_NEEDED=no
+        fi
+        rm -f "$stderr_log"
         echo BUILD_NEEDED=$BUILD_NEEDED >> $GITHUB_OUTPUT
         echo DERIVATION_PATH=$drvPath >> $GITHUB_OUTPUT
 

--- a/.github/workflows/wf_check.yaml
+++ b/.github/workflows/wf_check.yaml
@@ -83,7 +83,12 @@ jobs:
         # path-info --recursive` only sees the runtime closure, which
         # misses build-time intermediates.
         stderr_log=$(mktemp)
-        export drvPath=$(make check-dry-run 2>"$stderr_log")
+        if ! drvPath=$(make check-dry-run 2>"$stderr_log"); then
+          cat "$stderr_log" >&2
+          rm -f "$stderr_log"
+          exit 1
+        fi
+        export drvPath
         echo "Derivation path: $drvPath"
         if grep -q "will be built" "$stderr_log"; then
           export BUILD_NEEDED=yes

--- a/flake.nix
+++ b/flake.nix
@@ -394,6 +394,7 @@
           postgres-pg18-as-dir = postgresf.packages.pg18-as-dir;
           storage = storagef.package;
           storage-docker-image = storagef.dockerImage;
+          storage-vips = storagef.vips;
           clamav-docker-image = storagef.clamav-docker-image;
           tutorials = tutorialsf.package;
         };

--- a/nixops/overlays/nhost-cli.nix
+++ b/nixops/overlays/nhost-cli.nix
@@ -1,22 +1,22 @@
 { final }:
 let
-  version = "1.46.0";
+  version = "1.48.0";
   dist = {
     aarch64-darwin = {
       url = "https://github.com/nhost/nhost/releases/download/cli%40${version}/cli-${version}-darwin-arm64.tar.gz";
-      sha256 = "13dm6714h3sk2kjm293s070cl0ff7p10psxr8r7aikczilfmp8yd";
+      sha256 = "1bsdlb8hd57ncls836c2sb2pxsabh2j6idz84fba76j1vipxbia6";
     };
     x86_64-darwin = {
       url = "https://github.com/nhost/nhost/releases/download/cli%40${version}/cli-${version}-darwin-amd64.tar.gz";
-      sha256 = "1kfp0f1nvszdhmixwvyqzah0i3jhicdw8sqzyvsp5yfld5izln5s";
+      sha256 = "0vydy279zcvrxjwv5iix6i523wfvy0kfxk41n19xy5gjv6y49f49";
     };
     aarch64-linux = {
       url = "https://github.com/nhost/nhost/releases/download/cli%40${version}/cli-${version}-linux-arm64.tar.gz";
-      sha256 = "13px0yhl2mzhgr6rdnhxnkc1pkrfnjncnfhpkbwakiqam7s7w3gl";
+      sha256 = "0mh169wxa2caaaipb7ljhscahgb6jlfmmyhdjyxz1w6yiwrh8px8";
     };
     x86_64-linux = {
       url = "https://github.com/nhost/nhost/releases/download/cli%40${version}/cli-${version}-linux-amd64.tar.gz";
-      sha256 = "1ibcqlns85jsn5b7wr86swvrdwjq0ln15dvilb3waz2kacyv8mmg";
+      sha256 = "0y3891xsr1r792qnxfxjycmnz32n3321mcbhfyk6r5hg8mcmrh1j";
     };
   };
 

--- a/nixops/project.nix
+++ b/nixops/project.nix
@@ -25,19 +25,26 @@ let
 
   # we use this to just build and cache the packages.
   # this list is the union of all `buildInputs`, `checkDeps`, and
-  # `nativeBuildInputs` referenced by every `project.nix` in the repo so a
-  # single `nix build .#nixops` warms the cache for every project's
-  # dev-shell and `make check`.
+  # `nativeBuildInputs` referenced by every `project.nix` in the repo,
+  # plus the per-devShell extras (e.g. `go-migrate` from auth, `certbot-*`
+  # from cli) and the root `flake.nix` devShell extras (`gh`, `git-cliff`,
+  # `gnused`, `nixfmt`), so a single `nix build .#nixops` warms the cache
+  # for every project's dev-shell and `make check`.
   buildInputs =
     (with pkgs; [
       biome
       bun
       cacert
+      certbot-full
       clang
       curl
       diffutils
       docker-client
+      gh
+      git-cliff
+      gnused
       go
+      go-migrate
       gofumpt
       golangci-lint
       golines
@@ -48,6 +55,7 @@ let
       lychee
       mockgen
       nhost-cli
+      nixfmt
       nodejs
       nodePackages.vercel
       oapi-codegen
@@ -56,6 +64,7 @@ let
       pnpm
       postgresql_18
       postgresql_18-client
+      python312Packages.certbot-dns-route53
       skopeo
       sqlc
       vacuum-go
@@ -66,6 +75,8 @@ let
       self.packages.${pkgs.stdenv.hostPlatform.system}.codegen
       self.packages.${pkgs.stdenv.hostPlatform.system}.govulncheck-wrapper
       self.packages.${pkgs.stdenv.hostPlatform.system}.storage-vips
+    ]
+    ++ pkgs.lib.optionals pkgs.stdenv.isLinux [
     ]
     ++ pkgs.lib.optionals pkgs.stdenv.isDarwin [
       pkgs.apple-sdk_14

--- a/nixops/project.nix
+++ b/nixops/project.nix
@@ -23,30 +23,53 @@ let
 
   checkDeps = [ ];
 
-  # we use this to just build and cache the packages
-  buildInputs = with pkgs; [
-    biome
-    go
-    golangci-lint
-    mockgen
-    golines
-    govulncheck
-    gqlgen
-    gqlgenc
-    oapi-codegen
-    nhost-cli
-    gofumpt
-    golines
-    skopeo
-    postgresql_18-client
-    sqlc
-    vacuum-go
-    bun
-    clang
-    pkg-config
-    nodejs
-    nodePackages.vercel
-  ];
+  # we use this to just build and cache the packages.
+  # this list is the union of all `buildInputs`, `checkDeps`, and
+  # `nativeBuildInputs` referenced by every `project.nix` in the repo so a
+  # single `nix build .#nixops` warms the cache for every project's
+  # dev-shell and `make check`.
+  buildInputs =
+    (with pkgs; [
+      biome
+      bun
+      cacert
+      clang
+      curl
+      diffutils
+      docker-client
+      go
+      gofumpt
+      golangci-lint
+      golines
+      govulncheck
+      gqlgen
+      gqlgenc
+      jq
+      lychee
+      mockgen
+      nhost-cli
+      nodejs
+      nodePackages.vercel
+      oapi-codegen
+      pkg-config
+      playwright-driver
+      pnpm
+      postgresql_18
+      postgresql_18-client
+      skopeo
+      sqlc
+      vacuum-go
+      vale
+      wal-g
+    ])
+    ++ [
+      self.packages.${pkgs.stdenv.hostPlatform.system}.codegen
+      self.packages.${pkgs.stdenv.hostPlatform.system}.govulncheck-wrapper
+      self.packages.${pkgs.stdenv.hostPlatform.system}.storage-vips
+    ]
+    ++ pkgs.lib.optionals pkgs.stdenv.isDarwin [
+      pkgs.apple-sdk_14
+    ];
 
   nativeBuildInputs = [ ];
 


### PR DESCRIPTION
<!-- nhost-reviewer:start -->
### **What this PR solves**
Adds macOS to the `nixops` CI matrix so the dev-shell tooling is built and cached for Darwin runners alongside Linux. The cache-warming derivation is expanded to cover every tool referenced by any project's `project.nix`, and several CI scripts are made portable (bash 3.x on macOS, BSD coreutils) so the same workflow runs on both OSes.

___

### **PR Type**
Configuration

___

### **Description**
- Adds `blacksmith-6vcpu-macos-latest` to the `nixops` `OS_MATRIX` and disables Docker image build/upload on macOS runners.
- Forwards short-lived OIDC AWS credentials to the Nix daemon (different `root` HOMEs and service managers on macOS vs Linux) so the S3 substituter authenticates from the daemon process.
- Rewrites `cache-nix/action.yml` to be bash-3 / BSD-coreutils portable: replaces `stat -c%s` with `wc -c`, swaps `mapfile` for `while read` loops.
- Switches the "do we need to build?" gate in `wf_build_artifacts.yaml` / `wf_check.yaml` from a runtime-closure `nix path-info` check to a `nix build --dry-run` stderr scan, catching build-time deps that aren't in the runtime closure.
- Expands `nixops/project.nix` `buildInputs` to the union of every project's tooling (plus `apple-sdk_14` on Darwin) so one `nix build .#nixops` warms the cache for all dev shells.
- Exposes `storage-vips` as a top-level flake package so it can be referenced from the nixops cache-warming derivation.

___

<details> <summary><h3> File Walkthrough</h3></summary>

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody>
<tr><td><strong>CI actions</strong></td><td><details><summary>2 files</summary><table>
<tr>
  <td><strong>.github/actions/cache-nix/action.yml</strong><dd><code>Portable shell: wc -c instead of stat -c%s; while read instead of mapfile.</code></dd></td>
  <td><a href="https://github.com/nhost/nhost/pull/4361/files#diff-6f9d544e5069b5f9d2c56a5079c3da7e24a08b08f513e7e1775ad10393f5ad37">+12/-3</a></td>
</tr>
<tr>
  <td><strong>.github/actions/setup-nix/action.yml</strong><dd><code>Forward AWS OIDC creds to the nix-daemon's root home; remove --no-daemon install option.</code></dd></td>
  <td><a href="https://github.com/nhost/nhost/pull/4361/files#diff-d6d03b00722cea2a21415f2e41951abebd36b521b485d7e4fc9fbb4a3c0195dc">+35/-8</a></td>
</tr>
</table></details></td></tr>
<tr><td><strong>CI workflows</strong></td><td><details><summary>3 files</summary><table>
<tr>
  <td><strong>.github/workflows/nixops_checks.yaml</strong><dd><code>Add macOS runner to OS_MATRIX; disable DOCKER for nixops.</code></dd></td>
  <td><a href="https://github.com/nhost/nhost/pull/4361/files#diff-5201e3151155366e6bb8b672a9fb68b52ae38b8c20c5f09c44953c040892226f">+2/-2</a></td>
</tr>
<tr>
  <td><strong>.github/workflows/wf_build_artifacts.yaml</strong><dd><code>Gate build via dry-run stderr scan; skip docker steps on macOS.</code></dd></td>
  <td><a href="https://github.com/nhost/nhost/pull/4361/files#diff-63d6f3e2e5894df4d88cf2c82b3d0c90e7b0b7c8ca9da25a3d46f35f15270fb0">+18/-6</a></td>
</tr>
<tr>
  <td><strong>.github/workflows/wf_check.yaml</strong><dd><code>Same dry-run-based BUILD_NEEDED detection for checks.</code></dd></td>
  <td><a href="https://github.com/nhost/nhost/pull/4361/files#diff-c2ecea6736037ba6304681d744d612d44d7681788d2fbc58ce223cf52ecefa43">+16/-4</a></td>
</tr>
</table></details></td></tr>
<tr><td><strong>Nix</strong></td><td><details><summary>2 files</summary><table>
<tr>
  <td><strong>flake.nix</strong><dd><code>Expose storage-vips as a top-level package.</code></dd></td>
  <td><a href="https://github.com/nhost/nhost/pull/4361/files#diff-206b9ce276ab5971a2489d75eb1b12999d4bf3843b7988cbe8d687cfde61dea0">+1/-0</a></td>
</tr>
<tr>
  <td><strong>nixops/project.nix</strong><dd><code>Expand buildInputs to union of all projects' tools; add apple-sdk_14 on Darwin.</code></dd></td>
  <td><a href="https://github.com/nhost/nhost/pull/4361/files#diff-36b666e7f8b2a0262065708ad307cfcc07b3f959515ca2bfad889c3d09266eeb">+47/-24</a></td>
</tr>
</table></details></td></tr>
</tbody></table>

</details>

___

<!-- nhost-reviewer:end -->