### PR TITLE
chore(constellation): update README.md instructions

### DIFF
--- a/services/constellation/README.md
+++ b/services/constellation/README.md
@@ -55,7 +55,7 @@ The lowest-friction way to try Constellation is to enable it on an Nhost project
 
 ```toml
 [experimental.constellation]
-version = "0.3.0"
+version = "0.2.1"
 ```
 
 Pick the latest tag from [`CHANGELOG.md`](./CHANGELOG.md) — we recommend always running the latest. With this in place, an Nhost project runs Hasura and Constellation side by side:
@@ -71,7 +71,7 @@ All available settings under `[experimental.constellation]`:
 [experimental.constellation]
 # Constellation image tag. Available versions:
 # https://github.com/nhost/nhost/blob/main/services/constellation/CHANGELOG.md
-version = "0.2.0"
+version = "0.2.1"
 
 [experimental.constellation.settings]
 # CORS allowed origins. If set, used as-is.

--- a/services/constellation/README.md
+++ b/services/constellation/README.md
@@ -16,13 +16,6 @@ What this means in practice:
 
 Even without a dedicated optimisation pass, production workloads show Constellation is **slightly faster than Hasura at a fraction of the resources** — we're seeing **90–95% reduction in memory usage** in real production deployments while serving the same traffic. CPU is comparable to marginally lower. This is before any of the performance-focused work on the roadmap.
 
-The headline numbers come mostly from architectural choices that fall out of writing this in Go from scratch:
-
-- A raw-bytes response fast path that skips JSON re-serialisation when SQL connectors return raw JSON.
-- An LRU cache of parsed/validated GraphQL queries, keyed per role.
-- Multiplexed subscription polling that batches subscribers with identical queries into single SQL polls (cohort model).
-- Lock-free atomic state swap on metadata reload, so request handlers never block on configuration changes.
-
 ## Goals
 
 1. **Drop-in compatibility with Hasura** for everything that runs on the GraphQL request path. Same metadata format, same generated schema, same query/mutation/subscription semantics. A handful of small concessions exist for correctness — see [`KNOWN_DIFFERENCES.md`](./KNOWN_DIFFERENCES.md).
@@ -55,6 +48,50 @@ The headline numbers come mostly from architectural choices that fall out of wri
 Hasura owns metadata authoring; Constellation owns request serving. Both speak to the same database. Once Constellation supports metadata mutations on its own, the Hasura half can be dropped.
 
 ## Quick start
+
+### With an Nhost project (recommended)
+
+The lowest-friction way to try Constellation is to enable it on an Nhost project — local or cloud — via the `nhost-toml`. Add to `nhost/nhost.toml` either locally or in your cloud project's configuration editor:
+
+```toml
+[experimental.constellation]
+version = "0.3.0"
+```
+
+Pick the latest tag from [`CHANGELOG.md`](./CHANGELOG.md) — we recommend always running the latest. With this in place, an Nhost project runs Hasura and Constellation side by side:
+
+- `https://<subdomain>.hasura.<region>.nhost.run` — routed to Hasura (metadata authoring, plus anything Constellation doesn't serve yet).
+- `https://<subdomain>.graphql.<region>.nhost.run` — routed to Constellation.
+
+Because both engines share the same database and metadata, you can flip Constellation on to try it, run real traffic through it, and remove the block to fall back to Hasura at any time. While it's running, the schema-diff workflow in [Compatibility](#verifying-compatibility-against-your-hasura-instance) lets you confirm the two endpoints produce equivalent schemas per role.
+
+All available settings under `[experimental.constellation]`:
+
+```toml
+[experimental.constellation]
+# Constellation image tag. Available versions:
+# https://github.com/nhost/nhost/blob/main/services/constellation/CHANGELOG.md
+version = "0.2.0"
+
+[experimental.constellation.settings]
+# CORS allowed origins. If set, used as-is.
+# If unset, origins are derived from auth.redirections.clientUrl and
+# auth.redirections.allowedUrls (paths/queries/fragments stripped).
+corsAllowedOrigins = []
+
+# Enable debug logging.
+debug = false
+
+# Return raw connector/database error detail to clients instead of the
+# sanitized generic message. For development only — never enable in
+# production, as it leaks internal schema and data values.
+devMode = false
+
+# Polling interval for GraphQL subscriptions.
+subscriptionPollInterval = "1s"
+```
+
+If you'd rather run Constellation standalone (no Nhost project), keep reading.
 
 ### Prerequisites
 
@@ -153,29 +190,37 @@ Constellation aims to be a drop-in replacement for Hasura on the GraphQL request
 
 ### Verifying compatibility against your Hasura instance
 
-If you run Hasura and Constellation side-by-side against the same database, you can confirm Constellation generates the schema you expect by introspecting both and diffing the SDL per role. The `nhost schema dump` and `nhost schema diff` subcommands (in the Nhost CLI) do exactly that:
+If you run Hasura and Constellation side-by-side against the same database, you can confirm Constellation generates the schema you expect by introspecting both and diffing the SDL per role. The `nhost schema dump` and `nhost schema diff` subcommands (in the Nhost CLI) do exactly that (make sure you are running latest nhost cli version):
 
 ```bash
 #!/bin/bash
 set -euo pipefail
 
+DST_PATH="./schemas"
+
+mkdir -p "$DST_PATH"
+
+SUBDOMAIN="local"
+REGION="local"
+ADMIN_SECRET="nhost-admin-secret"
+
 ROLES=(admin user public)
-HASURA_URL="https://your-hasura-endpoint/v1"
-NHOST_URL="http://your-constellation-endpoint/v1/graphql"
-ADMIN_SECRET="your-admin-secret"
+
+HASURA_URL="https://${SUBDOMAIN}.hasura.${REGION}.nhost.run/v1/graphql"
+CONSTELLATION_URL="https://${SUBDOMAIN}.graphql.${REGION}.nhost.run/v1/graphql"
 
 for role in "${ROLES[@]}"; do
     nhost schema dump \
         --role "${role}" --admin-secret "${ADMIN_SECRET}" \
-        -u "${HASURA_URL}" -o "./schema.hasura.${role}.graphqls"
+        -u "${HASURA_URL}" -o "${DST_PATH}/schema.hasura.${role}.graphqls"
 
     nhost schema dump \
         --role "${role}" --admin-secret "${ADMIN_SECRET}" \
-        -u "${NHOST_URL}" -o "./schema.nhost.${role}.graphqls"
+        -u "${CONSTELLATION_URL}" -o "${DST_PATH}/schema.nhost.${role}.graphqls"
 
     nhost schema diff \
-        -a "schema.hasura.${role}.graphqls" \
-        -b "schema.nhost.${role}.graphqls" > "schema.${role}.diff"
+        -a "${DST_PATH}/schema.hasura.${role}.graphqls" \
+        -b "${DST_PATH}/schema.nhost.${role}.graphqls" > "${DST_PATH}/schema.${role}.diff"
 done
 ```
 
@@ -228,34 +273,6 @@ Patches welcome. Before opening a PR:
 2. Add tests — public symbols need black-box coverage; complex unexported logic gets white-box tests.
 3. Update goldens with `-update` if you intentionally changed generated output.
 4. See [`CLAUDE.md`](./CLAUDE.md) for the full project conventions and Go package design rules.
-
-## Roadmap
-
-### Shipped
-
-- GraphQL generation from database schema
-- CRUD operations, row permissions and presets, role-based access
-- Relationships, aggregations, custom scalars, enum types
-- PostgreSQL functions
-- Subscriptions, including `_stream`
-- Multi-database (independent queries and cross-database remote relationships)
-- Remote schemas with cross-source remote relationships
-- JWT auth (symmetric, asymmetric, JWKS, `claims_map`) and admin secret
-- Metadata loading from file or polled from `hdb_catalog.hdb_metadata`
-
-### Pre-1.0
-
-- Test coverage and benchmark comparisons against Hasura
-- Metrics and structured logging surface
-- Computed fields
-- Views (read fully supported today; first-class metadata configuration is open)
-- Database events / triggers
-- Pre / post-mutation checks beyond the SQL `check` clause
-- Persistent queries / allowlists
-- Metadata Management HTTP API (to drop the Hasura dependency)
-- Subscription revisit (correctness + performance pass)
-- Removing the admin-secret path from the WebSocket handler in favour of JWT-only
-- MySQL support (under consideration)
 
 ## License
 

--- a/services/constellation/README.md
+++ b/services/constellation/README.md
@@ -51,7 +51,7 @@ Hasura owns metadata authoring; Constellation owns request serving. Both speak t
 
 ### With an Nhost project (recommended)
 
-The lowest-friction way to try Constellation is to enable it on an Nhost project — local or cloud — via the `nhost-toml`. Add to `nhost/nhost.toml` either locally or in your cloud project's configuration editor:
+The lowest-friction way to try Constellation is to enable it on an Nhost project — local or cloud — via the `nhost.toml`. Add to `nhost/nhost.toml` either locally or in your cloud project's configuration editor:
 
 ```toml
 [experimental.constellation]


### PR DESCRIPTION
<!-- nhost-reviewer:start -->
### **What this PR solves**
The Constellation README pointed users at standalone setup as the only on-ramp and exposed internal architectural detail and a speculative roadmap that quickly go stale. This PR shifts the recommended path to enabling Constellation on an existing Nhost project via `nhost.toml`, documents the full `[experimental.constellation]` settings surface, and tightens the schema-diff example — while removing the now-distracting performance fast-path bullets and Roadmap section.

___

### **PR Type**
Documentation

___

### **Description**
- Add a new "With an Nhost project (recommended)" Quick-start subsection covering the `[experimental.constellation]` TOML block, the dual Hasura/Constellation routing (`*.hasura.*` vs `*.graphql.*`), and a full settings reference (`corsAllowedOrigins`, `debug`, `devMode`, `subscriptionPollInterval`).
- Rewrite the schema-diff bash snippet under "Verifying compatibility against your Hasura instance" with parameterised `SUBDOMAIN` / `REGION` / `ADMIN_SECRET` / `DST_PATH` variables, a `mkdir -p`, and `nhost.run` endpoint hostnames; adds a note to run the latest Nhost CLI.
- Drop the "Performance" section's four-bullet list of architectural fast paths (raw-bytes response, LRU query cache, multiplexed subscription polling, lock-free state swap) — the headline numbers stay; the implementation notes move to `docs/developers/architecture.md`.
- Delete the "## Roadmap" section (Shipped / Pre-1.0 bullets) to avoid maintaining a second, drifting feature list alongside `docs/user/hasura-metadata-support.md`.

___

<details> <summary><h3> File Walkthrough</h3></summary>

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody>
<tr><td><strong>Documentation</strong></td><td><details><summary>1 files</summary><table>
<tr>
  <td><strong>services/constellation/README.md</strong><dd><code>Add Nhost-project Quick start with full TOML settings reference, rewrite schema-diff example, drop Performance fast-path bullets and Roadmap section.</code></dd></td>
  <td><a href="https://github.com/nhost/nhost/pull/4363/files#diff-84a028508c3a75c60ec1b33705bbab8f84bee22345406912ad3fe789d4599b63">+60/-43</a></td>
</tr>
</table></details></td></tr>
</tbody></table>

</details>

___

<!-- nhost-reviewer:end -->