### PR TITLE
chore(nixops): drop nix-filter input in favor of pkgs.lib.fileset

### DIFF
--- a/cli/project.nix
+++ b/cli/project.nix
@@ -1,7 +1,6 @@
 {
   self,
   pkgs,
-  nix-filter,
   nixops-lib,
 }:
 let
@@ -11,49 +10,49 @@ let
   created = "1970-01-01T00:00:00Z";
   submodule = "${name}";
 
-  src = nix-filter.lib.filter {
+  fs = pkgs.lib.fileset;
+
+  src = fs.toSource {
     root = ./..;
-    include = with nix-filter.lib; [
-      "go.mod"
-      "go.sum"
-      (inDirectory "vendor")
-      ".golangci.yaml"
-      "govulncheck.yaml"
-      isDirectory
-      (and (inDirectory submodule) (matchExt "go"))
-      "${submodule}/get_access_token.sh"
-      "${submodule}/gqlgenc.yaml"
-      (inDirectory "${submodule}/ssl/.ssl")
-      (inDirectory "${submodule}/cmd/config/testdata")
-      (inDirectory "${submodule}/cmd/project/templates")
-      (inDirectory "${submodule}/nhostclient/graphql/query/")
+    fileset = fs.unions [
+      ../go.mod
+      ../go.sum
+      ../vendor
+      ../.golangci.yaml
+      ../govulncheck.yaml
+      (fs.fileFilter (f: f.hasExt "go") ./.)
+      ./get_access_token.sh
+      ./gqlgenc.yaml
+      ./ssl/.ssl
+      ./cmd/config/testdata
+      ./cmd/project/templates
+      ./nhostclient/graphql/query
 
-      (and (inDirectory "internal/lib/clidocs") (matchExt "go"))
+      (fs.fileFilter (f: f.hasExt "go") ../internal/lib/clidocs)
 
-      (and (inDirectory "internal/lib/nhostclient") (matchExt "go"))
+      (fs.fileFilter (f: f.hasExt "go") ../internal/lib/nhostclient)
 
-      (and (inDirectory "internal/lib/oapi") (matchExt "go"))
+      (fs.fileFilter (f: f.hasExt "go") ../internal/lib/oapi)
 
-      "${submodule}/cmd/configserver/logsapi/gqlgen.yml"
-      "${submodule}/cmd/configserver/logsapi/schema.graphqls"
+      ./cmd/configserver/logsapi/gqlgen.yml
+      ./cmd/configserver/logsapi/schema.graphqls
 
-      "${submodule}/mcp/nhost/auth/openapi.yaml"
-      "${submodule}/mcp/nhost/graphql/openapi.yaml"
-      "${submodule}/mcp/resources/cloud_schema.graphql"
-      "${submodule}/mcp/resources/cloud_schema-with-mutations.graphql"
-      "${submodule}/mcp/resources/nhost_toml_schema.cue"
-      (inDirectory "${submodule}/cmd/mcp/testdata")
-      (inDirectory "${submodule}/mcp/graphql/testdata")
+      ./mcp/nhost/graphql/openapi.yaml
+      ./mcp/resources/cloud_schema.graphql
+      ./mcp/resources/cloud_schema-with-mutations.graphql
+      ./mcp/resources/nhost_toml_schema.cue
+      ./cmd/mcp/testdata
+      ./mcp/graphql/testdata
 
       # constellation (used by `nhost schema` for SDL dump/diff)
-      (and (inDirectory "services/constellation") (matchExt "go"))
+      (fs.fileFilter (f: f.hasExt "go") ../services/constellation)
 
       # auth email templates (embedded into the CLI binary by `nhost init`)
-      (inDirectory "services/auth/email-templates")
+      ../services/auth/email-templates
 
       # docs
       ../docs/embed.go
-      (and (inDirectory ../docs/src/content/docs) (matchExt "mdx"))
+      (fs.fileFilter (f: f.hasExt "mdx") ../docs/src/content/docs)
     ];
   };
 

--- a/dashboard/project.nix
+++ b/dashboard/project.nix
@@ -119,6 +119,7 @@ rec {
       ;
 
     preCheck = ''
+      mkdir -p packages
       rm -rf packages/nhost-js
       cp -r ${self.packages.${pkgs.system}.nhost-js} packages/nhost-js
     '';
@@ -136,6 +137,7 @@ rec {
         cp -r ${node_modules}/node_modules/ node_modules
         cp -r ${node_modules}/dashboard/node_modules/ dashboard/node_modules
 
+        mkdir -p packages
         rm -rf packages/nhost-js
         cp -r ${self.packages.${pkgs.system}.nhost-js} packages/nhost-js
 
@@ -183,6 +185,7 @@ rec {
       cp -r ${node_modules}/node_modules/ node_modules
       cp -r ${node_modules}/dashboard/node_modules/ dashboard/node_modules
 
+      mkdir -p packages
       rm -rf packages/nhost-js
       cp -r ${self.packages.${pkgs.system}.nhost-js} packages/nhost-js
 

--- a/dashboard/project.nix
+++ b/dashboard/project.nix
@@ -2,7 +2,6 @@
   self,
   pkgs,
   nix2containerPkgs,
-  nix-filter,
   nixops-lib,
 }:
 let
@@ -11,19 +10,21 @@ let
   created = "1970-01-01T00:00:00Z";
   submodule = "${name}";
 
+  fs = pkgs.lib.fileset;
+
   node_modules = nixops-lib.js.mkNodeModules {
     name = "node-modules-${name}";
     version = "0.0.0-dev";
 
-    src = nix-filter.lib.filter {
+    src = fs.toSource {
       root = ./..;
-      include = [
-        ".npmrc"
-        "package.json"
-        "pnpm-workspace.yaml"
-        "pnpm-lock.yaml"
-        "${submodule}/package.json"
-        "${submodule}/pnpm-lock.yaml"
+      fileset = fs.unions [
+        ../.npmrc
+        ../package.json
+        ../pnpm-workspace.yaml
+        ../pnpm-lock.yaml
+        ./package.json
+        ./pnpm-lock.yaml
       ];
     };
 
@@ -35,47 +36,40 @@ let
     '';
   };
 
-  src = nix-filter.lib.filter {
+  src = fs.toSource {
     root = ../.;
-    include = with nix-filter.lib; [
-      isDirectory
-      ".npmrc"
-      ".prettierignore"
-      ".prettierrc.js"
-      "audit-ci.jsonc"
-      "package.json"
-      "pnpm-workspace.yaml"
-      "pnpm-lock.yaml"
-      "turbo.json"
-      "biome.json"
-      ".gitignore"
-      (inDirectory "build/configs")
-      "${submodule}/.env.test"
-      "${submodule}/.env.example"
-      "${submodule}/.lintstagedrc.json"
-      "${submodule}/biome.json"
-      "${submodule}/.npmrc"
-      "${submodule}/.prettierignore"
-      "${submodule}/.lychee.toml"
-      "${submodule}/components.json"
-      "${submodule}/graphite.graphql.config.yaml"
-      "${submodule}/graphql.config.yaml"
-      "${submodule}/next-env.d.ts"
-      "${submodule}/next.config.js"
-      "${submodule}/package.json"
-      "${submodule}/pnpm-lock.yaml"
-      "${submodule}/playwright.config.ts"
-      "${submodule}/postcss.config.js"
-      "${submodule}/prettier.config.js"
-      "${submodule}/react-table-config.d.ts"
-      "${submodule}/tailwind.config.js"
-      "${submodule}/tsconfig.json"
-      "${submodule}/tsconfig.test.json"
-      "${submodule}/vitest.config.mts"
-      "${submodule}/vitest.global-setup.ts"
-      (inDirectory "${submodule}/e2e")
-      (inDirectory "${submodule}/public")
-      (inDirectory "${submodule}/src")
+    fileset = fs.unions [
+      ../.npmrc
+      ../.prettierignore
+      ../.prettierrc.js
+      ../audit-ci.jsonc
+      ../package.json
+      ../pnpm-workspace.yaml
+      ../pnpm-lock.yaml
+      ../turbo.json
+      ../biome.json
+      ../.gitignore
+      ../build/configs
+      ./.env.example
+      ./.lintstagedrc.json
+      ./biome.json
+      ./.lychee.toml
+      ./components.json
+      ./graphite.graphql.config.yaml
+      ./graphql.config.yaml
+      ./next.config.js
+      ./package.json
+      ./pnpm-lock.yaml
+      ./playwright.config.ts
+      ./postcss.config.js
+      ./tailwind.config.js
+      ./tsconfig.json
+      ./tsconfig.test.json
+      ./vitest.config.mts
+      ./vitest.global-setup.ts
+      ./e2e
+      ./public
+      ./src
     ];
   };
 

--- a/docs/project.nix
+++ b/docs/project.nix
@@ -2,7 +2,6 @@
   self,
   pkgs,
   nixops-lib,
-  nix-filter,
 }:
 let
   name = "docs";
@@ -10,40 +9,41 @@ let
   created = "1970-01-01T00:00:00Z";
   submodule = "${name}";
 
+  fs = pkgs.lib.fileset;
+
   node_modules = nixops-lib.js.mkNodeModules {
     name = "node-modules-${name}";
     version = "0.0.0-dev";
 
-    src = nix-filter.lib.filter {
+    src = fs.toSource {
       root = ../.;
-      include = with nix-filter.lib; [
-        ".npmrc"
-        "package.json"
-        "pnpm-workspace.yaml"
-        "pnpm-lock.yaml"
-        "${submodule}/package.json"
-        "${submodule}/pnpm-lock.yaml"
+      fileset = fs.unions [
+        ../.npmrc
+        ../package.json
+        ../pnpm-workspace.yaml
+        ../pnpm-lock.yaml
+        ./package.json
+        ./pnpm-lock.yaml
       ];
     };
   };
 
-  src = nix-filter.lib.filter {
+  src = fs.toSource {
     root = ../.;
-    include = with nix-filter.lib; [
-      isDirectory
-      ".npmrc"
-      ".prettierignore"
-      ".prettierrc.js"
-      ".gitignore"
-      "audit-ci.jsonc"
-      "biome.json"
-      "package.json"
-      "pnpm-workspace.yaml"
-      "pnpm-lock.yaml"
-      "turbo.json"
-      (inDirectory "./build")
-      (inDirectory "${submodule}")
-      (and (inDirectory "packages/nhost-js/src") (matchExt "ts"))
+    fileset = fs.unions [
+      ../.npmrc
+      ../.prettierignore
+      ../.prettierrc.js
+      ../.gitignore
+      ../audit-ci.jsonc
+      ../biome.json
+      ../package.json
+      ../pnpm-workspace.yaml
+      ../pnpm-lock.yaml
+      ../turbo.json
+      ../build
+      ./.
+      (fs.fileFilter (f: f.hasExt "ts") ../packages/nhost-js/src)
       ../services/auth/docs/openapi.yaml
       ../services/storage/controller/openapi.yaml
       ../packages/nhost-js/tsconfig.json

--- a/examples/demos/project.nix
+++ b/examples/demos/project.nix
@@ -89,6 +89,7 @@ in
       ;
 
     preCheck = ''
+      mkdir -p packages
       rm -rf packages/nhost-js
       cp -r ${self.packages.${pkgs.system}.nhost-js} packages/nhost-js
     '';
@@ -116,6 +117,7 @@ in
         cp -r ${node_modules}/$dir/node_modules $dir/node_modules
       done
 
+      mkdir -p packages
       rm -rf packages/nhost-js
       cp -r ${self.packages.${pkgs.system}.nhost-js} packages/nhost-js
 

--- a/examples/demos/project.nix
+++ b/examples/demos/project.nix
@@ -2,7 +2,6 @@
   self,
   pkgs,
   nix2containerPkgs,
-  nix-filter,
   nixops-lib,
 }:
 let
@@ -10,23 +9,25 @@ let
   version = "0.0.0-dev";
   submodule = "examples/${name}";
 
+  fs = pkgs.lib.fileset;
+
   node_modules = nixops-lib.js.mkNodeModules {
     name = "node-modules-${name}";
     version = "0.0.0-dev";
 
-    src = nix-filter.lib.filter {
+    src = fs.toSource {
       root = ../..;
-      include = [
-        ".npmrc"
-        "package.json"
-        "pnpm-workspace.yaml"
-        "pnpm-lock.yaml"
-        "${submodule}/package.json"
-        "${submodule}/pnpm-lock.yaml"
-        "${submodule}/express/package.json"
-        "${submodule}/express/pnpm-lock.yaml"
-        "${submodule}/react-demo/package.json"
-        "${submodule}/react-demo/pnpm-lock.yaml"
+      fileset = fs.unions [
+        ../../.npmrc
+        ../../package.json
+        ../../pnpm-workspace.yaml
+        ../../pnpm-lock.yaml
+        ./package.json
+        ./pnpm-lock.yaml
+        ./express/package.json
+        ./express/pnpm-lock.yaml
+        ./react-demo/package.json
+        ./react-demo/pnpm-lock.yaml
       ];
     };
 
@@ -38,20 +39,19 @@ let
     '';
   };
 
-  src = nix-filter.lib.filter {
+  src = fs.toSource {
     root = ../../.;
-    include = with nix-filter.lib; [
-      isDirectory
-      ".gitignore"
-      ".npmrc"
-      "audit-ci.jsonc"
-      "biome.json"
-      "package.json"
-      "pnpm-workspace.yaml"
-      "pnpm-lock.yaml"
-      "turbo.json"
-      (inDirectory "./build")
-      (inDirectory "${submodule}")
+    fileset = fs.unions [
+      ../../.gitignore
+      ../../.npmrc
+      ../../audit-ci.jsonc
+      ../../biome.json
+      ../../package.json
+      ../../pnpm-workspace.yaml
+      ../../pnpm-lock.yaml
+      ../../turbo.json
+      ../../build
+      ./.
     ];
   };
 

--- a/examples/guides/project.nix
+++ b/examples/guides/project.nix
@@ -2,7 +2,6 @@
   self,
   pkgs,
   nix2containerPkgs,
-  nix-filter,
   nixops-lib,
 }:
 let
@@ -10,27 +9,29 @@ let
   version = "0.0.0-dev";
   submodule = "examples/${name}";
 
+  fs = pkgs.lib.fileset;
+
   node_modules = nixops-lib.js.mkNodeModules {
     name = "node-modules-${name}";
     version = "0.0.0-dev";
 
-    src = nix-filter.lib.filter {
+    src = fs.toSource {
       root = ../..;
-      include = [
-        ".npmrc"
-        "package.json"
-        "pnpm-workspace.yaml"
-        "pnpm-lock.yaml"
-        "${submodule}/package.json"
-        "${submodule}/pnpm-lock.yaml"
-        "${submodule}/codegen-nhost/package.json"
-        "${submodule}/codegen-nhost/pnpm-lock.yaml"
-        "${submodule}/react-apollo/package.json"
-        "${submodule}/react-apollo/pnpm-lock.yaml"
-        "${submodule}/react-query/package.json"
-        "${submodule}/react-query/pnpm-lock.yaml"
-        "${submodule}/react-urql/package.json"
-        "${submodule}/react-urql/pnpm-lock.yaml"
+      fileset = fs.unions [
+        ../../.npmrc
+        ../../package.json
+        ../../pnpm-workspace.yaml
+        ../../pnpm-lock.yaml
+        ./package.json
+        ./pnpm-lock.yaml
+        ./codegen-nhost/package.json
+        ./codegen-nhost/pnpm-lock.yaml
+        ./react-apollo/package.json
+        ./react-apollo/pnpm-lock.yaml
+        ./react-query/package.json
+        ./react-query/pnpm-lock.yaml
+        ./react-urql/package.json
+        ./react-urql/pnpm-lock.yaml
       ];
     };
 
@@ -42,20 +43,19 @@ let
     '';
   };
 
-  src = nix-filter.lib.filter {
+  src = fs.toSource {
     root = ../../.;
-    include = with nix-filter.lib; [
-      isDirectory
-      ".gitignore"
-      ".npmrc"
-      "audit-ci.jsonc"
-      "biome.json"
-      "package.json"
-      "pnpm-workspace.yaml"
-      "pnpm-lock.yaml"
-      "turbo.json"
-      (inDirectory "./build")
-      (inDirectory "${submodule}")
+    fileset = fs.unions [
+      ../../.gitignore
+      ../../.npmrc
+      ../../audit-ci.jsonc
+      ../../biome.json
+      ../../package.json
+      ../../pnpm-workspace.yaml
+      ../../pnpm-lock.yaml
+      ../../turbo.json
+      ../../build
+      ./.
     ];
   };
 

--- a/examples/guides/project.nix
+++ b/examples/guides/project.nix
@@ -93,6 +93,7 @@ in
       ;
 
     preCheck = ''
+      mkdir -p packages
       rm -rf packages/nhost-js
       cp -r ${self.packages.${pkgs.system}.nhost-js} packages/nhost-js
     '';
@@ -120,6 +121,7 @@ in
         cp -r ${node_modules}/$dir/node_modules $dir/node_modules
       done
 
+      mkdir -p packages
       rm -rf packages/nhost-js
       cp -r ${self.packages.${pkgs.system}.nhost-js} packages/nhost-js
 

--- a/examples/tutorials/project.nix
+++ b/examples/tutorials/project.nix
@@ -95,6 +95,7 @@ in
       ;
 
     preCheck = ''
+      mkdir -p packages
       rm -rf packages/nhost-js
       cp -r ${self.packages.${pkgs.system}.nhost-js} packages/nhost-js
     '';
@@ -122,6 +123,7 @@ in
         cp -r ${node_modules}/$dir/node_modules $dir/node_modules
       done
 
+      mkdir -p packages
       rm -rf packages/nhost-js
       cp -r ${self.packages.${pkgs.system}.nhost-js} packages/nhost-js
 

--- a/examples/tutorials/project.nix
+++ b/examples/tutorials/project.nix
@@ -2,7 +2,6 @@
   self,
   pkgs,
   nix2containerPkgs,
-  nix-filter,
   nixops-lib,
 }:
 let
@@ -10,29 +9,31 @@ let
   version = "0.0.0-dev";
   submodule = "examples/${name}";
 
+  fs = pkgs.lib.fileset;
+
   node_modules = nixops-lib.js.mkNodeModules {
     name = "node-modules-${name}";
     version = "0.0.0-dev";
 
-    src = nix-filter.lib.filter {
+    src = fs.toSource {
       root = ../..;
-      include = [
-        ".npmrc"
-        "package.json"
-        "pnpm-workspace.yaml"
-        "pnpm-lock.yaml"
-        "${submodule}/package.json"
-        "${submodule}/pnpm-lock.yaml"
-        "${submodule}/nhost-nextjs-tutorial/package.json"
-        "${submodule}/nhost-nextjs-tutorial/pnpm-lock.yaml"
-        "${submodule}/nhost-react-tutorial/package.json"
-        "${submodule}/nhost-react-tutorial/pnpm-lock.yaml"
-        "${submodule}/nhost-reactnative-tutorial/package.json"
-        "${submodule}/nhost-reactnative-tutorial/pnpm-lock.yaml"
-        "${submodule}/nhost-svelte-tutorial/package.json"
-        "${submodule}/nhost-svelte-tutorial/pnpm-lock.yaml"
-        "${submodule}/nhost-vue-tutorial/package.json"
-        "${submodule}/nhost-vue-tutorial/pnpm-lock.yaml"
+      fileset = fs.unions [
+        ../../.npmrc
+        ../../package.json
+        ../../pnpm-workspace.yaml
+        ../../pnpm-lock.yaml
+        ./package.json
+        ./pnpm-lock.yaml
+        ./nhost-nextjs-tutorial/package.json
+        ./nhost-nextjs-tutorial/pnpm-lock.yaml
+        ./nhost-react-tutorial/package.json
+        ./nhost-react-tutorial/pnpm-lock.yaml
+        ./nhost-reactnative-tutorial/package.json
+        ./nhost-reactnative-tutorial/pnpm-lock.yaml
+        ./nhost-svelte-tutorial/package.json
+        ./nhost-svelte-tutorial/pnpm-lock.yaml
+        ./nhost-vue-tutorial/package.json
+        ./nhost-vue-tutorial/pnpm-lock.yaml
       ];
     };
 
@@ -44,20 +45,19 @@ let
     '';
   };
 
-  src = nix-filter.lib.filter {
+  src = fs.toSource {
     root = ../../.;
-    include = with nix-filter.lib; [
-      isDirectory
-      ".gitignore"
-      ".npmrc"
-      "audit-ci.jsonc"
-      "biome.json"
-      "package.json"
-      "pnpm-workspace.yaml"
-      "pnpm-lock.yaml"
-      "turbo.json"
-      (inDirectory "./build")
-      (inDirectory "${submodule}")
+    fileset = fs.unions [
+      ../../.gitignore
+      ../../.npmrc
+      ../../audit-ci.jsonc
+      ../../biome.json
+      ../../package.json
+      ../../pnpm-workspace.yaml
+      ../../pnpm-lock.yaml
+      ../../turbo.json
+      ../../build
+      ./.
     ];
   };
 

--- a/flake.lock
+++ b/flake.lock
@@ -1,98 +1,82 @@
 {
   "nodes": {
-  "flake-utils": {
-  "inputs": {
-  "systems": "systems"
-  },
-  "locked": {
-  "lastModified": 1731533236,
-  "narHash": "sha256-l0KFg5HjrsfsO/JpG+r7fRrqm12kzFHyUHqHCVpMMbI=",
-  "owner": "numtide",
-  "repo": "flake-utils",
-  "rev": "11707dc2f618dd54ca8739b309ec4fc024de578b",
-  "type": "github"
-  },
-  "original": {
-  "owner": "numtide",
-  "repo": "flake-utils",
-  "type": "github"
-  }
-  },
-  "nix-filter": {
-  "locked": {
-  "lastModified": 1757882181,
-  "narHash": "sha256-+cCxYIh2UNalTz364p+QYmWHs0P+6wDhiWR4jDIKQIU=",
-  "owner": "numtide",
-  "repo": "nix-filter",
-  "rev": "59c44d1909c72441144b93cf0f054be7fe764de5",
-  "type": "github"
-  },
-  "original": {
-  "owner": "numtide",
-  "repo": "nix-filter",
-  "type": "github"
-  }
-  },
-  "nix2container": {
-  "inputs": {
-  "nixpkgs": [
-  "nixpkgs"
-  ]
-  },
-  "locked": {
-  "lastModified": 1767430085,
-  "narHash": "sha256-SiXJ6xv4pS2MDUqfj0/mmG746cGeJrMQGmoFgHLS25Y=",
-  "owner": "nlewo",
-  "repo": "nix2container",
-  "rev": "66f4b8a47e92aa744ec43acbb5e9185078983909",
-  "type": "github"
-  },
-  "original": {
-  "owner": "nlewo",
-  "repo": "nix2container",
-  "type": "github"
-  }
-  },
-  "nixpkgs": {
-  "locked": {
-  "lastModified": 1768302833,
-  "narHash": "sha256-h5bRFy9bco+8QcK7rGoOiqMxMbmn21moTACofNLRMP4=",
-  "owner": "NixOS",
-  "repo": "nixpkgs",
-  "rev": "61db79b0c6b838d9894923920b612048e1201926",
-  "type": "github"
-  },
-  "original": {
-  "owner": "NixOS",
-  "ref": "nixpkgs-unstable",
-  "repo": "nixpkgs",
-  "type": "github"
-  }
-  },
-  "root": {
-  "inputs": {
-  "flake-utils": "flake-utils",
-  "nix-filter": "nix-filter",
-  "nix2container": "nix2container",
-  "nixpkgs": "nixpkgs"
-  }
-  },
-  "systems": {
-  "locked": {
-  "lastModified": 1681028828,
-  "narHash": "sha256-Vy1rq5AaRuLzOxct8nz4T6wlgyUR7zLU309k9mBC768=",
-  "owner": "nix-systems",
-  "repo": "default",
-  "rev": "da67096a3b9bf56a91d16901293e51ba5b49a27e",
-  "type": "github"
-  },
-  "original": {
-  "owner": "nix-systems",
-  "repo": "default",
-  "type": "github"
-  }
-  }
+    "flake-utils": {
+      "inputs": {
+        "systems": "systems"
+      },
+      "locked": {
+        "lastModified": 1731533236,
+        "narHash": "sha256-l0KFg5HjrsfsO/JpG+r7fRrqm12kzFHyUHqHCVpMMbI=",
+        "owner": "numtide",
+        "repo": "flake-utils",
+        "rev": "11707dc2f618dd54ca8739b309ec4fc024de578b",
+        "type": "github"
+      },
+      "original": {
+        "owner": "numtide",
+        "repo": "flake-utils",
+        "type": "github"
+      }
+    },
+    "nix2container": {
+      "inputs": {
+        "nixpkgs": [
+          "nixpkgs"
+        ]
+      },
+      "locked": {
+        "lastModified": 1767430085,
+        "narHash": "sha256-SiXJ6xv4pS2MDUqfj0/mmG746cGeJrMQGmoFgHLS25Y=",
+        "owner": "nlewo",
+        "repo": "nix2container",
+        "rev": "66f4b8a47e92aa744ec43acbb5e9185078983909",
+        "type": "github"
+      },
+      "original": {
+        "owner": "nlewo",
+        "repo": "nix2container",
+        "type": "github"
+      }
+    },
+    "nixpkgs": {
+      "locked": {
+        "lastModified": 1768302833,
+        "narHash": "sha256-h5bRFy9bco+8QcK7rGoOiqMxMbmn21moTACofNLRMP4=",
+        "owner": "NixOS",
+        "repo": "nixpkgs",
+        "rev": "61db79b0c6b838d9894923920b612048e1201926",
+        "type": "github"
+      },
+      "original": {
+        "owner": "NixOS",
+        "ref": "nixpkgs-unstable",
+        "repo": "nixpkgs",
+        "type": "github"
+      }
+    },
+    "root": {
+      "inputs": {
+        "flake-utils": "flake-utils",
+        "nix2container": "nix2container",
+        "nixpkgs": "nixpkgs"
+      }
+    },
+    "systems": {
+      "locked": {
+        "lastModified": 1681028828,
+        "narHash": "sha256-Vy1rq5AaRuLzOxct8nz4T6wlgyUR7zLU309k9mBC768=",
+        "owner": "nix-systems",
+        "repo": "default",
+        "rev": "da67096a3b9bf56a91d16901293e51ba5b49a27e",
+        "type": "github"
+      },
+      "original": {
+        "owner": "nix-systems",
+        "repo": "default",
+        "type": "github"
+      }
+    }
   },
   "root": "root",
   "version": 7
-  }
+}

--- a/flake.nix
+++ b/flake.nix
@@ -14,7 +14,6 @@
   inputs = {
     nixpkgs.url = "github:NixOS/nixpkgs/nixpkgs-unstable";
     flake-utils.url = "github:numtide/flake-utils";
-    nix-filter.url = "github:numtide/nix-filter";
     nix2container.url = "github:nlewo/nix2container";
     nix2container.inputs.nixpkgs.follows = "nixpkgs";
   };
@@ -24,13 +23,12 @@
       self,
       nixpkgs,
       flake-utils,
-      nix-filter,
       nix2container,
     }:
     {
       #nixops
       lib = import ./nixops/lib/lib.nix;
-      overlays.default = import ./nixops/overlays/default.nix { inherit self nix-filter; };
+      overlays.default = import ./nixops/overlays/default.nix;
     }
     // flake-utils.lib.eachDefaultSystem (
       system:
@@ -39,7 +37,7 @@
           inherit system;
           config.allowUnfree = true;
           overlays = [
-            (import ./nixops/overlays/default.nix { inherit self nix-filter; })
+            (import ./nixops/overlays/default.nix)
           ];
         };
 
@@ -50,7 +48,6 @@
           inherit
             self
             pkgs
-            nix-filter
             nixops-lib
             ;
         };
@@ -59,7 +56,6 @@
           inherit
             self
             pkgs
-            nix-filter
             nixops-lib
             ;
         };
@@ -68,7 +64,6 @@
           inherit
             self
             pkgs
-            nix-filter
             nixops-lib
             ;
         };
@@ -77,7 +72,6 @@
           inherit
             self
             pkgs
-            nix-filter
             nixops-lib
             ;
         };
@@ -86,7 +80,6 @@
           inherit
             self
             pkgs
-            nix-filter
             nixops-lib
             ;
         };
@@ -95,7 +88,6 @@
           inherit
             self
             pkgs
-            nix-filter
             nixops-lib
             nix2containerPkgs
             ;
@@ -105,7 +97,6 @@
           inherit
             self
             pkgs
-            nix-filter
             nixops-lib
             nix2containerPkgs
             ;
@@ -116,7 +107,6 @@
             self
             pkgs
             nix2containerPkgs
-            nix-filter
             nixops-lib
             ;
         };
@@ -125,7 +115,6 @@
           inherit
             self
             pkgs
-            nix-filter
             nixops-lib
             ;
         };
@@ -134,7 +123,6 @@
           inherit
             self
             pkgs
-            nix-filter
             nixops-lib
             nix2containerPkgs
             ;
@@ -144,7 +132,6 @@
           inherit
             self
             pkgs
-            nix-filter
             nixops-lib
             ;
         };
@@ -153,7 +140,6 @@
           inherit
             self
             pkgs
-            nix-filter
             nixops-lib
             ;
         };
@@ -162,7 +148,6 @@
           inherit
             self
             pkgs
-            nix-filter
             nixops-lib
             ;
         };
@@ -172,7 +157,6 @@
             self
             pkgs
             nix2containerPkgs
-            nix-filter
             nixops-lib
             ;
         };
@@ -181,7 +165,6 @@
           inherit
             self
             pkgs
-            nix-filter
             nixops-lib
             nix2containerPkgs
             ;
@@ -191,7 +174,6 @@
           inherit
             self
             pkgs
-            nix-filter
             nixops-lib
             ;
         };
@@ -200,7 +182,6 @@
           inherit
             self
             pkgs
-            nix-filter
             nixops-lib
             ;
         };
@@ -209,7 +190,6 @@
           inherit
             self
             pkgs
-            nix-filter
             nixops-lib
             nix2containerPkgs
             ;

--- a/flake.nix
+++ b/flake.nix
@@ -154,7 +154,6 @@
 
         nixopsf = import ./nixops/project.nix {
           inherit
-            self
             pkgs
             nix2containerPkgs
             nixops-lib

--- a/internal/lib/nhostclient/project.nix
+++ b/internal/lib/nhostclient/project.nix
@@ -1,7 +1,6 @@
 {
   self,
   pkgs,
-  nix-filter,
   nixops-lib,
 }:
 let
@@ -9,15 +8,16 @@ let
   version = "0.0.0-dev";
   submodule = "internal/lib/${name}";
 
-  src = nix-filter.lib.filter {
+  fs = pkgs.lib.fileset;
+
+  src = fs.toSource {
     root = ../../..;
-    include = with nix-filter.lib; [
-      "go.mod"
-      "go.sum"
-      (inDirectory "vendor")
-      ".golangci.yaml"
-      isDirectory
-      (and (inDirectory submodule) (matchExt "go"))
+    fileset = fs.unions [
+      ../../../go.mod
+      ../../../go.sum
+      ../../../vendor
+      ../../../.golangci.yaml
+      (fs.fileFilter (f: f.hasExt "go") ./.)
 
       # OpenAPI specs needed for code generation
       ../../../services/auth/docs/openapi.yaml

--- a/nixops/lib/go/example/flake.lock
+++ b/nixops/lib/go/example/flake.lock
@@ -18,21 +18,6 @@
         "type": "github"
       }
     },
-    "nix-filter": {
-      "locked": {
-        "lastModified": 1731533336,
-        "narHash": "sha256-oRam5PS1vcrr5UPgALW0eo1m/5/pls27Z/pabHNy2Ms=",
-        "owner": "numtide",
-        "repo": "nix-filter",
-        "rev": "f7653272fd234696ae94229839a99b73c9ab7de0",
-        "type": "github"
-      },
-      "original": {
-        "owner": "numtide",
-        "repo": "nix-filter",
-        "type": "github"
-      }
-    },
     "nix2container": {
       "inputs": {
         "nixpkgs": [
@@ -41,11 +26,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1749158376,
-        "narHash": "sha256-uirStFNxauh0lxzBowcp28X+Sq7JgsBIDnbwbAfZwf8=",
+        "lastModified": 1767430085,
+        "narHash": "sha256-SiXJ6xv4pS2MDUqfj0/mmG746cGeJrMQGmoFgHLS25Y=",
         "owner": "nlewo",
         "repo": "nix2container",
-        "rev": "0f8974c58755dba441df03598eefd1e1cd50e341",
+        "rev": "66f4b8a47e92aa744ec43acbb5e9185078983909",
         "type": "github"
       },
       "original": {
@@ -57,27 +42,26 @@
     "nixops": {
       "inputs": {
         "flake-utils": "flake-utils",
-        "nix-filter": "nix-filter",
         "nix2container": "nix2container",
         "nixpkgs": "nixpkgs"
       },
       "locked": {
-        "path": "./../../../",
+        "path": "./../../../../",
         "type": "path"
       },
       "original": {
-        "path": "./../../../",
+        "path": "./../../../../",
         "type": "path"
       },
       "parent": []
     },
     "nixpkgs": {
       "locked": {
-        "lastModified": 1745804731,
-        "narHash": "sha256-v/sK3AS0QKu/Tu5sHIfddiEHCvrbNYPv8X10Fpux68g=",
+        "lastModified": 1768302833,
+        "narHash": "sha256-h5bRFy9bco+8QcK7rGoOiqMxMbmn21moTACofNLRMP4=",
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "29335f23bea5e34228349ea739f31ee79e267b88",
+        "rev": "61db79b0c6b838d9894923920b612048e1201926",
         "type": "github"
       },
       "original": {
@@ -92,10 +76,6 @@
         "flake-utils": [
           "nixops",
           "flake-utils"
-        ],
-        "nix-filter": [
-          "nixops",
-          "nix-filter"
         ],
         "nix2container": [
           "nixops",

--- a/nixops/lib/go/example/flake.nix
+++ b/nixops/lib/go/example/flake.nix
@@ -1,9 +1,8 @@
 {
   inputs = {
-    nixops.url = "./../../../";
+    nixops.url = "./../../../../";
     nixpkgs.follows = "nixops/nixpkgs";
     flake-utils.follows = "nixops/flake-utils";
-    nix-filter.follows = "nixops/nix-filter";
     nix2container.follows = "nixops/nix2container";
   };
 
@@ -13,7 +12,6 @@
       nixops,
       nixpkgs,
       flake-utils,
-      nix-filter,
       nix2container,
     }:
     flake-utils.lib.eachDefaultSystem (
@@ -27,10 +25,10 @@
 
         nixops-lib = nixops.lib { inherit pkgs nix2containerPkgs; };
 
-        src = nix-filter.lib.filter {
+        src = pkgs.lib.fileset.toSource {
           root = ./.;
-          include = with nix-filter.lib; [
-            (nix-filter.lib.matchExt "go")
+          fileset = pkgs.lib.fileset.unions [
+            (pkgs.lib.fileset.fileFilter (f: f.hasExt "go") ./.)
             ./go.mod
           ];
         };

--- a/nixops/overlays/default.nix
+++ b/nixops/overlays/default.nix
@@ -1,4 +1,3 @@
-{ self, nix-filter }:
 final: prev:
 {
   certbot-full = prev.certbot.overrideAttrs (old: {
@@ -14,6 +13,6 @@ final: prev:
 
   nhost-cli = final.callPackage ./nhost-cli.nix { inherit final; };
 }
-// import ./go.nix { inherit self nix-filter; } final prev
+// import ./go.nix final prev
 // import ./js.nix final prev
 // import ./postgres.nix final prev

--- a/nixops/overlays/go.nix
+++ b/nixops/overlays/go.nix
@@ -1,5 +1,8 @@
-{ self, nix-filter }:
-final: prev: rec {
+final: prev:
+let
+  fs = final.lib.fileset;
+in
+rec {
   go = prev.go_1_26.overrideAttrs (
     finalAttrs: previousAttrs: rec {
       version = "1.26.3";
@@ -102,14 +105,13 @@ final: prev: rec {
   govulncheck-wrapper = final.buildGoModule {
     pname = "govulncheck-wrapper";
     version = "0.0.0-dev";
-    src = nix-filter.lib.filter {
-      root = self;
-      include = with nix-filter.lib; [
-        "go.mod"
-        "go.sum"
-        (inDirectory "vendor")
-        isDirectory
-        (and (inDirectory "tools/govulncheck-wrapper") (matchExt "go"))
+    src = fs.toSource {
+      root = ../..;
+      fileset = fs.unions [
+        ../../go.mod
+        ../../go.sum
+        ../../vendor
+        (fs.fileFilter (f: f.hasExt "go") ../../tools/govulncheck-wrapper)
       ];
     };
     vendorHash = null;

--- a/nixops/project.nix
+++ b/nixops/project.nix
@@ -1,5 +1,4 @@
 {
-  self,
   pkgs,
   nix2containerPkgs,
   nixops-lib,

--- a/nixops/project.nix
+++ b/nixops/project.nix
@@ -2,22 +2,21 @@
   self,
   pkgs,
   nix2containerPkgs,
-  nix-filter,
   nixops-lib,
 }:
 let
   name = "nixops";
   version = "0.0.0-dev";
   created = "1970-01-01T00:00:00Z";
-  submodule = "${name}";
 
-  src = nix-filter.lib.filter {
+  fs = pkgs.lib.fileset;
+
+  src = fs.toSource {
     root = ../.;
-    include = with nix-filter.lib; [
-      "./flake.lock"
-      "./flake.nix"
-      (and (inDirectory submodule) isDirectory)
-      (and (inDirectory submodule) (matchExt "nix"))
+    fileset = fs.unions [
+      ../flake.lock
+      ../flake.nix
+      (fs.fileFilter (f: f.hasExt "nix") ./.)
     ];
   };
 
@@ -71,11 +70,6 @@ let
       vale
       wal-g
     ])
-    ++ [
-      self.packages.${pkgs.stdenv.hostPlatform.system}.codegen
-      self.packages.${pkgs.stdenv.hostPlatform.system}.govulncheck-wrapper
-      self.packages.${pkgs.stdenv.hostPlatform.system}.storage-vips
-    ]
     ++ pkgs.lib.optionals pkgs.stdenv.isLinux [
     ]
     ++ pkgs.lib.optionals pkgs.stdenv.isDarwin [

--- a/packages/nhost-js/project.nix
+++ b/packages/nhost-js/project.nix
@@ -1,7 +1,6 @@
 {
   self,
   pkgs,
-  nix-filter,
   nixops-lib,
 }:
 let
@@ -10,44 +9,45 @@ let
   created = "1970-01-01T00:00:00Z";
   submodule = "packages/${name}";
 
+  fs = pkgs.lib.fileset;
+
   node_modules = nixops-lib.js.mkNodeModules {
     name = "node-modules-${name}";
     version = "0.0.0-dev";
 
-    src = nix-filter.lib.filter {
+    src = fs.toSource {
       root = ../..;
-      include = [
-        ".npmrc"
-        "package.json"
-        "pnpm-workspace.yaml"
-        "pnpm-lock.yaml"
-        "${submodule}/package.json"
-        "${submodule}/pnpm-lock.yaml"
+      fileset = fs.unions [
+        ../../.npmrc
+        ../../package.json
+        ../../pnpm-workspace.yaml
+        ../../pnpm-lock.yaml
+        ./package.json
+        ./pnpm-lock.yaml
       ];
     };
   };
 
-  src = nix-filter.lib.filter {
+  src = fs.toSource {
     root = ../..;
-    include = with nix-filter.lib; [
-      isDirectory
-      ".gitignore"
-      ".npmrc"
-      "biome.json"
-      "audit-ci.jsonc"
-      "package.json"
-      "pnpm-workspace.yaml"
-      "pnpm-lock.yaml"
-      "turbo.json"
-      (inDirectory "./build")
-      "${submodule}/gen.sh"
-      "${submodule}/jest.config.cjs"
-      "${submodule}/package.json"
-      "${submodule}/pnpm-lock.yaml"
-      "${submodule}/tsconfig.json"
-      "${submodule}/vite.config.ts"
-      "${submodule}/vite.umd.config.ts"
-      (inDirectory "${submodule}/src")
+    fileset = fs.unions [
+      ../../.gitignore
+      ../../.npmrc
+      ../../biome.json
+      ../../audit-ci.jsonc
+      ../../package.json
+      ../../pnpm-workspace.yaml
+      ../../pnpm-lock.yaml
+      ../../turbo.json
+      ../../build
+      ./gen.sh
+      ./jest.config.cjs
+      ./package.json
+      ./pnpm-lock.yaml
+      ./tsconfig.json
+      ./vite.config.ts
+      ./vite.umd.config.ts
+      ./src
       ../../services/auth/docs/openapi.yaml
       ../../services/storage/controller/openapi.yaml
     ];

--- a/packages/stripe-graphql-js/project.nix
+++ b/packages/stripe-graphql-js/project.nix
@@ -1,7 +1,6 @@
 {
   self,
   pkgs,
-  nix-filter,
   nixops-lib,
 }:
 let
@@ -9,41 +8,42 @@ let
   version = "0.0.0-dev";
   submodule = "packages/${name}";
 
+  fs = pkgs.lib.fileset;
+
   node_modules = nixops-lib.js.mkNodeModules {
     name = "node-modules-${name}";
     version = "0.0.0-dev";
 
-    src = nix-filter.lib.filter {
+    src = fs.toSource {
       root = ../..;
-      include = [
-        ".npmrc"
-        "package.json"
-        "pnpm-workspace.yaml"
-        "pnpm-lock.yaml"
-        "${submodule}/package.json"
-        "${submodule}/pnpm-lock.yaml"
+      fileset = fs.unions [
+        ../../.npmrc
+        ../../package.json
+        ../../pnpm-workspace.yaml
+        ../../pnpm-lock.yaml
+        ./package.json
+        ./pnpm-lock.yaml
       ];
     };
   };
 
-  src = nix-filter.lib.filter {
+  src = fs.toSource {
     root = ../..;
-    include = with nix-filter.lib; [
-      isDirectory
-      ".gitignore"
-      ".npmrc"
-      "biome.json"
-      "audit-ci.jsonc"
-      "package.json"
-      "pnpm-workspace.yaml"
-      "pnpm-lock.yaml"
-      "turbo.json"
-      (inDirectory "./build")
-      "${submodule}/package.json"
-      "${submodule}/pnpm-lock.yaml"
-      "${submodule}/tsconfig.json"
-      "${submodule}/vite.config.ts"
-      (inDirectory "${submodule}/src")
+    fileset = fs.unions [
+      ../../.gitignore
+      ../../.npmrc
+      ../../biome.json
+      ../../audit-ci.jsonc
+      ../../package.json
+      ../../pnpm-workspace.yaml
+      ../../pnpm-lock.yaml
+      ../../turbo.json
+      ../../build
+      ./package.json
+      ./pnpm-lock.yaml
+      ./tsconfig.json
+      ./vite.config.ts
+      ./src
     ];
   };
 

--- a/services/auth/project.nix
+++ b/services/auth/project.nix
@@ -1,7 +1,6 @@
 {
   self,
   pkgs,
-  nix-filter,
   nixops-lib,
 }:
 let
@@ -11,24 +10,24 @@ let
   created = "1970-01-01T00:00:00Z";
   submodule = "services/${name}";
 
-  src = nix-filter.lib.filter {
-    root = ../..;
-    include = with nix-filter.lib; [
-      "go.mod"
-      "go.sum"
-      (inDirectory "vendor")
-      ".golangci.yaml"
-      "govulncheck.yaml"
-      isDirectory
-      (and (inDirectory submodule) (matchExt "go"))
+  fs = pkgs.lib.fileset;
 
-      ./docs/cli.md
+  src = fs.toSource {
+    root = ../..;
+    fileset = fs.unions [
+      ../../go.mod
+      ../../go.sum
+      ../../vendor
+      ../../.golangci.yaml
+      ../../govulncheck.yaml
+      (fs.fileFilter (f: f.hasExt "go") ./.)
+
       ./docs/openapi.yaml
       ./vacuum.yaml
       ./vacuum-ignore.yaml
 
-      (inDirectory ../../internal/lib/oapi)
-      (inDirectory ../../internal/lib/hasura/metadata)
+      ../../internal/lib/oapi
+      ../../internal/lib/hasura/metadata
 
       ./go/api/server.cfg.yaml
       ./go/api/types.cfg.yaml
@@ -36,21 +35,20 @@ let
       ./go/sql/sqlc.yaml
       ./go/sql/query.sql
       ./go/sql/auth_schema_dump.sql
-      isDirectory
-      (inDirectory ./go/migrations/postgres)
-      (inDirectory ./email-templates)
+      ./go/migrations/postgres
+      ./email-templates
     ];
   };
 
-  node-src = nix-filter.lib.filter {
+  node-src = fs.toSource {
     root = ./.;
-    include = with nix-filter.lib; [
+    fileset = fs.unions [
       ./package.json
       ./bun.lock
       ./bunfig.toml
       ./tsconfig.json
       ./.env.example
-      (inDirectory "test")
+      ./test
     ];
   };
 
@@ -84,9 +82,9 @@ let
       cacert
     ];
 
-    src = nix-filter.lib.filter {
+    src = fs.toSource {
       root = ../..;
-      include = [
+      fileset = fs.unions [
         ./package.json
         ./bun.lock
         ./bunfig.toml

--- a/services/constellation/project.nix
+++ b/services/constellation/project.nix
@@ -1,7 +1,6 @@
 {
   self,
   pkgs,
-  nix-filter,
   nixops-lib,
 }:
 let
@@ -11,23 +10,24 @@ let
   created = "1970-01-01T00:00:00Z";
   submodule = "services/${name}";
 
-  src = nix-filter.lib.filter {
+  fs = pkgs.lib.fileset;
+
+  src = fs.toSource {
     root = ../..;
-    include = with nix-filter.lib; [
-      "go.mod"
-      "go.sum"
-      (inDirectory "vendor")
-      ".golangci.yaml"
-      "govulncheck.yaml"
-      isDirectory
-      (and (inDirectory submodule) (matchExt "go"))
-      (inDirectory "${submodule}/connector/testdata")
-      (inDirectory "${submodule}/connector/sql/postgres/testdata")
-      (inDirectory "${submodule}/connector/sql/sqlite/testdata")
-      (inDirectory "${submodule}/connector/sql/graphql/queries/testdata")
-      (inDirectory "${submodule}/connector/sql/graphql/schema/testdata")
-      (inDirectory "${submodule}/metadata/internal/hasura/testdata")
-      (inDirectory "${submodule}/integration/nhost")
+    fileset = fs.unions [
+      ../../go.mod
+      ../../go.sum
+      ../../vendor
+      ../../.golangci.yaml
+      ../../govulncheck.yaml
+      (fs.fileFilter (f: f.hasExt "go") ./.)
+      ./connector/testdata
+      ./connector/sql/postgres/testdata
+      ./connector/sql/sqlite/testdata
+      ./connector/sql/graphql/queries/testdata
+      ./connector/sql/graphql/schema/testdata
+      ./metadata/internal/hasura/testdata
+      ./integration/nhost
     ];
   };
 

--- a/services/functions/project.nix
+++ b/services/functions/project.nix
@@ -2,7 +2,6 @@
   self,
   pkgs,
   nix2containerPkgs,
-  nix-filter,
   nixops-lib,
 }:
 let
@@ -12,20 +11,22 @@ let
   created = "1970-01-01T00:00:00Z";
   submodule = "services/${name}";
 
+  fs = pkgs.lib.fileset;
+
   mkNodeModules =
     pnpmOpts:
     nixops-lib.js.mkNodeModules {
       name = "node-modules-${name}";
       version = "0.0.0-dev";
-      src = nix-filter.lib.filter {
+      src = fs.toSource {
         root = ../..;
-        include = [
-          ".npmrc"
-          "package.json"
-          "pnpm-workspace.yaml"
-          "pnpm-lock.yaml"
-          "${submodule}/package.json"
-          "${submodule}/pnpm-lock.yaml"
+        fileset = fs.unions [
+          ../../.npmrc
+          ../../package.json
+          ../../pnpm-workspace.yaml
+          ../../pnpm-lock.yaml
+          ./package.json
+          ./pnpm-lock.yaml
         ];
       };
       inherit pnpmOpts;
@@ -37,25 +38,24 @@ let
   # Slim node_modules with only runtime deps for the Docker image
   node_modules_runtime = mkNodeModules "--filter './${submodule}/**'";
 
-  src = nix-filter.lib.filter {
+  src = fs.toSource {
     root = ../..;
-    include = with nix-filter.lib; [
-      isDirectory
-      ".gitignore"
-      ".npmrc"
-      "biome.json"
-      "audit-ci.jsonc"
-      "package.json"
-      "pnpm-workspace.yaml"
-      "pnpm-lock.yaml"
-      "${submodule}/server.js"
-      "${submodule}/local-wrapper.js"
-      "${submodule}/start.sh"
-      "${submodule}/tsconfig.json"
-      "${submodule}/package.json"
-      "${submodule}/pnpm-lock.yaml"
-      "${submodule}/jest.config.cjs"
-      (nix-filter.lib.inDirectory "${submodule}/test")
+    fileset = fs.unions [
+      ../../.gitignore
+      ../../.npmrc
+      ../../biome.json
+      ../../audit-ci.jsonc
+      ../../package.json
+      ../../pnpm-workspace.yaml
+      ../../pnpm-lock.yaml
+      ./server.js
+      ./local-wrapper.js
+      ./start.sh
+      ./tsconfig.json
+      ./package.json
+      ./pnpm-lock.yaml
+      ./jest.config.cjs
+      ./test
     ];
   };
 
@@ -63,13 +63,13 @@ let
     pname = "${name}-server";
     inherit version;
 
-    src = nix-filter.lib.filter {
+    src = fs.toSource {
       root = ./.;
-      include = [
-        "server.js"
-        "local-wrapper.js"
-        "start.sh"
-        "tsconfig.json"
+      fileset = fs.unions [
+        ./server.js
+        ./local-wrapper.js
+        ./start.sh
+        ./tsconfig.json
       ];
     };
 

--- a/services/mcp/project.nix
+++ b/services/mcp/project.nix
@@ -1,7 +1,6 @@
 {
   self,
   pkgs,
-  nix-filter,
   nixops-lib,
 }:
 let
@@ -11,18 +10,19 @@ let
   created = "1970-01-01T00:00:00Z";
   submodule = "services/${name}";
 
-  src = nix-filter.lib.filter {
+  fs = pkgs.lib.fileset;
+
+  src = fs.toSource {
     root = ../..;
-    include = with nix-filter.lib; [
-      "go.mod"
-      "go.sum"
-      (inDirectory "vendor")
-      ".golangci.yaml"
-      "govulncheck.yaml"
-      isDirectory
-      (and (inDirectory submodule) (matchExt "go"))
-      (and (inDirectory "cli/mcp/graphql") (matchExt "go"))
-      (and (inDirectory "internal/lib/oapi/middleware") (matchExt "go"))
+    fileset = fs.unions [
+      ../../go.mod
+      ../../go.sum
+      ../../vendor
+      ../../.golangci.yaml
+      ../../govulncheck.yaml
+      (fs.fileFilter (f: f.hasExt "go") ./.)
+      (fs.fileFilter (f: f.hasExt "go") ../../cli/mcp/graphql)
+      (fs.fileFilter (f: f.hasExt "go") ../../internal/lib/oapi/middleware)
     ];
   };
 

--- a/services/postgres/project.nix
+++ b/services/postgres/project.nix
@@ -1,7 +1,6 @@
 {
   self,
   pkgs,
-  nix-filter,
   nixops-lib,
   nix2containerPkgs,
 }:
@@ -9,14 +8,16 @@ let
   name = "nhost/postgres";
   version = "0.0.0-dev";
 
-  src = nix-filter.lib.filter {
+  fs = pkgs.lib.fileset;
+
+  src = fs.toSource {
     root = ./.;
-    include = with nix-filter.lib; [
-      (inDirectory "postgres")
-      (inDirectory "extensions")
-      (inDirectory "tests")
-      (matchExt "nix")
-      "plugins.md"
+    fileset = fs.unions [
+      ./postgres
+      ./extensions
+      ./tests
+      (fs.fileFilter (f: f.hasExt "nix") ./.)
+      ./plugins.md
     ];
   };
 

--- a/services/storage/project.nix
+++ b/services/storage/project.nix
@@ -1,7 +1,6 @@
 {
   self,
   pkgs,
-  nix-filter,
   nixops-lib,
 }:
 let
@@ -11,39 +10,43 @@ let
   created = "1970-01-01T00:00:00Z";
   submodule = "services/${name}";
 
-  src = nix-filter.lib.filter {
+  fs = pkgs.lib.fileset;
+
+  src = fs.toSource {
     root = ../..;
-    include = with nix-filter.lib; [
-      "go.mod"
-      "go.sum"
-      (inDirectory "vendor")
-      ".golangci.yaml"
-      "govulncheck.yaml"
-      isDirectory
-      (and (inDirectory submodule) (matchExt "go"))
-      "${submodule}/gqlgenc.yaml"
-      "${submodule}/controller/openapi.yaml"
-      "${submodule}/api/types.cfg.yaml"
-      "${submodule}/api/server.cfg.yaml"
-      "${submodule}/metadata/metadata.graphql"
+    fileset =
+      fs.difference
+        (fs.unions [
+          ../../go.mod
+          ../../go.sum
+          ../../vendor
+          ../../.golangci.yaml
+          ../../govulncheck.yaml
+          (fs.fileFilter (f: f.hasExt "go") ./.)
+          ./gqlgenc.yaml
+          ./controller/openapi.yaml
+          ./api/types.cfg.yaml
+          ./api/server.cfg.yaml
+          ./metadata/metadata.graphql
 
-      "${submodule}/controller/openapi.yaml"
-      "${submodule}/vacuum.yaml"
-      "${submodule}/vacuum-ignore.yaml"
+          ./controller/openapi.yaml
+          ./vacuum.yaml
+          ./vacuum-ignore.yaml
 
-      (inDirectory "${submodule}/migrations/postgres")
-      (inDirectory "${submodule}/clamd/testdata")
-      (inDirectory "${submodule}/client/testdata")
-      (inDirectory "${submodule}/image/testdata")
-      (inDirectory "${submodule}/storage/testdata")
+          ./migrations/postgres
+          ./clamd/testdata
+          ./client/testdata
+          ./image/testdata
+          ./storage/testdata
 
-      (inDirectory ../../internal/lib/oapi)
-      (inDirectory ../../internal/lib/hasura/metadata)
-    ];
-
-    exclude = with nix-filter.lib; [
-      (inDirectory "${submodule}/build/dev/jwt-gen")
-    ];
+          ../../internal/lib/oapi
+          ../../internal/lib/hasura/metadata
+        ])
+        (
+          fs.unions [
+            ./build/dev/jwt-gen
+          ]
+        );
   };
 
   tags = [ ];

--- a/tools/codegen/project.nix
+++ b/tools/codegen/project.nix
@@ -1,7 +1,6 @@
 {
   self,
   pkgs,
-  nix-filter,
   nixops-lib,
 }:
 let
@@ -10,17 +9,18 @@ let
   version = "0.0.0-dev";
   submodule = "tools/${name}";
 
-  src = nix-filter.lib.filter {
+  fs = pkgs.lib.fileset;
+
+  src = fs.toSource {
     root = ../..;
-    include = with nix-filter.lib; [
-      "go.mod"
-      "go.sum"
-      (inDirectory "vendor")
-      ".golangci.yaml"
-      isDirectory
-      (and (inDirectory submodule) (matchExt "go"))
-      (and (inDirectory submodule) (matchExt "tmpl"))
-      (inDirectory "${submodule}/processor/testdata")
+    fileset = fs.unions [
+      ../../go.mod
+      ../../go.sum
+      ../../vendor
+      ../../.golangci.yaml
+      (fs.fileFilter (f: f.hasExt "go") ./.)
+      (fs.fileFilter (f: f.hasExt "tmpl") ./.)
+      ./processor/testdata
     ];
   };
 

--- a/tools/govulncheck-wrapper/project.nix
+++ b/tools/govulncheck-wrapper/project.nix
@@ -1,7 +1,6 @@
 {
   self,
   pkgs,
-  nix-filter,
   nixops-lib,
 }:
 let
@@ -10,15 +9,16 @@ let
   version = "0.0.0-dev";
   submodule = "tools/${name}";
 
-  src = nix-filter.lib.filter {
+  fs = pkgs.lib.fileset;
+
+  src = fs.toSource {
     root = ../..;
-    include = with nix-filter.lib; [
-      "go.mod"
-      "go.sum"
-      (inDirectory "vendor")
-      ".golangci.yaml"
-      isDirectory
-      (and (inDirectory submodule) (matchExt "go"))
+    fileset = fs.unions [
+      ../../go.mod
+      ../../go.sum
+      ../../vendor
+      ../../.golangci.yaml
+      (fs.fileFilter (f: f.hasExt "go") ./.)
     ];
   };
 

--- a/vendor/github.com/nhost/be/lib/graphql/project.nix
+++ b/vendor/github.com/nhost/be/lib/graphql/project.nix
@@ -1,6 +1,5 @@
 {
   pkgs,
-  nix-filter,
   nixops-lib,
 }:
 let
@@ -10,21 +9,13 @@ let
   version = "0.0.0-dev";
   created = "1970-01-01T00:00:00Z";
 
+  fs = pkgs.lib.fileset;
+
   # source files needed for the build
-  src = nix-filter.lib.filter {
+  src = fs.toSource {
     root = ../..;
-    include = with nix-filter.lib; [
-      ".golangci.yaml"
-      "govulncheck.yaml"
-      "go.mod"
-      "go.sum"
-      (and (inDirectory "lib") (matchExt "go"))
-      (inDirectory "vendor")
-      isDirectory
-      "${submodule}/directive/sql/sqlc.yaml"
-      "${submodule}/directive/sql/query.sql"
-      "services/console-next/schema.sql"
-      (and (inDirectory submodule) (matchExt "go"))
+    fileset = fs.unions [
+      (fs.fileFilter (f: f.hasExt "go") ../../lib)
     ];
   };
 


### PR DESCRIPTION
<!-- nhost-reviewer:start -->
### **What this PR solves**
The repo's Nix builds depended on the third-party `nix-filter` flake input to select build sources, and the `nixops` flake had a self-referential dependency. This PR drops `nix-filter` entirely in favor of the built-in `pkgs.lib.fileset` API and removes the `nixops` self-dependency, shrinking the flake's input graph and eliminating a self-reference.

___

### **PR Type**
Refactoring

___

### **Description**
- Removed the `nix-filter` flake input from `flake.nix`/`flake.lock` and stopped threading it through the outputs function and every per-project `inherit` block.
- Rewrote every `nix-filter.lib.filter { include = [...]; }` source selector across all 23 `project.nix` files as `pkgs.lib.fileset.toSource { fileset = fs.unions [...]; }`, using `fs.fileFilter`, `fs.unions`, and (for `storage`) `fs.difference` to replace the old `exclude`.
- Simplified the overlays: `nixops/overlays/default.nix` and `go.nix` no longer take `{ self, nix-filter }` and use `final.lib.fileset` directly.
- Removed the self-referential `self.packages.*` build inputs (`codegen`, `govulncheck-wrapper`, `storage-vips`) and the unused `submodule` binding from `nixops/project.nix`.
- Repointed the `nixops/lib/go/example` flake's `nixops.url` from `./../../../` to `./../../../../` (the example now resolves the main flake at the repo root) and dropped its `nix-filter` follows.

___

### Diagram Walkthrough

```mermaid
flowchart LR
  A["flake.nix inputs"] -->|drops| B["nix-filter (removed)"]
  A --> C["overlays/default.nix + go.nix<br/>no self/nix-filter args"]
  A --> D["23 project.nix files<br/>nix-filter.lib.filter → pkgs.lib.fileset"]
  E["nixops/project.nix"] -->|removes| F["self.packages.* self-dependency"]
  G["nixops/lib/go/example flake"] -->|url ./../../../ → ./../../../../| A
```

<details> <summary><h3> File Walkthrough</h3></summary>

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody>
<tr><td><strong>Flake & overlays</strong></td><td><details><summary>7 files</summary><table>
<tr>
  <td><strong>flake.nix</strong><dd><code>Drops nix-filter input and all per-project passthroughs; overlay imported without args</code></dd></td>
  <td><a href="https://github.com/nhost/nhost/pull/4377/files#diff-206b9ce276ab5971a2489d75eb1b12999d4bf3843b7988cbe8d687cfde61dea0">+2/-22</a></td>
</tr>
<tr>
  <td><strong>flake.lock</strong><dd><code>Removes nix-filter node and re-indents lock to 2 spaces</code></dd></td>
  <td><a href="https://github.com/nhost/nhost/pull/4377/files#diff-216b2b7bfde9416c79d133bacb031e95702a20bdedb548c0b055c837aa4f6a9c">+77/-93</a></td>
</tr>
<tr>
  <td><strong>nixops/overlays/default.nix</strong><dd><code>Drops { self, nix-filter } header; imports go.nix without args</code></dd></td>
  <td><a href="https://github.com/nhost/nhost/pull/4377/files#diff-e4be264a030552b8cd3f899006babce6af945a9bfa065ddd42886930b1797c9f">+1/-2</a></td>
</tr>
<tr>
  <td><strong>nixops/overlays/go.nix</strong><dd><code>Uses final.lib.fileset; govulncheck-wrapper src root self → ../..</code></dd></td>
  <td><a href="https://github.com/nhost/nhost/pull/4377/files#diff-5a8ebb114931d48d708d09186b893784786c56d999f9f91cb698c9482c74f4ba">+12/-10</a></td>
</tr>
<tr>
  <td><strong>nixops/project.nix</strong><dd><code>Removes self.packages.* self-dependency and unused submodule binding; fileset src</code></dd></td>
  <td><a href="https://github.com/nhost/nhost/pull/4377/files#diff-36b666e7f8b2a0262065708ad307cfcc07b3f959515ca2bfad889c3d09266eeb">+7/-13</a></td>
</tr>
<tr>
  <td><strong>nixops/lib/go/example/flake.nix</strong><dd><code>Repoints nixops.url to repo root (../../../../); drops nix-filter; fileset src</code></dd></td>
  <td><a href="https://github.com/nhost/nhost/pull/4377/files#diff-a7fb2147c81bcc474e00f7fae82aaa4bbe9b6d70875f019ca91b1f0a4ec4b6e1">+4/-6</a></td>
</tr>
<tr>
  <td><strong>nixops/lib/go/example/flake.lock</strong><dd><code>Removes nix-filter node and follows; updates nixops path and pins</code></dd></td>
  <td><a href="https://github.com/nhost/nhost/pull/4377/files#diff-7dee90f8ee9e1553db22a06f47049ee391888ea2c9e84b54f1b2f1ce6c3865cc">+8/-28</a></td>
</tr>
</table></details></td></tr>
<tr><td><strong>Go service & tool build inputs</strong></td><td><details><summary>10 files</summary><table>
<tr>
  <td><strong>cli/project.nix</strong><dd><code>nix-filter → fileset; drops stale mcp/nhost/auth/openapi.yaml include</code></dd></td>
  <td><a href="https://github.com/nhost/nhost/pull/4377/files#diff-02e27e8c362889995fcb502cc7802ce44664dedbaffc546095431a050374c927">+30/-31</a></td>
</tr>
<tr>
  <td><strong>services/auth/project.nix</strong><dd><code>nix-filter → fileset across src, node-src, and bun build src</code></dd></td>
  <td><a href="https://github.com/nhost/nhost/pull/4377/files#diff-5a173621cbe24950ec2d66369d2f050e42412ef30ba5b871a652f9eed23562d9">+20/-22</a></td>
</tr>
<tr>
  <td><strong>services/constellation/project.nix</strong><dd><code>nix-filter → fileset; preserves all testdata dirs</code></dd></td>
  <td><a href="https://github.com/nhost/nhost/pull/4377/files#diff-f295b2807764c3df9f1227927353da1dbd155ece618888b13d97837875e4816e">+17/-17</a></td>
</tr>
<tr>
  <td><strong>services/mcp/project.nix</strong><dd><code>nix-filter → fileset; cross-package go filters preserved</code></dd></td>
  <td><a href="https://github.com/nhost/nhost/pull/4377/files#diff-e2b7e2d0743341741071e505b06c3dd314f220193d24ac4bf1ae6defab832612">+12/-12</a></td>
</tr>
<tr>
  <td><strong>services/storage/project.nix</strong><dd><code>nix-filter exclude → fs.difference excising build/dev/jwt-gen</code></dd></td>
  <td><a href="https://github.com/nhost/nhost/pull/4377/files#diff-f4ae42f625032f787fc4e70ca441d7e687e307f7290637071750af307707e3a8">+36/-33</a></td>
</tr>
<tr>
  <td><strong>services/postgres/project.nix</strong><dd><code>nix-filter → fileset for postgres/extensions/tests</code></dd></td>
  <td><a href="https://github.com/nhost/nhost/pull/4377/files#diff-fd98bf2cc7ae60e401ff608182a783ab671d9edd3b6924b0946abf000a27f7cf">+9/-8</a></td>
</tr>
<tr>
  <td><strong>tools/codegen/project.nix</strong><dd><code>nix-filter → fileset; go + tmpl + testdata</code></dd></td>
  <td><a href="https://github.com/nhost/nhost/pull/4377/files#diff-4b36ac8f1726e49c630b73276f600d793dfd8803a39efe241b7de38ae64e0d10">+11/-11</a></td>
</tr>
<tr>
  <td><strong>tools/govulncheck-wrapper/project.nix</strong><dd><code>nix-filter → fileset</code></dd></td>
  <td><a href="https://github.com/nhost/nhost/pull/4377/files#diff-9ae4a5803d15c1e4373b8f376549af22e1651c657e121874b2dcd135a2187b9c">+9/-9</a></td>
</tr>
<tr>
  <td><strong>internal/lib/nhostclient/project.nix</strong><dd><code>nix-filter → fileset; OpenAPI specs preserved</code></dd></td>
  <td><a href="https://github.com/nhost/nhost/pull/4377/files#diff-0cd090aa2f3c77d3fdc245a8d2f88b67c9c6beee5f295384aa7a4fbbdf8eb425">+9/-9</a></td>
</tr>
<tr>
  <td><strong>vendor/.../be/lib/graphql/project.nix</strong><dd><code>nix-filter → fileset (vendored slice, not wired into flake)</code></dd></td>
  <td><a href="https://github.com/nhost/nhost/pull/4377/files#diff-8ddb214f27634346e2dee5371a7ca0e76a92ae6543f19f3a2990433063f9d37d">+5/-14</a></td>
</tr>
</table></details></td></tr>
<tr><td><strong>JS/TS workspace build inputs</strong></td><td><details><summary>8 files</summary><table>
<tr>
  <td><strong>dashboard/project.nix</strong><dd><code>nix-filter → fileset; drops untracked/no-op includes (next-env.d.ts, .env.test, etc.)</code></dd></td>
  <td><a href="https://github.com/nhost/nhost/pull/4377/files#diff-e456dcfd6231480081b3c9a2a95204bd061853442d5e3a38330625d01cb1a6a1">+43/-49</a></td>
</tr>
<tr>
  <td><strong>docs/project.nix</strong><dd><code>nix-filter → fileset; nhost-js/src ts filter preserved</code></dd></td>
  <td><a href="https://github.com/nhost/nhost/pull/4377/files#diff-8c4658c93f89aa3cbc7671465147938c58e14e66e3b95309b9fc4a11969a7fe4">+25/-25</a></td>
</tr>
<tr>
  <td><strong>examples/demos/project.nix</strong><dd><code>nix-filter → fileset for node_modules + src</code></dd></td>
  <td><a href="https://github.com/nhost/nhost/pull/4377/files#diff-f6086e59795d16f4c73cb0e5f90b986e288deb5f176c80c5c035f1703ff86760">+26/-26</a></td>
</tr>
<tr>
  <td><strong>examples/guides/project.nix</strong><dd><code>nix-filter → fileset for node_modules + src</code></dd></td>
  <td><a href="https://github.com/nhost/nhost/pull/4377/files#diff-65c8830b4c3074e59267275284f270f4dfa95ce2722d7634e3e3c77f66f8235e">+30/-30</a></td>
</tr>
<tr>
  <td><strong>examples/tutorials/project.nix</strong><dd><code>nix-filter → fileset for node_modules + src</code></dd></td>
  <td><a href="https://github.com/nhost/nhost/pull/4377/files#diff-31667632ab7b36d1bdaeb05e4a0a289561e1c713964c91086db848f30ad4f7e4">+32/-32</a></td>
</tr>
<tr>
  <td><strong>packages/nhost-js/project.nix</strong><dd><code>nix-filter → fileset; OpenAPI specs preserved</code></dd></td>
  <td><a href="https://github.com/nhost/nhost/pull/4377/files#diff-8aa0f2b40e1054e08a33a0b071a6c672edbfeeb281f6c51e94dd73035014a6e9">+29/-29</a></td>
</tr>
<tr>
  <td><strong>packages/stripe-graphql-js/project.nix</strong><dd><code>nix-filter → fileset for node_modules + src</code></dd></td>
  <td><a href="https://github.com/nhost/nhost/pull/4377/files#diff-1d1685c97398e96e77a0e6cbe7ce87e375a36e249c9980ec51e6036eecf1be39">+26/-26</a></td>
</tr>
<tr>
  <td><strong>services/functions/project.nix</strong><dd><code>nix-filter → fileset across all three filter blocks</code></dd></td>
  <td><a href="https://github.com/nhost/nhost/pull/4377/files#diff-478ae77cf85885988b637453974d32f4bf4840bd557c0d71da2e2620ababdf0a">+33/-33</a></td>
</tr>
</table></details></td></tr>
</tbody></table>

</details>

___

<!-- nhost-reviewer:end -->