### PR TITLE
fix(govulncheck): bump modules via `go mod edit -require` to avoid go get overshoot

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -36,8 +36,10 @@ Where `PKG` is:
 - `functions`: For changes to the Nhost Functions service
 - `govulncheck-wrapper`: For changes to the govulncheck wrapper tool
 - `internal/lib`: For changes to Nhost's common libraries (internal)
+- `mcp`: For changes to the Nhost MCP server
 - `nhost-js`: For changes to the Nhost JavaScript SDK
 - `nixops`: For changes to the NixOps
+- `postgres`: For changes to the Nhost Postgres image
 - `storage`: For changes to the Nhost Storage service
 - `observability`: For changes to the Nhost Observability managed service
 - `stripe-graphql-js`: For changes to the Stripe GraphQL JS SDK

--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -34,6 +34,7 @@ Where `PKG` is:
 - `docs`: For changes to the documentation
 - `examples`: For changes to the examples
 - `functions`: For changes to the Nhost Functions service
+- `govulncheck-wrapper`: For changes to the govulncheck wrapper tool
 - `internal/lib`: For changes to Nhost's common libraries (internal)
 - `nhost-js`: For changes to the Nhost JavaScript SDK
 - `nixops`: For changes to the NixOps

--- a/.github/workflows/ci_final_status_check.yaml
+++ b/.github/workflows/ci_final_status_check.yaml
@@ -27,7 +27,7 @@ jobs:
           echo "Validating PR title: $PR_TITLE"
 
           VALID_TYPES="feat|fix|chore|release"
-          VALID_PKGS="auth|ci|cli|codegen|constellation|dashboard|deps|docs|examples|functions|internal\/lib|mcp|nhost-js|nixops|postgres|storage|observability|stripe-graphql-js"
+          VALID_PKGS="auth|ci|cli|codegen|constellation|dashboard|deps|docs|examples|functions|govulncheck-wrapper|internal\/lib|mcp|nhost-js|nixops|postgres|storage|observability|stripe-graphql-js"
 
           if [[ ! "$PR_TITLE" =~ ^(${VALID_TYPES})\((${VALID_PKGS})\):\ .+ ]]; then
             echo "PR title does not follow the required format!"
@@ -41,8 +41,8 @@ jobs:
             echo ""
             echo "Valid PKGs:"
             echo "  - auth, ci, cli, codegen, constellation, dashboard, deps, docs, examples, functions,"
-            echo "  - mcp, nhost-js, nixops, postgres, storage, observability, internal/lib"
-            echo "  - stripe-graphql-js"
+            echo "  - govulncheck-wrapper, mcp, nhost-js, nixops, postgres, storage, observability,"
+            echo "  - internal/lib, stripe-graphql-js"
             echo ""
             echo "Example: feat(cli): add new command for database migrations"
             exit 1

--- a/.github/workflows/gen_security_updates.yaml
+++ b/.github/workflows/gen_security_updates.yaml
@@ -51,11 +51,12 @@ jobs:
 
       - name: Apply Go security fixes
         # govulncheck-wrapper -fix bumps each non-allowlisted finding via
-        # `go get module@fixed-version` then runs `go mod tidy && go mod vendor`
-        # to keep go.sum and vendor/ in sync. No overrides, no vendoring tricks —
-        # just standard module bumps. No-op when nothing is flagged.
+        # `go mod edit -require=module@fixed-version` then runs
+        # `go mod tidy && go mod vendor` to keep go.sum and vendor/ in sync. No
+        # overrides, no vendoring tricks — just standard module bumps. No-op when
+        # nothing is flagged.
         #
-        # `go get` resolves the full module graph, which includes the private
+        # `go mod tidy` resolves the full module graph, which includes the private
         # github.com/nhost/be dep — so we wire the app token into git and set
         # GOPRIVATE to bypass the public proxy/sumdb for nhost org modules.
         env:
@@ -99,7 +100,7 @@ jobs:
             Daily security updates.
 
             * **pnpm**: `pnpm audit --fix=update` per workspace lockfile (no overrides added).
-            * **Go**: `go get` for modules flagged by `govulncheck`, then `go mod tidy && go mod vendor`.
+            * **Go**: `go mod edit -require` for modules flagged by `govulncheck`, then `go mod tidy && go mod vendor`.
 
             Anything still flagged after this PR will fail the regular CI checks (`govulncheck`, `audit-ci-recursive`) — fix manually.
           labels: |

--- a/tools/govulncheck-wrapper/main.go
+++ b/tools/govulncheck-wrapper/main.go
@@ -169,23 +169,26 @@ func printVulnerability(
 }
 
 // isToolchainModule reports whether the given module name is a govulncheck
-// pseudo-module that cannot be bumped via `go get` and instead requires a
-// manual Go toolchain upgrade (handled outside this wrapper, e.g. by bumping
-// the nix overlay that installs Go).
+// pseudo-module that cannot be expressed as a go.mod requirement and instead
+// requires a manual Go toolchain upgrade (handled outside this wrapper, e.g. by
+// bumping the nix overlay that installs Go).
 func isToolchainModule(mod string) bool {
 	return mod == "stdlib" || mod == "toolchain"
 }
 
-// collectFixes returns module@version pairs that, when fed to `go get`, raise
-// each vulnerable module to its OSV-reported fixed version. Only non-allowlisted
-// findings are considered; for modules referenced by multiple findings the
-// highest fixed version (by semver) wins so a later `go get` cannot downgrade
-// an earlier one.
+// collectFixes returns module@version pairs that, when applied via
+// `go mod edit -require`, raise each vulnerable module to its OSV-reported fixed
+// version. Only non-allowlisted findings are considered; for modules referenced
+// by multiple findings the highest fixed version (by semver) wins. Because
+// `go mod edit -require` overrides any existing requirement outright (rather
+// than taking the max the way `go get` would), keeping only the highest fix per
+// module is what prevents a later edit from overwriting an earlier one with a
+// lower version.
 //
 // Findings whose module is a Go toolchain pseudo-module (`stdlib`, `toolchain`)
-// are returned in a separate slice: feeding `stdlib@vX.Y.Z` to `go get` would
-// abort the entire fix run, so the caller logs them as requiring a manual
-// toolchain upgrade and continues bumping the remaining modules.
+// are returned in a separate slice: they cannot be expressed as a go.mod
+// requirement, so the caller logs them as requiring a manual toolchain upgrade
+// and continues bumping the remaining modules.
 func collectFixes(
 	findingsMap map[string][]*finding, blocked []string,
 ) ([]string, []string) {
@@ -325,7 +328,7 @@ func main() {
 	)
 	fix := flag.Bool(
 		"fix", false,
-		"bump non-allowlisted findings via `go get`, then run `go mod tidy` and `go mod vendor`",
+		"bump non-allowlisted findings via `go mod edit -require`, then run `go mod tidy` and `go mod vendor`",
 	)
 
 	flag.Parse()

--- a/tools/govulncheck-wrapper/main.go
+++ b/tools/govulncheck-wrapper/main.go
@@ -248,11 +248,20 @@ func runCmd(name string, args ...string) error {
 	return nil
 }
 
-// applyFixes runs `go get` for each module@version pair, then `go mod tidy`
-// and `go mod vendor` so go.sum and vendor/ stay in sync. No-op when there
-// is nothing to bump. Toolchain pairs are logged but not passed to `go get`
-// because they cannot be bumped that way; they require a manual Go toolchain
-// upgrade (e.g. via the nix overlay).
+// applyFixes raises each module@version pair via `go mod edit -require`, then
+// runs `go mod tidy` and `go mod vendor` so go.sum and vendor/ stay in sync.
+// No-op when there is nothing to bump. Toolchain pairs are logged but not
+// edited into go.mod because they cannot be bumped that way; they require a
+// manual Go toolchain upgrade (e.g. via the nix overlay).
+//
+// `go mod edit -require` is used instead of `go get pkg@version` because
+// `go get` resolves its argument as a package path and walks up to the owning
+// module. For modules whose path has an intermediate module versioned on a
+// different major track (e.g. go.opentelemetry.io/otel/exporters/otlp/otlpmetric
+// is v0.x while its otlpmetrichttp submodule is v1.x), that walk-up overshoots
+// to the v1.x root module, which does not contain the package, and `go get`
+// fails. `go mod edit -require` sets the requirement on the exact module path
+// directly, and the subsequent `go mod tidy` resolves the rest of the graph.
 func applyFixes(pairs, toolchainPairs []string, run cmdRunner) error {
 	for _, pair := range toolchainPairs {
 		fmt.Fprintf(
@@ -275,7 +284,7 @@ func applyFixes(pairs, toolchainPairs []string, run cmdRunner) error {
 	}
 
 	for _, pair := range pairs {
-		if err := run("go", "get", pair); err != nil {
+		if err := run("go", "mod", "edit", "-require="+pair); err != nil {
 			return err
 		}
 	}

--- a/tools/govulncheck-wrapper/main.go
+++ b/tools/govulncheck-wrapper/main.go
@@ -327,7 +327,8 @@ func main() {
 		"config", "govulncheck.yaml", "path to allowlist config file",
 	)
 	fix := flag.Bool(
-		"fix", false,
+		"fix",
+		false,
 		"bump non-allowlisted findings via `go mod edit -require`, then run `go mod tidy` and `go mod vendor`",
 	)
 

--- a/tools/govulncheck-wrapper/main_test.go
+++ b/tools/govulncheck-wrapper/main_test.go
@@ -391,12 +391,12 @@ func TestApplyFixes(t *testing.T) {
 			wantErr:        false,
 		},
 		{
-			name:           "happy path runs go get per pair then tidy then vendor",
+			name:           "happy path edits each require then tidy then vendor",
 			pairs:          []string{"example.com/a@v1.0.0", "example.com/b@v2.0.0"},
 			toolchainPairs: nil,
 			wantCalls: []string{
-				"go get example.com/a@v1.0.0",
-				"go get example.com/b@v2.0.0",
+				"go mod edit -require=example.com/a@v1.0.0",
+				"go mod edit -require=example.com/b@v2.0.0",
 				"go mod tidy",
 				"go mod vendor",
 			},
@@ -407,18 +407,18 @@ func TestApplyFixes(t *testing.T) {
 			pairs:          []string{"example.com/a@v1.0.0"},
 			toolchainPairs: []string{"stdlib@v1.23.5", "toolchain@v1.23.4"},
 			wantCalls: []string{
-				"go get example.com/a@v1.0.0",
+				"go mod edit -require=example.com/a@v1.0.0",
 				"go mod tidy",
 				"go mod vendor",
 			},
 			wantErr: false,
 		},
 		{
-			name:           "first failing go get aborts before tidy/vendor",
+			name:           "first failing edit aborts before tidy/vendor",
 			pairs:          []string{"example.com/a@v1.0.0", "example.com/b@v2.0.0"},
 			toolchainPairs: nil,
-			failOn:         "go get example.com/a@v1.0.0",
-			wantCalls:      []string{"go get example.com/a@v1.0.0"},
+			failOn:         "go mod edit -require=example.com/a@v1.0.0",
+			wantCalls:      []string{"go mod edit -require=example.com/a@v1.0.0"},
 			wantErr:        true,
 		},
 		{
@@ -427,7 +427,7 @@ func TestApplyFixes(t *testing.T) {
 			toolchainPairs: nil,
 			failOn:         "go mod tidy",
 			wantCalls: []string{
-				"go get example.com/a@v1.0.0",
+				"go mod edit -require=example.com/a@v1.0.0",
 				"go mod tidy",
 			},
 			wantErr: true,
@@ -438,7 +438,7 @@ func TestApplyFixes(t *testing.T) {
 			toolchainPairs: nil,
 			failOn:         "go mod vendor",
 			wantCalls: []string{
-				"go get example.com/a@v1.0.0",
+				"go mod edit -require=example.com/a@v1.0.0",
 				"go mod tidy",
 				"go mod vendor",
 			},


### PR DESCRIPTION
<!-- nhost-reviewer:start -->
### **What this PR solves**
The `-fix` mode of the govulncheck wrapper bumped vulnerable modules with `go get pkg@version`, which resolves the argument as a *package* path and walks up to the owning module. For modules whose path crosses a major-version boundary (e.g. `go.opentelemetry.io/otel/exporters/otlp/otlpmetric` is v0.x while its `otlpmetrichttp` submodule is v1.x), that walk-up overshoots to the v1.x root module — which doesn't contain the package — and `go get` fails, aborting the whole fix run. Switching to `go mod edit -require=pkg@version` sets the requirement on the exact module path, letting the follow-up `go mod tidy` resolve the rest of the graph.

___

### **PR Type**
Bug fix

___

### **Description**
- Replaced the per-pair `go get pkg@version` call in `applyFixes` with `go mod edit -require=pkg@version`, avoiding `go get`'s package-to-module walk-up that overshoots across major-version boundaries.
- Expanded the `applyFixes` doc comment to explain why `go mod edit -require` is used instead of `go get`.
- Updated `TestApplyFixes` cases (names, `wantCalls`, `failOn`) to assert the new `go mod edit -require=...` command strings while preserving ordering and abort-point coverage.

___

<details> <summary><h3> File Walkthrough</h3></summary>

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody>
<tr><td><strong>Bug fix</strong></td><td><details><summary>1 files</summary><table>
<tr>
  <td><strong>main.go</strong><dd><code>Use `go mod edit -require` instead of `go get` to bump modules</code></dd></td>
  <td><a href="https://github.com/nhost/nhost/pull/XXX/files#diff-3128981a5ea4ccba357fa30946a2fb885b050687e6f1a3279c18d4b0a9c69eb3">+15/-6</a></td>
</tr>
</table></details></td></tr>
<tr><td><strong>Tests</strong></td><td><details><summary>1 files</summary><table>
<tr>
  <td><strong>main_test.go</strong><dd><code>Assert new `go mod edit -require` command strings in TestApplyFixes</code></dd></td>
  <td><a href="https://github.com/nhost/nhost/pull/XXX/files#diff-1a950541b3b6ea102d107009d28ec021e17579a856a831ac981054bfccb565f3">+9/-9</a></td>
</tr>
</table></details></td></tr>
</tbody></table>

</details>

___

<!-- nhost-reviewer:end -->