### PR TITLE
fix(dashboard): avoid flaky lychee check in cron trigger tests

### DIFF
--- a/dashboard/src/features/orgs/projects/events/cron-triggers/utils/buildCronTriggerDTO/buildCronTriggerDTO.test.ts
+++ b/dashboard/src/features/orgs/projects/events/cron-triggers/utils/buildCronTriggerDTO/buildCronTriggerDTO.test.ts
@@ -8,7 +8,7 @@ describe('buildCronTriggerDTO', () => {
     const values: BaseCronTriggerFormValues = {
       triggerName: 'triggerName',
       comment: 'triggerComment',
-      webhook: 'https://httpbin.org/delay/5',
+      webhook: 'https://httpbin.org/post',
       schedule: '0 0 1 * *',
       payload: '{\n    "payload": "value"\n}',
       retryConf: {
@@ -46,7 +46,7 @@ describe('buildCronTriggerDTO', () => {
 
     const expected: CreateCronTriggerArgs = {
       name: 'triggerName',
-      webhook: 'https://httpbin.org/delay/5',
+      webhook: 'https://httpbin.org/post',
       schedule: '0 0 1 * *',
       payload: {
         payload: 'value',

--- a/dashboard/src/features/orgs/projects/events/cron-triggers/utils/parseCronTriggerFormInitialData/parseCronTriggerFormInitialData.test.ts
+++ b/dashboard/src/features/orgs/projects/events/cron-triggers/utils/parseCronTriggerFormInitialData/parseCronTriggerFormInitialData.test.ts
@@ -31,7 +31,7 @@ describe('parseCronTriggerFormInitialData', () => {
         tolerance_seconds: 21601,
       },
       schedule: '*/5 * * * *',
-      webhook: 'https://httpbin.org/delay/5',
+      webhook: 'https://httpbin.org/post',
     };
 
     const result = parseCronTriggerFormInitialData(cronTrigger);
@@ -44,7 +44,7 @@ describe('parseCronTriggerFormInitialData', () => {
     const expectedWithoutPayloadTransform: BaseCronTriggerFormInitialData = {
       triggerName: 'triggerName',
       comment: 'triggerComment',
-      webhook: 'https://httpbin.org/delay/5',
+      webhook: 'https://httpbin.org/post',
       schedule: '*/5 * * * *',
       payload: '{}',
       retryConf: {


### PR DESCRIPTION
### Checklist

- [X] No breaking changes
- [X] Tests pass
- [X] New features have new tests
- [X] Documentation is updated (if applicable)
- [X] Title of the PR is in the correct format (see below)

<!-- nhost-reviewer:start -->
### **What this PR solves**

The cron-trigger test fixtures used `https://httpbin.org/delay/5` as a sample webhook URL. The `check` CI target runs `lychee` over `src/**/*.ts(x)`, which pings every URL-shaped string it finds — and `/delay/5` is not in `.lychee.toml`'s exclude list, so a transient httpbin `503` failed the link check and turned CI red even though every test passed. Switching the fixtures to the already-excluded `https://httpbin.org/post` makes the link check deterministic without any config change.

___

### **PR Type**
Tests

___

### **Description**
- Replaced the sample webhook URL `https://httpbin.org/delay/5` with `https://httpbin.org/post` in two cron-trigger fixture tests (`buildCronTriggerDTO`, `parseCronTriggerFormInitialData`), updating both the input and the expected values together so the assertions still hold.
- Reuses the existing `^https://httpbin\.org/post` lychee exclusion, so no `.lychee.toml` change is required; `/post` is also more representative (a cron webhook fires a POST) and matches the placeholder already shown in `BaseCronTriggerForm`.

___

<details> <summary><h3> File Walkthrough</h3></summary>

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody>
<tr><td><strong>Tests</strong></td><td><details><summary>2 files</summary><table>
<tr>
  <td><strong>buildCronTriggerDTO.test.ts</strong><dd><code>Swap /delay/5 webhook fixture for the lychee-excluded /post URL</code></dd></td>
  <td><a href="https://github.com/nhost/nhost/pull/4381/files#diff-b6b8f51efd60c171be61fa89dfc9a115c40bb517eb235cab0f5e83abffaf7cd3">+2/-2</a></td>
</tr>
<tr>
  <td><strong>parseCronTriggerFormInitialData.test.ts</strong><dd><code>Swap /delay/5 webhook fixture for the lychee-excluded /post URL</code></dd></td>
  <td><a href="https://github.com/nhost/nhost/pull/4381/files#diff-8509b2cd5948b14008a636262df9c19687ca95fce8d21e498af26ecd11db7b77">+2/-2</a></td>
</tr>
</table></details></td></tr>
</tbody></table>

</details>

___

<!-- nhost-reviewer:end -->
