### PR TITLE
fix(constellation): treat null top-level `where` as no filter, matching Hasura

### DIFF
--- a/services/constellation/connector/sql/graphql/queries/where/where.go
+++ b/services/constellation/connector/sql/graphql/queries/where/where.go
@@ -43,20 +43,33 @@ func (w Clause) WriteCondition(
 	return params, paramIndex, nil
 }
 
+// parseWhereResolveVariable resolves a where argument that may be a variable
+// reference to its concrete AST value. The boolean result reports whether the
+// argument imposes a filter at all: a where argument that resolves to null (an
+// explicitly-null variable, `where: $where` with $where = null, or a literal
+// `where: null`) imposes no filter, exactly like leaving the argument out, and
+// is reported with ok == false so the caller can skip it instead of erroring.
+// A genuinely omitted variable is not handled here: values.ResolveVariable
+// returns ErrVariableNotFound for a key absent from the variables map, so it
+// errors rather than being treated as no-filter.
 func parseWhereResolveVariable(
 	whereArg *ast.Value,
 	variables map[string]any,
-) (*ast.Value, error) {
+) (*ast.Value, bool, error) {
 	whereArg, err := values.ResolveVariable(whereArg, variables)
 	if err != nil {
-		return nil, fmt.Errorf("resolving where variable: %w", err)
+		return nil, false, fmt.Errorf("resolving where variable: %w", err)
+	}
+
+	if whereArg.Kind == ast.NullValue {
+		return nil, false, nil
 	}
 
 	if whereArg.Kind != ast.ObjectValue {
-		return nil, fmt.Errorf("%w: got %v", errExpectedObjectValue, whereArg.Kind)
+		return nil, false, fmt.Errorf("%w: got %v", errExpectedObjectValue, whereArg.Kind)
 	}
 
-	return whereArg, nil
+	return whereArg, true, nil
 }
 
 // Parse parses a GraphQL where-clause argument value into a Clause.
@@ -77,9 +90,13 @@ func Parse(
 		return nil, nil
 	}
 
-	whereArg, err := parseWhereResolveVariable(whereArg, variables)
+	whereArg, ok, err := parseWhereResolveVariable(whereArg, variables)
 	if err != nil {
 		return nil, err
+	}
+
+	if !ok {
+		return nil, nil
 	}
 
 	conditions := make(Clause, 0, len(whereArg.Children))

--- a/services/constellation/connector/sql/graphql/queries/where/where.go
+++ b/services/constellation/connector/sql/graphql/queries/where/where.go
@@ -157,6 +157,14 @@ func parseWhereChild(
 			return nil, fmt.Errorf("failed to parse _not: %w", err)
 		}
 
+		// `_not: null` (and `_not: {}`) impose no constraint, matching Hasura's
+		// no-op semantics. parseLogicalNot returns a nil filter in that case;
+		// appending it would emit an invalid `NOT ()` fragment, so contribute
+		// zero statements instead.
+		if notCondition == nil {
+			return Clause{}, nil
+		}
+
 		return Clause{notCondition}, nil
 
 	case "_exists":
@@ -346,6 +354,14 @@ func parseLogicalNot(
 	)
 	if err != nil {
 		return nil, err
+	}
+
+	// A nil/empty inner clause (e.g. `_not: null` or `_not: {}`) imposes no
+	// constraint. Return a nil filter so the caller can skip it rather than
+	// wrapping an empty clause in `NOT ()`, which is invalid SQL. This mirrors
+	// the nil-Clause guard in parseRelationshipField.
+	if len(conditions) == 0 {
+		return nil, nil //nolint:nilnil
 	}
 
 	return &notFilter{condition: conditions}, nil

--- a/services/constellation/connector/sql/graphql/queries/where/where.go
+++ b/services/constellation/connector/sql/graphql/queries/where/where.go
@@ -32,7 +32,11 @@ func (w Clause) WriteCondition(
 	for i, condition := range w {
 		params, paramIndex, err = condition.WriteCondition(b, source, params, paramIndex)
 		if err != nil {
-			return nil, 0, fmt.Errorf("failed to write where condition at pos %d: %w", i, err)
+			return nil, 0, fmt.Errorf(
+				"failed to write where condition at pos %d: %w",
+				i,
+				err,
+			)
 		}
 
 		if i < len(w)-1 {
@@ -43,40 +47,20 @@ func (w Clause) WriteCondition(
 	return params, paramIndex, nil
 }
 
-// parseWhereResolveVariable resolves a where argument that may be a variable
-// reference to its concrete AST value. The boolean result reports whether the
-// argument imposes a filter at all: a where argument that resolves to null (an
-// explicitly-null variable, `where: $where` with $where = null, or a literal
-// `where: null`) imposes no filter, exactly like leaving the argument out, and
-// is reported with ok == false so the caller can skip it instead of erroring.
-// A genuinely omitted variable is not handled here: values.ResolveVariable
-// returns ErrVariableNotFound for a key absent from the variables map, so it
-// errors rather than being treated as no-filter.
-func parseWhereResolveVariable(
-	whereArg *ast.Value,
-	variables map[string]any,
-) (*ast.Value, bool, error) {
-	whereArg, err := values.ResolveVariable(whereArg, variables)
-	if err != nil {
-		return nil, false, fmt.Errorf("resolving where variable: %w", err)
-	}
-
-	if whereArg.Kind == ast.NullValue {
-		return nil, false, nil
-	}
-
-	if whereArg.Kind != ast.ObjectValue {
-		return nil, false, fmt.Errorf("%w: got %v", errExpectedObjectValue, whereArg.Kind)
-	}
-
-	return whereArg, true, nil
-}
-
-// Parse parses a GraphQL where-clause argument value into a Clause.
-// It walks the object, dispatching logical combinators, _exists, field
-// comparisons, and relationship traversals. nestingLevel and aliases control
-// alias generation for EXISTS subqueries; pass 0 and QueryAliases at the top
-// level for user queries, PermissionAliases for permission filters.
+// Parse parses a top-level GraphQL where-clause argument into a Clause. The
+// where argument is nullable, matching Hasura: a literal `where: null` or a
+// variable that resolves to null (`where: $where` with $where = null) imposes
+// no filter and yields a nil clause, exactly like omitting the argument. A
+// genuinely omitted variable still errors, since values.ResolveVariable returns
+// ErrVariableNotFound for a key absent from the variables map.
+//
+// Every nested bool_exp position (a relationship, `_not`, or an `_and`/`_or`
+// element) goes through parseBoolExp instead, which rejects an explicit null:
+// Hasura permits null only for the top-level argument.
+//
+// nestingLevel and aliases control alias generation for EXISTS subqueries; pass
+// 0 and QueryAliases at the top level for user queries, PermissionAliases for
+// permission filters.
 func Parse(
 	t Table,
 	whereArg *ast.Value,
@@ -90,13 +74,41 @@ func Parse(
 		return nil, nil
 	}
 
-	whereArg, ok, err := parseWhereResolveVariable(whereArg, variables)
+	resolved, err := values.ResolveVariable(whereArg, variables)
 	if err != nil {
-		return nil, err
+		return nil, fmt.Errorf("resolving where variable: %w", err)
 	}
 
-	if !ok {
+	if resolved.Kind == ast.NullValue {
 		return nil, nil
+	}
+
+	return parseBoolExp(
+		t, resolved, variables, role, sessionVariables, nestingLevel, aliases,
+	)
+}
+
+// parseBoolExp parses a non-null bool_exp object into a Clause. It backs the
+// resolved top-level argument and every nested bool_exp position. A value that
+// resolves to anything other than an object -- including an explicit null -- is
+// a validation error, matching Hasura, which only treats the top-level where
+// argument as nullable.
+func parseBoolExp(
+	t Table,
+	whereArg *ast.Value,
+	variables map[string]any,
+	role string,
+	sessionVariables map[string]any,
+	nestingLevel int,
+	aliases Aliases,
+) (Clause, error) {
+	whereArg, err := values.ResolveVariable(whereArg, variables)
+	if err != nil {
+		return nil, fmt.Errorf("resolving where variable: %w", err)
+	}
+
+	if whereArg.Kind != ast.ObjectValue {
+		return nil, fmt.Errorf("%w: got %v", errExpectedObjectValue, whereArg.Kind)
 	}
 
 	conditions := make(Clause, 0, len(whereArg.Children))
@@ -155,14 +167,6 @@ func parseWhereChild(
 		)
 		if err != nil {
 			return nil, fmt.Errorf("failed to parse _not: %w", err)
-		}
-
-		// `_not: null` (and `_not: {}`) impose no constraint, matching Hasura's
-		// no-op semantics. parseLogicalNot returns a nil filter in that case;
-		// appending it would emit an invalid `NOT ()` fragment, so contribute
-		// zero statements instead.
-		if notCondition == nil {
-			return Clause{}, nil
 		}
 
 		return Clause{notCondition}, nil
@@ -227,10 +231,13 @@ func parseFieldOrRelationship( //nolint:ireturn,nolintlint
 }
 
 // parseRelationshipField builds a relationshipFilter by recursively parsing
-// the nested where object against the relationship's target table. The
-// nil-Clause guard preserves a nil Statement interface rather than wrapping
-// a nil Clause in a non-nil interface, which downstream WriteCondition
-// callers rely on.
+// the nested where object against the relationship's target table via
+// parseBoolExp, so a null nested filter (`relationship: null`) is rejected like
+// Hasura does. An empty nested object (`relationship: {}`) parses to an empty
+// clause: the empty-Clause guard leaves conds as a nil Statement interface so
+// the filter renders the EXISTS join with no inner predicate (Hasura's
+// "any related row exists"), rather than wrapping an empty clause in a non-nil
+// interface, which downstream WriteCondition callers must not see.
 func parseRelationshipField(
 	relationship Relationship,
 	value *ast.Value,
@@ -240,7 +247,7 @@ func parseRelationshipField(
 	nestingLevel int,
 	aliases Aliases,
 ) (*relationshipFilter, error) {
-	relationshipConditions, err := Parse(
+	relationshipConditions, err := parseBoolExp(
 		relationship.Target(),
 		value,
 		variables,
@@ -254,7 +261,7 @@ func parseRelationshipField(
 	}
 
 	var conds Statement
-	if relationshipConditions != nil {
+	if len(relationshipConditions) > 0 {
 		conds = relationshipConditions
 	}
 
@@ -278,7 +285,15 @@ func parseLogicalAnd(
 	aliases Aliases,
 ) (Clause, error) {
 	if value.Kind == ast.ObjectValue {
-		return Parse(t, value, variables, role, sessionVariables, nestingLevel, aliases)
+		return parseBoolExp(
+			t,
+			value,
+			variables,
+			role,
+			sessionVariables,
+			nestingLevel,
+			aliases,
+		)
 	}
 
 	if value.Kind != ast.ListValue {
@@ -288,7 +303,7 @@ func parseLogicalAnd(
 	conditions := make(Clause, 0, len(value.Children))
 
 	for _, item := range value.Children {
-		itemConditions, err := Parse(
+		itemConditions, err := parseBoolExp(
 			t, item.Value, variables, role, sessionVariables, nestingLevel, aliases,
 		)
 		if err != nil {
@@ -311,14 +326,14 @@ func parseLogicalOr(
 	aliases Aliases,
 ) (*orFilter, error) {
 	if value.Kind == ast.ObjectValue {
-		itemConditions, err := Parse(
+		itemConditions, err := parseBoolExp(
 			t, value, variables, role, sessionVariables, nestingLevel, aliases,
 		)
 		if err != nil {
 			return nil, err
 		}
 
-		return &orFilter{conditions: []Statement{itemConditions}}, nil
+		return &orFilter{conditions: []Statement{orElement(itemConditions)}}, nil
 	}
 
 	if value.Kind != ast.ListValue {
@@ -327,20 +342,32 @@ func parseLogicalOr(
 
 	orConditions := make([]Statement, 0, len(value.Children))
 	for _, item := range value.Children {
-		itemConditions, err := Parse(
+		itemConditions, err := parseBoolExp(
 			t, item.Value, variables, role, sessionVariables, nestingLevel, aliases,
 		)
 		if err != nil {
 			return nil, err
 		}
 
-		orConditions = append(orConditions, itemConditions)
+		orConditions = append(orConditions, orElement(itemConditions))
 	}
 
 	return &orFilter{conditions: orConditions}, nil
 }
 
-func parseLogicalNot(
+// orElement renders one element of an `_or` list. An empty bool_exp element
+// (`{}` or `_and: []`) is always true, and Hasura keeps it as a true disjunct
+// (e.g. `_or: [{}, ...]` matches everything). Returning the constant avoids an
+// empty fragment inside the parenthesised OR.
+func orElement(conditions Clause) Statement { //nolint:ireturn
+	if len(conditions) == 0 {
+		return boolConstant(true)
+	}
+
+	return conditions
+}
+
+func parseLogicalNot( //nolint:ireturn
 	t Table,
 	value *ast.Value,
 	variables map[string]any,
@@ -348,20 +375,21 @@ func parseLogicalNot(
 	sessionVariables map[string]any,
 	nestingLevel int,
 	aliases Aliases,
-) (*notFilter, error) {
-	conditions, err := Parse(
+) (Statement, error) {
+	conditions, err := parseBoolExp(
 		t, value, variables, role, sessionVariables, nestingLevel, aliases,
 	)
 	if err != nil {
 		return nil, err
 	}
 
-	// A nil/empty inner clause (e.g. `_not: null` or `_not: {}`) imposes no
-	// constraint. Return a nil filter so the caller can skip it rather than
-	// wrapping an empty clause in `NOT ()`, which is invalid SQL. This mirrors
-	// the nil-Clause guard in parseRelationshipField.
+	// `_not: {}` (and `_not: {_and: []}`) negate the always-true empty bool_exp,
+	// so they are always false -- matching Hasura, where `_not: {}` returns no
+	// rows. Emit the constant rather than `NOT ()`, which is invalid SQL.
+	// `_not: null` never reaches here: parseBoolExp rejects a null bool_exp, as
+	// Hasura does.
 	if len(conditions) == 0 {
-		return nil, nil //nolint:nilnil
+		return boolConstant(false), nil
 	}
 
 	return &notFilter{condition: conditions}, nil
@@ -385,7 +413,10 @@ func resolveScalarValue(operatorValue *ast.Value, variables map[string]any) (any
 
 // resolveArrayValue resolves a variable reference and extracts an array of values.
 // This is the common pattern for array operators (_in, _nin).
-func resolveArrayValue(operatorValue *ast.Value, variables map[string]any) ([]any, error) {
+func resolveArrayValue(
+	operatorValue *ast.Value,
+	variables map[string]any,
+) ([]any, error) {
 	resolved, err := values.ResolveVariable(operatorValue, variables)
 	if err != nil {
 		return nil, fmt.Errorf("resolving array variable: %w", err)
@@ -401,7 +432,10 @@ func resolveArrayValue(operatorValue *ast.Value, variables map[string]any) ([]an
 
 // resolveStringArrayValue resolves a variable reference and extracts a string array.
 // This is the common pattern for JSONB key operators (_has_keys_all, _has_keys_any).
-func resolveStringArrayValue(operatorValue *ast.Value, variables map[string]any) ([]string, error) {
+func resolveStringArrayValue(
+	operatorValue *ast.Value,
+	variables map[string]any,
+) ([]string, error) {
 	resolved, err := values.ResolveVariable(operatorValue, variables)
 	if err != nil {
 		return nil, fmt.Errorf("resolving string array variable: %w", err)
@@ -475,7 +509,11 @@ func (f *andFilter) WriteCondition(
 
 		params, paramIndex, err = condition.WriteCondition(b, source, params, paramIndex)
 		if err != nil {
-			return nil, 0, fmt.Errorf("failed to write AND condition at pos %d: %w", i, err)
+			return nil, 0, fmt.Errorf(
+				"failed to write AND condition at pos %d: %w",
+				i,
+				err,
+			)
 		}
 	}
 
@@ -492,13 +530,25 @@ func (f *orFilter) WriteCondition(
 	params []any,
 	paramIndex int,
 ) ([]any, int, error) {
+	// An empty disjunction (`_or: []`) is false, matching Hasura. Rendering the
+	// constant also avoids the invalid empty `()` fragment.
+	if len(f.conditions) == 0 {
+		b.WriteString("false")
+
+		return params, paramIndex, nil
+	}
+
 	b.WriteByte('(')
 
 	var err error
 	for i, clause := range f.conditions {
 		params, paramIndex, err = clause.WriteCondition(b, source, params, paramIndex)
 		if err != nil {
-			return nil, 0, fmt.Errorf("failed to write OR condition at pos %d: %w", i, err)
+			return nil, 0, fmt.Errorf(
+				"failed to write OR condition at pos %d: %w",
+				i,
+				err,
+			)
 		}
 
 		if i < len(f.conditions)-1 {
@@ -507,6 +557,24 @@ func (f *orFilter) WriteCondition(
 	}
 
 	b.WriteByte(')')
+
+	return params, paramIndex, nil
+}
+
+// boolConstant renders a SQL boolean literal for logical expressions whose
+// truth value is fixed regardless of any row: an empty `_or` element is true, a
+// `_not` of the always-true empty bool_exp is false. Mirrors how Hasura
+// evaluates these degenerate forms.
+type boolConstant bool
+
+func (c boolConstant) WriteCondition(
+	b *strings.Builder, _ string, params []any, paramIndex int,
+) ([]any, int, error) {
+	if c {
+		b.WriteString("true")
+	} else {
+		b.WriteString("false")
+	}
 
 	return params, paramIndex, nil
 }

--- a/services/constellation/connector/sql/graphql/queries/where/where_test.go
+++ b/services/constellation/connector/sql/graphql/queries/where/where_test.go
@@ -1969,6 +1969,65 @@ func TestParse_NullNestedRelationship(t *testing.T) {
 	}
 }
 
+// TestParse_NullNot covers `where: {_not: null}`. The `_not` field is generated
+// as a nullable bool_exp, so an explicit null passes GraphQL validation. Hasura
+// treats it as a no-op (the `_not` contributes no constraint), so Parse must
+// yield an empty clause that renders to nothing -- never the invalid `NOT ()`
+// fragment.
+func TestParse_NullNot(t *testing.T) {
+	t.Parallel()
+
+	tbl := &parseTestTable{}
+
+	value := &ast.Value{
+		Kind: ast.ObjectValue,
+		Children: []*ast.ChildValue{
+			{Name: "_not", Value: &ast.Value{Kind: ast.NullValue}},
+		},
+	}
+
+	clause, err := where.Parse(tbl, value, nil, "", nil, 0, where.QueryAliases)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	sql, params := renderClause(t, clause)
+	if strings.Contains(sql, "NOT") {
+		t.Errorf("expected no NOT fragment for null _not, got: %s", sql)
+	}
+
+	if sql != "" {
+		t.Errorf("expected empty SQL for null _not no-op, got: %q", sql)
+	}
+
+	if len(params) != 0 {
+		t.Errorf("params = %v, want none", params)
+	}
+}
+
+// TestParse_NullAnd covers `where: {_and: null}`. Unlike `_not`, the null
+// handling in the shared Parse never runs for `_and`: parseLogicalAnd inspects
+// the child value's Kind directly and rejects a NullValue, so `_and: null` is a
+// clean error (it is neither a list nor an object). This pins that pre-existing
+// behavior, which is unaffected by the `_not: null` fix.
+func TestParse_NullAnd(t *testing.T) {
+	t.Parallel()
+
+	tbl := &parseTestTable{}
+
+	value := &ast.Value{
+		Kind: ast.ObjectValue,
+		Children: []*ast.ChildValue{
+			{Name: "_and", Value: &ast.Value{Kind: ast.NullValue}},
+		},
+	}
+
+	_, err := where.Parse(tbl, value, nil, "", nil, 0, where.QueryAliases)
+	if err == nil {
+		t.Fatal("expected error for null _and, got nil")
+	}
+}
+
 // TestParseFieldComparison_Regex_Supported exercises the SupportsRegex=true
 // happy path through the operator dispatch table: the regex operator parser
 // emits a Postgres regex predicate and the placeholder is taken from the

--- a/services/constellation/connector/sql/graphql/queries/where/where_test.go
+++ b/services/constellation/connector/sql/graphql/queries/where/where_test.go
@@ -28,13 +28,31 @@ func (s *stubTableForFieldComparison) ColumnFromGraphqlName(string) *core.Column
 	return nil
 }
 
-func (s *stubTableForFieldComparison) RelationshipFromGraphqlName(string) where.Relationship {
+func (s *stubTableForFieldComparison) RelationshipFromGraphqlName(
+	string,
+) where.Relationship {
 	return nil
 }
-func (s *stubTableForFieldComparison) TableBySchemaName(_, _ string) where.Table { return nil }
-func (s *stubTableForFieldComparison) HasRowLevelPermissions(string) bool        { return false }
+
+func (s *stubTableForFieldComparison) TableBySchemaName(
+	_, _ string,
+) where.Table {
+	return nil
+}
+
+func (s *stubTableForFieldComparison) HasRowLevelPermissions(
+	string,
+) bool {
+	return false
+}
+
 func (s *stubTableForFieldComparison) WriteRowLevelPermissions(
-	_ *strings.Builder, params []any, paramIndex int, _ string, _ map[string]any, _ string,
+	_ *strings.Builder,
+	params []any,
+	paramIndex int,
+	_ string,
+	_ map[string]any,
+	_ string,
 ) ([]any, int, error) {
 	return params, paramIndex, nil
 }
@@ -190,7 +208,13 @@ func TestParseFieldComparison_IsNotNull(t *testing.T) {
 		},
 	}
 
-	sql, _, err := runParseFieldComparison(t, &stubTableForFieldComparison{d: d}, col, value, nil)
+	sql, _, err := runParseFieldComparison(
+		t,
+		&stubTableForFieldComparison{d: d},
+		col,
+		value,
+		nil,
+	)
 	if err != nil {
 		t.Fatalf("unexpected error: %v", err)
 	}
@@ -208,9 +232,12 @@ func TestParseFieldComparison_MultipleOperators(t *testing.T) {
 	d.EXPECT().Placeholder(gomock.Any()).DoAndReturn(func(idx int) string {
 		return "$" + string(rune('0'+idx))
 	}).AnyTimes()
-	d.EXPECT().TypeCast(gomock.Any(), gomock.Any()).DoAndReturn(func(ph, sqlType string) string {
-		return ph + "::" + sqlType
-	}).AnyTimes()
+	d.EXPECT().
+		TypeCast(gomock.Any(), gomock.Any()).
+		DoAndReturn(func(ph, sqlType string) string {
+			return ph + "::" + sqlType
+		}).
+		AnyTimes()
 
 	col := &core.Column{
 		SQLName:     "age",
@@ -276,7 +303,13 @@ func TestParseFieldComparison_UnknownOperator(t *testing.T) {
 		},
 	}
 
-	_, _, err := runParseFieldComparison(t, &stubTableForFieldComparison{d: d}, col, value, nil)
+	_, _, err := runParseFieldComparison(
+		t,
+		&stubTableForFieldComparison{d: d},
+		col,
+		value,
+		nil,
+	)
 	if err == nil {
 		t.Error("expected error for unknown operator, got nil")
 	}
@@ -342,7 +375,13 @@ func TestParseFieldComparison_NonObjectValue(t *testing.T) {
 		Raw:  "not-an-object",
 	}
 
-	_, _, err := runParseFieldComparison(t, &stubTableForFieldComparison{d: d}, col, value, nil)
+	_, _, err := runParseFieldComparison(
+		t,
+		&stubTableForFieldComparison{d: d},
+		col,
+		value,
+		nil,
+	)
 	if err == nil {
 		t.Error("expected error for non-object value, got nil")
 	}
@@ -914,7 +953,10 @@ func TestNewRawFilter_WritesLiteralCondition(t *testing.T) {
 	}
 
 	if paramIndex != 5 {
-		t.Errorf("rawFilter must not consume a placeholder, paramIndex = %d, want 5", paramIndex)
+		t.Errorf(
+			"rawFilter must not consume a placeholder, paramIndex = %d, want 5",
+			paramIndex,
+		)
 	}
 }
 
@@ -1364,7 +1406,10 @@ func TestParse_LogicalAnd_ObjectForm(t *testing.T) {
 						{Name: "a", Value: &ast.Value{
 							Kind: ast.ObjectValue,
 							Children: []*ast.ChildValue{
-								{Name: "_eq", Value: &ast.Value{Kind: ast.StringValue, Raw: "x"}},
+								{
+									Name:  "_eq",
+									Value: &ast.Value{Kind: ast.StringValue, Raw: "x"},
+								},
 							},
 						}},
 					},
@@ -1427,7 +1472,10 @@ func TestParse_LogicalOr_ObjectForm(t *testing.T) {
 						{Name: "a", Value: &ast.Value{
 							Kind: ast.ObjectValue,
 							Children: []*ast.ChildValue{
-								{Name: "_eq", Value: &ast.Value{Kind: ast.StringValue, Raw: "x"}},
+								{
+									Name:  "_eq",
+									Value: &ast.Value{Kind: ast.StringValue, Raw: "x"},
+								},
 							},
 						}},
 					},
@@ -1494,7 +1542,10 @@ func TestParse_LogicalNot(t *testing.T) {
 						{Name: "a", Value: &ast.Value{
 							Kind: ast.ObjectValue,
 							Children: []*ast.ChildValue{
-								{Name: "_eq", Value: &ast.Value{Kind: ast.StringValue, Raw: "x"}},
+								{
+									Name:  "_eq",
+									Value: &ast.Value{Kind: ast.StringValue, Raw: "x"},
+								},
 							},
 						}},
 					},
@@ -1802,7 +1853,10 @@ func TestParse_RelationshipTraversal(t *testing.T) {
 
 	sql, params := renderClause(t, clause)
 	if !strings.Contains(sql, `EXISTS (SELECT 1 FROM "public"."authors" f`) {
-		t.Errorf("expected EXISTS for relationship using QueryAliases.Relationship, got: %s", sql)
+		t.Errorf(
+			"expected EXISTS for relationship using QueryAliases.Relationship, got: %s",
+			sql,
+		)
 	}
 
 	if !strings.Contains(sql, `"t".author_id = f.id`) {
@@ -1832,8 +1886,8 @@ func TestParse_TopLevelVariable(t *testing.T) {
 		columns: map[string]*core.Column{"name": col},
 	}
 
-	// A top-level Variable value gets resolved into the captured Go map via
-	// parseWhereResolveVariable, then traversed like a literal object.
+	// A top-level Variable value gets resolved into the captured Go map by
+	// Parse via values.ResolveVariable, then traversed like a literal object.
 	value := &ast.Value{Kind: ast.Variable, Raw: "filter"}
 
 	variables := map[string]any{
@@ -1865,7 +1919,13 @@ func TestParse_VariableNotObject(t *testing.T) {
 	value := &ast.Value{Kind: ast.Variable, Raw: "filter"}
 
 	_, err := where.Parse(
-		tbl, value, map[string]any{"filter": "not-an-object"}, "", nil, 0, where.QueryAliases,
+		tbl,
+		value,
+		map[string]any{"filter": "not-an-object"},
+		"",
+		nil,
+		0,
+		where.QueryAliases,
 	)
 	if err == nil {
 		t.Fatal("expected error when resolved variable is not an object, got nil")
@@ -1914,14 +1974,10 @@ func TestParse_NullVariable(t *testing.T) {
 	}
 }
 
-// TestParse_NullNestedRelationship covers `where: {<relationship>: null}`. A
-// null nested under a relationship routes through parseRelationshipField into a
-// recursive Parse(null), which must yield a nil inner clause exactly like the
-// top-level cases. The relationship still renders its EXISTS join with no inner
-// predicate and no params, exercising the recursive path of the null guard.
-func TestParse_NullNestedRelationship(t *testing.T) {
-	t.Parallel()
-
+// newRelationshipTable builds a table exposing a single "author" relationship
+// whose join renders `<parent>.author_id = <target>.id`, shared by the nested
+// relationship tests below.
+func newRelationshipTable() *parseTestTable {
 	target := &parseTestTable{
 		fromClause: `"public"."authors"`,
 	}
@@ -1936,14 +1992,49 @@ func TestParse_NullNestedRelationship(t *testing.T) {
 		},
 	}
 
-	tbl := &parseTestTable{
+	return &parseTestTable{
 		relationship: map[string]where.Relationship{"author": rel},
 	}
+}
+
+// TestParse_NullNestedRelationship covers `where: {<relationship>: null}`. Only
+// the top-level where argument is nullable; a null nested under a relationship
+// is rejected, matching Hasura ("expected an object ... but found null").
+func TestParse_NullNestedRelationship(t *testing.T) {
+	t.Parallel()
+
+	tbl := newRelationshipTable()
 
 	value := &ast.Value{
 		Kind: ast.ObjectValue,
 		Children: []*ast.ChildValue{
 			{Name: "author", Value: &ast.Value{Kind: ast.NullValue}},
+		},
+	}
+
+	_, err := where.Parse(tbl, value, nil, "", nil, 0, where.QueryAliases)
+	if err == nil {
+		t.Fatal("expected error for null nested relationship, got nil")
+	}
+
+	if !strings.Contains(err.Error(), "expected object value") {
+		t.Errorf("error = %v, want 'expected object value'", err)
+	}
+}
+
+// TestParse_EmptyNestedRelationship covers `where: {<relationship>: {}}`. An
+// empty nested bool_exp is the always-true filter, so the relationship renders
+// its EXISTS join with no inner predicate and no params -- Hasura's "any
+// related row exists".
+func TestParse_EmptyNestedRelationship(t *testing.T) {
+	t.Parallel()
+
+	tbl := newRelationshipTable()
+
+	value := &ast.Value{
+		Kind: ast.ObjectValue,
+		Children: []*ast.ChildValue{
+			{Name: "author", Value: &ast.Value{Kind: ast.ObjectValue}},
 		},
 	}
 
@@ -1961,7 +2052,7 @@ func TestParse_NullNestedRelationship(t *testing.T) {
 	}
 
 	if strings.Contains(sql, " AND ") {
-		t.Errorf("expected no inner predicate for null relationship, got: %s", sql)
+		t.Errorf("expected no inner predicate for empty relationship, got: %s", sql)
 	}
 
 	if len(params) != 0 {
@@ -1969,11 +2060,9 @@ func TestParse_NullNestedRelationship(t *testing.T) {
 	}
 }
 
-// TestParse_NullNot covers `where: {_not: null}`. The `_not` field is generated
-// as a nullable bool_exp, so an explicit null passes GraphQL validation. Hasura
-// treats it as a no-op (the `_not` contributes no constraint), so Parse must
-// yield an empty clause that renders to nothing -- never the invalid `NOT ()`
-// fragment.
+// TestParse_NullNot covers `where: {_not: null}`. `_not` is a nested bool_exp
+// position, so an explicit null is rejected, matching Hasura, which returns a
+// validation error rather than treating it as a no-op.
 func TestParse_NullNot(t *testing.T) {
 	t.Parallel()
 
@@ -1986,18 +2075,137 @@ func TestParse_NullNot(t *testing.T) {
 		},
 	}
 
+	_, err := where.Parse(tbl, value, nil, "", nil, 0, where.QueryAliases)
+	if err == nil {
+		t.Fatal("expected error for null _not, got nil")
+	}
+
+	if !strings.Contains(err.Error(), "expected object value") {
+		t.Errorf("error = %v, want 'expected object value'", err)
+	}
+}
+
+// TestParse_EmptyNot covers `where: {_not: {}}`. The empty inner bool_exp is
+// always true, so `_not: {}` is always false. It must render the `false`
+// constant (Hasura returns no rows) -- never the invalid `NOT ()` fragment.
+func TestParse_EmptyNot(t *testing.T) {
+	t.Parallel()
+
+	tbl := &parseTestTable{}
+
+	value := &ast.Value{
+		Kind: ast.ObjectValue,
+		Children: []*ast.ChildValue{
+			{Name: "_not", Value: &ast.Value{Kind: ast.ObjectValue}},
+		},
+	}
+
 	clause, err := where.Parse(tbl, value, nil, "", nil, 0, where.QueryAliases)
 	if err != nil {
 		t.Fatalf("unexpected error: %v", err)
 	}
 
 	sql, params := renderClause(t, clause)
-	if strings.Contains(sql, "NOT") {
-		t.Errorf("expected no NOT fragment for null _not, got: %s", sql)
+	if sql != "false" {
+		t.Errorf("Parse(_not: {}) rendered %q, want \"false\"", sql)
 	}
 
-	if sql != "" {
-		t.Errorf("expected empty SQL for null _not no-op, got: %q", sql)
+	if len(params) != 0 {
+		t.Errorf("params = %v, want none", params)
+	}
+}
+
+// TestParse_EmptyOr covers `where: {_or: []}`. An empty disjunction is false,
+// matching Hasura (no rows); it must render the `false` constant, not the
+// invalid empty `()` fragment.
+func TestParse_EmptyOr(t *testing.T) {
+	t.Parallel()
+
+	tbl := &parseTestTable{}
+
+	value := &ast.Value{
+		Kind: ast.ObjectValue,
+		Children: []*ast.ChildValue{
+			{Name: "_or", Value: &ast.Value{Kind: ast.ListValue}},
+		},
+	}
+
+	clause, err := where.Parse(tbl, value, nil, "", nil, 0, where.QueryAliases)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	sql, params := renderClause(t, clause)
+	if sql != "false" {
+		t.Errorf("Parse(_or: []) rendered %q, want \"false\"", sql)
+	}
+
+	if len(params) != 0 {
+		t.Errorf("params = %v, want none", params)
+	}
+}
+
+// TestParse_OrWithEmptyElement covers `where: {_or: [{}]}`. An empty bool_exp
+// element is always true, so the disjunction is true; it must render `(true)`,
+// matching Hasura (all rows), rather than an invalid empty `()` element.
+func TestParse_OrWithEmptyElement(t *testing.T) {
+	t.Parallel()
+
+	tbl := &parseTestTable{}
+
+	value := &ast.Value{
+		Kind: ast.ObjectValue,
+		Children: []*ast.ChildValue{
+			{Name: "_or", Value: &ast.Value{
+				Kind:     ast.ListValue,
+				Children: []*ast.ChildValue{{Value: &ast.Value{Kind: ast.ObjectValue}}},
+			}},
+		},
+	}
+
+	clause, err := where.Parse(tbl, value, nil, "", nil, 0, where.QueryAliases)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	sql, params := renderClause(t, clause)
+	if sql != "(true)" {
+		t.Errorf("Parse(_or: [{}]) rendered %q, want \"(true)\"", sql)
+	}
+
+	if len(params) != 0 {
+		t.Errorf("params = %v, want none", params)
+	}
+}
+
+// TestParse_NotOfEmptyOr covers `where: {_not: {_or: []}}`. The inner `_or: []`
+// is false, so its negation is true; it must render `NOT (false)`, matching
+// Hasura (all rows).
+func TestParse_NotOfEmptyOr(t *testing.T) {
+	t.Parallel()
+
+	tbl := &parseTestTable{}
+
+	value := &ast.Value{
+		Kind: ast.ObjectValue,
+		Children: []*ast.ChildValue{
+			{Name: "_not", Value: &ast.Value{
+				Kind: ast.ObjectValue,
+				Children: []*ast.ChildValue{
+					{Name: "_or", Value: &ast.Value{Kind: ast.ListValue}},
+				},
+			}},
+		},
+	}
+
+	clause, err := where.Parse(tbl, value, nil, "", nil, 0, where.QueryAliases)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	sql, params := renderClause(t, clause)
+	if sql != "NOT (false)" {
+		t.Errorf("Parse(_not: {_or: []}) rendered %q, want \"NOT (false)\"", sql)
 	}
 
 	if len(params) != 0 {
@@ -2025,6 +2233,27 @@ func TestParse_NullAnd(t *testing.T) {
 	_, err := where.Parse(tbl, value, nil, "", nil, 0, where.QueryAliases)
 	if err == nil {
 		t.Fatal("expected error for null _and, got nil")
+	}
+}
+
+// TestParse_NullOr covers `where: {_or: null}`. Like `_and`, parseLogicalOr
+// inspects the child value's Kind directly and rejects a NullValue (neither a
+// list nor an object), matching Hasura's "expected a list, but found null".
+func TestParse_NullOr(t *testing.T) {
+	t.Parallel()
+
+	tbl := &parseTestTable{}
+
+	value := &ast.Value{
+		Kind: ast.ObjectValue,
+		Children: []*ast.ChildValue{
+			{Name: "_or", Value: &ast.Value{Kind: ast.NullValue}},
+		},
+	}
+
+	_, err := where.Parse(tbl, value, nil, "", nil, 0, where.QueryAliases)
+	if err == nil {
+		t.Fatal("expected error for null _or, got nil")
 	}
 }
 

--- a/services/constellation/connector/sql/graphql/queries/where/where_test.go
+++ b/services/constellation/connector/sql/graphql/queries/where/where_test.go
@@ -1872,6 +1872,103 @@ func TestParse_VariableNotObject(t *testing.T) {
 	}
 }
 
+// TestParse_NullArg covers a literal `where: null`. An explicit null filter is
+// equivalent to omitting the argument: it must yield a nil clause, not an
+// "expected object value" error.
+func TestParse_NullArg(t *testing.T) {
+	t.Parallel()
+
+	tbl := &parseTestTable{}
+
+	value := &ast.Value{Kind: ast.NullValue}
+
+	clause, err := where.Parse(tbl, value, nil, "", nil, 0, where.QueryAliases)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	if clause != nil {
+		t.Errorf("Parse(null) = %v, want nil clause", clause)
+	}
+}
+
+// TestParse_NullVariable covers `where: $where` with $where = null, an
+// explicitly-null bool_exp variable present in the variables map. It must be
+// treated as no filter rather than rejected.
+func TestParse_NullVariable(t *testing.T) {
+	t.Parallel()
+
+	tbl := &parseTestTable{}
+
+	value := &ast.Value{Kind: ast.Variable, Raw: "where"}
+
+	clause, err := where.Parse(
+		tbl, value, map[string]any{"where": nil}, "", nil, 0, where.QueryAliases,
+	)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	if clause != nil {
+		t.Errorf("Parse(null variable) = %v, want nil clause", clause)
+	}
+}
+
+// TestParse_NullNestedRelationship covers `where: {<relationship>: null}`. A
+// null nested under a relationship routes through parseRelationshipField into a
+// recursive Parse(null), which must yield a nil inner clause exactly like the
+// top-level cases. The relationship still renders its EXISTS join with no inner
+// predicate and no params, exercising the recursive path of the null guard.
+func TestParse_NullNestedRelationship(t *testing.T) {
+	t.Parallel()
+
+	target := &parseTestTable{
+		fromClause: `"public"."authors"`,
+	}
+
+	rel := &parseTestRelationship{
+		target: target,
+		joinWriter: func(b *strings.Builder, parent, target string) {
+			b.WriteString(parent)
+			b.WriteString(".author_id = ")
+			b.WriteString(target)
+			b.WriteString(".id")
+		},
+	}
+
+	tbl := &parseTestTable{
+		relationship: map[string]where.Relationship{"author": rel},
+	}
+
+	value := &ast.Value{
+		Kind: ast.ObjectValue,
+		Children: []*ast.ChildValue{
+			{Name: "author", Value: &ast.Value{Kind: ast.NullValue}},
+		},
+	}
+
+	clause, err := where.Parse(tbl, value, nil, "", nil, 0, where.QueryAliases)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	sql, params := renderClause(t, clause)
+	if !strings.Contains(
+		sql,
+		`EXISTS (SELECT 1 FROM "public"."authors" f WHERE "t".author_id = f.id)`,
+	) {
+		t.Errorf("expected EXISTS with join only and no inner predicate, got: %s", sql)
+	}
+
+	if strings.Contains(sql, " AND ") {
+		t.Errorf("expected no inner predicate for null relationship, got: %s", sql)
+	}
+
+	if len(params) != 0 {
+		t.Errorf("params = %v, want none", params)
+	}
+}
+
 // TestParseFieldComparison_Regex_Supported exercises the SupportsRegex=true
 // happy path through the operator dispatch table: the regex operator parser
 // emits a Postgres regex predicate and the placeholder is taken from the

--- a/services/constellation/integration/query_where_null_empty_test.go
+++ b/services/constellation/integration/query_where_null_empty_test.go
@@ -1,0 +1,139 @@
+package integration_test
+
+import "testing"
+
+// TestSelectWhereNullEmpty pins constellation's handling of null and empty
+// where/bool_exp forms against live Hasura. Only the top-level where argument
+// is nullable (no filter); empty logical forms follow boolean algebra: an empty
+// bool_exp / `_and: []` is true, `_or: []` is false, and `_not: {}` is false.
+//
+// The null-rejection cases (`_not: null`, `relationship: null`, `_and: null`,
+// `_or: null`, `column: null`) are covered by the where package unit tests
+// instead: both engines reject them, but their error text differs, so they are
+// not suited to the response-diffing harness here.
+func TestSelectWhereNullEmpty(t *testing.T) { //nolint:paralleltest
+	cases := []TestCase{
+		{
+			name: "where null literal is no filter",
+			query: query{
+				Query: `query {
+					departments(where: null, order_by: {id: asc}) { id name }
+				}`,
+				Role: "admin",
+			},
+		},
+		{
+			name: "where null variable is no filter",
+			query: query{
+				Query: `query($where: departments_bool_exp) {
+					departments(where: $where, order_by: {id: asc}) { id name }
+				}`,
+				Variables: map[string]any{"where": nil},
+				Role:      "admin",
+			},
+		},
+		{
+			name: "where empty object matches all",
+			query: query{
+				Query: `query {
+					departments(where: {}, order_by: {id: asc}) { id name }
+				}`,
+				Role: "admin",
+			},
+		},
+		{
+			name: "empty _and matches all",
+			query: query{
+				Query: `query {
+					departments(where: {_and: []}, order_by: {id: asc}) { id name }
+				}`,
+				Role: "admin",
+			},
+		},
+		{
+			name: "empty _or matches none",
+			query: query{
+				Query: `query {
+					departments(where: {_or: []}, order_by: {id: asc}) { id name }
+				}`,
+				Role: "admin",
+			},
+		},
+		{
+			name: "_or with empty element matches all",
+			query: query{
+				Query: `query {
+					departments(where: {_or: [{}]}, order_by: {id: asc}) { id name }
+				}`,
+				Role: "admin",
+			},
+		},
+		{
+			name: "_or with empty element beside a real one matches all",
+			query: query{
+				Query: `query {
+					departments(
+						where: {_or: [{}, {name: {_eq: "Sales"}}]}, order_by: {id: asc}
+					) { id name }
+				}`,
+				Role: "admin",
+			},
+		},
+		{
+			name: "_and with empty element matches all",
+			query: query{
+				Query: `query {
+					departments(where: {_and: [{}]}, order_by: {id: asc}) { id name }
+				}`,
+				Role: "admin",
+			},
+		},
+		{
+			name: "double negation of empty matches all",
+			query: query{
+				Query: `query {
+					departments(where: {_not: {_not: {}}}, order_by: {id: asc}) { id name }
+				}`,
+				Role: "admin",
+			},
+		},
+		{
+			name: "_not of empty object matches none",
+			query: query{
+				Query: `query {
+					departments(where: {_not: {}}, order_by: {id: asc}) { id name }
+				}`,
+				Role: "admin",
+			},
+		},
+		{
+			name: "_not of empty _and matches none",
+			query: query{
+				Query: `query {
+					departments(where: {_not: {_and: []}}, order_by: {id: asc}) { id name }
+				}`,
+				Role: "admin",
+			},
+		},
+		{
+			name: "_not of empty _or matches all",
+			query: query{
+				Query: `query {
+					departments(where: {_not: {_or: []}}, order_by: {id: asc}) { id name }
+				}`,
+				Role: "admin",
+			},
+		},
+		{
+			name: "empty relationship filter is exists join",
+			query: query{
+				Query: `query {
+					departments(where: {employees: {}}, order_by: {id: asc}) { id name }
+				}`,
+				Role: "admin",
+			},
+		},
+	}
+
+	RunGraphQLTests(t, cases, TestConfig{IsMutation: false, ReinitBetweenQueries: false})
+}


### PR DESCRIPTION
<!-- nhost-reviewer:start -->
### **What this PR solves**
A GraphQL `where` argument that resolved to `null` (literal `where: null`, or `where: $where` with a nullable `..._bool_exp` variable set to `null`) was rejected with `expected object value`, whereas Hasura treats a null top-level `where` as no filter. This fixes that and aligns the engine with Hasura's exact semantics for every null/empty bool_exp form — verified case-by-case against a live Hasura instance. Because `where.Parse` is shared with row-level permission filters, the Hasura-matching behavior is also the fail-closed one (a deny-all filter stays deny-all).

___

### **PR Type**
Bug fix

___

### **Description**
- **Null tolerance is now top-level only.** Public `Parse` (the entry for the `where` argument and permission filters) treats a null-resolving value as no filter. A new internal `parseBoolExp` backs every *nested* position (`_not`, `_and`/`_or` elements, relationships) and rejects an explicit null — matching Hasura, where `_not: null`, `relationship: null`, `_and/_or/column: null` are validation errors.
- **Empty logical forms follow boolean algebra, matching Hasura:** empty bool_exp / `_and: []` → true; `_or: []` → false; `_not: {}` (and `_not: {_and: []}`) → false; an empty `_or` element → true; `relationship: {}` → EXISTS-join-only. This also fixes the pre-existing invalid SQL (`NOT ()`, `()`) those forms produced.
- Adds a `boolConstant` Statement for the fixed-truth-value forms; `orFilter` renders `false` when empty; `orElement` maps an empty `_or` element to `true`; `parseRelationshipField` guards on clause length so empty `{}` renders join-only.
- **Tests:** rewrote/expanded the `where` unit tests to pin the verified semantics (including the null-rejection error cases and the `false`/`(true)`/`NOT (false)` rendering), and added `integration/query_where_null_empty_test.go` — 13 cases diffed against live Hasura, all passing.

___

### Diagram Walkthrough

```mermaid
flowchart LR
  A["where argument"] --> B{"Parse: null?"}
  B -- "yes (top-level only)" --> C["nil clause (no filter)"]
  B -- "no" --> D["parseBoolExp"]
  D --> E["_not / _and / _or / relationship"]
  E -- "nested null" --> F["validation error"]
  E -- "empty form" --> G["boolean constant: true/false"]
```

___

<details> <summary><h3> File Walkthrough</h3></summary>

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody>
<tr><td><strong>Bug fix</strong></td><td><details><summary>1 files</summary><table>
<tr>
  <td><strong>where.go</strong><dd><code>Split top-level Parse (null=no filter) from nested parseBoolExp (null=error); render empty _or/_not/_and per Hasura boolean algebra via boolConstant</code></dd></td>
  <td><a href="https://github.com/nhost/nhost/pull/4382/files#diff-c97dfdb1bb84263c63a6a987a85ccadfde83f170ad17d1655543199d7486266c">+138/-37</a></td>
</tr>
</table></details></td></tr>
<tr><td><strong>Tests</strong></td><td><details><summary>2 files</summary><table>
<tr>
  <td><strong>where_test.go</strong><dd><code>Pin Hasura-verified semantics: top-level null = no filter, nested null = error, empty _not/_or/relationship rendering</code></dd></td>
  <td><a href="https://github.com/nhost/nhost/pull/4382/files#diff-d7784aa4549572e9449bfafa20b98afd8b83c4d506737416813721ebb4b60ed7">+403/-18</a></td>
</tr>
<tr>
  <td><strong>integration/query_where_null_empty_test.go</strong><dd><code>New: 13 null/empty where cases diffed against live Hasura</code></dd></td>
  <td><a href="https://github.com/nhost/nhost/pull/4382/files#diff-af1f68f84ff12d99ab0605f2146b025afaca8d6877c1d01017c41518db2e9036">+139/-0</a></td>
</tr>
</table></details></td></tr>
</tbody></table>

</details>

___

<!-- nhost-reviewer:end -->