### PR TITLE
fix(constellation): resolve where variables

### DIFF
--- a/services/constellation/connector/sql/graphql/queries/where/errors.go
+++ b/services/constellation/connector/sql/graphql/queries/where/errors.go
@@ -15,6 +15,7 @@ var (
 	errUnknownFieldInWhereClause   = errors.New("unknown field in where clause")
 	errAndMustBeListOrObject       = errors.New("_and must be a list or an object")
 	errOrMustBeListOrObject        = errors.New("_or must be a list or an object")
+	errIsNullMustBeBoolean         = errors.New("_is_null must be a boolean")
 	errFieldComparisonMustBeObject = errors.New("field comparison must be an object")
 	errUnknownWhereOperator        = errors.New("unknown operator")
 )

--- a/services/constellation/connector/sql/graphql/queries/where/operators.go
+++ b/services/constellation/connector/sql/graphql/queries/where/operators.go
@@ -126,12 +126,33 @@ func buildRegex(negated, caseInsensitive bool) operatorParser {
 	}
 }
 
-// parseIsNull handles _is_null: the value is read as a raw boolean, no
-// variable resolution is needed.
+// parseIsNull handles _is_null. The value must be resolved first: a client may
+// parameterize it as `_is_null: $v` (the schema types it as a nullable Boolean),
+// in which case the AST is an ast.Variable whose .Raw is the variable name, not
+// the boolean — so reading .Raw directly would ignore $v entirely. A literal or
+// variable-resolved true yields IS NULL, false yields IS NOT NULL. An explicit
+// null (literal or variable) is rejected, matching Hasura, which fails such a
+// query with "expected a boolean for type 'Boolean', but found null" rather
+// than treating it as a filter.
 func parseIsNull( //nolint:ireturn,nolintlint
-	column *core.Column, value *ast.Value, _ map[string]any, _ dialect.Dialect,
+	column *core.Column, value *ast.Value, variables map[string]any, _ dialect.Dialect,
 ) (Statement, error) {
-	return &isNullFilter{column: column.SQLName, isNull: value.Raw == "true"}, nil
+	resolved, err := values.ResolveVariable(value, variables)
+	if err != nil {
+		return nil, fmt.Errorf("resolving _is_null value: %w", err)
+	}
+
+	v, err := values.ExtractGoValue(resolved)
+	if err != nil {
+		return nil, fmt.Errorf("extracting _is_null value: %w", err)
+	}
+
+	isNull, ok := v.(bool)
+	if !ok {
+		return nil, fmt.Errorf("%w: got %T", errIsNullMustBeBoolean, v)
+	}
+
+	return &isNullFilter{column: column.SQLName, isNull: isNull}, nil
 }
 
 // containmentParser handles _contains / _contained_in, which dispatch on

--- a/services/constellation/connector/sql/graphql/queries/where/where.go
+++ b/services/constellation/connector/sql/graphql/queries/where/where.go
@@ -284,6 +284,16 @@ func parseLogicalAnd(
 	nestingLevel int,
 	aliases Aliases,
 ) (Clause, error) {
+	// Resolve a `_and: $conds` whole-argument variable before inspecting Kind:
+	// the schema types _and as [<table>_bool_exp!], so a list-typed variable is
+	// valid GraphQL and must be substituted to its list (or object) AST here,
+	// exactly as parseBoolExp does. Element-level variables (`_and: [$c]`) are
+	// resolved by the per-item parseBoolExp call below.
+	value, err := values.ResolveVariable(value, variables)
+	if err != nil {
+		return nil, fmt.Errorf("resolving _and value: %w", err)
+	}
+
 	if value.Kind == ast.ObjectValue {
 		return parseBoolExp(
 			t,
@@ -325,6 +335,14 @@ func parseLogicalOr(
 	nestingLevel int,
 	aliases Aliases,
 ) (*orFilter, error) {
+	// Resolve a `_or: $conds` whole-argument variable before inspecting Kind,
+	// mirroring parseLogicalAnd: _or is also typed [<table>_bool_exp!], so a
+	// list/object variable for the whole argument must be substituted here.
+	value, err := values.ResolveVariable(value, variables)
+	if err != nil {
+		return nil, fmt.Errorf("resolving _or value: %w", err)
+	}
+
 	if value.Kind == ast.ObjectValue {
 		itemConditions, err := parseBoolExp(
 			t, value, variables, role, sessionVariables, nestingLevel, aliases,

--- a/services/constellation/connector/sql/graphql/queries/where/where_test.go
+++ b/services/constellation/connector/sql/graphql/queries/where/where_test.go
@@ -2426,48 +2426,65 @@ func TestParse_NotOfEmptyOr(t *testing.T) {
 	}
 }
 
-// TestParse_NullAnd covers `where: {_and: null}`. Unlike `_not`, the null
-// handling in the shared Parse never runs for `_and`: parseLogicalAnd inspects
-// the child value's Kind directly and rejects a NullValue, so `_and: null` is a
-// clean error (it is neither a list nor an object). This pins that pre-existing
-// behavior, which is unaffected by the `_not: null` fix.
-func TestParse_NullAnd(t *testing.T) {
-	t.Parallel()
+func assertNullLogicalCombinatorRejected(t *testing.T, fieldName string) {
+	t.Helper()
 
 	tbl := &parseTestTable{}
 
-	value := &ast.Value{
-		Kind: ast.ObjectValue,
-		Children: []*ast.ChildValue{
-			{Name: "_and", Value: &ast.Value{Kind: ast.NullValue}},
+	tests := []struct {
+		name      string
+		child     *ast.Value
+		variables map[string]any
+	}{
+		{
+			name:  "literal null",
+			child: &ast.Value{Kind: ast.NullValue},
+		},
+		{
+			name:      "variable resolving to null",
+			child:     &ast.Value{Kind: ast.Variable, Raw: "conds"},
+			variables: map[string]any{"conds": nil},
 		},
 	}
 
-	_, err := where.Parse(tbl, value, nil, "", nil, 0, where.QueryAliases)
-	if err == nil {
-		t.Fatal("expected error for null _and, got nil")
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+
+			value := &ast.Value{
+				Kind: ast.ObjectValue,
+				Children: []*ast.ChildValue{
+					{Name: fieldName, Value: tt.child},
+				},
+			}
+
+			_, err := where.Parse(tbl, value, tt.variables, "", nil, 0, where.QueryAliases)
+			if err == nil {
+				t.Fatalf("expected error for null %s, got nil", fieldName)
+			}
+		})
 	}
 }
 
-// TestParse_NullOr covers `where: {_or: null}`. Like `_and`, parseLogicalOr
-// inspects the child value's Kind directly and rejects a NullValue (neither a
-// list nor an object), matching Hasura's "expected a list, but found null".
+// TestParse_NullAnd covers `where: {_and: null}` and `_and: $conds` with a
+// null variable. Unlike top-level where, `_and` does not treat null as an
+// omitted filter: parseLogicalAnd resolves the child value and then rejects
+// NullValue because it is neither a list nor an object. This pins the behavior
+// preserved by whole-list variable resolution.
+func TestParse_NullAnd(t *testing.T) {
+	t.Parallel()
+
+	assertNullLogicalCombinatorRejected(t, "_and")
+}
+
+// TestParse_NullOr covers `where: {_or: null}` and `_or: $conds` with a null
+// variable. Like `_and`, parseLogicalOr resolves the child value and then
+// rejects NullValue because it is neither a list nor an object, matching
+// Hasura's "expected a list, but found null".
 func TestParse_NullOr(t *testing.T) {
 	t.Parallel()
 
-	tbl := &parseTestTable{}
-
-	value := &ast.Value{
-		Kind: ast.ObjectValue,
-		Children: []*ast.ChildValue{
-			{Name: "_or", Value: &ast.Value{Kind: ast.NullValue}},
-		},
-	}
-
-	_, err := where.Parse(tbl, value, nil, "", nil, 0, where.QueryAliases)
-	if err == nil {
-		t.Fatal("expected error for null _or, got nil")
-	}
+	assertNullLogicalCombinatorRejected(t, "_or")
 }
 
 // TestParseFieldComparison_Regex_Supported exercises the SupportsRegex=true

--- a/services/constellation/connector/sql/graphql/queries/where/where_test.go
+++ b/services/constellation/connector/sql/graphql/queries/where/where_test.go
@@ -224,6 +224,124 @@ func TestParseFieldComparison_IsNotNull(t *testing.T) {
 	}
 }
 
+// TestParseFieldComparison_IsNull_Variable pins that `_is_null: $v` resolves the
+// GraphQL variable: $v=true yields IS NULL, $v=false yields IS NOT NULL. Before
+// the fix the parser read value.Raw (the variable *name*) == "true", which is
+// always false, so any variable produced IS NOT NULL regardless of $v.
+func TestParseFieldComparison_IsNull_Variable(t *testing.T) {
+	t.Parallel()
+
+	col := &core.Column{
+		SQLName:     "deleted_at",
+		GraphqlName: "deleted_at",
+		SQLType:     "timestamptz",
+		IsArray:     false,
+	}
+
+	value := &ast.Value{
+		Kind: ast.ObjectValue,
+		Children: []*ast.ChildValue{
+			{Name: "_is_null", Value: &ast.Value{Kind: ast.Variable, Raw: "v"}},
+		},
+	}
+
+	tests := []struct {
+		name     string
+		varValue any
+		want     string
+	}{
+		{name: "variable true yields IS NULL", varValue: true, want: "IS NULL"},
+		{name: "variable false yields IS NOT NULL", varValue: false, want: "IS NOT NULL"},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+
+			ctrl := gomock.NewController(t)
+			d := dialectmock.NewMockDialect(ctrl)
+
+			sql, params, err := runParseFieldComparison(
+				t,
+				&stubTableForFieldComparison{d: d},
+				col,
+				value,
+				map[string]any{"v": tt.varValue},
+			)
+			if err != nil {
+				t.Fatalf("unexpected error: %v", err)
+			}
+
+			if !strings.Contains(sql, tt.want) {
+				t.Errorf("SQL should contain %q, got: %s", tt.want, sql)
+			}
+
+			if len(params) != 0 {
+				t.Errorf("params should be empty for IS [NOT] NULL, got: %v", params)
+			}
+		})
+	}
+}
+
+// TestParseFieldComparison_IsNull_NullRejected pins that an explicit null for
+// _is_null is rejected, matching Hasura ("expected a boolean for type 'Boolean',
+// but found null"). It must hold for a literal null and for a variable that
+// resolves to null; both reach the parser because the schema types _is_null as a
+// nullable Boolean, so GraphQL validation lets the null through.
+func TestParseFieldComparison_IsNull_NullRejected(t *testing.T) {
+	t.Parallel()
+
+	col := &core.Column{
+		SQLName:     "deleted_at",
+		GraphqlName: "deleted_at",
+		SQLType:     "timestamptz",
+		IsArray:     false,
+	}
+
+	tests := []struct {
+		name      string
+		value     *ast.Value
+		variables map[string]any
+	}{
+		{
+			name:  "literal null",
+			value: &ast.Value{Kind: ast.NullValue},
+		},
+		{
+			name:      "variable resolving to null",
+			value:     &ast.Value{Kind: ast.Variable, Raw: "v"},
+			variables: map[string]any{"v": nil},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+
+			ctrl := gomock.NewController(t)
+			d := dialectmock.NewMockDialect(ctrl)
+
+			value := &ast.Value{
+				Kind: ast.ObjectValue,
+				Children: []*ast.ChildValue{
+					{Name: "_is_null", Value: tt.value},
+				},
+			}
+
+			_, _, err := runParseFieldComparison(
+				t,
+				&stubTableForFieldComparison{d: d},
+				col,
+				value,
+				tt.variables,
+			)
+			if err == nil {
+				t.Fatal("expected error for null _is_null, got nil")
+			}
+		})
+	}
+}
+
 func TestParseFieldComparison_MultipleOperators(t *testing.T) {
 	t.Parallel()
 
@@ -1514,6 +1632,101 @@ func TestParse_LogicalOr_InvalidValueKind(t *testing.T) {
 	_, err := where.Parse(tbl, value, nil, "", nil, 0, where.QueryAliases)
 	if err == nil {
 		t.Fatal("expected error for non-list/object _or, got nil")
+	}
+}
+
+// TestParse_LogicalAnd_WholeListVariable pins that `_and: $conds`, where the
+// whole list is supplied as a single variable (typed [<table>_bool_exp!]),
+// resolves and AND-joins. Before the fix value.Kind was ast.Variable, matching
+// neither the ObjectValue nor ListValue branch, so it errored even though the
+// same query succeeds on Hasura.
+func TestParse_LogicalAnd_WholeListVariable(t *testing.T) {
+	t.Parallel()
+
+	ctrl := gomock.NewController(t)
+	d := dialectmock.NewMockDialect(ctrl)
+	d.EXPECT().Placeholder(1).Return("$1")
+	d.EXPECT().TypeCast("$1", "text").Return("$1::text")
+
+	col := &core.Column{SQLName: "a", GraphqlName: "a", SQLType: "text"}
+	tbl := &parseTestTable{
+		d:       d,
+		columns: map[string]*core.Column{"a": col},
+	}
+
+	value := &ast.Value{
+		Kind: ast.ObjectValue,
+		Children: []*ast.ChildValue{
+			{Name: "_and", Value: &ast.Value{Kind: ast.Variable, Raw: "conds"}},
+		},
+	}
+
+	variables := map[string]any{
+		"conds": []any{
+			map[string]any{"a": map[string]any{"_eq": "x"}},
+		},
+	}
+
+	clause, err := where.Parse(tbl, value, variables, "", nil, 0, where.QueryAliases)
+	if err != nil {
+		t.Fatalf("Parse: %v", err)
+	}
+
+	sql, params := renderClause(t, clause)
+	if !strings.Contains(sql, `"t"."a" = $1::text`) {
+		t.Errorf("expected equals predicate from list-variable _and, got: %s", sql)
+	}
+
+	if len(params) != 1 || params[0] != "x" {
+		t.Errorf("params = %v, want [x]", params)
+	}
+}
+
+// TestParse_LogicalOr_WholeListVariable is the _or counterpart: a whole-list
+// variable resolves and the disjunction is parenthesised, matching Hasura.
+func TestParse_LogicalOr_WholeListVariable(t *testing.T) {
+	t.Parallel()
+
+	ctrl := gomock.NewController(t)
+	d := dialectmock.NewMockDialect(ctrl)
+	d.EXPECT().Placeholder(1).Return("$1")
+	d.EXPECT().TypeCast("$1", "text").Return("$1::text")
+
+	col := &core.Column{SQLName: "a", GraphqlName: "a", SQLType: "text"}
+	tbl := &parseTestTable{
+		d:       d,
+		columns: map[string]*core.Column{"a": col},
+	}
+
+	value := &ast.Value{
+		Kind: ast.ObjectValue,
+		Children: []*ast.ChildValue{
+			{Name: "_or", Value: &ast.Value{Kind: ast.Variable, Raw: "conds"}},
+		},
+	}
+
+	variables := map[string]any{
+		"conds": []any{
+			map[string]any{"a": map[string]any{"_eq": "x"}},
+		},
+	}
+
+	clause, err := where.Parse(tbl, value, variables, "", nil, 0, where.QueryAliases)
+	if err != nil {
+		t.Fatalf("Parse: %v", err)
+	}
+
+	sql, params := renderClause(t, clause)
+	if !strings.HasPrefix(sql, "(") || !strings.HasSuffix(sql, ")") {
+		t.Errorf("_or list variable should wrap in parens, got: %s", sql)
+	}
+
+	if !strings.Contains(sql, `"t"."a" = $1::text`) {
+		t.Errorf("expected nested predicate, got: %s", sql)
+	}
+
+	if len(params) != 1 || params[0] != "x" {
+		t.Errorf("params = %v, want [x]", params)
 	}
 }
 

--- a/services/constellation/integration/query_where_variable_test.go
+++ b/services/constellation/integration/query_where_variable_test.go
@@ -1,0 +1,97 @@
+package integration_test
+
+import "testing"
+
+// TestSelectWhereVariable pins constellation's resolution of GraphQL `$variable`
+// values supplied at operator positions in the where/bool_exp builder, against
+// live Hasura. These forms previously misbehaved because the parser inspected
+// the raw AST without first substituting the variable:
+//
+//   - `_is_null: $v` was read as the literal variable *name*, so any variable
+//     produced IS NOT NULL regardless of $v (BUG_MEDIUM_1).
+//   - `_and: $conds` / `_or: $conds` supplied as a single list variable hit a
+//     Kind switch that rejected ast.Variable outright, erroring on a query that
+//     succeeds on Hasura (INCON_LOW_1).
+//
+// The null-rejection forms (`_is_null: null`, `_is_null: $v` with $v=null) are
+// covered by the where package unit tests instead: Hasura rejects them at
+// validation ("expected a boolean for type 'Boolean', but found null") while
+// constellation rejects them in the where builder, so the error text differs and
+// they are not suited to this response-diffing harness — mirroring how the null
+// `_and`/`_or` cases are handled in query_where_null_empty_test.go.
+func TestSelectWhereVariable(t *testing.T) { //nolint:paralleltest
+	cases := []TestCase{
+		{
+			name: "_is_null variable true",
+			query: query{
+				Query: `query($v: Boolean) {
+					departments(
+						where: {description: {_is_null: $v}}, order_by: {id: asc}
+					) { id name }
+				}`,
+				Variables: map[string]any{"v": true},
+				Role:      "admin",
+			},
+		},
+		{
+			name: "_is_null variable false",
+			query: query{
+				Query: `query($v: Boolean) {
+					departments(
+						where: {description: {_is_null: $v}}, order_by: {id: asc}
+					) { id name }
+				}`,
+				Variables: map[string]any{"v": false},
+				Role:      "admin",
+			},
+		},
+		{
+			name: "_and whole-list variable",
+			query: query{
+				Query: `query($c: [departments_bool_exp!]) {
+					departments(where: {_and: $c}, order_by: {name: asc}) { name }
+				}`,
+				Variables: map[string]any{
+					"c": []any{
+						map[string]any{"name": map[string]any{"_eq": "Sales"}},
+					},
+				},
+				Role: "admin",
+			},
+		},
+		{
+			name: "_or whole-list variable",
+			query: query{
+				Query: `query($c: [departments_bool_exp!]) {
+					departments(where: {_or: $c}, order_by: {name: asc}) { name }
+				}`,
+				Variables: map[string]any{
+					"c": []any{
+						map[string]any{"name": map[string]any{"_eq": "Sales"}},
+						map[string]any{"name": map[string]any{"_eq": "Finance"}},
+					},
+				},
+				Role: "admin",
+			},
+		},
+		{
+			name: "_and whole-list variable combined with a sibling predicate",
+			query: query{
+				Query: `query($c: [departments_bool_exp!]) {
+					departments(
+						where: {_and: $c, name: {_neq: "Operations"}},
+						order_by: {name: asc}
+					) { name }
+				}`,
+				Variables: map[string]any{
+					"c": []any{
+						map[string]any{"budget": map[string]any{"_gt": "300000"}},
+					},
+				},
+				Role: "admin",
+			},
+		},
+	}
+
+	RunGraphQLTests(t, cases, TestConfig{IsMutation: false, ReinitBetweenQueries: false})
+}


### PR DESCRIPTION
<!-- nhost-reviewer:start -->
### **What this PR solves**
Fixes where-clause variable handling so `_is_null`, `_and`, and `_or` correctly resolve GraphQL variables before building SQL. This aligns Constellation behavior with Hasura for variable-driven boolean expressions while preserving null rejection semantics.

___

### **PR Type**
Bug fix

___

### **Description**
- Resolve `_is_null` variables before extracting booleans and reject null/non-boolean values explicitly.
- Resolve whole-argument `_and` and `_or` variables before choosing object vs. list parsing paths.
- Add unit and integration coverage for variable-driven where predicates and null rejection.

___

<details> <summary><h3> File Walkthrough</h3></summary>

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody>
<tr><td><strong>Where parser</strong></td><td><details><summary>3 files</summary><table>
<tr>
  <td><strong>errors.go</strong><dd><code>Adds a dedicated error for non-boolean _is_null values.</code></dd></td>
  <td><a href="https://github.com/nhost/nhost/pull/XXX/files#diff-8fd990f042ff2ac0177b764fc613e0806d9833e573d32a98a771cd81af3490fb">+1/-0</a></td>
</tr>
<tr>
  <td><strong>operators.go</strong><dd><code>Resolves _is_null variables before extracting and validating the boolean value.</code></dd></td>
  <td><a href="https://github.com/nhost/nhost/pull/XXX/files#diff-9bcc642d0620b70577a125e03f3003f7671d7517bd630a8dbbe3db8e658ac10e">+25/-4</a></td>
</tr>
<tr>
  <td><strong>where.go</strong><dd><code>Resolves whole-argument _and and _or variables before parsing logical combinators.</code></dd></td>
  <td><a href="https://github.com/nhost/nhost/pull/XXX/files#diff-c97dfdb1bb84263c63a6a987a85ccadfde83f170ad17d1655543199d7486266c">+18/-0</a></td>
</tr>
</table></details></td></tr>
<tr><td><strong>Tests</strong></td><td><details><summary>2 files</summary><table>
<tr>
  <td><strong>where_test.go</strong><dd><code>Adds unit coverage for _is_null variables, logical combinator variables, and null rejection.</code></dd></td>
  <td><a href="https://github.com/nhost/nhost/pull/XXX/files#diff-d7784aa4549572e9449bfafa20b98afd8b83c4d506737416813721ebb4b60ed7">+259/-29</a></td>
</tr>
<tr>
  <td><strong>query_where_variable_test.go</strong><dd><code>Adds integration coverage comparing variable-based where filters against Hasura.</code></dd></td>
  <td><a href="https://github.com/nhost/nhost/pull/XXX/files#diff-df540a51a0f4e71f4ce6b9862db9dd9c4964609294617f2e5a4befe90c66e1e3">+97/-0</a></td>
</tr>
</table></details></td></tr>
</tbody></table>

</details>

___

<!-- nhost-reviewer:end -->