### PR TITLE
fix(constellation): preserve x-hasura literals in subscriptions

### DIFF
--- a/services/constellation/connector/sql/graphql/queries/core/core.go
+++ b/services/constellation/connector/sql/graphql/queries/core/core.go
@@ -228,6 +228,38 @@ type CursorValue struct {
 	Value any
 }
 
+// SessionVarValue marks a parameter that is a permission session-variable
+// reference (e.g. "x-hasura-user-id"), as distinct from ordinary user-supplied
+// data that merely happens to begin with "x-hasura-". The multiplexed converter
+// (multiplexed.Multiplex) recognises the marker by type and rewrites the
+// corresponding placeholder into a "_subs"."result_vars" JSON-path lookup so
+// each cohort member reads its own session value.
+//
+// The marker is born only in the subscription cohort managers, which seed their
+// template session-variable maps with SessionVarValue entries; the permission
+// layer's SubstituteSessionVariable then resolves a genuine permission marker to
+// it. Non-subscription queries resolve session variables to their concrete
+// values instead, so a SessionVarValue never reaches direct (non-multiplexed)
+// execution. Classifying by this type — rather than by string-sniffing a
+// finalised parameter value — keeps user where/_set/_in literals that begin with
+// "x-hasura-" as ordinary data, matching Hasura.
+type SessionVarValue struct {
+	// Name is the lowercased session-variable name (e.g. "x-hasura-user-id"),
+	// used as the result_vars JSON key the multiplexed converter emits.
+	Name string
+}
+
+// MarshalJSON renders the marker as its bare Name string. A SQL function's
+// session argument is built by JSON-marshalling the (template) session-variable
+// map (see queries.function), where the value for each key is this marker;
+// emitting the struct form would change that embedded JSON, so we serialise the
+// name — the same placeholder the map held before this type existed. Mirrors
+// OrderDirection.MarshalJSON's strconv.Quote approach; session-variable names
+// are controlled, lowercased x-hasura-* keys.
+func (s SessionVarValue) MarshalJSON() ([]byte, error) {
+	return []byte(strconv.Quote(s.Name)), nil
+}
+
 // MultiplexedResult is a single per-subscriber row produced by a SQL driver's
 // ExecuteMultiplexedOperation. It pairs the subscription ID extracted from
 // the query's result_vars with the raw JSON payload for that subscriber.

--- a/services/constellation/connector/sql/graphql/queries/core/core_test.go
+++ b/services/constellation/connector/sql/graphql/queries/core/core_test.go
@@ -1,11 +1,61 @@
 package core_test
 
 import (
+	json "encoding/json/v2"
 	"strings"
 	"testing"
 
 	"github.com/nhost/nhost/services/constellation/connector/sql/graphql/queries/core"
 )
+
+func TestSessionVarValue_MarshalJSON(t *testing.T) {
+	t.Parallel()
+
+	cases := []struct {
+		name string
+		in   core.SessionVarValue
+		want string
+	}{
+		{"x-hasura name", core.SessionVarValue{Name: "x-hasura-user-id"}, `"x-hasura-user-id"`},
+		{"empty name", core.SessionVarValue{Name: ""}, `""`},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+
+			got, err := json.Marshal(tc.in)
+			if err != nil {
+				t.Fatalf("Marshal(%+v) error: %v", tc.in, err)
+			}
+
+			if string(got) != tc.want {
+				t.Fatalf("Marshal(%+v) = %s, want %s", tc.in, got, tc.want)
+			}
+		})
+	}
+}
+
+// TestSessionVarValue_MarshalJSONInMap covers the shape that motivates the
+// custom marshaller: a SQL function's session argument is built by marshalling
+// the (template) session-variable map, whose values are SessionVarValue markers.
+// Each marker must serialise as its bare name so the embedded JSON is identical
+// to the pre-marker behaviour (a plain x-hasura-* string), not a struct.
+func TestSessionVarValue_MarshalJSONInMap(t *testing.T) {
+	t.Parallel()
+
+	got, err := json.Marshal(map[string]any{
+		"x-hasura-user-id": core.SessionVarValue{Name: "x-hasura-user-id"},
+	})
+	if err != nil {
+		t.Fatalf("Marshal map error: %v", err)
+	}
+
+	want := `{"x-hasura-user-id":"x-hasura-user-id"}`
+	if string(got) != want {
+		t.Fatalf("Marshal map = %s, want %s", got, want)
+	}
+}
 
 func TestOrderDirection_SQL(t *testing.T) {
 	t.Parallel()

--- a/services/constellation/connector/sql/graphql/queries/multiplexed/multiplexed.go
+++ b/services/constellation/connector/sql/graphql/queries/multiplexed/multiplexed.go
@@ -117,6 +117,10 @@ func extractSessionVarName(param any) (string, bool) {
 				return sv.Name, true
 			}
 		}
+	case []core.SessionVarValue:
+		if len(v) == 1 {
+			return v[0].Name, true
+		}
 	}
 
 	return "", false

--- a/services/constellation/connector/sql/graphql/queries/multiplexed/multiplexed.go
+++ b/services/constellation/connector/sql/graphql/queries/multiplexed/multiplexed.go
@@ -7,12 +7,29 @@ package multiplexed
 
 import (
 	json "encoding/json/v2"
+	"errors"
 	"fmt"
 	"regexp"
+	"slices"
 	"strconv"
 	"strings"
 
 	"github.com/nhost/nhost/services/constellation/connector/sql/graphql/queries/core"
+)
+
+// ErrSessionVarInMultiElementArray is returned by Multiplex when a permission
+// session-variable marker is trapped inside a multi-element array parameter
+// (e.g. `_in: ["x-hasura-user-id", "<literal>"]` or
+// `_has_keys_any: ["x-hasura-key", "<literal>"]`). Such an array maps to a
+// single SQL placeholder bound as a whole array, so its session-variable
+// element cannot be rewritten into a per-subscriber result_vars JSON path
+// without restructuring the array into per-element expressions — which is not
+// yet supported. Rather than silently binding the variable's literal name (and
+// evaluating the row-level permission against "x-hasura-…" instead of the
+// subscriber's session value), the subscription is rejected so the divergence
+// is loud rather than a silent wrong/empty result set.
+var ErrSessionVarInMultiElementArray = errors.New(
+	"session variable in a multi-element array filter is not supported in subscriptions",
 )
 
 // paramPattern matches $N optionally followed by ::type or ::type[].
@@ -44,19 +61,24 @@ var paramPattern = regexp.MustCompile(`\$(\d+)(?:::([a-zA-Z_][a-zA-Z0-9_]*(?:\[\
 // string value: a user-supplied where/_set/_in/by_pk literal that happens to
 // begin with "x-hasura-" is ordinary data and is left as a static parameter,
 // matching Hasura (which tracks session-variable positions structurally).
-func Multiplex(op core.SQLOperation) (string, []any) {
-	innerSQL, staticParams := rewriteMultiplexedSQL(op)
+func Multiplex(op core.SQLOperation) (string, []any, error) {
+	innerSQL, staticParams, err := rewriteMultiplexedSQL(op)
+	if err != nil {
+		return "", nil, err
+	}
 
-	return buildMultiplexedSQL(op.Name, innerSQL), staticParams
+	return buildMultiplexedSQL(op.Name, innerSQL), staticParams, nil
 }
 
 // rewriteMultiplexedSQL converts a regular core.SQLOperation into its inner
 // multiplexed form: the SQL with session and cursor parameter references
 // rewritten to JSON path expressions, and the residual static parameters
-// (renumbered to start at $3).
-func rewriteMultiplexedSQL(op core.SQLOperation) (string, []any) {
+// (renumbered to start at $3). It returns ErrSessionVarInMultiElementArray when
+// a session-variable marker is trapped inside a multi-element array parameter
+// that cannot be rewritten into a single result_vars lookup.
+func rewriteMultiplexedSQL(op core.SQLOperation) (string, []any, error) {
 	if len(op.Parameters) == 0 {
-		return op.SQL, nil
+		return op.SQL, nil, nil
 	}
 
 	sessionVarIndices := make(map[int]string)
@@ -70,6 +92,17 @@ func rewriteMultiplexedSQL(op core.SQLOperation) (string, []any) {
 			sessionVarIndices[paramIdx] = varName
 		} else if cursorVal, ok := param.(core.CursorValue); ok {
 			cursorVarIndices[paramIdx] = cursorVal.ColumnName
+		} else if containsSessionVarMarker(param) {
+			// extractSessionVarName recognises a lone (or single-element-array)
+			// session-variable marker above; if a marker survives here it is
+			// trapped inside a multi-element array param that cannot be rewritten
+			// to a result_vars path, so reject the subscription rather than bind
+			// the variable's literal name.
+			return "", nil, fmt.Errorf(
+				"%w: parameter %d",
+				ErrSessionVarInMultiElementArray,
+				paramIdx,
+			)
 		} else {
 			staticParamOldIndices = append(staticParamOldIndices, paramIdx)
 		}
@@ -86,7 +119,7 @@ func rewriteMultiplexedSQL(op core.SQLOperation) (string, []any) {
 
 	staticParams := make([]any, len(staticParamOldIndices))
 	for i, oldIdx := range staticParamOldIndices {
-		staticParams[i] = sanitizeStaticParam(op.Parameters[oldIdx-1])
+		staticParams[i] = op.Parameters[oldIdx-1]
 	}
 
 	innerSQL := rewriteSQLForMultiplexing(
@@ -96,7 +129,7 @@ func rewriteMultiplexedSQL(op core.SQLOperation) (string, []any) {
 		staticParamMapping,
 	)
 
-	return innerSQL, staticParams
+	return innerSQL, staticParams, nil
 }
 
 // extractSessionVarName extracts the session-variable name from a parameter
@@ -126,44 +159,21 @@ func extractSessionVarName(param any) (string, bool) {
 	return "", false
 }
 
-// sanitizeStaticParam unwraps any core.SessionVarValue marker that has reached
-// the static-parameter list back into its bare name string. A lone marker is
-// rewritten to a result_vars JSON path by extractSessionVarName and never
-// reaches here, but a permission `_in`/`_nin` filter that mixes a session
-// variable with another element — e.g. _in: ["x-hasura-tenant-id", "<uuid>"] —
-// leaves the marker nested inside a multi-element []any that cannot be reduced
-// to a single JSON path, so it falls through to the static params. Per-element
-// array rewriting is out of scope (and Postgres-only), so we preserve the
-// pre-existing behaviour of binding the variable's name rather than letting a
-// marker reach the driver, where pgx would fail to encode it.
-func sanitizeStaticParam(param any) any {
+// containsSessionVarMarker reports whether param is, or transitively contains,
+// a core.SessionVarValue marker. extractSessionVarName already recognises a lone
+// marker and a single-element array wrapping one (the rewritable shapes); this
+// detects a marker trapped in a multi-element array, where it cannot be reduced
+// to a single result_vars path. rewriteMultiplexedSQL rejects such params rather
+// than letting a marker reach the driver (pgx cannot encode it) or silently
+// binding the variable's literal name.
+func containsSessionVarMarker(param any) bool {
 	switch v := param.(type) {
 	case core.SessionVarValue:
-		return v.Name
+		return true
 	case []any:
-		if !containsSessionVarMarker(v) {
-			return param
-		}
-
-		out := make([]any, len(v))
-		for i, elem := range v {
-			out[i] = sanitizeStaticParam(elem)
-		}
-
-		return out
-	default:
-		return param
-	}
-}
-
-// containsSessionVarMarker reports whether arr has any core.SessionVarValue
-// element, so sanitizeStaticParam copies (rather than mutates) only the rare
-// slices that actually carry a stray marker.
-func containsSessionVarMarker(arr []any) bool {
-	for _, elem := range arr {
-		if _, ok := elem.(core.SessionVarValue); ok {
-			return true
-		}
+		return slices.ContainsFunc(v, containsSessionVarMarker)
+	case []core.SessionVarValue:
+		return len(v) > 0
 	}
 
 	return false

--- a/services/constellation/connector/sql/graphql/queries/multiplexed/multiplexed.go
+++ b/services/constellation/connector/sql/graphql/queries/multiplexed/multiplexed.go
@@ -32,12 +32,18 @@ var paramPattern = regexp.MustCompile(`\$(\d+)(?:::([a-zA-Z_][a-zA-Z0-9_]*(?:\[\
 // placeholders for session/cursor values, while static GraphQL variables remain
 // as numbered parameters ($3, $4, ...).
 //
-// Session variables (strings prefixed with "x-hasura-") and cursor values
-// (core.CursorValue markers) in op.Parameters are recognised and rewritten to
-// JSON path expressions accessing _subs.result_vars. Type casts are extracted
-// from the SQL pattern $N::type. The remaining entries form the static params
-// slice, renumbered starting at $3 (after $1=sub_ids, $2=result_vars). Callers
-// pass that slice as the tail of the parameter list — see PrepareParams.
+// Session variables (core.SessionVarValue markers) and cursor values
+// (core.CursorValue markers) in op.Parameters are recognised by type and
+// rewritten to JSON path expressions accessing _subs.result_vars. Type casts
+// are extracted from the SQL pattern $N::type. The remaining entries form the
+// static params slice, renumbered starting at $3 (after $1=sub_ids,
+// $2=result_vars). Callers pass that slice as the tail of the parameter list —
+// see PrepareParams.
+//
+// Classification is purely by marker type, never by sniffing a parameter's
+// string value: a user-supplied where/_set/_in/by_pk literal that happens to
+// begin with "x-hasura-" is ordinary data and is left as a static parameter,
+// matching Hasura (which tracks session-variable positions structurally).
 func Multiplex(op core.SQLOperation) (string, []any) {
 	innerSQL, staticParams := rewriteMultiplexedSQL(op)
 
@@ -80,7 +86,7 @@ func rewriteMultiplexedSQL(op core.SQLOperation) (string, []any) {
 
 	staticParams := make([]any, len(staticParamOldIndices))
 	for i, oldIdx := range staticParamOldIndices {
-		staticParams[i] = op.Parameters[oldIdx-1]
+		staticParams[i] = sanitizeStaticParam(op.Parameters[oldIdx-1])
 	}
 
 	innerSQL := rewriteSQLForMultiplexing(
@@ -93,36 +99,70 @@ func rewriteMultiplexedSQL(op core.SQLOperation) (string, []any) {
 	return innerSQL, staticParams
 }
 
-// extractSessionVarName extracts the session variable name from a parameter.
-// It handles both direct string values and arrays containing a single session variable reference.
+// extractSessionVarName extracts the session-variable name from a parameter
+// that is a core.SessionVarValue marker (or a single-element array wrapping
+// one, the shape a scalar session variable in an `_in` filter can take).
+// Classification is by marker type only: a plain string is never treated as a
+// session variable, even when it begins with "x-hasura-", because such a value
+// is user-supplied data rather than a permission session-variable reference.
+// The marker is produced exclusively by the subscription cohort managers (see
+// core.SessionVarValue), so it cannot originate from user input.
 func extractSessionVarName(param any) (string, bool) {
-	if s, ok := param.(string); ok {
-		if strings.HasPrefix(strings.ToLower(s), "x-hasura-") {
-			return s, true
-		}
-
-		return "", false
-	}
-
-	if arr, ok := param.([]string); ok {
-		if len(arr) == 1 && strings.HasPrefix(strings.ToLower(arr[0]), "x-hasura-") {
-			return arr[0], true
-		}
-
-		return "", false
-	}
-
-	if arr, ok := param.([]any); ok {
-		if len(arr) == 1 {
-			if s, ok := arr[0].(string); ok && strings.HasPrefix(strings.ToLower(s), "x-hasura-") {
-				return s, true
+	switch v := param.(type) {
+	case core.SessionVarValue:
+		return v.Name, true
+	case []any:
+		if len(v) == 1 {
+			if sv, ok := v[0].(core.SessionVarValue); ok {
+				return sv.Name, true
 			}
 		}
-
-		return "", false
 	}
 
 	return "", false
+}
+
+// sanitizeStaticParam unwraps any core.SessionVarValue marker that has reached
+// the static-parameter list back into its bare name string. A lone marker is
+// rewritten to a result_vars JSON path by extractSessionVarName and never
+// reaches here, but a permission `_in`/`_nin` filter that mixes a session
+// variable with another element — e.g. _in: ["x-hasura-tenant-id", "<uuid>"] —
+// leaves the marker nested inside a multi-element []any that cannot be reduced
+// to a single JSON path, so it falls through to the static params. Per-element
+// array rewriting is out of scope (and Postgres-only), so we preserve the
+// pre-existing behaviour of binding the variable's name rather than letting a
+// marker reach the driver, where pgx would fail to encode it.
+func sanitizeStaticParam(param any) any {
+	switch v := param.(type) {
+	case core.SessionVarValue:
+		return v.Name
+	case []any:
+		if !containsSessionVarMarker(v) {
+			return param
+		}
+
+		out := make([]any, len(v))
+		for i, elem := range v {
+			out[i] = sanitizeStaticParam(elem)
+		}
+
+		return out
+	default:
+		return param
+	}
+}
+
+// containsSessionVarMarker reports whether arr has any core.SessionVarValue
+// element, so sanitizeStaticParam copies (rather than mutates) only the rare
+// slices that actually carry a stray marker.
+func containsSessionVarMarker(arr []any) bool {
+	for _, elem := range arr {
+		if _, ok := elem.(core.SessionVarValue); ok {
+			return true
+		}
+	}
+
+	return false
 }
 
 // rewriteSQLForMultiplexing rewrites SQL to use JSON path extraction for session variables

--- a/services/constellation/connector/sql/graphql/queries/multiplexed/multiplexed_internal_test.go
+++ b/services/constellation/connector/sql/graphql/queries/multiplexed/multiplexed_internal_test.go
@@ -28,6 +28,12 @@ func TestExtractSessionVarName(t *testing.T) {
 			wantOK:   true,
 		},
 		{
+			name:     "single-element typed marker array",
+			param:    []core.SessionVarValue{{Name: "x-hasura-team-id"}},
+			wantName: "x-hasura-team-id",
+			wantOK:   true,
+		},
+		{
 			// Regression for the misclassification bug: a user-supplied literal
 			// that merely begins with "x-hasura-" is ordinary data, not a
 			// session-variable reference, and must NOT be rewritten into a

--- a/services/constellation/connector/sql/graphql/queries/multiplexed/multiplexed_internal_test.go
+++ b/services/constellation/connector/sql/graphql/queries/multiplexed/multiplexed_internal_test.go
@@ -2,6 +2,8 @@ package multiplexed
 
 import (
 	"testing"
+
+	"github.com/nhost/nhost/services/constellation/connector/sql/graphql/queries/core"
 )
 
 func TestExtractSessionVarName(t *testing.T) {
@@ -14,16 +16,30 @@ func TestExtractSessionVarName(t *testing.T) {
 		wantOK   bool
 	}{
 		{
-			name:     "direct session variable string",
-			param:    "x-hasura-user-id",
+			name:     "session variable marker",
+			param:    core.SessionVarValue{Name: "x-hasura-user-id"},
 			wantName: "x-hasura-user-id",
 			wantOK:   true,
 		},
 		{
-			name:     "case insensitive prefix",
-			param:    "X-Hasura-Role",
-			wantName: "X-Hasura-Role",
+			name:     "single-element any array wrapping a marker",
+			param:    []any{core.SessionVarValue{Name: "x-hasura-org-id"}},
+			wantName: "x-hasura-org-id",
 			wantOK:   true,
+		},
+		{
+			// Regression for the misclassification bug: a user-supplied literal
+			// that merely begins with "x-hasura-" is ordinary data, not a
+			// session-variable reference, and must NOT be rewritten into a
+			// result_vars lookup.
+			name:   "plain x-hasura string is not a session variable",
+			param:  "x-hasura-legacy",
+			wantOK: false,
+		},
+		{
+			name:   "plain x-hasura string inside any array is not a session variable",
+			param:  []any{"x-hasura-legacy"},
+			wantOK: false,
 		},
 		{
 			name:   "non-session string",
@@ -31,21 +47,12 @@ func TestExtractSessionVarName(t *testing.T) {
 			wantOK: false,
 		},
 		{
-			name:     "single-element string array",
-			param:    []string{"x-hasura-departments"},
-			wantName: "x-hasura-departments",
-			wantOK:   true,
-		},
-		{
-			name:   "multi-element string array",
-			param:  []string{"x-hasura-a", "x-hasura-b"},
+			// A multi-element array (e.g. an _in mixing a session var and a
+			// literal) is not a single rewritable marker, so it stays a static
+			// parameter rather than becoming a JSON path.
+			name:   "multi-element any array with a marker",
+			param:  []any{core.SessionVarValue{Name: "x-hasura-a"}, "literal"},
 			wantOK: false,
-		},
-		{
-			name:     "single-element any array",
-			param:    []any{"x-hasura-org-id"},
-			wantName: "x-hasura-org-id",
-			wantOK:   true,
 		},
 		{
 			name:   "integer param",
@@ -58,12 +65,12 @@ func TestExtractSessionVarName(t *testing.T) {
 			wantOK: false,
 		},
 		{
-			name:   "empty string array",
-			param:  []string{},
+			name:   "empty any array",
+			param:  []any{},
 			wantOK: false,
 		},
 		{
-			name:   "any array with non-string",
+			name:   "any array with non-marker",
 			param:  []any{42},
 			wantOK: false,
 		},

--- a/services/constellation/connector/sql/graphql/queries/multiplexed/multiplexed_test.go
+++ b/services/constellation/connector/sql/graphql/queries/multiplexed/multiplexed_test.go
@@ -40,7 +40,7 @@ func TestMultiplex(t *testing.T) {
 				Name: "users",
 				SQL:  `SELECT "id", "name" FROM "users" WHERE "user_id" = $1::uuid`,
 				Parameters: []any{
-					"x-hasura-user-id",
+					core.SessionVarValue{Name: "x-hasura-user-id"},
 				},
 				StreamCursors: nil,
 			},
@@ -57,7 +57,7 @@ func TestMultiplex(t *testing.T) {
 				Name: "users",
 				SQL:  `SELECT "id", "name" FROM "users" WHERE "org_id" = $1::uuid AND "status" = $2`,
 				Parameters: []any{
-					"x-hasura-org-id",
+					core.SessionVarValue{Name: "x-hasura-org-id"},
 					"active",
 				},
 				StreamCursors: nil,
@@ -70,13 +70,35 @@ func TestMultiplex(t *testing.T) {
 			expectedParams: []any{"active"},
 		},
 		{
+			// Regression for the session-variable misclassification bug: a
+			// user-supplied where literal that begins with "x-hasura-" is data,
+			// so it must stay a renumbered static parameter ($3), while only the
+			// genuine permission marker becomes a result_vars JSON path.
+			name: "user literal beginning with x-hasura stays a static param",
+			op: core.SQLOperation{
+				Name: "users",
+				SQL:  `SELECT "id" FROM "users" WHERE "tag" = $1 AND "org_id" = $2::uuid`,
+				Parameters: []any{
+					"x-hasura-legacy",
+					core.SessionVarValue{Name: "x-hasura-org-id"},
+				},
+				StreamCursors: nil,
+			},
+			expectedSQL: `SELECT "_subs"."result_id", "_fld_resp"."root" AS "result" FROM ` +
+				`UNNEST($1::text[], $2::json[]) AS "_subs"("result_id", "result_vars") ` +
+				`LEFT OUTER JOIN LATERAL (SELECT json_build_object('users', (` +
+				`SELECT "id" FROM "users" WHERE "tag" = $3 AND "org_id" = (("_subs"."result_vars" #>> '{session,x-hasura-org-id}')::uuid)` +
+				`)) AS "root") AS "_fld_resp" ON ('true')`,
+			expectedParams: []any{"x-hasura-legacy"},
+		},
+		{
 			name: "cursor values",
 			op: core.SQLOperation{
 				Name: "users_stream",
 				SQL:  `SELECT "id", "name" FROM "users" WHERE "id" > $1::uuid AND "org_id" = $2::uuid`,
 				Parameters: []any{
 					core.CursorValue{ColumnName: "id", Value: "initial-id"},
-					"x-hasura-org-id",
+					core.SessionVarValue{Name: "x-hasura-org-id"},
 				},
 				StreamCursors: nil,
 			},
@@ -104,6 +126,28 @@ func TestMultiplex(t *testing.T) {
 				`SELECT "id", "name" FROM "items" WHERE "category" = $3 AND "price" > $4` +
 				`)) AS "root") AS "_fld_resp" ON ('true')`,
 			expectedParams: []any{"electronics", 99.99},
+		},
+		{
+			// A permission _in mixing a session variable with a literal leaves
+			// the marker nested in a multi-element array that cannot reduce to a
+			// single JSON path; it stays a static array parameter ($3), and the
+			// stray marker is unwrapped to its name so pgx can bind the array
+			// instead of failing to encode a SessionVarValue.
+			name: "multi-element in with marker is sanitized to a static array",
+			op: core.SQLOperation{
+				Name: "users",
+				SQL:  `SELECT "id" FROM "users" WHERE "tenant_id" = ANY($1::uuid[])`,
+				Parameters: []any{
+					[]any{core.SessionVarValue{Name: "x-hasura-tenant-id"}, "default"},
+				},
+				StreamCursors: nil,
+			},
+			expectedSQL: `SELECT "_subs"."result_id", "_fld_resp"."root" AS "result" FROM ` +
+				`UNNEST($1::text[], $2::json[]) AS "_subs"("result_id", "result_vars") ` +
+				`LEFT OUTER JOIN LATERAL (SELECT json_build_object('users', (` +
+				`SELECT "id" FROM "users" WHERE "tenant_id" = ANY($3::uuid[])` +
+				`)) AS "root") AS "_fld_resp" ON ('true')`,
+			expectedParams: []any{[]any{"x-hasura-tenant-id", "default"}},
 		},
 	}
 

--- a/services/constellation/connector/sql/graphql/queries/multiplexed/multiplexed_test.go
+++ b/services/constellation/connector/sql/graphql/queries/multiplexed/multiplexed_test.go
@@ -2,6 +2,7 @@ package multiplexed_test
 
 import (
 	"encoding/json"
+	"errors"
 	"testing"
 
 	"github.com/google/go-cmp/cmp"
@@ -18,6 +19,7 @@ func TestMultiplex(t *testing.T) {
 		expectedSQL     string
 		expectedParams  []any
 		expectedNoParam bool
+		expectErr       error
 	}{
 		{
 			name: "no parameters",
@@ -129,11 +131,12 @@ func TestMultiplex(t *testing.T) {
 		},
 		{
 			// A permission _in mixing a session variable with a literal leaves
-			// the marker nested in a multi-element array that cannot reduce to a
-			// single JSON path; it stays a static array parameter ($3), and the
-			// stray marker is unwrapped to its name so pgx can bind the array
-			// instead of failing to encode a SessionVarValue.
-			name: "multi-element in with marker is sanitized to a static array",
+			// the marker trapped in a multi-element array that cannot reduce to a
+			// single result_vars path. Rather than silently bind the variable's
+			// literal name (which would evaluate the row-level permission against
+			// "x-hasura-…" instead of the subscriber's value), Multiplex rejects
+			// the subscription with a clear error.
+			name: "multi-element in with marker is rejected",
 			op: core.SQLOperation{
 				Name: "users",
 				SQL:  `SELECT "id" FROM "users" WHERE "tenant_id" = ANY($1::uuid[])`,
@@ -142,12 +145,7 @@ func TestMultiplex(t *testing.T) {
 				},
 				StreamCursors: nil,
 			},
-			expectedSQL: `SELECT "_subs"."result_id", "_fld_resp"."root" AS "result" FROM ` +
-				`UNNEST($1::text[], $2::json[]) AS "_subs"("result_id", "result_vars") ` +
-				`LEFT OUTER JOIN LATERAL (SELECT json_build_object('users', (` +
-				`SELECT "id" FROM "users" WHERE "tenant_id" = ANY($3::uuid[])` +
-				`)) AS "root") AS "_fld_resp" ON ('true')`,
-			expectedParams: []any{[]any{"x-hasura-tenant-id", "default"}},
+			expectErr: multiplexed.ErrSessionVarInMultiElementArray,
 		},
 	}
 
@@ -155,7 +153,19 @@ func TestMultiplex(t *testing.T) {
 		t.Run(tc.name, func(t *testing.T) {
 			t.Parallel()
 
-			gotSQL, gotParams := multiplexed.Multiplex(tc.op)
+			gotSQL, gotParams, err := multiplexed.Multiplex(tc.op)
+
+			if tc.expectErr != nil {
+				if !errors.Is(err, tc.expectErr) {
+					t.Fatalf("Multiplex error = %v, want errors.Is %v", err, tc.expectErr)
+				}
+
+				return
+			}
+
+			if err != nil {
+				t.Fatalf("unexpected error: %v", err)
+			}
 
 			if gotSQL != tc.expectedSQL {
 				t.Errorf("sql:\ngot:  %s\nwant: %s", gotSQL, tc.expectedSQL)

--- a/services/constellation/connector/sql/graphql/queries/permissions/permissions.go
+++ b/services/constellation/connector/sql/graphql/queries/permissions/permissions.go
@@ -602,14 +602,22 @@ func SubstituteSessionVariable(v any, sessionVariables map[string]any) (any, err
 	return v, nil
 }
 
-// substituteSessionVariables resolves all session-variable markers in params
-// in place. Returns the (now-mutated) params slice so callers can use a single
-// = assignment instead of a separate error check + reassignment.
+// substituteSessionVariables resolves session-variable markers in params[start:]
+// in place, leaving params[:start] untouched. Callers pass start = len(params)
+// captured *before* the permission clause appended its own parameters, so only
+// the permission clause's values are substituted — never the user-supplied
+// where/_set/_in/by_pk literals that precede them in the slice. A user literal
+// that happens to begin with "x-hasura-" must stay verbatim (it is data, not a
+// session-variable reference), matching Hasura; only the permission metadata is
+// a legitimate source of session-variable markers.
+//
+// Returns the (now-mutated) params slice so callers can use a single =
+// assignment instead of a separate error check + reassignment.
 func substituteSessionVariables(
-	params []any, sessionVariables map[string]any,
+	params []any, sessionVariables map[string]any, start int,
 ) ([]any, error) {
-	for i, p := range params {
-		substituted, err := SubstituteSessionVariable(p, sessionVariables)
+	for i := start; i < len(params); i++ {
+		substituted, err := SubstituteSessionVariable(params[i], sessionVariables)
 		if err != nil {
 			return nil, err
 		}
@@ -674,12 +682,14 @@ func (s *Store) WriteRowLevel(
 		return params, paramIndex, nil
 	}
 
+	startLen := len(params)
+
 	params, paramIndex, err := clause.WriteCondition(b, sourceRef, params, paramIndex)
 	if err != nil {
 		return nil, 0, fmt.Errorf("writing row-level permission clause: %w", err)
 	}
 
-	params, err = substituteSessionVariables(params, sessionVariables)
+	params, err = substituteSessionVariables(params, sessionVariables, startLen)
 	if err != nil {
 		return nil, 0, err
 	}
@@ -720,6 +730,8 @@ func (s *Store) WriteInsertCheckSubstituted(
 		return params, paramIndex, false, nil
 	}
 
+	startLen := len(params)
+
 	params, paramIndex, err := where.WriteConditionSubstituted(
 		clause, b, sourceRef, params, paramIndex, subs,
 	)
@@ -727,7 +739,7 @@ func (s *Store) WriteInsertCheckSubstituted(
 		return nil, 0, false, fmt.Errorf("failed to apply insert permission check: %w", err)
 	}
 
-	params, err = substituteSessionVariables(params, sessionVariables)
+	params, err = substituteSessionVariables(params, sessionVariables, startLen)
 	if err != nil {
 		return nil, 0, false, err
 	}
@@ -752,12 +764,14 @@ func (s *Store) WriteUpdateFilter(
 		return params, paramIndex, false, nil
 	}
 
+	startLen := len(params)
+
 	params, paramIndex, err := clause.WriteCondition(b, sourceRef, params, paramIndex)
 	if err != nil {
 		return nil, 0, false, fmt.Errorf("writing update permission clause: %w", err)
 	}
 
-	params, err = substituteSessionVariables(params, sessionVariables)
+	params, err = substituteSessionVariables(params, sessionVariables, startLen)
 	if err != nil {
 		return nil, 0, false, err
 	}
@@ -788,12 +802,14 @@ func (s *Store) WriteUpdateCheck(
 		return params, paramIndex, false, nil
 	}
 
+	startLen := len(params)
+
 	params, paramIndex, err := clause.WriteCondition(b, sourceRef, params, paramIndex)
 	if err != nil {
 		return nil, 0, false, fmt.Errorf("failed to apply update permission check: %w", err)
 	}
 
-	params, err = substituteSessionVariables(params, sessionVariables)
+	params, err = substituteSessionVariables(params, sessionVariables, startLen)
 	if err != nil {
 		return nil, 0, false, err
 	}
@@ -816,12 +832,14 @@ func (s *Store) WriteDeleteFilter(
 		return params, paramIndex, false, nil
 	}
 
+	startLen := len(params)
+
 	params, paramIndex, err := clause.WriteCondition(b, sourceRef, params, paramIndex)
 	if err != nil {
 		return nil, 0, false, fmt.Errorf("writing delete permission clause: %w", err)
 	}
 
-	params, err = substituteSessionVariables(params, sessionVariables)
+	params, err = substituteSessionVariables(params, sessionVariables, startLen)
 	if err != nil {
 		return nil, 0, false, err
 	}

--- a/services/constellation/connector/sql/graphql/queries/permissions/permissions.go
+++ b/services/constellation/connector/sql/graphql/queries/permissions/permissions.go
@@ -553,8 +553,9 @@ func normalizePresets(presets map[string]any) map[string]any {
 
 // SubstituteSessionVariable resolves a single permission-filter parameter:
 // "x-hasura-*" strings are replaced with the matching value from
-// sessionVariables; slice values recurse element-wise and substitute in
-// place. As a special case, a single-element slice whose lone element is a
+// sessionVariables; slice values recurse element-wise into a copied slice so
+// shared permission metadata is not mutated by one request/subscription build.
+// As a special case, a single-element slice whose lone element is a
 // session-variable marker that resolves to a non-slice value is flattened to
 // that scalar — this preserves the semantics of
 // `column _eq x-hasura-user-id` against a scalar variable. Multi-element
@@ -574,6 +575,11 @@ func SubstituteSessionVariable(v any, sessionVariables map[string]any) (any, err
 			return nil, fmt.Errorf("%w: %s", ErrSessionVariableNotFound, v)
 		}
 	case []any:
+		if v == nil {
+			return v, nil
+		}
+
+		out := make([]any, len(v))
 		for i, item := range v {
 			substituted, err := SubstituteSessionVariable(item, sessionVariables)
 			if err != nil {
@@ -595,8 +601,10 @@ func SubstituteSessionVariable(v any, sessionVariables map[string]any) (any, err
 				}
 			}
 
-			v[i] = substituted
+			out[i] = substituted
 		}
+
+		return out, nil
 	}
 
 	return v, nil

--- a/services/constellation/connector/sql/graphql/queries/permissions/permissions.go
+++ b/services/constellation/connector/sql/graphql/queries/permissions/permissions.go
@@ -605,9 +605,58 @@ func SubstituteSessionVariable(v any, sessionVariables map[string]any) (any, err
 		}
 
 		return out, nil
+	case []string:
+		return substituteStringArray(v, sessionVariables)
 	}
 
 	return v, nil
+}
+
+// substituteStringArray resolves session-variable references inside the
+// []string produced by the JSONB key operators (_has_keys_all / _has_keys_any).
+// A single whole-array session variable (e.g. `_has_keys_any: X-Hasura-Keys`)
+// flattens to the resolved value — a SessionVarValue marker on the subscription
+// template path, or the concrete session value on the direct path — mirroring
+// the []any (_in) handling. When any element is a session variable the slice
+// widens to []any so it can carry a marker alongside literal keys; a slice of
+// plain literals is returned unchanged so ordinary JSONB keys keep their type.
+// Only permission metadata is fed through here, so a user-supplied look-alike
+// literal such as ["x-hasura-foo"] is never reinterpreted as a session variable.
+func substituteStringArray(v []string, sessionVariables map[string]any) (any, error) {
+	hasSessionVar := false
+
+	for _, item := range v {
+		if strings.HasPrefix(strings.ToLower(item), "x-hasura-") {
+			hasSessionVar = true
+
+			break
+		}
+	}
+
+	if !hasSessionVar {
+		return v, nil
+	}
+
+	out := make([]any, len(v))
+
+	for i, item := range v {
+		substituted, err := SubstituteSessionVariable(item, sessionVariables)
+		if err != nil {
+			return nil, err
+		}
+
+		// Flatten a single whole-array session variable to its resolved value
+		// (marker or concrete value), matching the []any scalar flatten.
+		if len(v) == 1 {
+			if _, isSlice := substituted.([]any); !isSlice {
+				return substituted, nil
+			}
+		}
+
+		out[i] = substituted
+	}
+
+	return out, nil
 }
 
 // substituteSessionVariables resolves session-variable markers in params[start:]

--- a/services/constellation/connector/sql/graphql/queries/permissions/permissions_internal_test.go
+++ b/services/constellation/connector/sql/graphql/queries/permissions/permissions_internal_test.go
@@ -1483,6 +1483,105 @@ func TestStoreWriteRowLevel_WithPermission(t *testing.T) {
 	}
 }
 
+// TestStoreWritePermission_PreservesUserParams is the regression guard for the
+// session-variable misclassification bug (BUG_MEDIUM_10): each Write* helper
+// substitutes only the parameters its own permission clause appended, never the
+// user-supplied values already in the slice. A user value that happens to equal
+// a session-variable name ("x-hasura-user-id") must survive verbatim while the
+// permission-appended marker is resolved to the requester's session value —
+// matching Hasura, which never reinterprets user argument values as session
+// variables. Before the boundary fix the whole slice was substituted, rewriting
+// the user value (or hard-failing with ErrSessionVariableNotFound).
+func TestStoreWritePermission_PreservesUserParams(t *testing.T) {
+	t.Parallel()
+
+	sessionVars := map[string]any{"x-hasura-user-id": "42"}
+
+	permClause := func() where.Clause {
+		return where.Clause{appendParamStatement("user_id", "x-hasura-user-id")}
+	}
+
+	tests := []struct {
+		name string
+		run  func(s *Store, params []any) ([]any, error)
+	}{
+		{
+			name: "WriteRowLevel",
+			run: func(s *Store, params []any) ([]any, error) {
+				s.Select["user"] = permClause()
+				p, _, err := s.WriteRowLevel(
+					&strings.Builder{}, params, 2, "user", sessionVars, "t",
+				)
+
+				return p, err
+			},
+		},
+		{
+			name: "WriteUpdateFilter",
+			run: func(s *Store, params []any) ([]any, error) {
+				s.Update["user"] = permClause()
+				p, _, _, err := s.WriteUpdateFilter(
+					&strings.Builder{}, params, 2, "user", sessionVars, "t",
+				)
+
+				return p, err
+			},
+		},
+		{
+			name: "WriteDeleteFilter",
+			run: func(s *Store, params []any) ([]any, error) {
+				s.Delete["user"] = permClause()
+				p, _, _, err := s.WriteDeleteFilter(
+					&strings.Builder{}, params, 2, "user", sessionVars, "t",
+				)
+
+				return p, err
+			},
+		},
+		{
+			name: "WriteUpdateCheck",
+			run: func(s *Store, params []any) ([]any, error) {
+				s.UpdateCheck["user"] = permClause()
+				p, _, _, err := s.WriteUpdateCheck(
+					&strings.Builder{}, "user", sessionVars, params, 2, "_mutation_result",
+				)
+
+				return p, err
+			},
+		},
+		{
+			name: "WriteInsertCheckSubstituted",
+			run: func(s *Store, params []any) ([]any, error) {
+				s.Insert["user"] = permClause()
+				p, _, _, err := s.WriteInsertCheckSubstituted(
+					&strings.Builder{}, "user", sessionVars, params, 2, "data", nil,
+				)
+
+				return p, err
+			},
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+
+			// Index 0 is a user-supplied literal that collides with a
+			// session-variable name; the permission clause appends its marker
+			// after it.
+			got, err := tc.run(NewStore(), []any{"x-hasura-user-id"})
+			if err != nil {
+				t.Fatalf("unexpected error: %v", err)
+			}
+
+			want := []any{"x-hasura-user-id", "42"}
+			if diff := cmp.Diff(want, got); diff != "" {
+				t.Errorf("params mismatch (-want +got):\n%s", diff)
+			}
+		})
+	}
+}
+
 func TestStoreWriteUpdateFilter_ClauseError(t *testing.T) {
 	t.Parallel()
 

--- a/services/constellation/connector/sql/graphql/queries/permissions/permissions_internal_test.go
+++ b/services/constellation/connector/sql/graphql/queries/permissions/permissions_internal_test.go
@@ -190,6 +190,52 @@ func TestSubstituteSessionVariable(t *testing.T) {
 	}
 }
 
+func TestSubstituteSessionVariable_DoesNotMutateSharedSlice(t *testing.T) {
+	t.Parallel()
+
+	metadataValues := []any{"x-hasura-user-id", "alice"}
+
+	s := NewStore()
+	s.Select["user"] = where.Clause{appendParamStatement("user_id", metadataValues)}
+
+	marker := core.SessionVarValue{Name: "x-hasura-user-id"}
+
+	params, _, err := s.WriteRowLevel(
+		&strings.Builder{}, nil, 1, "user",
+		map[string]any{"x-hasura-user-id": marker},
+		"t",
+	)
+	if err != nil {
+		t.Fatalf("template substitution failed: %v", err)
+	}
+
+	if diff := cmp.Diff([]any{[]any{marker, "alice"}}, params); diff != "" {
+		t.Fatalf("template params mismatch (-want +got):\n%s", diff)
+	}
+
+	// The subscription/template build above must not poison the permission
+	// clause's stored []any value with SessionVarValue. The same Store is reused
+	// across requests, so a later direct query must still substitute the original
+	// string marker to the concrete requester value rather than trying to bind the
+	// template marker as a SQL argument.
+	params, _, err = s.WriteRowLevel(
+		&strings.Builder{}, nil, 1, "user",
+		map[string]any{"x-hasura-user-id": "42"},
+		"t",
+	)
+	if err != nil {
+		t.Fatalf("direct substitution failed: %v", err)
+	}
+
+	if diff := cmp.Diff([]any{[]any{"42", "alice"}}, params); diff != "" {
+		t.Errorf("direct params mismatch (-want +got):\n%s", diff)
+	}
+
+	if diff := cmp.Diff([]any{"x-hasura-user-id", "alice"}, metadataValues); diff != "" {
+		t.Errorf("metadata values were mutated (-want +got):\n%s", diff)
+	}
+}
+
 func TestNormalizePresets(t *testing.T) {
 	t.Parallel()
 

--- a/services/constellation/connector/sql/graphql/queries/permissions/permissions_internal_test.go
+++ b/services/constellation/connector/sql/graphql/queries/permissions/permissions_internal_test.go
@@ -236,6 +236,65 @@ func TestSubstituteSessionVariable_DoesNotMutateSharedSlice(t *testing.T) {
 	}
 }
 
+// TestSubstituteSessionVariable_StringArray covers the []string shape produced
+// by the JSONB key operators (_has_keys_all / _has_keys_any). A session variable
+// there must be carried structurally like an _in session variable: flattened to
+// its resolved value on the direct path and to a SessionVarValue marker on the
+// subscription template path, while ordinary literal keys stay a plain []string
+// so a user-supplied look-alike is never reinterpreted.
+func TestSubstituteSessionVariable_StringArray(t *testing.T) {
+	t.Parallel()
+
+	marker := core.SessionVarValue{Name: "x-hasura-keys"}
+
+	tests := []struct {
+		name        string
+		in          []string
+		sessionVars map[string]any
+		want        any
+	}{
+		{
+			name:        "single whole-array session var flattens to concrete value (direct path)",
+			in:          []string{"x-hasura-keys"},
+			sessionVars: map[string]any{"x-hasura-keys": "{a,b}"},
+			want:        "{a,b}",
+		},
+		{
+			name:        "single whole-array session var flattens to marker (template path)",
+			in:          []string{"x-hasura-keys"},
+			sessionVars: map[string]any{"x-hasura-keys": marker},
+			want:        marker,
+		},
+		{
+			name:        "plain literal keys stay a []string",
+			in:          []string{"alpha", "beta"},
+			sessionVars: map[string]any{},
+			want:        []string{"alpha", "beta"},
+		},
+		{
+			name:        "multi-element mix widens to []any carrying the marker",
+			in:          []string{"x-hasura-keys", "literal"},
+			sessionVars: map[string]any{"x-hasura-keys": marker},
+			want:        []any{marker, "literal"},
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+
+			got, err := SubstituteSessionVariable(tc.in, tc.sessionVars)
+			if err != nil {
+				t.Fatalf("unexpected error: %v", err)
+			}
+
+			if diff := cmp.Diff(tc.want, got); diff != "" {
+				t.Errorf("SubstituteSessionVariable mismatch (-want +got):\n%s", diff)
+			}
+		})
+	}
+}
+
 func TestNormalizePresets(t *testing.T) {
 	t.Parallel()
 

--- a/services/constellation/connector/sql/graphql/queries/root_subscription_stream.go
+++ b/services/constellation/connector/sql/graphql/queries/root_subscription_stream.go
@@ -66,10 +66,32 @@ func (t *table) buildSubscriptionStreamSQL(
 	sql := b.String()
 	putBuilder(b)
 
-	// Build cursor metadata for the subscription manager
-	streamCursors := make([]core.StreamCursorInfo, len(streamArgs.Cursors))
-	for i, cursor := range streamArgs.Cursors {
-		streamCursors[i] = core.StreamCursorInfo{
+	op := core.SQLOperation{
+		Name:          alias,
+		SQL:           sql,
+		Parameters:    params,
+		StreamCursors: streamCursorInfos(streamArgs.Cursors),
+	}
+
+	// Convert to multiplexed and build final SQL
+	op.SQL, op.Parameters, err = multiplexed.Multiplex(op)
+	if err != nil {
+		return core.SQLOperation{}, fmt.Errorf(
+			"failed to multiplex stream subscription SQL: %w",
+			err,
+		)
+	}
+
+	return op, nil
+}
+
+// streamCursorInfos converts parsed stream cursors into the StreamCursorInfo
+// metadata the subscription manager uses to seed and advance result_vars
+// between polls.
+func streamCursorInfos(cursors []arguments.StreamCursor) []core.StreamCursorInfo {
+	infos := make([]core.StreamCursorInfo, len(cursors))
+	for i, cursor := range cursors {
+		infos[i] = core.StreamCursorInfo{
 			ColumnName:   cursor.Column.SQLName,
 			GraphQLName:  cursor.Column.GraphqlName,
 			InitialValue: cursor.Value,
@@ -77,17 +99,7 @@ func (t *table) buildSubscriptionStreamSQL(
 		}
 	}
 
-	op := core.SQLOperation{
-		Name:          alias,
-		SQL:           sql,
-		Parameters:    params,
-		StreamCursors: streamCursors,
-	}
-
-	// Convert to multiplexed and build final SQL
-	op.SQL, op.Parameters = multiplexed.Multiplex(op)
-
-	return op, nil
+	return infos
 }
 
 // buildQueryStreamSQL builds the inner SQL for a stream query.

--- a/services/constellation/connector/sql/graphql/queries/subscription_multiplexify.go
+++ b/services/constellation/connector/sql/graphql/queries/subscription_multiplexify.go
@@ -33,7 +33,12 @@ func multiplexify(name string, builder core.Operation) core.Operation {
 			)
 		}
 
-		op.SQL, op.Parameters = multiplexed.Multiplex(op)
+		op.SQL, op.Parameters, err = multiplexed.Multiplex(op)
+		if err != nil {
+			return core.SQLOperation{}, fmt.Errorf(
+				"failed to multiplex subscription %s SQL: %w", name, err,
+			)
+		}
 
 		return op, nil
 	}

--- a/services/constellation/connector/sql/subscription/cohort_manager.go
+++ b/services/constellation/connector/sql/subscription/cohort_manager.go
@@ -352,10 +352,14 @@ func (m *cohortManager) getOrBuildSQL(
 		return *c.cachedOp, nil
 	}
 
-	// Build template session vars (names only — values don't affect SQL shape).
+	// Build template session vars: each resolves to a SessionVarValue marker
+	// (names only — values don't affect SQL shape). The marker lets the
+	// multiplexed converter recognise genuine permission session variables by
+	// type and rewrite them into per-subscriber result_vars lookups, while
+	// user-supplied literals beginning with "x-hasura-" stay ordinary data.
 	templateSessionVars := make(map[string]any, len(sessionVarArrays))
 	for varName := range sessionVarArrays {
-		templateSessionVars[varName] = varName
+		templateSessionVars[varName] = core.SessionVarValue{Name: varName}
 	}
 
 	// Use any subscriber's GraphQL variables — they're identical within a cohort.

--- a/services/constellation/connector/sql/subscription/handler.go
+++ b/services/constellation/connector/sql/subscription/handler.go
@@ -160,7 +160,7 @@ func (h *Handler) detectStreamSubscription(
 
 	templateSessionVars := make(map[string]any)
 	for varName := range req.SessionVariables {
-		templateSessionVars[varName] = varName
+		templateSessionVars[varName] = core.SessionVarValue{Name: varName}
 	}
 
 	operations, err := h.roots.BuildQuery(

--- a/services/constellation/connector/sql/subscription/stream_cohort_manager.go
+++ b/services/constellation/connector/sql/subscription/stream_cohort_manager.go
@@ -513,7 +513,7 @@ func buildStreamTemplateVars(
 ) (map[string]any, map[string]any) {
 	templateSessionVars := make(map[string]any, len(sessionVarArrays))
 	for varName := range sessionVarArrays {
-		templateSessionVars[varName] = varName
+		templateSessionVars[varName] = core.SessionVarValue{Name: varName}
 	}
 
 	templateGraphQLVars := make(map[string]any, len(graphQLVarArrays))

--- a/services/constellation/integration/subscription_permissions_test.go
+++ b/services/constellation/integration/subscription_permissions_test.go
@@ -117,3 +117,56 @@ func TestSubscriptionUserRole(t *testing.T) { //nolint:paralleltest,dupl
 		}
 	}).Close()
 }
+
+// TestSubscriptionXHasuraLiteralFilterNotSubstituted is the end-to-end
+// regression guard for the session-variable misclassification bug
+// (BUG_MEDIUM_10 / BUG_MEDIUM_13). A subscription filter value that merely
+// begins with "x-hasura-" is user-supplied data and must be treated as a
+// literal — never as a permission session-variable reference. The exists_test
+// role has a row-level filter that references X-Hasura-User-Id, so the
+// permission layer runs its session-variable substitution; before the fix that
+// pass scanned the whole parameter slice and hit the user's "x-hasura-…" filter
+// value, hard-failing the subscription with "session variable not found". After
+// the fix only the permission clause's own parameters are substituted, so the
+// subscription succeeds and returns rows matching the literal (none here),
+// matching Hasura.
+func TestSubscriptionXHasuraLiteralFilterNotSubstituted(t *testing.T) { //nolint:paralleltest
+	ReinitializeTestData(t)
+
+	c, err := subtest.NewClient(t, wsURL)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	c.Send(subtest.Message{
+		Type: subtest.ConnectionInit,
+		// x-hasura-user-id is the genuine session variable the exists_test
+		// row-level filter references; the title filter value below is a
+		// look-alike literal that is NOT a session variable.
+		Payload: initWithRole("exists_test", map[string]string{
+			"x-hasura-user-id": "00000000-0000-0000-0000-000000000000",
+		}),
+	}).Expect(func(msg subtest.Message) {
+		if msg.Type != subtest.ConnectionAck {
+			t.Fatalf("expected connection_ack, got %s", msg.Type)
+		}
+	}).Send(subtest.Message{
+		ID:   "1",
+		Type: subtest.Subscribe,
+		Payload: subscribePayload(`subscription {
+			news(where: { title: { _eq: "x-hasura-not-a-session-var" } }) {
+				title
+			}
+		}`),
+	}).Expect(func(msg subtest.Message) {
+		// Must be data (empty: no news titled "x-hasura-not-a-session-var"),
+		// NOT an error. A "session variable not found" error here is the bug.
+		if diff := cmp.Diff(msg, subtest.Message{
+			ID:      "1",
+			Type:    subtest.Next,
+			Payload: jsontext.Value(`{"data":{"news":[]}}`),
+		}); diff != "" {
+			t.Fatalf("unexpected message (a session-variable error indicates regression): %s", diff)
+		}
+	}).Close()
+}


### PR DESCRIPTION
<!-- nhost-reviewer:start -->
### **What this PR solves**
Fixes subscription permission handling so user-provided values that happen to start with `x-hasura-` are preserved as literals instead of being misclassified as session-variable references. It adds structural markers for genuine permission session variables and rejects unsupported multiplexed mixed-array cases instead of silently returning wrong results.

___

### **PR Type**
Bug fix

___

### **Description**
- Introduce `SessionVarValue` markers to distinguish permission session variables from ordinary string data.
- Restrict permission substitution to parameters appended by permission clauses and avoid mutating shared permission metadata slices.
- Update subscription multiplexing to rewrite only structural session/cursor markers, keep look-alike literals static, and surface unsupported mixed-array markers as errors.
- Seed subscription template session variables with markers and add unit/integration regression coverage.

___

### Diagram Walkthrough

```mermaid
flowchart LR
  A["Permission metadata"] --> B["Substitute session vars"]
  B --> C["SessionVarValue markers"]
  D["User GraphQL literals"] --> E["Static SQL params"]
  C --> F["Multiplex SQL rewrite"]
  E --> F
  F --> G["Per-subscriber result_vars lookups"]
```

<details> <summary><h3> File Walkthrough</h3></summary>

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody>
<tr><td><strong>Core marker</strong></td><td><details><summary>2 files</summary><table>
<tr>
  <td><strong>core.go</strong><dd><code>Add SessionVarValue marker and JSON marshalling for template session-variable maps.</code></dd></td>
  <td><a href="https://github.com/nhost/nhost/pull/XXX/files#diff-b38da07745f1dd01df85df78b991abfd0b391fe312361ed6709f7b55b8a43953">+32/-0</a></td>
</tr>
<tr>
  <td><strong>core_test.go</strong><dd><code>Cover SessionVarValue JSON output directly and inside maps.</code></dd></td>
  <td><a href="https://github.com/nhost/nhost/pull/XXX/files#diff-692dd00f6d91f8b5c06a90d9edc1540c48cca504e592059eed7324988fb1a967">+50/-0</a></td>
</tr>
</table></details></td></tr>
<tr><td><strong>Multiplexing</strong></td><td><details><summary>3 files</summary><table>
<tr>
  <td><strong>multiplexed.go</strong><dd><code>Classify session variables by marker type, preserve literals, and error on unsupported mixed marker arrays.</code></dd></td>
  <td><a href="https://github.com/nhost/nhost/pull/XXX/files#diff-64852dccb0f2ca1b3833b0983697e31e4aad14b244cb07a9210ef61863c1b73a">+90/-36</a></td>
</tr>
<tr>
  <td><strong>multiplexed_internal_test.go</strong><dd><code>Update extraction tests for marker-only session-variable recognition.</code></dd></td>
  <td><a href="https://github.com/nhost/nhost/pull/XXX/files#diff-c8279c3d108b8ee5defb73e1dfb7f565e479b7d51a528a90be59990027f4a36d">+33/-20</a></td>
</tr>
<tr>
  <td><strong>multiplexed_test.go</strong><dd><code>Cover literal preservation, marker rewrites, and mixed-array rejection.</code></dd></td>
  <td><a href="https://github.com/nhost/nhost/pull/XXX/files#diff-005fde91bad9c798fd1e43bbfdeb9816549f24a84890468759a0f6d4c437874b">+58/-4</a></td>
</tr>
</table></details></td></tr>
<tr><td><strong>Permission substitution</strong></td><td><details><summary>2 files</summary><table>
<tr>
  <td><strong>permissions.go</strong><dd><code>Copy substituted slices, support string-array permissions, and substitute only permission-appended params.</code></dd></td>
  <td><a href="https://github.com/nhost/nhost/pull/XXX/files#diff-25af7fb89bb39f0e646e48c2e6a58781cc03afe8a22ec5df7d0bccee4ec1b3bb">+89/-14</a></td>
</tr>
<tr>
  <td><strong>permissions_internal_test.go</strong><dd><code>Add regression tests for slice mutation, string arrays, and preserving user parameters.</code></dd></td>
  <td><a href="https://github.com/nhost/nhost/pull/XXX/files#diff-805d7dc7359ba6b59562fc8326dc2e8266e327e32a84ac4b9e712c4e665acd9e">+204/-0</a></td>
</tr>
</table></details></td></tr>
<tr><td><strong>Subscription wiring</strong></td><td><details><summary>4 files</summary><table>
<tr>
  <td><strong>root_subscription_stream.go</strong><dd><code>Propagate multiplexing errors for stream subscriptions and factor cursor metadata conversion.</code></dd></td>
  <td><a href="https://github.com/nhost/nhost/pull/XXX/files#diff-54a5c758b0d51d05304f30de4aa87a4ad41931f2a3b3ef49f1dde68c1729cf94">+25/-13</a></td>
</tr>
<tr>
  <td><strong>subscription_multiplexify.go</strong><dd><code>Propagate multiplexing errors for regular subscriptions.</code></dd></td>
  <td><a href="https://github.com/nhost/nhost/pull/XXX/files#diff-45a6278fcec1f7d719ebd7a98b50fe57b644bd099e969b96449739a65b0ab657">+6/-1</a></td>
</tr>
<tr>
  <td><strong>cohort_manager.go</strong><dd><code>Seed regular subscription templates with SessionVarValue markers.</code></dd></td>
  <td><a href="https://github.com/nhost/nhost/pull/XXX/files#diff-910bfc15c050ea2c1dabf4eda81aa8ae9a603108a442b7e120fcfaffc8feb961">+6/-2</a></td>
</tr>
<tr>
  <td><strong>handler.go</strong><dd><code>Use SessionVarValue markers while detecting stream subscriptions.</code></dd></td>
  <td><a href="https://github.com/nhost/nhost/pull/XXX/files#diff-2b29b0321cb50adc68ffd136d8cf600413cef4566399ba67a938a6433f907016">+1/-1</a></td>
</tr>
</table></details></td></tr>
<tr><td><strong>Stream and integration tests</strong></td><td><details><summary>2 files</summary><table>
<tr>
  <td><strong>stream_cohort_manager.go</strong><dd><code>Seed stream cohort template variables with SessionVarValue markers.</code></dd></td>
  <td><a href="https://github.com/nhost/nhost/pull/XXX/files#diff-328d2b7f85019a37153b6d4a82bbe331a4cec0a0212338aa5deec8fd1c4f3fc7">+1/-1</a></td>
</tr>
<tr>
  <td><strong>subscription_permissions_test.go</strong><dd><code>Add end-to-end regression coverage for x-hasura-looking subscription filter literals.</code></dd></td>
  <td><a href="https://github.com/nhost/nhost/pull/XXX/files#diff-173ec7f73b268578addc21ebb68ae2e4dad7a08d104b9b9cc91fd5cc00bdfc3a">+53/-0</a></td>
</tr>
</table></details></td></tr>
</tbody></table>

</details>

___

<!-- nhost-reviewer:end -->