### PR TITLE
fix(constellation): honor field aliases at every aggregate scope

### DIFF
--- a/services/constellation/connector/groupedaggregate/groupedaggregate.go
+++ b/services/constellation/connector/groupedaggregate/groupedaggregate.go
@@ -94,10 +94,11 @@ func NewRequest(req Request) (Request, error) {
 //
 // Result-map invariants. The returned map is keyed by the stringified join
 // value — specifically fmt.Sprintf("%v", v) of each entry in Request.JoinValues
-// — and each value is shaped { "aggregate": {...}, "nodes": [...] }, the same
-// shape as the same-database aggregate field. An entry is present for every
-// value in Request.JoinValues, including those with no matching target rows
-// (count: 0, nodes: []). Because keys are %v-stringified, distinct JoinValues
+// — and each value preserves the same GraphQL response fields as the same-
+// database aggregate field (aliases when present, otherwise "aggregate" /
+// "nodes"). An entry is present for every value in Request.JoinValues,
+// including those with no matching target rows (count: 0, nodes: []). Because
+// keys are %v-stringified, distinct JoinValues
 // entries that share the same %v representation (e.g. a []byte and its string
 // equivalent) will collide on the same key; callers must dedupe in a way that
 // matches that formatting. The resolver-side stitcher applies the same

--- a/services/constellation/connector/sql/graphql/queries/dispatch_test.go
+++ b/services/constellation/connector/sql/graphql/queries/dispatch_test.go
@@ -420,6 +420,79 @@ func TestBuildGroupedAggregate_NoWindowWithoutLimitOffset(t *testing.T) {
 	}
 }
 
+func TestBuildGroupedAggregate_ReservedJoinKeyResponseNameRejected(t *testing.T) {
+	t.Parallel()
+
+	objects := buildObjectsWithUsersTable()
+	md := &metadata.DatabaseMetadata{Tables: []metadata.TableMetadata{tableMetaFor("users")}}
+
+	_, groupedAgg, err := queries.BuildRoots(objects, md, &dialect.PostgresDialect{})
+	if err != nil {
+		t.Fatalf("BuildRoots: %v", err)
+	}
+
+	tests := []struct {
+		name  string
+		query string
+	}{
+		{
+			name: "aggregate alias",
+			query: `query {
+				_root {
+					_join_key: aggregate { count }
+				}
+			}`,
+		},
+		{
+			name: "nodes alias",
+			query: `query {
+				_root {
+					_join_key: nodes { id }
+				}
+			}`,
+		},
+		{
+			name: "typename alias",
+			query: `query {
+				_root {
+					_join_key: __typename
+				}
+			}`,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+
+			_, field, fragments := parseSingleField(t, tt.query)
+
+			_, err := groupedAgg.BuildGroupedAggregateSQL(groupedaggdispatch.BuildInput{
+				TableSchema:       "public",
+				TableName:         "users",
+				Field:             field,
+				Fragments:         fragments,
+				Variables:         nil,
+				Role:              "admin",
+				SessionVariables:  nil,
+				JoinColumnSQLName: "id",
+				JoinValues:        []any{"11111111-1111-1111-1111-111111111111"},
+			})
+			if err == nil {
+				t.Fatal("expected reserved response-name error, got nil")
+			}
+
+			if !strings.Contains(err.Error(), "grouped aggregate response name is reserved") {
+				t.Errorf("error should mention reserved response name; got: %v", err)
+			}
+
+			if !strings.Contains(err.Error(), groupedaggdispatch.ResultJoinKeyField) {
+				t.Errorf("error should name reserved field; got: %v", err)
+			}
+		})
+	}
+}
+
 // TestBuildGroupedAggregate_DistinctOnApplied asserts that distinct_on partitions
 // the DISTINCT ON by the parent join key so each group is deduplicated
 // independently, matching Hasura's per-parent-row distinct_on on a cross-database

--- a/services/constellation/connector/sql/graphql/queries/groupedaggregate/groupedaggregate.go
+++ b/services/constellation/connector/sql/graphql/queries/groupedaggregate/groupedaggregate.go
@@ -19,6 +19,12 @@ import (
 // requested schema.table has no registered Builder.
 var ErrTableNotRegistered = errors.New("table not registered for grouped aggregate builds")
 
+// ResultJoinKeyField is the internal JSON field used to carry each grouped
+// aggregate row's join key from the SQL builder to the SQL connector parser.
+// It is reserved for this transport contract and must not be emitted as a
+// GraphQL response field.
+const ResultJoinKeyField = "_join_key"
+
 // BuildInput bundles the inputs to a grouped-aggregate SQL build. The
 // dispatcher and the per-table Builder both take this single value so callers
 // initialise fields by name; this prevents silent argument swaps among the

--- a/services/constellation/connector/sql/graphql/queries/root_query_aggregate.go
+++ b/services/constellation/connector/sql/graphql/queries/root_query_aggregate.go
@@ -74,7 +74,7 @@ func (t *table) writeQueryAggregateSQL( //nolint:cyclop,funlen
 	sourceRef string,
 	queryModifiers ...queryModifierFunc,
 ) ([]any, int, error) {
-	outerTypenames, aggregateSel, nodesField, err := t.astToAggregateSelection(
+	outerTypenames, aggregateFields, nodesFields, err := t.astToAggregateSelection(
 		field, fragments, variables,
 	)
 	if err != nil {
@@ -170,20 +170,68 @@ func (t *table) writeQueryAggregateSQL( //nolint:cyclop,funlen
 		firstOuter = false
 	}
 
-	// Add aggregate functions if requested
-	if len(aggregateSel) > 0 {
-		if !firstOuter {
+	hasOuterFields := !firstOuter
+	hasOuterFields = t.writeAggregateFieldSelections(
+		b, aggregateFields, baseAlias, hasOuterFields,
+	)
+
+	for i := range nodesFields {
+		params, paramIndex, err = t.writeAggregateNodes(
+			b,
+			fragments,
+			variables,
+			role,
+			sessionVariables,
+			roots,
+			params,
+			paramIndex,
+			distinctOn,
+			nodesFields[i].responseName,
+			nodesFields[i].field,
+			baseAlias,
+			hasOuterFields,
+		)
+		if err != nil {
+			return nil, 0, err
+		}
+
+		hasOuterFields = true
+	}
+
+	b.WriteString(`) AS "`)
+	b.WriteString(outputAlias)
+	b.WriteByte('"')
+
+	return params, paramIndex, nil
+}
+
+func (t *table) writeAggregateFieldSelections(
+	b *strings.Builder,
+	aggregateFields []aggregateFieldSelection,
+	baseAlias string,
+	hasPrecedingFields bool,
+) bool {
+	hasOuterFields := hasPrecedingFields
+
+	for i := range aggregateFields {
+		if len(aggregateFields[i].selections) == 0 {
+			continue
+		}
+
+		if hasOuterFields {
 			b.WriteString(", ")
 		}
 
-		firstOuter = false
+		hasOuterFields = true
 
-		b.WriteString("'aggregate', (SELECT ")
+		b.WriteByte('\'')
+		b.WriteString(aggregateFields[i].responseName)
+		b.WriteString("', (SELECT ")
 		b.WriteString(t.dialect.JSONBuildObject())
 		b.WriteByte('(')
 
-		for i, agg := range aggregateSel {
-			if i > 0 {
+		for j, agg := range aggregateFields[i].selections {
+			if j > 0 {
 				b.WriteString(", ")
 			}
 
@@ -195,31 +243,7 @@ func (t *table) writeQueryAggregateSQL( //nolint:cyclop,funlen
 		b.WriteString(`")`)
 	}
 
-	if nodesField != nil {
-		params, paramIndex, err = t.writeAggregateNodes(
-			b,
-			fragments,
-			variables,
-			role,
-			sessionVariables,
-			roots,
-			params,
-			paramIndex,
-			distinctOn,
-			nodesField,
-			baseAlias,
-			!firstOuter,
-		)
-		if err != nil {
-			return nil, 0, err
-		}
-	}
-
-	b.WriteString(`) AS "`)
-	b.WriteString(outputAlias)
-	b.WriteByte('"')
-
-	return params, paramIndex, nil
+	return hasOuterFields
 }
 
 func (t *table) writeAggregateNodes(
@@ -232,6 +256,7 @@ func (t *table) writeAggregateNodes(
 	params []any,
 	paramIndex int,
 	distinctOn *arguments.DistinctOn,
+	responseName string,
 	nodesField *ast.Field,
 	baseAlias string,
 	hasPrecedingFields bool,
@@ -261,7 +286,9 @@ func (t *table) writeAggregateNodes(
 		jsonAggExpr = t.dialect.JSONAggQuotedAlias("_root")
 	}
 
-	b.WriteString("'nodes', (SELECT coalesce(")
+	b.WriteByte('\'')
+	b.WriteString(responseName)
+	b.WriteString("', (SELECT coalesce(")
 	b.WriteString(jsonAggExpr)
 	b.WriteString(", '[]') FROM (")
 

--- a/services/constellation/connector/sql/graphql/queries/root_query_aggregate_test.go
+++ b/services/constellation/connector/sql/graphql/queries/root_query_aggregate_test.go
@@ -140,6 +140,36 @@ func TestAggregateBuildQuery(t *testing.T) { //nolint:paralleltest,maintidx
 			},
 		},
 		{
+			// Aliases must be honored at every aggregate-root level: the root
+			// operation name, aggregate field, aggregate-function columns, and nodes.
+			// The second aggregate alias catches accidental merging of differently
+			// aliased `aggregate` selections into one JSON key.
+			name: "aggregate field aliases at every scope",
+			query: query{
+				Query: `
+					query {
+						depts: departments_aggregate(order_by: {name: asc}, limit: 3) {
+							summary: aggregate {
+								total: count
+								distinct_ids: count(columns: [id], distinct: true)
+								budget_total: sum {
+									amount: budget
+								}
+							}
+							extremes: aggregate {
+								budget_high: max {
+									value: budget
+								}
+							}
+							rows: nodes {
+								dept_id: id
+								label: name
+							}
+						}
+					}`,
+			},
+		},
+		{
 			name: "sum aggregate",
 			query: query{
 				Query: `

--- a/services/constellation/connector/sql/graphql/queries/root_query_grouped_aggregate.go
+++ b/services/constellation/connector/sql/graphql/queries/root_query_grouped_aggregate.go
@@ -84,12 +84,11 @@ func (lo groupedLimitOffset) effectiveOffset() int {
 // array-aggregate relationship resolution to batch-fetch aggregates across
 // many parent rows in a single round-trip.
 //
-// The returned SQL emits rows shaped:
-//
-//	{ "_join_key": <value>, "aggregate": {...}, "nodes": [...] }
-//
-// One row is emitted for every value in in.JoinValues, including those with
-// no matching target rows (count is 0, nodes is []).
+// The returned SQL emits one JSON object per join key. Each object contains
+// "_join_key" plus the requested aggregate/nodes response names (aliases when
+// present, otherwise "aggregate" / "nodes"). One row is emitted for every value
+// in in.JoinValues, including those with no matching target rows (count is 0,
+// and nodes selections are []).
 func (t *table) BuildGroupedAggregateSQL(
 	in groupedaggdispatch.BuildInput,
 ) (core.SQLOperation, error) {
@@ -107,7 +106,7 @@ func (t *table) BuildGroupedAggregateSQL(
 		alias = in.Field.Name
 	}
 
-	outerTypenames, aggregateSel, nodesField, err := t.astToAggregateSelection(
+	outerTypenames, aggregateFields, nodesFields, err := t.astToAggregateSelection(
 		in.Field,
 		in.Fragments,
 		in.Variables,
@@ -122,13 +121,13 @@ func (t *table) BuildGroupedAggregateSQL(
 	}
 
 	sel := groupedAggregateSelection{
-		outerTypenames: outerTypenames,
-		aggregateSel:   aggregateSel,
-		nodesField:     nodesField,
-		whereClause:    whereClause,
-		distinctOn:     distinctOn,
-		orderBy:        orderBy,
-		limitOffset:    limitOffset,
+		outerTypenames:  outerTypenames,
+		aggregateFields: aggregateFields,
+		nodesFields:     nodesFields,
+		whereClause:     whereClause,
+		distinctOn:      distinctOn,
+		orderBy:         orderBy,
+		limitOffset:     limitOffset,
 	}
 
 	sql, params, err := t.writeGroupedAggregateStatement(in, joinCol, alias, sel)
@@ -148,13 +147,13 @@ func (t *table) BuildGroupedAggregateSQL(
 // grouped-aggregate query so they can be threaded through the SQL-assembly
 // helper without an unwieldy parameter list.
 type groupedAggregateSelection struct {
-	outerTypenames []typenameSelection
-	aggregateSel   []aggregateQuerySelection
-	nodesField     *ast.Field
-	whereClause    where.Clause
-	distinctOn     *arguments.DistinctOn
-	orderBy        *arguments.OrderBy
-	limitOffset    groupedLimitOffset
+	outerTypenames  []typenameSelection
+	aggregateFields []aggregateFieldSelection
+	nodesFields     []aggregateNodesSelection
+	whereClause     where.Clause
+	distinctOn      *arguments.DistinctOn
+	orderBy         *arguments.OrderBy
+	limitOffset     groupedLimitOffset
 }
 
 // writeGroupedAggregateStatement assembles the full grouped-aggregate SQL: the
@@ -195,7 +194,7 @@ func (t *table) writeGroupedAggregateStatement(
 
 	params, err = t.writeGroupedAggregateOuter(
 		b, params, paramIndex,
-		in.Fragments, sel.outerTypenames, sel.aggregateSel, sel.nodesField, joinCol, alias,
+		in.Fragments, sel.outerTypenames, sel.aggregateFields, sel.nodesFields, joinCol, alias,
 		sel.distinctOn, sel.orderBy, sourceAlias, sel.limitOffset,
 	)
 	if err != nil {
@@ -556,14 +555,15 @@ func writeGroupedDistinctOrderBy(b *strings.Builder, orderBy *arguments.OrderBy)
 //
 // The single-row, single-column result preserves the existing one-row-per-
 // operation contract of Driver.ExecuteOperations: the value is a JSON array
-// of group objects, each shaped { "_join_key": ..., "aggregate": ..., "nodes": ... }.
+// of group objects, each shaped with "_join_key" plus the requested aggregate
+// and nodes response names.
 func (t *table) writeGroupedAggregateOuter( //nolint:funlen
 	b *strings.Builder,
 	params []any, paramIndex int,
 	fragments ast.FragmentDefinitionList,
 	outerTypenames []typenameSelection,
-	aggregateSel []aggregateQuerySelection,
-	nodesField *ast.Field,
+	aggregateFields []aggregateFieldSelection,
+	nodesFields []aggregateNodesSelection,
 	joinCol *core.Column,
 	outputAlias string,
 	distinctOn *arguments.DistinctOn,
@@ -598,13 +598,19 @@ func (t *table) writeGroupedAggregateOuter( //nolint:funlen
 		outerTypenames[i].Write(b)
 	}
 
-	if len(aggregateSel) > 0 {
-		b.WriteString(", 'aggregate', ")
+	for i := range aggregateFields {
+		if len(aggregateFields[i].selections) == 0 {
+			continue
+		}
+
+		b.WriteString(", '")
+		b.WriteString(aggregateFields[i].responseName)
+		b.WriteString("', ")
 		b.WriteString(t.dialect.JSONBuildObject())
 		b.WriteByte('(')
 
-		for i, agg := range aggregateSel {
-			if i > 0 {
+		for j, agg := range aggregateFields[i].selections {
+			if j > 0 {
 				b.WriteString(", ")
 			}
 
@@ -614,9 +620,10 @@ func (t *table) writeGroupedAggregateOuter( //nolint:funlen
 		b.WriteByte(')')
 	}
 
-	if nodesField != nil {
+	for i := range nodesFields {
 		if err := t.writeGroupedAggregateNodes(
-			b, nodesField, fragments, joinCol, distinctOn, orderBy, sourceAlias,
+			b, nodesFields[i].responseName, nodesFields[i].field,
+			fragments, joinCol, distinctOn, orderBy, sourceAlias,
 		); err != nil {
 			return nil, err
 		}
@@ -680,7 +687,7 @@ func (t *table) writeGroupedAggregateSelection(
 	agg.Write(b)
 }
 
-// writeGroupedAggregateNodes writes the 'nodes' entry: a json_agg of an
+// writeGroupedAggregateNodes writes the nodes response entry: a json_agg of an
 // inline row-to-json expression, FILTERed by join_col IS NOT NULL so empty
 // groups produce [] rather than an array containing a single all-null row.
 // sourceAlias is the base CTE, or the windowed CTE when a per-group limit/offset
@@ -696,6 +703,7 @@ func (t *table) writeGroupedAggregateSelection(
 // that don't compose with the GROUP BY here.
 func (t *table) writeGroupedAggregateNodes(
 	b *strings.Builder,
+	responseName string,
 	nodesField *ast.Field,
 	fragments ast.FragmentDefinitionList,
 	joinCol *core.Column,
@@ -712,7 +720,9 @@ func (t *table) writeGroupedAggregateNodes(
 		return errGroupedAggregateNestedRelationships
 	}
 
-	b.WriteString(", 'nodes', coalesce(")
+	b.WriteString(", '")
+	b.WriteString(responseName)
+	b.WriteString("', coalesce(")
 
 	var rowB strings.Builder
 

--- a/services/constellation/connector/sql/graphql/queries/root_query_grouped_aggregate.go
+++ b/services/constellation/connector/sql/graphql/queries/root_query_grouped_aggregate.go
@@ -19,7 +19,7 @@ var _ groupedaggdispatch.Builder = (*table)(nil)
 
 const (
 	groupedAggregateKeysAlias       = "__cs_grp_keys"
-	groupedAggregateKeyCol          = "_join_key"
+	groupedAggregateKeyCol          = groupedaggdispatch.ResultJoinKeyField
 	groupedAggregateBaseAlias       = "_root.base"
 	groupedAggregateWindowedAlias   = "_root.windowed"
 	groupedAggregateWindowKeysAlias = "_root.keys"
@@ -51,6 +51,14 @@ var ErrGroupedAggregateRelationshipOrderBy = errors.New(
 // for cross-database aggregates.
 var errGroupedAggregateNestedRelationships = errors.New(
 	"nested relationships inside cross-database aggregate nodes are not supported",
+)
+
+// errGroupedAggregateReservedResponseName is returned when a grouped aggregate
+// selection uses the internal join-key transport field as a GraphQL response
+// name. The parser drops that field after keying the grouped result map, so the
+// builder must reserve it to avoid silently discarding user-selected data.
+var errGroupedAggregateReservedResponseName = errors.New(
+	"grouped aggregate response name is reserved",
 )
 
 // groupedLimitOffset carries the per-group limit/offset parsed from the
@@ -85,10 +93,10 @@ func (lo groupedLimitOffset) effectiveOffset() int {
 // many parent rows in a single round-trip.
 //
 // The returned SQL emits one JSON object per join key. Each object contains
-// "_join_key" plus the requested aggregate/nodes response names (aliases when
-// present, otherwise "aggregate" / "nodes"). One row is emitted for every value
-// in in.JoinValues, including those with no matching target rows (count is 0,
-// and nodes selections are []).
+// the reserved internal join key plus the requested aggregate/nodes response
+// names (aliases when present, otherwise "aggregate" / "nodes"). One row is
+// emitted for every value in in.JoinValues, including those with no matching
+// target rows (count is 0, and nodes selections are []).
 func (t *table) BuildGroupedAggregateSQL(
 	in groupedaggdispatch.BuildInput,
 ) (core.SQLOperation, error) {
@@ -112,6 +120,12 @@ func (t *table) BuildGroupedAggregateSQL(
 		in.Variables,
 	)
 	if err != nil {
+		return core.SQLOperation{}, err
+	}
+
+	if err := validateGroupedAggregateResponseNames(
+		outerTypenames, aggregateFields, nodesFields,
+	); err != nil {
 		return core.SQLOperation{}, err
 	}
 
@@ -154,6 +168,51 @@ type groupedAggregateSelection struct {
 	distinctOn      *arguments.DistinctOn
 	orderBy         *arguments.OrderBy
 	limitOffset     groupedLimitOffset
+}
+
+func validateGroupedAggregateResponseNames(
+	outerTypenames []typenameSelection,
+	aggregateFields []aggregateFieldSelection,
+	nodesFields []aggregateNodesSelection,
+) error {
+	for i := range outerTypenames {
+		if err := validateGroupedAggregateResponseName(
+			"__typename", outerTypenames[i].alias,
+		); err != nil {
+			return err
+		}
+	}
+
+	for i := range aggregateFields {
+		if err := validateGroupedAggregateResponseName(
+			"aggregate", aggregateFields[i].responseName,
+		); err != nil {
+			return err
+		}
+	}
+
+	for i := range nodesFields {
+		if err := validateGroupedAggregateResponseName(
+			"nodes", nodesFields[i].responseName,
+		); err != nil {
+			return err
+		}
+	}
+
+	return nil
+}
+
+func validateGroupedAggregateResponseName(fieldName string, responseName string) error {
+	if responseName != groupedaggdispatch.ResultJoinKeyField {
+		return nil
+	}
+
+	return fmt.Errorf(
+		"%w: %q is reserved for grouped aggregate join keys; alias %s differently",
+		errGroupedAggregateReservedResponseName,
+		responseName,
+		fieldName,
+	)
 }
 
 // writeGroupedAggregateStatement assembles the full grouped-aggregate SQL: the
@@ -555,8 +614,8 @@ func writeGroupedDistinctOrderBy(b *strings.Builder, orderBy *arguments.OrderBy)
 //
 // The single-row, single-column result preserves the existing one-row-per-
 // operation contract of Driver.ExecuteOperations: the value is a JSON array
-// of group objects, each shaped with "_join_key" plus the requested aggregate
-// and nodes response names.
+// of group objects, each shaped with the reserved internal join key plus the
+// requested GraphQL response names.
 func (t *table) writeGroupedAggregateOuter( //nolint:funlen
 	b *strings.Builder,
 	params []any, paramIndex int,

--- a/services/constellation/connector/sql/graphql/queries/root_query_grouped_aggregate_test.go
+++ b/services/constellation/connector/sql/graphql/queries/root_query_grouped_aggregate_test.go
@@ -162,6 +162,30 @@ func TestGroupedAggregateBuildQuery(t *testing.T) { //nolint:paralleltest,mainti
 				}`,
 		},
 		{
+			// The grouped path shares astToAggregateSelection with root aggregates
+			// but has its own outer writer. Exercise aliases for the aggregate key,
+			// aggregate-function column key, and nodes key there too.
+			name:              "outer_field_aliases",
+			tableSchema:       "public",
+			tableName:         "user_departments",
+			joinColumnSQLName: "user_id",
+			joinValues:        []any{testUser1, testUser2, testUserMissing},
+			query: `
+				query {
+					_root {
+						stats: aggregate {
+							total: count
+							highest: max {
+								role_name: role
+							}
+						}
+						rows: nodes {
+							role_name: role
+						}
+					}
+				}`,
+		},
+		{
 			name:              "aggregate_with_nodes",
 			tableSchema:       "public",
 			tableName:         "user_departments",

--- a/services/constellation/connector/sql/graphql/queries/selection_aggregate.go
+++ b/services/constellation/connector/sql/graphql/queries/selection_aggregate.go
@@ -123,8 +123,16 @@ func (s *typenameSelection) Write(b *strings.Builder) {
 	b.WriteByte('\'')
 }
 
+// aggregateColumnSelection is one column inside an aggregate function
+// selection. responseName is the GraphQL response key for that column: the
+// alias when present, otherwise the column field name.
+type aggregateColumnSelection struct {
+	responseName string
+	column       *core.Column
+}
+
 type aggregateFunctionSelection struct {
-	Columns   []*core.Column
+	Columns   []aggregateColumnSelection
 	Typenames []typenameSelection
 	// responseName is the JSON key for this aggregate sub-object: the field
 	// alias if present, otherwise the field name ("sum", "avg", ...). Storing
@@ -146,7 +154,7 @@ func newAggregateFunctionSelection(
 	selectionSet ast.SelectionSet,
 	fragments ast.FragmentDefinitionList,
 ) (*aggregateFunctionSelection, error) {
-	columns := make([]*core.Column, 0, len(selectionSet))
+	columns := make([]aggregateColumnSelection, 0, len(selectionSet))
 	fieldsTypeName := t.graphqlTypeName + "_" + fieldName + "_fields"
 
 	var (
@@ -168,13 +176,10 @@ func newAggregateFunctionSelection(
 					continue
 				}
 
-				col := t.columnFromGraphqlName(s.Name)
-				if col == nil {
-					collectErr = fmt.Errorf("%w: %s", errUnknownAggregateColumn, s.Name)
+				columns, collectErr = t.appendAggregateFunctionColumn(columns, s)
+				if collectErr != nil {
 					return
 				}
-
-				columns = append(columns, col)
 
 			case *ast.InlineFragment:
 				collectFields(s.SelectionSet)
@@ -206,6 +211,36 @@ func newAggregateFunctionSelection(
 	}, nil
 }
 
+func (t *table) appendAggregateFunctionColumn(
+	columns []aggregateColumnSelection,
+	field *ast.Field,
+) ([]aggregateColumnSelection, error) {
+	col := t.columnFromGraphqlName(field.Name)
+	if col == nil {
+		return nil, fmt.Errorf("%w: %s", errUnknownAggregateColumn, field.Name)
+	}
+
+	columnResponseName := fieldResponseName(field)
+	if hasAggregateColumnResponseName(columns, columnResponseName) {
+		return columns, nil
+	}
+
+	return append(columns, aggregateColumnSelection{
+		responseName: columnResponseName,
+		column:       col,
+	}), nil
+}
+
+func hasAggregateColumnResponseName(columns []aggregateColumnSelection, responseName string) bool {
+	for i := range columns {
+		if columns[i].responseName == responseName {
+			return true
+		}
+	}
+
+	return false
+}
+
 // Write emits a JSON key/value pair where the value is a nested object of
 // per-column aggregate results, e.g. 'sum', json_build_object('col', SUM(col)).
 // The key is the field's response name (alias if present, otherwise the field
@@ -227,17 +262,17 @@ func (s *aggregateFunctionSelection) write(b *strings.Builder, source string) {
 
 	first := true
 
-	for _, col := range s.Columns {
+	for _, colSel := range s.Columns {
 		if !first {
 			b.WriteString(", ")
 		}
 
 		b.WriteByte('\'')
-		b.WriteString(col.GraphqlName)
+		b.WriteString(colSel.responseName)
 		b.WriteString("', ")
 		b.WriteString(s.FuncName)
 		b.WriteByte('(')
-		core.WriteQualifiedColumn(b, source, col.SQLName)
+		core.WriteQualifiedColumn(b, source, colSel.column.SQLName)
 		b.WriteByte(')')
 
 		first = false
@@ -256,18 +291,32 @@ func (s *aggregateFunctionSelection) write(b *strings.Builder, source string) {
 	b.WriteString(")")
 }
 
+// aggregateFieldSelection is one `aggregate` field at the aggregate-root
+// scope. responseName is the field alias if present, otherwise "aggregate".
+type aggregateFieldSelection struct {
+	responseName string
+	selections   []aggregateQuerySelection
+}
+
+// aggregateNodesSelection is one `nodes` field at the aggregate-root scope.
+// responseName is the field alias if present, otherwise "nodes".
+type aggregateNodesSelection struct {
+	responseName string
+	field        *ast.Field
+}
+
 // aggregateSelectionCollector walks an aggregate root selection, accumulating
-// the outer __typename entries, the aggregate-scope selections, and the merged
-// `nodes` field. It is constructed once per call to astToAggregateSelection.
+// the outer __typename entries plus aggregate/nodes fields keyed by response
+// name. It is constructed once per call to astToAggregateSelection.
 type aggregateSelectionCollector struct {
-	table          *table
-	fragments      ast.FragmentDefinitionList
-	variables      map[string]any
-	outerTypeName  string
-	outerTypenames []typenameSelection
-	sel            []aggregateQuerySelection
-	nodesField     *ast.Field
-	err            error
+	table           *table
+	fragments       ast.FragmentDefinitionList
+	variables       map[string]any
+	outerTypeName   string
+	outerTypenames  []typenameSelection
+	aggregateFields []aggregateFieldSelection
+	nodesFields     []aggregateNodesSelection
+	err             error
 }
 
 // collectFields walks a selection set, recursing through inline fragments and
@@ -314,36 +363,67 @@ func (c *aggregateSelectionCollector) collectField(s *ast.Field) {
 			return
 		}
 
-		c.sel = append(c.sel, aggSel...)
+		c.mergeAggregateField(fieldResponseName(s), aggSel)
 	case "nodes":
-		// Merge nodes fields according to GraphQL field selection merging.
-		// Shallow-copy the first occurrence so appending to SelectionSet
-		// does not mutate the original AST (avoids accumulating duplicates
-		// when the same AST is processed more than once).
-		if c.nodesField == nil {
-			tmp := *s
-			tmp.SelectionSet = append(ast.SelectionSet(nil), s.SelectionSet...)
-			c.nodesField = &tmp
-		} else {
-			c.nodesField.SelectionSet = append(c.nodesField.SelectionSet, s.SelectionSet...)
+		c.mergeNodesField(fieldResponseName(s), s)
+	}
+}
+
+func (c *aggregateSelectionCollector) mergeAggregateField(
+	responseName string, selections []aggregateQuerySelection,
+) {
+	for i := range c.aggregateFields {
+		if c.aggregateFields[i].responseName == responseName {
+			c.aggregateFields[i].selections = append(
+				c.aggregateFields[i].selections, selections...,
+			)
+
+			return
 		}
 	}
+
+	c.aggregateFields = append(c.aggregateFields, aggregateFieldSelection{
+		responseName: responseName,
+		selections:   selections,
+	})
+}
+
+func (c *aggregateSelectionCollector) mergeNodesField(responseName string, field *ast.Field) {
+	for i := range c.nodesFields {
+		if c.nodesFields[i].responseName == responseName {
+			c.nodesFields[i].field.SelectionSet = append(
+				c.nodesFields[i].field.SelectionSet, field.SelectionSet...,
+			)
+
+			return
+		}
+	}
+
+	// Shallow-copy the first occurrence so appending to SelectionSet does not
+	// mutate the original AST (avoids accumulating duplicates when the same AST
+	// is processed more than once).
+	tmp := *field
+	tmp.SelectionSet = append(ast.SelectionSet(nil), field.SelectionSet...)
+	c.nodesFields = append(c.nodesFields, aggregateNodesSelection{
+		responseName: responseName,
+		field:        &tmp,
+	})
 }
 
 func (t *table) astToAggregateSelection(
 	field *ast.Field,
 	fragments ast.FragmentDefinitionList,
 	variables map[string]any,
-) ([]typenameSelection, []aggregateQuerySelection, *ast.Field, error) {
+) ([]typenameSelection, []aggregateFieldSelection, []aggregateNodesSelection, error) {
 	c := &aggregateSelectionCollector{
-		table:          t,
-		fragments:      fragments,
-		variables:      variables,
-		outerTypeName:  t.graphqlTypeName + "_aggregate",
-		outerTypenames: nil,
-		sel:            nil,
-		nodesField:     nil,
-		err:            nil,
+		table:           t,
+		fragments:       fragments,
+		variables:       variables,
+		outerTypeName:   t.graphqlTypeName + "_aggregate",
+		outerTypenames:  nil,
+		aggregateFields: nil,
+		nodesFields:     nil,
+		err:             nil,
 	}
 
 	c.collectFields(field.SelectionSet)
@@ -352,7 +432,15 @@ func (t *table) astToAggregateSelection(
 		return nil, nil, nil, c.err
 	}
 
-	return c.outerTypenames, c.sel, c.nodesField, nil
+	return c.outerTypenames, c.aggregateFields, c.nodesFields, nil
+}
+
+func fieldResponseName(field *ast.Field) string {
+	if field.Alias != "" {
+		return field.Alias
+	}
+
+	return field.Name
 }
 
 // appendTypename appends a typenameSelection for the __typename meta-field,
@@ -362,10 +450,7 @@ func appendTypename(
 	field *ast.Field,
 	typeName string,
 ) []typenameSelection {
-	alias := field.Alias
-	if alias == "" {
-		alias = field.Name
-	}
+	alias := fieldResponseName(field)
 
 	if hasTypenameAlias(dst, alias) {
 		return dst
@@ -415,10 +500,7 @@ func (t *table) appendAggregateField(
 ) ([]aggregateQuerySelection, error) {
 	switch f.Name {
 	case typenameField:
-		tnAlias := f.Alias
-		if tnAlias == "" {
-			tnAlias = f.Name
-		}
+		tnAlias := fieldResponseName(f)
 
 		if hasTypenameAliasInSelections(sel, tnAlias) {
 			return sel, nil
@@ -446,10 +528,7 @@ func (t *table) appendAggregateField(
 			return nil, fmt.Errorf("%w: %s", ErrUnsupportedVarianceAggregate, f.Name)
 		}
 
-		responseName := f.Alias
-		if responseName == "" {
-			responseName = f.Name
-		}
+		responseName := fieldResponseName(f)
 
 		a, err := newAggregateFunctionSelection(
 			f.Name, responseName, strings.ToUpper(f.Name), t, f.SelectionSet, fragments,
@@ -473,10 +552,7 @@ func (t *table) parseCountSelection(
 	f *ast.Field,
 	variables map[string]any,
 ) (*countSelection, error) {
-	responseName := f.Alias
-	if responseName == "" {
-		responseName = f.Name
-	}
+	responseName := fieldResponseName(f)
 
 	cs := &countSelection{
 		columns:      nil,

--- a/services/constellation/connector/sql/graphql/queries/sqlite_query_test.go
+++ b/services/constellation/connector/sql/graphql/queries/sqlite_query_test.go
@@ -565,6 +565,28 @@ func TestAggregateBuildQuery_SQLite(t *testing.T) { //nolint:paralleltest
 			},
 		},
 		{
+			// SQLite shares the aggregate-root selection writer with PostgreSQL, so
+			// aliases for aggregate, nested aggregate columns, and nodes must affect
+			// JSON keys even though the emitted JSON functions differ.
+			name: "aggregate field aliases at every scope",
+			query: query{
+				Query: `
+					query {
+						depts: departments_aggregate(order_by: {name: asc}, limit: 3) {
+							summary: aggregate {
+								total: count
+								budget_total: sum {
+									amount: budget
+								}
+							}
+							rows: nodes {
+								dept_id: id
+							}
+						}
+					}`,
+			},
+		},
+		{
 			name: "sum aggregate",
 			query: query{
 				Query: `

--- a/services/constellation/connector/sql/graphql/queries/testdata/TestAggregateBuildQuery/aggregate_field_aliases_at_every_scope.json
+++ b/services/constellation/connector/sql/graphql/queries/testdata/TestAggregateBuildQuery/aggregate_field_aliases_at_every_scope.json
@@ -1,0 +1,8 @@
+[
+  {
+    "Name": "depts",
+    "SQL": "WITH \"_root.base\" AS MATERIALIZED (SELECT * FROM \"public\".\"departments\" ORDER BY \"name\" ASC LIMIT 3) SELECT json_build_object('summary', (SELECT json_build_object('total', COUNT(*), 'distinct_ids', COUNT(DISTINCT (\"id\")), 'budget_total', json_build_object('amount', SUM(\"budget\"))) FROM \"_root.base\"), 'extremes', (SELECT json_build_object('budget_high', json_build_object('value', MAX(\"budget\"))) FROM \"_root.base\"), 'rows', (SELECT coalesce(json_agg(\"_root\"), '[]') FROM (SELECT row_to_json((SELECT \"_e\" FROM (SELECT \"_root.base\".\"id\" AS \"dept_id\", \"_root.base\".\"name\" AS \"label\") AS \"_e\")) AS \"_root\" FROM \"_root.base\") AS \"_root\")) AS \"depts\"",
+    "Parameters": [],
+    "StreamCursors": null
+  }
+]

--- a/services/constellation/connector/sql/graphql/queries/testdata/TestAggregateBuildQuery/aggregate_field_aliases_at_every_scope_data.json
+++ b/services/constellation/connector/sql/graphql/queries/testdata/TestAggregateBuildQuery/aggregate_field_aliases_at_every_scope_data.json
@@ -1,0 +1,32 @@
+[
+  [
+    {
+      "extremes": {
+        "budget_high": {
+          "value": 1200000
+        }
+      },
+      "rows": [
+        {
+          "dept_id": "023d4410-715e-4675-96a5-a58fd50ef33c",
+          "label": "Engineering"
+        },
+        {
+          "dept_id": "24e9b8db-acf8-439f-9d63-7f83de523fb3",
+          "label": "Finance"
+        },
+        {
+          "dept_id": "2db9de0a-b9ba-416e-8619-783a399ae2b3",
+          "label": "Human Resources"
+        }
+      ],
+      "summary": {
+        "distinct_ids": 3,
+        "budget_total": {
+          "amount": 1750000
+        },
+        "total": 3
+      }
+    }
+  ]
+]

--- a/services/constellation/connector/sql/graphql/queries/testdata/TestAggregateBuildQuery_SQLite/aggregate_field_aliases_at_every_scope.json
+++ b/services/constellation/connector/sql/graphql/queries/testdata/TestAggregateBuildQuery_SQLite/aggregate_field_aliases_at_every_scope.json
@@ -1,0 +1,8 @@
+[
+  {
+    "Name": "depts",
+    "SQL": "WITH \"_root.base\" AS (SELECT * FROM \"departments\" ORDER BY \"name\" ASC LIMIT 3) SELECT json_object('summary', (SELECT json_object('total', COUNT(*), 'budget_total', json_object('amount', SUM(\"budget\"))) FROM \"_root.base\"), 'rows', (SELECT coalesce(json_group_array(json(\"_root\")), '[]') FROM (SELECT json_object('dept_id', \"_root.base\".\"id\") AS \"_root\" FROM \"_root.base\") AS \"_root\")) AS \"depts\"",
+    "Parameters": [],
+    "StreamCursors": null
+  }
+]

--- a/services/constellation/connector/sql/graphql/queries/testdata/TestGroupedAggregateBuildQuery/outer_field_aliases.json
+++ b/services/constellation/connector/sql/graphql/queries/testdata/TestGroupedAggregateBuildQuery/outer_field_aliases.json
@@ -1,0 +1,14 @@
+[
+  {
+    "Name": "_root",
+    "SQL": "WITH \"_root.base\" AS MATERIALIZED (SELECT \"public\".\"user_departments\".*, \"__cs_grp_keys\".\"_join_key\" AS \"__cs_join_key\" FROM unnest($1::uuid[]) AS \"__cs_grp_keys\"(\"_join_key\") LEFT JOIN \"public\".\"user_departments\" ON \"public\".\"user_departments\".\"user_id\" = \"__cs_grp_keys\".\"_join_key\") SELECT coalesce(json_agg(\"per_group\"), '[]'::json) AS \"_root\" FROM (SELECT json_build_object('_join_key', \"__cs_join_key\", 'stats', json_build_object('total', COUNT(\"_root.base\".\"user_id\"), 'highest', json_build_object('role_name', MAX(\"_root.base\".\"role\"))), 'rows', coalesce(json_agg(row_to_json((SELECT \"_e\" FROM (SELECT \"_root.base\".\"role\" AS \"role_name\") AS \"_e\"))) FILTER (WHERE \"_root.base\".\"user_id\" IS NOT NULL), '[]'::json)) AS \"per_group\" FROM \"_root.base\" GROUP BY \"__cs_join_key\") AS \"_groups\"",
+    "Parameters": [
+      [
+        "550e8400-e29b-41d4-a716-446655440001",
+        "550e8400-e29b-41d4-a716-446655440002",
+        "00000000-0000-0000-0000-000000000099"
+      ]
+    ],
+    "StreamCursors": null
+  }
+]

--- a/services/constellation/connector/sql/graphql/queries/testdata/TestGroupedAggregateBuildQuery/outer_field_aliases_data.json
+++ b/services/constellation/connector/sql/graphql/queries/testdata/TestGroupedAggregateBuildQuery/outer_field_aliases_data.json
@@ -1,0 +1,48 @@
+[
+  [
+    {
+      "_join_key": "00000000-0000-0000-0000-000000000099",
+      "stats": {
+        "total": 0,
+        "highest": {
+          "role_name": null
+        }
+      },
+      "rows": []
+    },
+    {
+      "_join_key": "550e8400-e29b-41d4-a716-446655440001",
+      "stats": {
+        "total": 2,
+        "highest": {
+          "role_name": "member"
+        }
+      },
+      "rows": [
+        {
+          "role_name": "manager"
+        },
+        {
+          "role_name": "member"
+        }
+      ]
+    },
+    {
+      "_join_key": "550e8400-e29b-41d4-a716-446655440002",
+      "stats": {
+        "total": 2,
+        "highest": {
+          "role_name": "member"
+        }
+      },
+      "rows": [
+        {
+          "role_name": "member"
+        },
+        {
+          "role_name": "member"
+        }
+      ]
+    }
+  ]
+]

--- a/services/constellation/connector/sql/grouped_aggregate.go
+++ b/services/constellation/connector/sql/grouped_aggregate.go
@@ -31,13 +31,11 @@ var (
 // results keyed by the stringified join value. Implements
 // connector.GroupedAggregateExecutor.
 //
-// The shape of each value is
-//
-//	{ "aggregate": {...}, "nodes": [...] }
-//
-// matching the same-database aggregate field's response. An entry is present
-// for every join value, including those with no matching target rows
-// (count: 0, nodes: []).
+// Each value preserves the same GraphQL response fields emitted by the grouped
+// aggregate SQL (aliases when present, otherwise "aggregate" / "nodes"), with
+// only the internal join-key transport field removed. An entry is present for
+// every join value, including those with no matching target rows (count: 0,
+// nodes: []).
 func (c *Connector) ExecuteGroupedAggregate(
 	ctx context.Context,
 	req groupedaggregate.Request,
@@ -95,18 +93,18 @@ func parseGroupedAggregateResult(raw any) (map[string]any, error) {
 	out := make(map[string]any, len(rows))
 
 	for _, row := range rows {
-		key, hasKey := row["_join_key"]
+		key, hasKey := row[groupedaggdispatch.ResultJoinKeyField]
 		if !hasKey {
 			return nil, fmt.Errorf("%w: %v", ErrGroupedAggregateMissingJoinKey, row)
 		}
 
-		entry := make(map[string]any, 2) //nolint:mnd
-		if agg, ok := row["aggregate"]; ok {
-			entry["aggregate"] = agg
-		}
+		entry := make(map[string]any, len(row)-1)
+		for name, value := range row {
+			if name == groupedaggdispatch.ResultJoinKeyField {
+				continue
+			}
 
-		if nodes, ok := row["nodes"]; ok {
-			entry["nodes"] = nodes
+			entry[name] = value
 		}
 
 		out[fmt.Sprintf("%v", key)] = entry

--- a/services/constellation/connector/sql/grouped_aggregate_internal_test.go
+++ b/services/constellation/connector/sql/grouped_aggregate_internal_test.go
@@ -4,6 +4,8 @@ import (
 	"encoding/json/jsontext"
 	"strings"
 	"testing"
+
+	"github.com/google/go-cmp/cmp"
 )
 
 // TestParseGroupedAggregateResult is white-box because parseGroupedAggregateResult
@@ -63,6 +65,27 @@ func TestParseGroupedAggregateResult(t *testing.T) {
 
 				if _, ok := entry["nodes"]; !ok {
 					t.Errorf("entry missing nodes")
+				}
+			},
+		},
+		{
+			name: "aliased aggregate and nodes are preserved",
+			raw: jsontext.Value(
+				`[{"_join_key":"abc","stats":{"total":2},"rows":[{"role_name":"admin"}],"__typename":"user_departments_aggregate"}]`,
+			),
+			wantKeys: []string{"abc"},
+			checkValues: func(t *testing.T, out map[string]any) {
+				t.Helper()
+
+				want := map[string]any{
+					"stats": map[string]any{"total": float64(2)},
+					"rows": []any{
+						map[string]any{"role_name": "admin"},
+					},
+					"__typename": "user_departments_aggregate",
+				}
+				if diff := cmp.Diff(want, out["abc"]); diff != "" {
+					t.Errorf("aliased entry mismatch (-want +got):\n%s", diff)
 				}
 			},
 		},

--- a/services/constellation/connector/sql/grouped_aggregate_test.go
+++ b/services/constellation/connector/sql/grouped_aggregate_test.go
@@ -69,7 +69,14 @@ func newUsersConnector(t *testing.T, driver *mock.MockDriver) *csql.Connector {
 func parseAggregateField(t *testing.T) (*ast.Field, ast.FragmentDefinitionList) {
 	t.Helper()
 
-	const src = `query { _root { aggregate { count } } }`
+	return parseAggregateFieldSource(t, `query { _root { aggregate { count } } }`)
+}
+
+func parseAggregateFieldSource(
+	t *testing.T,
+	src string,
+) (*ast.Field, ast.FragmentDefinitionList) {
+	t.Helper()
 
 	doc, gqlErr := parser.ParseQuery(&ast.Source{Input: src})
 	if gqlErr != nil {
@@ -318,5 +325,76 @@ func TestConnector_ExecuteGroupedAggregate_Success(t *testing.T) {
 		if _, ok := out[k]; !ok {
 			t.Errorf("missing key %q", k)
 		}
+	}
+}
+
+func TestConnector_ExecuteGroupedAggregate_PreservesAliasedResultFields(t *testing.T) {
+	t.Parallel()
+
+	ctrl := gomock.NewController(t)
+	driver := mock.NewMockDriver(ctrl)
+
+	c := newUsersConnector(t, driver)
+
+	field, fragments := parseAggregateFieldSource(t, `query {
+		_root {
+			stats: aggregate { total: count }
+			rows: nodes { id }
+		}
+	}`)
+
+	payload := jsontext.Value(
+		`[{"_join_key":"k1","stats":{"total":2},"rows":[{"id":"u1"}]}]`,
+	)
+
+	driver.EXPECT().
+		ExecuteOperations(gomock.Any(), gomock.Any(), gomock.Any()).
+		DoAndReturn(func(
+			_ context.Context, ops []core.SQLOperation, _ *slog.Logger,
+		) (map[string]any, error) {
+			if len(ops) != 1 {
+				t.Fatalf("expected 1 op, got %d", len(ops))
+			}
+
+			return map[string]any{ops[0].Name: payload}, nil
+		})
+
+	out, err := c.ExecuteGroupedAggregate(
+		context.Background(),
+		groupedaggregate.Request{
+			TableSchema:       "public",
+			TableName:         "users",
+			JoinColumnSQLName: "id",
+			JoinValues:        []any{"k1"},
+			Field:             field,
+			Fragments:         fragments,
+		},
+		"admin",
+		nil,
+		slog.Default(),
+	)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	entry, ok := out["k1"].(map[string]any)
+	if !ok {
+		t.Fatalf("entry for k1 is not map[string]any: %T", out["k1"])
+	}
+
+	if _, ok := entry["stats"]; !ok {
+		t.Errorf("entry missing stats alias: %v", entry)
+	}
+
+	if _, ok := entry["rows"]; !ok {
+		t.Errorf("entry missing rows alias: %v", entry)
+	}
+
+	if _, ok := entry["aggregate"]; ok {
+		t.Errorf("entry should not synthesize unaliased aggregate: %v", entry)
+	}
+
+	if _, ok := entry["nodes"]; ok {
+		t.Errorf("entry should not synthesize unaliased nodes: %v", entry)
 	}
 }

--- a/services/constellation/controller/resolver/aggregate_resolver.go
+++ b/services/constellation/controller/resolver/aggregate_resolver.go
@@ -156,7 +156,8 @@ func stitchAggregateResults(
 }
 
 // aggregateSubFieldCount is the number of top-level sub-fields a grouped-
-// aggregate payload exposes: "aggregate" and "nodes".
+// aggregate payload commonly exposes: aggregate and nodes, each under its
+// GraphQL response name.
 const aggregateSubFieldCount = 2
 
 // emptyAggregateForSelection produces a default { aggregate: {...}, nodes: [] }
@@ -171,15 +172,25 @@ func emptyAggregateForSelection(field *ast.Field) map[string]any {
 			continue
 		}
 
+		responseName := aggregateResponseName(sub)
+
 		switch sub.Name {
 		case "aggregate":
-			out["aggregate"] = emptyAggregateBlock(sub)
+			out[responseName] = emptyAggregateBlock(sub)
 		case "nodes":
-			out["nodes"] = []any{}
+			out[responseName] = []any{}
 		}
 	}
 
 	return out
+}
+
+func aggregateResponseName(field *ast.Field) string {
+	if field.Alias != "" {
+		return field.Alias
+	}
+
+	return field.Name
 }
 
 // emptyAggregateBlock fills the requested aggregate sub-fields with zero values:
@@ -193,8 +204,9 @@ func emptyAggregateBlock(field *ast.Field) map[string]any {
 			continue
 		}
 
+		responseName := aggregateResponseName(sub)
 		if sub.Name == "count" {
-			out["count"] = 0
+			out[responseName] = 0
 
 			continue
 		}
@@ -202,11 +214,11 @@ func emptyAggregateBlock(field *ast.Field) map[string]any {
 		cols := make(map[string]any, len(sub.SelectionSet))
 		for _, colSel := range sub.SelectionSet {
 			if colField, isField := colSel.(*ast.Field); isField {
-				cols[colField.Name] = nil
+				cols[aggregateResponseName(colField)] = nil
 			}
 		}
 
-		out[sub.Name] = cols
+		out[responseName] = cols
 	}
 
 	return out

--- a/services/constellation/controller/resolver/aggregate_resolver_internal_test.go
+++ b/services/constellation/controller/resolver/aggregate_resolver_internal_test.go
@@ -460,6 +460,44 @@ func TestEmptyAggregateForSelection_ShapesPayload(t *testing.T) {
 	}
 }
 
+func TestEmptyAggregateForSelection_UsesResponseNames(t *testing.T) {
+	t.Parallel()
+
+	field := &ast.Field{
+		Name: "members_aggregate",
+		SelectionSet: ast.SelectionSet{
+			&ast.Field{
+				Alias: "stats",
+				Name:  "aggregate",
+				SelectionSet: ast.SelectionSet{
+					&ast.Field{Alias: "total", Name: "count"},
+					&ast.Field{
+						Alias: "total_salary",
+						Name:  "sum",
+						SelectionSet: ast.SelectionSet{
+							&ast.Field{Alias: "amount", Name: "salary"},
+						},
+					},
+				},
+			},
+			&ast.Field{Alias: "rows", Name: "nodes"},
+		},
+	}
+
+	got := emptyAggregateForSelection(field)
+
+	want := map[string]any{
+		"stats": map[string]any{
+			"total":        0,
+			"total_salary": map[string]any{"amount": nil},
+		},
+		"rows": []any{},
+	}
+	if diff := cmp.Diff(want, got); diff != "" {
+		t.Errorf("emptyAggregateForSelection aliases mismatch (-want +got):\n%s", diff)
+	}
+}
+
 // TestEmptyAggregateForSelection_IgnoresUnknownSubfields verifies that
 // selections outside aggregate/nodes are ignored.
 func TestEmptyAggregateForSelection_IgnoresUnknownSubfields(t *testing.T) {

--- a/services/constellation/integration/query_aggregates_test.go
+++ b/services/constellation/integration/query_aggregates_test.go
@@ -91,6 +91,32 @@ func TestQueryAggregates(t *testing.T) { //nolint:paralleltest,maintidx
 			},
 		},
 		{
+			name: "aggregate aliases at every scope",
+			query: query{
+				Query: `query {
+					depts: departments_aggregate(order_by: {name: asc}, limit: 3) {
+						summary: aggregate {
+							total: count
+							distinct_ids: count(columns: [id], distinct: true)
+							budget_total: sum {
+								amount: budget
+							}
+						}
+						extremes: aggregate {
+							budget_high: max {
+								value: budget
+							}
+						}
+						rows: nodes {
+							dept_id: id
+							label: name
+						}
+					}
+				}`,
+				Role: "admin",
+			},
+		},
+		{
 			name: "sum aggregate",
 			query: query{
 				Query: `query {


### PR DESCRIPTION
<!-- nhost-reviewer:start -->
### **What this PR solves**
Constellation's aggregate GraphQL queries ignored field aliases at the aggregate-root scope: multiple differently-aliased `aggregate`/`nodes` selections collapsed into single `aggregate`/`nodes` JSON keys, and aliased aggregate-function columns emitted the column name instead of the alias. This change makes the SQL builder honor aliases at every aggregate level — root operation, each `aggregate` field, aggregate-function columns, and each `nodes` field — so responses match Hasura.

___

### **PR Type**
Bug fix

___

### **Description**
- Replace the single `aggregateSel`/`nodesField` accumulators returned by `astToAggregateSelection` with response-name-keyed slices (`[]aggregateFieldSelection`, `[]aggregateNodesSelection`), so multiple aliased `aggregate`/`nodes` selections each produce their own JSON key while same-named ones still merge per GraphQL field-merging rules.
- Carry a per-column `responseName` through aggregate-function selections (`aggregateColumnSelection`) so aliased columns such as `sum { amount: budget }` emit the alias as the JSON key.
- Extract `writeAggregateFieldSelections` and thread a `responseName` argument through both the root (`writeAggregateNodes`) and grouped/array-relationship (`writeGroupedAggregateOuter`, `writeGroupedAggregateNodes`) writers.
- Add a shared `fieldResponseName` helper (alias-or-name) and dedupe selections/columns by response name.
- Add PostgreSQL + SQLite unit goldens, a grouped-aggregate golden, and an integration test exercising aliases at every scope.

___

### Diagram Walkthrough

```mermaid
flowchart LR
  Q["GraphQL aggregate<br/>selection set"] --> C["aggregateSelectionCollector<br/>merge by responseName"]
  C --> AF["[]aggregateFieldSelection"]
  C --> NF["[]aggregateNodesSelection"]
  AF --> R["writeQueryAggregateSQL<br/>(root path)"]
  NF --> R
  AF --> G["writeGroupedAggregateOuter<br/>(array-rel path)"]
  NF --> G
  R --> SQL["JSON-shaped SQL<br/>with aliased keys"]
  G --> SQL
```

<details> <summary><h3> File Walkthrough</h3></summary>

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody>
<tr><td><strong>Core logic</strong></td><td><details><summary>3 files</summary><table>
<tr>
  <td><strong>selection_aggregate.go</strong><dd><code>Response-name-keyed collector, per-column aliases, fieldResponseName helper</code></dd></td>
  <td><a href="https://github.com/nhost/nhost/pull/XXX/files#diff-de1f02bf62c5439173304545bc5cf9b9a03dea284622ee6f3a006fc60a3a7764">+133/-57</a></td>
</tr>
<tr>
  <td><strong>root_query_aggregate.go</strong><dd><code>Multi-aggregate/nodes writing via writeAggregateFieldSelections + threaded responseName</code></dd></td>
  <td><a href="https://github.com/nhost/nhost/pull/XXX/files#diff-e20fe68d71fb0e9a2bb6cdbb438afd4a26c5a0171c7f603a3a4791752d99ced6">+56/-29</a></td>
</tr>
<tr>
  <td><strong>root_query_grouped_aggregate.go</strong><dd><code>Grouped/array-rel path honors aggregate & nodes response names</code></dd></td>
  <td><a href="https://github.com/nhost/nhost/pull/XXX/files#diff-190f26ce820d2ad4e5899718d65d5dd4a6315e6714eb6d1533de159cd8b976a1">+43/-33</a></td>
</tr>
</table></details></td></tr>
<tr><td><strong>Tests</strong></td><td><details><summary>4 files</summary><table>
<tr>
  <td><strong>root_query_aggregate_test.go</strong><dd><code>Unit case: aliases at every aggregate scope (PostgreSQL)</code></dd></td>
  <td><a href="https://github.com/nhost/nhost/pull/XXX/files#diff-eab1d73be4a271b235d72e9a1f82e6ee23ff468e4745c02bf06fd4565830eaad">+30/-0</a></td>
</tr>
<tr>
  <td><strong>root_query_grouped_aggregate_test.go</strong><dd><code>Unit case: outer field aliases on the grouped path</code></dd></td>
  <td><a href="https://github.com/nhost/nhost/pull/XXX/files#diff-7d8e8c077ca0e85447ca8c8e3dbfb85b2f6e82e9e605f5a0d58ec8c29bb60a72">+24/-0</a></td>
</tr>
<tr>
  <td><strong>sqlite_query_test.go</strong><dd><code>Unit case: aliases at every aggregate scope (SQLite)</code></dd></td>
  <td><a href="https://github.com/nhost/nhost/pull/XXX/files#diff-68faf6e048a40dc3244a6d490acca6664e89362e9d40455320919490374a63a3">+22/-0</a></td>
</tr>
<tr>
  <td><strong>integration/query_aggregates_test.go</strong><dd><code>Integration case: aggregate aliases at every scope</code></dd></td>
  <td><a href="https://github.com/nhost/nhost/pull/XXX/files#diff-9c225dccba584cbab9f629e450e98e95c77f00efb13dcbf0a364217093b94ad1">+26/-0</a></td>
</tr>
</table></details></td></tr>
<tr><td><strong>Test data (goldens)</strong></td><td><details><summary>5 files</summary><table>
<tr>
  <td><strong>TestAggregateBuildQuery/aggregate_field_aliases_at_every_scope.json</strong><dd><code>PostgreSQL expected SQL golden</code></dd></td>
  <td><a href="https://github.com/nhost/nhost/pull/XXX/files#diff-ae123addd7c1d6d8980fdb2127cb533d6a0fb570a0f6d2b1c3bbc3263ff6ccde">+8/-0</a></td>
</tr>
<tr>
  <td><strong>TestAggregateBuildQuery/aggregate_field_aliases_at_every_scope_data.json</strong><dd><code>PostgreSQL expected result data golden</code></dd></td>
  <td><a href="https://github.com/nhost/nhost/pull/XXX/files#diff-62b6d4c349979b4bfe24a841abd8bad278e1888407a7ffabf1e42368b14a3f15">+32/-0</a></td>
</tr>
<tr>
  <td><strong>TestAggregateBuildQuery_SQLite/aggregate_field_aliases_at_every_scope.json</strong><dd><code>SQLite expected SQL golden</code></dd></td>
  <td><a href="https://github.com/nhost/nhost/pull/XXX/files#diff-0eab1f2eac65326718936365cd7fe6b8b1283b3937a02c46754728a80fd6c300">+8/-0</a></td>
</tr>
<tr>
  <td><strong>TestGroupedAggregateBuildQuery/outer_field_aliases.json</strong><dd><code>Grouped-aggregate expected SQL golden</code></dd></td>
  <td><a href="https://github.com/nhost/nhost/pull/XXX/files#diff-a7194017068732f206368367ea23ee12e47ff244fe953e8c06362351454d5478">+14/-0</a></td>
</tr>
<tr>
  <td><strong>TestGroupedAggregateBuildQuery/outer_field_aliases_data.json</strong><dd><code>Grouped-aggregate expected result data golden</code></dd></td>
  <td><a href="https://github.com/nhost/nhost/pull/XXX/files#diff-16707095fbdfab0c6d96ba8ef7a195ff457457d3cd9bbc06824c62652dbf509d">+48/-0</a></td>
</tr>
</table></details></td></tr>
</tbody></table>

</details>

___

<!-- nhost-reviewer:end -->