### PR TITLE
fix(docs): fix broken links and enable external link checking

### DIFF
--- a/docs/check_broken_links.sh
+++ b/docs/check_broken_links.sh
@@ -4,14 +4,32 @@ set -euo pipefail
 
 echo "⚒️⚒️⚒️ Checking for broken links..."
 
+# linkinator serves dist/client/ from its own local server and validates every
+# <a>/<link>/<script>/<img> URL it finds, external links included.
+#
+SKIP=(
+  # Generated reference docs & build artifacts (not authored content)
+  '\/reference\/'
+  '\/deprecated\/'
+  '\/favicon.svg$'
+  '\/@vite\/client$'
+
+  # Per-project runtime domains — user-specific examples, never resolvable
+  '\.nhost\.run'
+
+  # Sign-in portals that reject automated requests with 4xx (false positives)
+  'portal\.azure\.com'
+)
+
+skip_args=()
+for pattern in "${SKIP[@]}"; do
+  skip_args+=(--skip "$pattern")
+done
+
 pnpm exec linkinator dist/client/ \
-    --recurse \
-    --skip '^https?://(?!localhost)' \
-    --skip '\/reference\/' \
-    --skip '\/deprecated\/' \
-    --skip '\/favicon.svg$' \
-    --skip '\/@vite\/client$' \
-    --concurrency 10 \
-    --timeout 30000 \
-    --retry-errors \
-    --retry-errors-count 3
+  --recurse \
+  --concurrency 10 \
+  --timeout 30000 \
+  --retry-errors \
+  --retry-errors-count 3 \
+  "${skip_args[@]}"

--- a/docs/src/content/docs/products/auth/bot-protection.mdx
+++ b/docs/src/content/docs/products/auth/bot-protection.mdx
@@ -8,7 +8,7 @@ import { Tabs, TabItem } from '@astrojs/starlight/components';
 
 ## Overview
 
-To safeguard your Auth API against automated attacks from scripts and bots, you can implement [Cloudflare's Turnstile](https://www.cloudflare.com/en-gb/products/turnstile/). Turnstile offers CAPTCHA-like protection without user friction, as it doesn't require solving puzzles.
+To safeguard your Auth API against automated attacks from scripts and bots, you can implement [Cloudflare's Turnstile](https://www.cloudflare.com/products/turnstile/). Turnstile offers CAPTCHA-like protection without user friction, as it doesn't require solving puzzles.
 
 ![Turnstile Check in Action](/images/auth/turnstile/turnstile.gif)
 

--- a/docs/src/content/docs/products/auth/elevated-permissions.mdx
+++ b/docs/src/content/docs/products/auth/elevated-permissions.mdx
@@ -63,7 +63,7 @@ If you are allowing users to perform changes to auth data directly by performing
 
 ## Example
 
-To demonstrate this functionality we have implemented them in our [react-apollo](https://react-apollo.example.nhost.io) ([source](https://github.com/nhost/nhost/tree/main/examples/react-apollo)) and [vue-apollo](https://vue-apollo.example.nhost.io) ([source](https://github.com/nhost/nhost/tree/main/examples/vue-apollo)) examples.
+To demonstrate this functionality we have implemented them in our [react-apollo](https://react-apollo.example.nhost.io) ([source](https://github.com/nhost/nhost/tree/6ad1cfcb131a8b4380526cd8d1f927591901fad4/examples/react-apollo)) and [vue-apollo](https://vue-apollo.example.nhost.io) ([source](https://github.com/nhost/nhost/tree/6ad1cfcb131a8b4380526cd8d1f927591901fad4/examples/vue-apollo)) examples.
 
 ### Secret Notes
 

--- a/docs/src/content/docs/products/database/extensions.mdx
+++ b/docs/src/content/docs/products/database/extensions.mdx
@@ -401,7 +401,7 @@ DROP EXTENSION pg_search;
 ### Resources
 
 - [GitHub](https://github.com/paradedb/paradedb/tree/main/pg_search)
-- [Documentation](https://docs.paradedb.com/documentation/getting-started/quickstart)
+- [Documentation](https://docs.paradedb.com/documentation/getting-started/install)
 
 ## pg_squeeze
 

--- a/docs/src/content/docs/products/graphql/permissions/index.mdx
+++ b/docs/src/content/docs/products/graphql/permissions/index.mdx
@@ -48,9 +48,9 @@ In certain situations, permission checks can cause significant delays. One way t
 For deeper background, Hasura's own docs cover permissions in detail:
 
 - [Authorization / Access control](https://hasura.io/docs/latest/graphql/core/auth/authorization/index/)
-- [Access control basics](https://hasura.io/docs/latest/graphql/core/auth/authorization/basics/)
+- [Access control basics](https://hasura.io/docs/latest/auth/authorization/basics/)
 - [Roles & Session variables](https://hasura.io/docs/latest/graphql/core/auth/authorization/roles-variables/)
 - [Inherited roles](https://hasura.io/docs/latest/graphql/core/auth/authorization/inherited-roles/)
-- [Configuring permission rules](https://hasura.io/docs/latest/graphql/core/auth/authorization/permission-rules/)
-- [Access control examples](https://hasura.io/docs/latest/graphql/core/auth/authorization/common-roles-auth-examples/)
-- [Multiple column + row permissions for the same role](https://hasura.io/docs/latest/graphql/core/auth/authorization/role-multiple-rules/)
+- [Configuring permission rules](https://hasura.io/docs/latest/auth/authorization/permission-rules/)
+- [Access control examples](https://hasura.io/docs/latest/auth/authorization/common-roles-auth-examples/)
+- [Multiple column + row permissions for the same role](https://hasura.io/docs/latest/auth/authorization/role-multiple-rules/)


### PR DESCRIPTION
### Checklist

- [X] No breaking changes
- [X] Tests pass
- [X] New features have new tests
- [X] Documentation is updated (if applicable)
- [X] Title of the PR is in the correct format (see below)

<!-- nhost-reviewer:start -->
### **What this PR solves**
The docs link checker previously skipped every external URL, so broken or outdated external links went undetected. This PR switches the checker to validate external links as well — with a small skip-list for unresolvable per-project runtime domains and bot-hostile sign-in portals — and fixes the stale external links that surfaced: Cloudflare's Turnstile locale URL, ParadeDB's moved docs page, and several Hasura authorization links that changed in Hasura's docs restructure.

___

### **PR Type**
Documentation

___

### **Description**
- Reworked `check_broken_links.sh` to validate external links too (removed the blanket `^https?://(?!localhost)` skip) and moved skip patterns into a maintainable array, adding entries for `*.nhost.run` runtime domains and the `portal.azure.com` sign-in portal.
- Fixed the Cloudflare Turnstile link by dropping the `/en-gb` locale prefix.
- Updated the ParadeDB docs link from the moved `getting-started/quickstart` page to `getting-started/install`.
- Migrated several Hasura authorization doc links to Hasura's current `/docs/latest/auth/authorization/...` structure.
- Pinned the `react-apollo` / `vue-apollo` example `[source]` links to commit `6ad1cfcb` so they reference a stable snapshot.

___

<details> <summary><h3> File Walkthrough</h3></summary>

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody>
<tr><td><strong>Tooling</strong></td><td><details><summary>1 files</summary><table>
<tr>
  <td><strong>check_broken_links.sh</strong><dd><code>Validate external links too; move skip patterns into an array with new nhost.run / portal.azure.com entries</code></dd></td>
  <td><a href="https://github.com/nhost/nhost/pull/4410/files#diff-c8b3d6b1fcf1a2e33a14c5549c5a8617089bc64a7b7e5ccac0791bac580d6fb3">+29/-11</a></td>
</tr>
</table></details></td></tr>
<tr><td><strong>Documentation</strong></td><td><details><summary>4 files</summary><table>
<tr>
  <td><strong>bot-protection.mdx</strong><dd><code>Drop the /en-gb locale prefix from the Cloudflare Turnstile link</code></dd></td>
  <td><a href="https://github.com/nhost/nhost/pull/4410/files#diff-374eeffd146622e3f0ab902f5c2aeb1481f637b8ce9c9d74d4aecaac24a3076d">+1/-1</a></td>
</tr>
<tr>
  <td><strong>elevated-permissions.mdx</strong><dd><code>Pin react-apollo / vue-apollo source links to commit 6ad1cfcb</code></dd></td>
  <td><a href="https://github.com/nhost/nhost/pull/4410/files#diff-f55e523d458320c58f24b36d55bbc33dc881a5541b7e1f88b9d070152e9376c1">+1/-1</a></td>
</tr>
<tr>
  <td><strong>extensions.mdx</strong><dd><code>Update the ParadeDB docs link from getting-started/quickstart to /install</code></dd></td>
  <td><a href="https://github.com/nhost/nhost/pull/4410/files#diff-63b8ad8584060ece61d18f0b7aaba978a78da00cf3a782f0bfeb9e7b4529117b">+1/-1</a></td>
</tr>
<tr>
  <td><strong>permissions/index.mdx</strong><dd><code>Migrate several Hasura authorization links to the current /auth/authorization path</code></dd></td>
  <td><a href="https://github.com/nhost/nhost/pull/4410/files#diff-965f6b6509f785af6d244634503a67b307f1e5be5a11fa654b07e6ec718addc7">+4/-4</a></td>
</tr>
</table></details></td></tr>
</tbody></table>

</details>

___

<!-- nhost-reviewer:end -->
