### PR TITLE
fix(dashboard): migrate Foreign key form to v3

### DIFF
--- a/dashboard/e2e/database/tables/create-table.test.ts
+++ b/dashboard/e2e/database/tables/create-table.test.ts
@@ -194,7 +194,7 @@ test('should create table with foreign key constraint', async ({
 
   await page.getByRole('button', { name: /add foreign key/i }).click();
 
-  await page.locator('#columnName').click();
+  await page.getByRole('combobox', { name: 'Column' }).first().click();
   await page.getByRole('option', { name: /author_id/i }).click();
 
   // select reference schema
@@ -205,7 +205,7 @@ test('should create table with foreign key constraint', async ({
   await page.getByRole('combobox', { name: 'Table' }).click();
   await page.getByRole('option', { name: firstTableName, exact: true }).click();
 
-  await page.locator('#referencedColumn').click();
+  await page.getByRole('combobox', { name: 'Column' }).last().click();
   await page.getByRole('option', { name: /id/i }).click();
 
   await page.getByRole('button', { name: /add/i }).click();

--- a/dashboard/e2e/database/tables/delete-table.test.ts
+++ b/dashboard/e2e/database/tables/delete-table.test.ts
@@ -85,7 +85,7 @@ test('should not be able to delete a table if other tables have foreign keys ref
   await page.getByRole('button', { name: /add foreign key/i }).click();
 
   // select column in current table
-  await page.locator('#columnName').click();
+  await page.getByRole('combobox', { name: 'Column' }).first().click();
 
   await page.getByRole('option', { name: /author_id/i }).click();
 
@@ -98,7 +98,7 @@ test('should not be able to delete a table if other tables have foreign keys ref
   await page.getByRole('option', { name: firstTableName, exact: true }).click();
 
   // select reference column
-  await page.locator('#referencedColumn').click();
+  await page.getByRole('combobox', { name: 'Column' }).last().click();
   await page.getByRole('option', { name: /id/i }).click();
   await page.getByRole('button', { name: /add/i }).click();
 

--- a/dashboard/e2e/database/tables/multiple-foreign-keys.test.ts
+++ b/dashboard/e2e/database/tables/multiple-foreign-keys.test.ts
@@ -86,7 +86,7 @@ test('should create table with multiple foreign keys, then edit by removing one 
 
   await page.getByRole('button', { name: /add foreign key/i }).click();
 
-  await page.locator('#columnName').click();
+  await page.getByRole('combobox', { name: 'Column' }).first().click();
   await page.getByRole('option', { name: /author_id/i }).click();
 
   await page.getByLabel('Schema').click();
@@ -97,7 +97,7 @@ test('should create table with multiple foreign keys, then edit by removing one 
     .getByRole('option', { name: firstRefTableName, exact: true })
     .click();
 
-  await page.locator('#referencedColumn').click();
+  await page.getByRole('combobox', { name: 'Column' }).last().click();
   await page.getByRole('option', { name: /id/i }).click();
 
   await page.getByRole('button', { name: /add/i }).click();
@@ -113,7 +113,7 @@ test('should create table with multiple foreign keys, then edit by removing one 
   // Add second foreign key (publisher_id -> secondRefTableName)
   await page.getByRole('button', { name: /add foreign key/i }).click();
 
-  await page.locator('#columnName').click();
+  await page.getByRole('combobox', { name: 'Column' }).first().click();
   await page.getByRole('option', { name: /publisher_id/i }).click();
 
   await page.getByLabel('Schema').click();
@@ -124,7 +124,7 @@ test('should create table with multiple foreign keys, then edit by removing one 
     .getByRole('option', { name: secondRefTableName, exact: true })
     .click();
 
-  await page.locator('#referencedColumn').click();
+  await page.getByRole('combobox', { name: 'Column' }).last().click();
   await page.getByRole('option', { name: /id/i }).click();
 
   await page.getByRole('button', { name: /add/i }).click();
@@ -176,7 +176,7 @@ test('should create table with multiple foreign keys, then edit by removing one 
 
   await page.getByRole('button', { name: /add foreign key/i }).click();
 
-  await page.locator('#columnName').click();
+  await page.getByRole('combobox', { name: 'Column' }).first().click();
   await page.getByRole('option', { name: /category_id/i }).click();
 
   await page.getByLabel('Schema').click();
@@ -187,7 +187,7 @@ test('should create table with multiple foreign keys, then edit by removing one 
     .getByRole('option', { name: thirdRefTableName, exact: true })
     .click();
 
-  await page.locator('#referencedColumn').click();
+  await page.getByRole('combobox', { name: 'Column' }).last().click();
   await page.getByRole('option', { name: /id/i }).click();
 
   await page.getByRole('button', { name: /add/i }).click();
@@ -263,7 +263,7 @@ test('should create table with multiple foreign keys pointing to the same column
 
   await page.getByRole('button', { name: /add foreign key/i }).click();
 
-  await page.locator('#columnName').click();
+  await page.getByRole('combobox', { name: 'Column' }).first().click();
   await page.getByRole('option', { name: /primary_address_id/i }).click();
 
   await page.getByLabel('Schema').click();
@@ -274,7 +274,7 @@ test('should create table with multiple foreign keys pointing to the same column
     .getByRole('option', { name: addressTableName, exact: true })
     .click();
 
-  await page.locator('#referencedColumn').click();
+  await page.getByRole('combobox', { name: 'Column' }).last().click();
   await page.getByRole('option', { name: /id/i }).click();
 
   await page.getByRole('button', { name: /add/i }).click();
@@ -289,7 +289,7 @@ test('should create table with multiple foreign keys pointing to the same column
 
   await page.getByRole('button', { name: /add foreign key/i }).click();
 
-  await page.locator('#columnName').click();
+  await page.getByRole('combobox', { name: 'Column' }).first().click();
   await page.getByRole('option', { name: /secondary_address_id/i }).click();
 
   await page.getByLabel('Schema').click();
@@ -300,7 +300,7 @@ test('should create table with multiple foreign keys pointing to the same column
     .getByRole('option', { name: addressTableName, exact: true })
     .click();
 
-  await page.locator('#referencedColumn').click();
+  await page.getByRole('combobox', { name: 'Column' }).last().click();
   await page.getByRole('option', { name: /id/i }).click();
 
   await page.getByRole('button', { name: /add/i }).click();

--- a/dashboard/src/components/form/FormSelect/FormSelect.tsx
+++ b/dashboard/src/components/form/FormSelect/FormSelect.tsx
@@ -38,9 +38,14 @@ interface FormSelectProps<
   placeholder?: string;
   className?: string;
   containerClassName?: string;
+  // Forwarded to the dropdown content. Needed to raise the z-index when the
+  // select lives inside a higher-stacked container such as a MUI dialog.
+  contentClassName?: string;
   inline?: boolean;
   helperText?: string | null;
+  helperTextClassName?: string;
   disabled?: boolean;
+  autoFocus?: boolean;
   transform?: Transformer;
   'data-testid'?: string;
 }
@@ -56,9 +61,12 @@ function FormSelectImpl<
     placeholder,
     className,
     containerClassName,
+    contentClassName,
     inline,
     helperText,
+    helperTextClassName,
     disabled,
+    autoFocus,
     children,
     transform,
     'data-testid': dataTestId,
@@ -110,14 +118,19 @@ function FormSelectImpl<
                     className={cn(selectClasses, className)}
                     ref={mergeRefs([fieldRef, ref])}
                     data-testid={dataTestId}
+                    autoFocus={autoFocus}
                   >
                     <SelectValue placeholder={placeholder} />
                   </SelectTrigger>
                 </FormControl>
-                <SelectContent>{children}</SelectContent>
+                <SelectContent className={contentClassName}>
+                  {children}
+                </SelectContent>
               </Select>
               {!!helperText && (
-                <FormDescription className="break-all px-[1px]">
+                <FormDescription
+                  className={cn('break-all px-[1px]', helperTextClassName)}
+                >
                   {helperText}
                 </FormDescription>
               )}

--- a/dashboard/src/features/orgs/projects/database/dataGrid/components/BaseForeignKeyForm/BaseForeignKeyForm.tsx
+++ b/dashboard/src/features/orgs/projects/database/dataGrid/components/BaseForeignKeyForm/BaseForeignKeyForm.tsx
@@ -1,15 +1,12 @@
 import { useRouter } from 'next/router';
 import { useEffect } from 'react';
-import { useFormState } from 'react-hook-form';
+import { useFormContext, useFormState } from 'react-hook-form';
 import * as Yup from 'yup';
 import { useDialog } from '@/components/common/DialogProvider';
-import { ControlledSelect } from '@/components/form/ControlledSelect';
 import { Form } from '@/components/form/Form';
-import { Box } from '@/components/ui/v2/Box';
-import { Button } from '@/components/ui/v2/Button';
-import { Divider } from '@/components/ui/v2/Divider';
-import { Option } from '@/components/ui/v2/Option';
-import { Text } from '@/components/ui/v2/Text';
+import { FormSelect } from '@/components/form/FormSelect';
+import { Button, ButtonWithLoading } from '@/components/ui/v3/button';
+import { SelectItem } from '@/components/ui/v3/select';
 import { useDatabaseQuery } from '@/features/orgs/projects/database/dataGrid/hooks/useDatabaseQuery';
 import type {
   DatabaseColumn,
@@ -83,7 +80,9 @@ export default function BaseForeignKeyForm({
     query: { dataSourceSlug },
   } = router;
 
-  const { dirtyFields, errors, isSubmitting } =
+  const form = useFormContext<BaseForeignKeySchemaValues>();
+  const { control } = form;
+  const { dirtyFields, isSubmitting } =
     useFormState<BaseForeignKeySchemaValues>();
 
   const { data } = useDatabaseQuery([dataSourceSlug]);
@@ -96,8 +95,18 @@ export default function BaseForeignKeyForm({
   const isDirty = Object.keys(dirtyFields).length > 0;
 
   useEffect(() => {
-    onDirtyStateChange(isDirty, location);
-  }, [isDirty, location, onDirtyStateChange]);
+    const unsubscribe = form.subscribe({
+      formState: { dirtyFields: true },
+      callback: ({ dirtyFields: subscribedDirtyFields }) => {
+        onDirtyStateChange(
+          Object.keys(subscribedDirtyFields ?? {}).length > 0,
+          location,
+        );
+      },
+    });
+
+    return () => unsubscribe();
+  }, [form, onDirtyStateChange, location]);
 
   return (
     <Form
@@ -113,34 +122,35 @@ export default function BaseForeignKeyForm({
       }}
       className="flex flex-auto flex-col content-between overflow-hidden pb-4"
     >
-      <Box className="grid flex-auto grid-flow-row gap-4 overflow-y-auto border-t-1 py-4">
-        <Box component="section" className="grid grid-flow-row gap-4 px-6">
-          <Text variant="h3">From</Text>
+      <div className="grid flex-auto grid-flow-row gap-4 overflow-y-auto border-t-1 py-4">
+        <section className="grid grid-flow-row gap-4 px-6">
+          <h3 className="font-semibold text-foreground text-lg leading-6">
+            From
+          </h3>
 
-          <ControlledSelect
-            id="columnName"
+          <FormSelect
+            control={control}
             name="columnName"
             label="Column"
-            fullWidth
             placeholder="Select a column"
-            hideEmptyHelperText
-            error={Boolean(errors.columnName)}
-            helperText={errors.columnName?.message}
             autoFocus={!disableOriginColumn}
             disabled={disableOriginColumn}
+            contentClassName="z-[1400]"
           >
             {availableColumns?.map(({ name }) => (
-              <Option value={name} key={name}>
+              <SelectItem value={name} key={name}>
                 {name}
-              </Option>
+              </SelectItem>
             ))}
-          </ControlledSelect>
-        </Box>
+          </FormSelect>
+        </section>
 
-        <Divider />
+        <hr className="border-t-1" />
 
-        <Box component="section" className="grid grid-flow-row gap-4 px-6">
-          <Text variant="h3">To</Text>
+        <section className="grid grid-flow-row gap-4 px-6">
+          <h3 className="font-semibold text-foreground text-lg leading-6">
+            To
+          </h3>
 
           <ReferencedSchemaSelect
             options={schemas}
@@ -148,66 +158,60 @@ export default function BaseForeignKeyForm({
           />
           <ReferencedTableSelect options={tables} />
           <ReferencedColumnSelect />
-        </Box>
+        </section>
 
-        <Divider />
+        <hr className="border-t-1" />
 
-        <Box component="section" className="grid grid-cols-2 gap-4 px-6">
-          <ControlledSelect
-            id="updateAction"
+        <section className="grid grid-cols-2 gap-4 px-6">
+          <FormSelect
+            control={control}
             name="updateAction"
             label="On Update"
-            fullWidth
-            hideEmptyHelperText
-            error={Boolean(errors.updateAction)}
-            helperText={errors.updateAction?.message}
-            className="col-span-1"
+            containerClassName="col-span-1"
+            contentClassName="z-[1400]"
           >
-            <Option value="RESTRICT">RESTRICT</Option>
-            <Option value="CASCADE">CASCADE</Option>
-            <Option value="SET NULL">SET NULL</Option>
-            <Option value="SET DEFAULT">SET DEFAULT</Option>
-            <Option value="NO ACTION">NO ACTION</Option>
-          </ControlledSelect>
+            <SelectItem value="RESTRICT">RESTRICT</SelectItem>
+            <SelectItem value="CASCADE">CASCADE</SelectItem>
+            <SelectItem value="SET NULL">SET NULL</SelectItem>
+            <SelectItem value="SET DEFAULT">SET DEFAULT</SelectItem>
+            <SelectItem value="NO ACTION">NO ACTION</SelectItem>
+          </FormSelect>
 
-          <ControlledSelect
-            id="deleteAction"
+          <FormSelect
+            control={control}
             name="deleteAction"
             label="On Delete"
-            fullWidth
-            hideEmptyHelperText
-            error={Boolean(errors.deleteAction)}
-            helperText={errors.deleteAction?.message}
-            className="col-span-1"
+            containerClassName="col-span-1"
+            contentClassName="z-[1400]"
           >
-            <Option value="RESTRICT">RESTRICT</Option>
-            <Option value="CASCADE">CASCADE</Option>
-            <Option value="SET NULL">SET NULL</Option>
-            <Option value="SET DEFAULT">SET DEFAULT</Option>
-            <Option value="NO ACTION">NO ACTION</Option>
-          </ControlledSelect>
-        </Box>
-      </Box>
+            <SelectItem value="RESTRICT">RESTRICT</SelectItem>
+            <SelectItem value="CASCADE">CASCADE</SelectItem>
+            <SelectItem value="SET NULL">SET NULL</SelectItem>
+            <SelectItem value="SET DEFAULT">SET DEFAULT</SelectItem>
+            <SelectItem value="NO ACTION">NO ACTION</SelectItem>
+          </FormSelect>
+        </section>
+      </div>
 
-      <Box className="grid flex-shrink-0 grid-flow-row gap-2 border-t-1 px-6 pt-4">
-        <Button
+      <div className="grid flex-shrink-0 grid-flow-row gap-2 border-t-1 px-6 pt-4">
+        <ButtonWithLoading
           loading={isSubmitting}
           disabled={isSubmitting}
           type="submit"
           data-testid="foreignKeyFormSubmitButton"
         >
           {submitButtonText}
-        </Button>
+        </ButtonWithLoading>
 
         <Button
-          variant="outlined"
-          color="secondary"
+          type="button"
+          variant="outline"
           onClick={onCancel}
           tabIndex={isDirty ? -1 : 0}
         >
           Cancel
         </Button>
-      </Box>
+      </div>
     </Form>
   );
 }

--- a/dashboard/src/features/orgs/projects/database/dataGrid/components/BaseForeignKeyForm/ReferencedColumnSelect.tsx
+++ b/dashboard/src/features/orgs/projects/database/dataGrid/components/BaseForeignKeyForm/ReferencedColumnSelect.tsx
@@ -1,10 +1,11 @@
-import { useFormState, useWatch } from 'react-hook-form';
-import { ControlledSelect } from '@/components/form/ControlledSelect';
-import { Option } from '@/components/ui/v2/Option';
+import { useFormContext, useWatch } from 'react-hook-form';
+import { FormSelect } from '@/components/form/FormSelect';
+import { SelectItem } from '@/components/ui/v3/select';
 import { useTableSchemaQuery } from '@/features/orgs/projects/database/common/hooks/useTableSchemaQuery';
+import type { BaseForeignKeySchemaValues } from './BaseForeignKeyForm';
 
 export default function ReferencedColumnSelect() {
-  const { errors } = useFormState({ name: 'referencedColumn' });
+  const { control } = useFormContext<BaseForeignKeySchemaValues>();
   const columnName = useWatch({ name: 'columnName' });
   const referencedSchema = useWatch({ name: 'referencedSchema' });
   const referencedTable = useWatch({ name: 'referencedTable' });
@@ -30,48 +31,31 @@ export default function ReferencedColumnSelect() {
     referencedSchema &&
     referencedTable &&
     !availableColumnsInSelectedTable.length &&
-    status === 'success' ? (
-      <span>
-        There are no available columns in the{' '}
-        <strong>
-          {referencedSchema}.{referencedTable}
-        </strong>{' '}
-        table.
-      </span>
-    ) : (
-      <span>
-        Only the primary and unique keys of the referenced table are listed
-        here.
-      </span>
-    );
+    status === 'success'
+      ? `There are no available columns in the ${referencedSchema}.${referencedTable} table.`
+      : 'Only the primary and unique keys of the referenced table are listed here.';
 
   return (
-    <ControlledSelect
-      id="referencedColumn"
+    <FormSelect
+      control={control}
       name="referencedColumn"
       label="Column"
-      fullWidth
+      placeholder="Select a column"
       disabled={
         !columnName ||
         !referencedSchema ||
         !referencedTable ||
         availableColumnsInSelectedTable.length === 0
       }
-      placeholder="Select a column"
-      slotProps={{ listbox: { className: 'max-h-[13rem]' } }}
-      hideEmptyHelperText
-      error={Boolean(errors.referencedColumn)}
-      helperText={
-        typeof errors?.referencedColumn?.message === 'string'
-          ? errors?.referencedColumn?.message
-          : helperText
-      }
+      helperText={helperText}
+      helperTextClassName="text-xs break-normal"
+      contentClassName="z-[1400]"
     >
       {availableColumnsInSelectedTable.map((name) => (
-        <Option value={name} key={name}>
+        <SelectItem value={name} key={name}>
           {name}
-        </Option>
+        </SelectItem>
       ))}
-    </ControlledSelect>
+    </FormSelect>
   );
 }

--- a/dashboard/src/features/orgs/projects/database/dataGrid/components/BaseForeignKeyForm/ReferencedSchemaSelect.tsx
+++ b/dashboard/src/features/orgs/projects/database/dataGrid/components/BaseForeignKeyForm/ReferencedSchemaSelect.tsx
@@ -1,61 +1,52 @@
-import type { ForwardedRef, PropsWithoutRef } from 'react';
-import { forwardRef } from 'react';
-import { useFormContext, useFormState } from 'react-hook-form';
-import type { ControlledSelectProps } from '@/components/form/ControlledSelect';
-import { ControlledSelect } from '@/components/form/ControlledSelect';
-import { Option } from '@/components/ui/v2/Option';
+import { useFormContext } from 'react-hook-form';
+import { FormSelect } from '@/components/form/FormSelect';
+import { SelectItem } from '@/components/ui/v3/select';
 import type { NormalizedQueryDataRow } from '@/features/orgs/projects/database/dataGrid/types/dataBrowser';
 import type { BaseForeignKeySchemaValues } from './BaseForeignKeyForm';
 
-export interface ReferencedSchemaSelectProps
-  extends PropsWithoutRef<ControlledSelectProps> {
+export interface ReferencedSchemaSelectProps {
   /**
    * Available schemas in the database.
    */
   options: NormalizedQueryDataRow[];
+  /**
+   * Determines whether the select should be focused on mount.
+   */
+  autoFocus?: boolean;
 }
 
-const ReferencedSchemaSelect = forwardRef(
-  (
-    { options, ...props }: ReferencedSchemaSelectProps,
-    ref: ForwardedRef<HTMLButtonElement>,
-  ) => {
-    const { setValue } = useFormContext<BaseForeignKeySchemaValues>();
-    const { errors } = useFormState({ name: 'referencedSchema' });
+export default function ReferencedSchemaSelect({
+  options,
+  autoFocus,
+}: ReferencedSchemaSelectProps) {
+  const { control, setValue } = useFormContext<BaseForeignKeySchemaValues>();
 
-    const availableSchemas = options.map(
-      ({ schema_name: schemaName }) => schemaName,
-    );
+  const availableSchemas = options.map(
+    ({ schema_name: schemaName }) => schemaName,
+  );
 
-    return (
-      <ControlledSelect
-        {...props}
-        ref={ref}
-        id="referencedSchema"
-        name="referencedSchema"
-        label="Schema"
-        fullWidth
-        placeholder="Select a schema"
-        hideEmptyHelperText
-        error={Boolean(errors.referencedSchema)}
-        helperText={
-          typeof errors.referencedSchema?.message === 'string'
-            ? errors.referencedSchema?.message
-            : ''
-        }
-        onChange={() => {
+  return (
+    <FormSelect
+      control={control}
+      name="referencedSchema"
+      label="Schema"
+      placeholder="Select a schema"
+      autoFocus={autoFocus}
+      contentClassName="z-[1400]"
+      transform={{
+        in: (value: string) => value ?? '',
+        out: (value: string) => {
           setValue('referencedTable', '');
           setValue('referencedColumn', '');
-        }}
-      >
-        {availableSchemas.map((name) => (
-          <Option value={name} key={name}>
-            {name}
-          </Option>
-        ))}
-      </ControlledSelect>
-    );
-  },
-);
-
-export default ReferencedSchemaSelect;
+          return value;
+        },
+      }}
+    >
+      {availableSchemas.map((name) => (
+        <SelectItem value={name} key={name}>
+          {name}
+        </SelectItem>
+      ))}
+    </FormSelect>
+  );
+}

--- a/dashboard/src/features/orgs/projects/database/dataGrid/components/BaseForeignKeyForm/ReferencedTableSelect.tsx
+++ b/dashboard/src/features/orgs/projects/database/dataGrid/components/BaseForeignKeyForm/ReferencedTableSelect.tsx
@@ -1,6 +1,6 @@
-import { useFormContext, useFormState, useWatch } from 'react-hook-form';
-import { ControlledSelect } from '@/components/form/ControlledSelect';
-import { Option } from '@/components/ui/v2/Option';
+import { useFormContext, useWatch } from 'react-hook-form';
+import { FormSelect } from '@/components/form/FormSelect';
+import { SelectItem } from '@/components/ui/v3/select';
 import type { NormalizedQueryDataRow } from '@/features/orgs/projects/database/dataGrid/types/dataBrowser';
 import type { BaseForeignKeySchemaValues } from './BaseForeignKeyForm';
 
@@ -14,8 +14,7 @@ export interface ReferencedTableSelectProps {
 export default function ReferencedTableSelect({
   options,
 }: ReferencedTableSelectProps) {
-  const { setValue } = useFormContext<BaseForeignKeySchemaValues>();
-  const { errors } = useFormState({ name: 'referencedTable' });
+  const { control, setValue } = useFormContext<BaseForeignKeySchemaValues>();
   const columnName = useWatch({ name: 'columnName' });
   const referencedSchema = useWatch({ name: 'referencedSchema' });
 
@@ -24,30 +23,26 @@ export default function ReferencedTableSelect({
     .map(({ table_name: tableName }) => tableName);
 
   return (
-    <ControlledSelect
-      id="referencedTable"
+    <FormSelect
+      control={control}
       name="referencedTable"
       label="Table"
-      fullWidth
-      disabled={!columnName || !referencedSchema}
       placeholder="Select a table"
-      slotProps={{ listbox: { className: 'max-h-[13rem]' } }}
-      hideEmptyHelperText
-      error={Boolean(errors.referencedTable)}
-      helperText={
-        typeof errors.referencedTable?.message === 'string'
-          ? errors.referencedTable?.message
-          : ''
-      }
-      onChange={() => {
-        setValue('referencedColumn', '');
+      disabled={!columnName || !referencedSchema}
+      contentClassName="z-[1400]"
+      transform={{
+        in: (value: string) => value ?? '',
+        out: (value: string) => {
+          setValue('referencedColumn', '');
+          return value;
+        },
       }}
     >
       {availableTablesInSelectedSchema.map((name) => (
-        <Option value={name} key={name}>
+        <SelectItem value={name} key={name}>
           {name}
-        </Option>
+        </SelectItem>
       ))}
-    </ControlledSelect>
+    </FormSelect>
   );
 }

--- a/dashboard/src/features/orgs/projects/database/dataGrid/components/ColumnAutocomplete/types.ts
+++ b/dashboard/src/features/orgs/projects/database/dataGrid/components/ColumnAutocomplete/types.ts
@@ -1,0 +1,27 @@
+export interface AutocompleteOption<TValue = string> {
+  /**
+   * Label to display.
+   */
+  label: string;
+  /**
+   * Label to display in the dropdown.
+   */
+  dropdownLabel?: string;
+  /**
+   * Value to be submitted.
+   */
+  value: TValue;
+  /**
+   * Determines whether the option is custom.
+   */
+  custom?: boolean;
+  /**
+   * Value that can be used to group options.
+   */
+  group?: string;
+  /**
+   * Any additional data to be passed to the option.
+   */
+  // biome-ignore lint/suspicious/noExplicitAny: option metadata is intentionally untyped
+  metadata?: any;
+}

--- a/dashboard/src/features/orgs/projects/database/dataGrid/components/ColumnAutocomplete/useAsyncValue.ts
+++ b/dashboard/src/features/orgs/projects/database/dataGrid/components/ColumnAutocomplete/useAsyncValue.ts
@@ -1,8 +1,8 @@
 import { useEffect, useState } from 'react';
-import type { AutocompleteOption } from '@/components/ui/v2/Autocomplete';
 import type { FetchTableSchemaReturnType } from '@/features/orgs/projects/database/common/hooks/useTableSchemaQuery';
 import type { FetchMetadataReturnType } from '@/features/orgs/projects/database/dataGrid/hooks/useMetadataQuery';
 import type { HasuraMetadataTable } from '@/features/orgs/projects/database/dataGrid/types/dataBrowser';
+import type { AutocompleteOption } from './types';
 
 export interface UseAsyncValueOptions {
   /**

--- a/dashboard/src/features/orgs/projects/database/dataGrid/components/ColumnAutocomplete/useColumnGroups.ts
+++ b/dashboard/src/features/orgs/projects/database/dataGrid/components/ColumnAutocomplete/useColumnGroups.ts
@@ -1,7 +1,7 @@
-import type { AutocompleteOption } from '@/components/ui/v2/Autocomplete';
 import type { FetchTableSchemaReturnType } from '@/features/orgs/projects/database/common/hooks/useTableSchemaQuery';
 import type { FetchMetadataReturnType } from '@/features/orgs/projects/database/dataGrid/hooks/useMetadataQuery';
 import { isNotEmptyValue } from '@/lib/utils';
+import type { AutocompleteOption } from './types';
 
 export interface UseColumnGroupsOptions {
   /**

--- a/dashboard/src/features/orgs/projects/database/dataGrid/components/CreateForeignKeyForm/CreateForeignKeyForm.tsx
+++ b/dashboard/src/features/orgs/projects/database/dataGrid/components/CreateForeignKeyForm/CreateForeignKeyForm.tsx
@@ -2,8 +2,8 @@ import { yupResolver } from '@hookform/resolvers/yup';
 import { useState } from 'react';
 import { FormProvider, useForm } from 'react-hook-form';
 import type * as Yup from 'yup';
-import { Alert } from '@/components/ui/v2/Alert';
-import { Button } from '@/components/ui/v2/Button';
+import { Alert } from '@/components/ui/v3/alert';
+import { Button } from '@/components/ui/v3/button';
 import type {
   BaseForeignKeyFormProps,
   BaseForeignKeyFormValues,
@@ -68,18 +68,18 @@ export default function CreateForeignKeyForm({
       {error && (
         <div className="mb-4 px-6">
           <Alert
-            severity="error"
-            className="grid grid-flow-col items-center justify-between px-4 py-3"
+            variant="destructive"
+            className="grid grid-flow-col items-center justify-between border-none bg-destructive/20 px-4 py-3"
           >
             <span className="text-left">
               <strong>Error:</strong> {error.message}
             </span>
 
             <Button
-              variant="borderless"
-              color="error"
-              size="small"
               onClick={() => setError(null)}
+              size="sm"
+              variant="destructive"
+              className="bg-transparent text-destructive hover:bg-destructive/10"
             >
               Clear
             </Button>

--- a/dashboard/src/features/orgs/projects/database/dataGrid/components/CreateTableForm/CreateTableForm.tsx
+++ b/dashboard/src/features/orgs/projects/database/dataGrid/components/CreateTableForm/CreateTableForm.tsx
@@ -4,8 +4,8 @@ import { useState } from 'react';
 import { FormProvider, useForm } from 'react-hook-form';
 import type * as Yup from 'yup';
 import { useDialog } from '@/components/common/DialogProvider';
-import { Alert } from '@/components/ui/v2/Alert';
-import { Button } from '@/components/ui/v2/Button';
+import { Alert } from '@/components/ui/v3/alert';
+import { Button } from '@/components/ui/v3/button';
 import { useGetMetadataResourceVersion } from '@/features/orgs/projects/common/hooks/useGetMetadataResourceVersion';
 import type {
   BaseTableFormProps,
@@ -171,21 +171,21 @@ export default function CreateTableForm({
       {error && error instanceof Error ? (
         <div className="-mt-3 mb-4 px-6">
           <Alert
-            severity="error"
-            className="grid grid-flow-col items-center justify-between px-4 py-3"
+            variant="destructive"
+            className="grid grid-flow-col items-center justify-between border-none bg-destructive/20 px-4 py-3"
           >
             <span className="text-left">
               <strong>Error:</strong> {error.message}
             </span>
 
             <Button
-              variant="borderless"
-              color="secondary"
-              className="p-1"
               onClick={() => {
                 resetCreateError();
                 resetTrackError();
               }}
+              size="sm"
+              variant="destructive"
+              className="bg-transparent text-destructive hover:bg-destructive/10"
             >
               Clear
             </Button>

--- a/dashboard/src/features/orgs/projects/database/dataGrid/components/EditForeignKeyForm/EditForeignKeyForm.tsx
+++ b/dashboard/src/features/orgs/projects/database/dataGrid/components/EditForeignKeyForm/EditForeignKeyForm.tsx
@@ -2,8 +2,8 @@ import { yupResolver } from '@hookform/resolvers/yup';
 import { useState } from 'react';
 import { FormProvider, useForm } from 'react-hook-form';
 import type * as Yup from 'yup';
-import { Alert } from '@/components/ui/v2/Alert';
-import { Button } from '@/components/ui/v2/Button';
+import { Alert } from '@/components/ui/v3/alert';
+import { Button } from '@/components/ui/v3/button';
 import type {
   BaseForeignKeyFormProps,
   BaseForeignKeyFormValues,
@@ -78,18 +78,18 @@ export default function EditForeignKeyForm({
       {error && (
         <div className="mb-4 px-6">
           <Alert
-            severity="error"
-            className="grid grid-flow-col items-center justify-between px-4 py-3"
+            variant="destructive"
+            className="grid grid-flow-col items-center justify-between border-none bg-destructive/20 px-4 py-3"
           >
             <span className="text-left">
               <strong>Error:</strong> {error.message}
             </span>
 
             <Button
-              variant="borderless"
-              color="error"
-              size="small"
               onClick={() => setError(null)}
+              size="sm"
+              variant="destructive"
+              className="bg-transparent text-destructive hover:bg-destructive/10"
             >
               Clear
             </Button>

--- a/dashboard/src/features/orgs/projects/database/dataGrid/components/EditTableForm/EditTableForm.tsx
+++ b/dashboard/src/features/orgs/projects/database/dataGrid/components/EditTableForm/EditTableForm.tsx
@@ -3,9 +3,9 @@ import { useRouter } from 'next/router';
 import { useEffect, useState } from 'react';
 import { FormProvider, useForm } from 'react-hook-form';
 import type * as Yup from 'yup';
-import { ActivityIndicator } from '@/components/ui/v2/ActivityIndicator';
-import { Alert } from '@/components/ui/v2/Alert';
-import { Button } from '@/components/ui/v2/Button';
+import { Alert } from '@/components/ui/v3/alert';
+import { Button } from '@/components/ui/v3/button';
+import { Spinner } from '@/components/ui/v3/spinner';
 import { useTableSchemaQuery } from '@/features/orgs/projects/database/common/hooks/useTableSchemaQuery';
 import type {
   BaseTableFormProps,
@@ -205,7 +205,13 @@ export default function EditTableForm({
   if (columnsStatus === 'loading') {
     return (
       <div className="px-6">
-        <ActivityIndicator label="Loading columns..." delay={1000} />
+        <Spinner
+          delay={1000}
+          wrapperClassName="flex-row text-[12px] leading-[1.66] font-normal gap-1"
+          className="h-4 w-4 justify-center"
+        >
+          Loading columns...
+        </Spinner>
       </div>
     );
   }
@@ -213,7 +219,13 @@ export default function EditTableForm({
   if (!formInitialized) {
     return (
       <div className="px-6">
-        <ActivityIndicator label="Loading..." delay={1000} />
+        <Spinner
+          delay={1000}
+          wrapperClassName="flex-row text-[12px] leading-[1.66] font-normal gap-1"
+          className="h-4 w-4 justify-center"
+        >
+          Loading...
+        </Spinner>
       </div>
     );
   }
@@ -221,7 +233,10 @@ export default function EditTableForm({
   if (columnsStatus === 'error') {
     return (
       <div className="-mt-3 px-6">
-        <Alert severity="error" className="text-left">
+        <Alert
+          variant="destructive"
+          className="border-none bg-destructive/20 px-4 py-3 text-left"
+        >
           <strong>Error:</strong>{' '}
           {columnsError && columnsError instanceof Error
             ? columnsError?.message
@@ -236,18 +251,18 @@ export default function EditTableForm({
       {error && error instanceof Error ? (
         <div className="-mt-3 mb-4 px-6">
           <Alert
-            severity="error"
-            className="grid grid-flow-col items-center justify-between px-4 py-3"
+            variant="destructive"
+            className="grid grid-flow-col items-center justify-between border-none bg-destructive/20 px-4 py-3"
           >
             <span className="text-left">
               <strong>Error:</strong> {error.message}
             </span>
 
             <Button
-              variant="borderless"
-              color="error"
-              size="small"
               onClick={resetError}
+              size="sm"
+              variant="destructive"
+              className="bg-transparent text-destructive hover:bg-destructive/10"
             >
               Clear
             </Button>


### PR DESCRIPTION
### Checklist

- [x] No breaking changes
- [x] Tests pass
- [ ] New features have new tests
- [ ] Documentation is updated (if applicable)
- [x] Title of the PR is in the correct format (see below)

<!-- nhost-reviewer:start -->
### **What this PR solves**
The Foreign Key form (and the surrounding Create/Edit Table and Foreign Key forms) still relied on legacy v2 MUI components (`ControlledSelect`, `Box`, `Divider`, `Text`, `Alert`, `Button`, `ActivityIndicator`). This PR migrates them to the v3 design system (`FormSelect`, native HTML elements, `v3/button`, `v3/alert`, `v3/spinner`), so the database forms render with the current UI primitives and consistent styling.

___

### **PR Type**
Refactoring

___

### **Description**
- Migrated `BaseForeignKeyForm` and its sub-selects (`ReferencedSchemaSelect`, `ReferencedTableSelect`, `ReferencedColumnSelect`) from `ControlledSelect`/v2 layout primitives to `FormSelect` and native HTML elements, using RHF `transform` for cascade-reset side effects and `form.subscribe` for dirty-state tracking.
- Extended the shared `FormSelect` component with `contentClassName`, `helperTextClassName`, and `autoFocus` props to support dropdown z-index raising inside MUI dialogs and focus-on-mount behavior.
- Migrated `CreateForeignKeyForm`, `CreateTableForm`, `EditForeignKeyForm`, and `EditTableForm` from v2 `Alert`/`Button`/`ActivityIndicator` to v3 `alert`/`button`/`spinner`.
- Extracted a local `AutocompleteOption` type into `ColumnAutocomplete/types.ts` and repointed `useAsyncValue`/`useColumnGroups` imports to it (decoupling from the v2 Autocomplete type).
- Updated e2e tests to select columns by accessible role (`getByRole('combobox', { name: 'Column' })`) instead of v2 element IDs (`#columnName`, `#referencedColumn`).

___

<details> <summary><h3> File Walkthrough</h3></summary>

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody>
<tr><td><strong>Foreign Key form</strong></td><td><details><summary>4 files</summary><table>
<tr>
  <td><strong>BaseForeignKeyForm.tsx</strong><dd><code>Migrate form to FormSelect/v3 button and subscribe-based dirty tracking</code></dd></td>
  <td><a href="https://github.com/nhost/nhost/pull/4413/files#diff-cbe94cfc99f8a498d6dad78f69b72f41b3841a67f244aa10b8916424e4d8c9bc">+70/-66</a></td>
</tr>
<tr>
  <td><strong>ReferencedSchemaSelect.tsx</strong><dd><code>Convert to FormSelect, use transform for cascade reset</code></dd></td>
  <td><a href="https://github.com/nhost/nhost/pull/4413/files#diff-450038e1607012a27e047ef0fa3e7c3ba58a4be7750940aa21c7166713b15c76">+39/-48</a></td>
</tr>
<tr>
  <td><strong>ReferencedColumnSelect.tsx</strong><dd><code>Convert to FormSelect, simplify helper text to plain strings</code></dd></td>
  <td><a href="https://github.com/nhost/nhost/pull/4413/files#diff-7e9afa554ed7f130247a48e4a3cee02968bb3b5af5955e0f5d9020faf146a4a9">+17/-33</a></td>
</tr>
<tr>
  <td><strong>ReferencedTableSelect.tsx</strong><dd><code>Convert to FormSelect, use transform for cascade reset</code></dd></td>
  <td><a href="https://github.com/nhost/nhost/pull/4413/files#diff-78b98fbc309a889022b7fc1ca9e2f694022503cedb56a4f16ef4c3f1cdb9e73d">+17/-22</a></td>
</tr>
</table></details></td></tr>
<tr><td><strong>Shared form component</strong></td><td><details><summary>1 files</summary><table>
<tr>
  <td><strong>FormSelect.tsx</strong><dd><code>Add contentClassName, helperTextClassName, and autoFocus props</code></dd></td>
  <td><a href="https://github.com/nhost/nhost/pull/4413/files#diff-890ea1e64209c6159a561e86234617ecf523cdfd7310c31e2bde84ce2b68b006">+15/-2</a></td>
</tr>
</table></details></td></tr>
<tr><td><strong>Other database forms</strong></td><td><details><summary>4 files</summary><table>
<tr>
  <td><strong>EditTableForm.tsx</strong><dd><code>Migrate Alert/Button/ActivityIndicator to v3 spinner/alert/button</code></dd></td>
  <td><a href="https://github.com/nhost/nhost/pull/4413/files#diff-e628e74884ed048e1498960b80ad4d2a9fa6b4e05c89545c404e0ed50b43e50a">+26/-11</a></td>
</tr>
<tr>
  <td><strong>CreateForeignKeyForm.tsx</strong><dd><code>Migrate Alert/Button to v3</code></dd></td>
  <td><a href="https://github.com/nhost/nhost/pull/4413/files#diff-539f8dec6d78ec1015e698fdb851d8c3948afe3c3db8a2a002d41f004a88c1c5">+7/-7</a></td>
</tr>
<tr>
  <td><strong>CreateTableForm.tsx</strong><dd><code>Migrate Alert/Button to v3</code></dd></td>
  <td><a href="https://github.com/nhost/nhost/pull/4413/files#diff-ccbaedba43e2b50ee80f458d1ff1dc37739dae73f266e1f18aeaebb427be1c4c">+7/-7</a></td>
</tr>
<tr>
  <td><strong>EditForeignKeyForm.tsx</strong><dd><code>Migrate Alert/Button to v3</code></dd></td>
  <td><a href="https://github.com/nhost/nhost/pull/4413/files#diff-0a8e488a969d2958c347526f9d63a236242a84c91c23a48a5de05aa83f4cc763">+7/-7</a></td>
</tr>
</table></details></td></tr>
<tr><td><strong>ColumnAutocomplete types</strong></td><td><details><summary>3 files</summary><table>
<tr>
  <td><strong>types.ts</strong><dd><code>New local AutocompleteOption type</code></dd></td>
  <td><a href="https://github.com/nhost/nhost/pull/4413/files#diff-749a192f7e59c31ec9c8d913c837bde9954c6503bddcf48f9b8510868bc4ef23">+27/-0</a></td>
</tr>
<tr>
  <td><strong>useAsyncValue.ts</strong><dd><code>Repoint AutocompleteOption import to local types</code></dd></td>
  <td><a href="https://github.com/nhost/nhost/pull/4413/files#diff-154398dc1685c03bb632fa8ad690d8d1a83a4376e9b5128cb1d6566b7ed51ec4">+1/-1</a></td>
</tr>
<tr>
  <td><strong>useColumnGroups.ts</strong><dd><code>Repoint AutocompleteOption import to local types</code></dd></td>
  <td><a href="https://github.com/nhost/nhost/pull/4413/files#diff-5e0216d402f78429c7c284e099190e3fa6bd13bfb131d947a04f924ba527c7fd">+1/-1</a></td>
</tr>
</table></details></td></tr>
<tr><td><strong>E2E tests</strong></td><td><details><summary>3 files</summary><table>
<tr>
  <td><strong>multiple-foreign-keys.test.ts</strong><dd><code>Select columns by role instead of element ID</code></dd></td>
  <td><a href="https://github.com/nhost/nhost/pull/4413/files#diff-798ae5d1269a08a9cf2907550b34233a042bb18bece2b8570595ee91fd4d8a7b">+10/-10</a></td>
</tr>
<tr>
  <td><strong>create-table.test.ts</strong><dd><code>Select columns by role instead of element ID</code></dd></td>
  <td><a href="https://github.com/nhost/nhost/pull/4413/files#diff-19e0c464bd95747dc862948978817a9f694a2429db29608c43f440928b773c40">+2/-2</a></td>
</tr>
<tr>
  <td><strong>delete-table.test.ts</strong><dd><code>Select columns by role instead of element ID</code></dd></td>
  <td><a href="https://github.com/nhost/nhost/pull/4413/files#diff-e8b79d5488f1d332b6cab70f3b9abcde7d3929ad030836af4b70eb39e75d954f">+2/-2</a></td>
</tr>
</table></details></td></tr>
</tbody></table>

</details>

___

<!-- nhost-reviewer:end -->
