### PR TITLE
fix(constellation): apply remote-schema presets under non-default root types

### DIFF
--- a/services/constellation/connector/remoteschema/connector.go
+++ b/services/constellation/connector/remoteschema/connector.go
@@ -224,6 +224,30 @@ func (c *Connector) GetTypeName(identifier string) string {
 	return ""
 }
 
+func (c *Connector) roleRootTypeName(role string, operation ast.Operation) string {
+	schema := c.schemas[role]
+	if schema == nil {
+		return defaultRootTypeName(operation)
+	}
+
+	switch operation {
+	case ast.Query:
+		if schema.QueryType != nil {
+			return *schema.QueryType
+		}
+	case ast.Mutation:
+		if schema.MutationType != nil {
+			return *schema.MutationType
+		}
+	case ast.Subscription:
+		if schema.SubscriptionType != nil {
+			return *schema.SubscriptionType
+		}
+	}
+
+	return defaultRootTypeName(operation)
+}
+
 // Close releases connector-owned resources. Currently a no-op because the
 // remote schema connector borrows its HTTP transport from the caller and
 // holds no other state requiring shutdown.
@@ -240,7 +264,12 @@ func (c *Connector) Execute(
 	sessionVariables map[string]any,
 	logger *slog.Logger,
 ) (map[string]any, error) {
-	modifiedOp := applyPresets(operation, c.presets[role], sessionVariables)
+	rootTypeName := ""
+	if operation != nil {
+		rootTypeName = c.roleRootTypeName(role, operation.Operation)
+	}
+
+	modifiedOp := applyPresets(operation, c.presets[role], sessionVariables, rootTypeName)
 	query := buildQueryString(modifiedOp, fragments)
 
 	var clientHeaders http.Header

--- a/services/constellation/connector/remoteschema/connector_test.go
+++ b/services/constellation/connector/remoteschema/connector_test.go
@@ -1135,6 +1135,151 @@ func TestExecute_AppliesPresets(t *testing.T) {
 	}
 }
 
+// TestExecute_AppliesPresetsWithNonDefaultRootType exercises the dashboard-style
+// permission SDL shape `schema { query: query_root }` (and the mutation/
+// subscription equivalents). Presets are stored under the SDL root type name, so
+// Execute must look them up with that real root name rather than the
+// operation-kind default ("Query"/"Mutation"/"Subscription"). The mutation and
+// subscription cases are the only coverage of the corresponding
+// schema.MutationType / schema.SubscriptionType branches of roleRootTypeName.
+func TestExecute_AppliesPresetsWithNonDefaultRootType(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name      string
+		sdl       string
+		operation ast.Operation
+		field     string
+		// response is the remote endpoint's reply for the operation call; its
+		// top-level data key must match field so Execute returns it intact.
+		response string
+	}{
+		{
+			name: "query",
+			sdl: `
+				schema { query: query_root }
+				type query_root {
+					qthings(tenantId: String @preset(value: "x-hasura-tenant-id")): [Thing!]!
+				}
+				type Thing {
+					id: String
+					tenantId: String
+				}
+			`,
+			operation: ast.Query,
+			field:     "qthings",
+			response:  `{"data":{"qthings":[{"id":"thing-1","tenantId":"tenant-A"}]}}`,
+		},
+		{
+			name: "mutation",
+			sdl: `
+				schema { mutation: mutation_root }
+				type mutation_root {
+					createThing(tenantId: String @preset(value: "x-hasura-tenant-id")): Thing
+				}
+				type Thing {
+					id: String
+					tenantId: String
+				}
+			`,
+			operation: ast.Mutation,
+			field:     "createThing",
+			response:  `{"data":{"createThing":{"id":"thing-1","tenantId":"tenant-A"}}}`,
+		},
+		{
+			name: "subscription",
+			sdl: `
+				schema { subscription: subscription_root }
+				type subscription_root {
+					watchThing(tenantId: String @preset(value: "x-hasura-tenant-id")): Thing
+				}
+				type Thing {
+					id: String
+					tenantId: String
+				}
+			`,
+			operation: ast.Subscription,
+			field:     "watchThing",
+			response:  `{"data":{"watchThing":{"id":"thing-1","tenantId":"tenant-A"}}}`,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+
+			ctrl := gomock.NewController(t)
+			mockDoer := mock.NewMockHTTPDoer(ctrl)
+
+			introspectionCall := mockDoer.EXPECT().Do(gomock.Any()).Return(&http.Response{
+				StatusCode: http.StatusOK,
+				Body:       io.NopCloser(strings.NewReader(testIntrospectionResponse)),
+			}, nil)
+
+			var capturedBody string
+
+			executeCall := mockDoer.EXPECT().Do(gomock.Any()).DoAndReturn(
+				func(req *http.Request) (*http.Response, error) {
+					capturedBody = string(readAllOrFail(t, req.Body))
+
+					return &http.Response{
+						StatusCode: http.StatusOK,
+						Body:       io.NopCloser(strings.NewReader(tt.response)),
+					}, nil
+				},
+			)
+
+			gomock.InOrder(introspectionCall, executeCall)
+
+			meta := newTestMetadata("http://example.com", []metadata.RemoteSchemaPermission{
+				{
+					Role: "user",
+					Definition: metadata.RemoteSchemaPermissionDef{
+						Schema: tt.sdl,
+					},
+				},
+			})
+
+			connector, err := remoteschema.New(context.Background(), meta, mockDoer)
+			if err != nil {
+				t.Fatalf("New() error: %v", err)
+			}
+
+			op := &ast.OperationDefinition{
+				Operation: tt.operation,
+				SelectionSet: ast.SelectionSet{
+					&ast.Field{
+						Name: tt.field,
+						SelectionSet: ast.SelectionSet{
+							&ast.Field{Name: "id"},
+							&ast.Field{Name: "tenantId"},
+						},
+					},
+				},
+			}
+
+			sessionVars := map[string]any{
+				"x-hasura-tenant-id": "tenant-A",
+			}
+
+			_, err = connector.Execute(
+				context.Background(), op, nil, nil, "user", sessionVars, slog.Default(),
+			)
+			if err != nil {
+				t.Fatalf("Execute error: %v", err)
+			}
+
+			if !strings.Contains(capturedBody, `tenantId:\"tenant-A\"`) &&
+				!strings.Contains(capturedBody, `tenantId: \"tenant-A\"`) {
+				t.Errorf(
+					"expected preset-injected tenantId argument in outgoing %s, got: %s",
+					tt.name, capturedBody,
+				)
+			}
+		})
+	}
+}
+
 // TestExecute_AppliesPresetsInInlineFragment exercises the inline-fragment
 // branch of applyPresetsToSelectionSet: the operation wraps the preset-bearing
 // field in `... on Query`, so the walker must descend into the fragment using

--- a/services/constellation/connector/remoteschema/execute.go
+++ b/services/constellation/connector/remoteschema/execute.go
@@ -27,24 +27,30 @@ type graphQLResponse struct {
 }
 
 // applyPresets modifies an operation to inject preset argument values.
-// It clones the operation to avoid mutating the original.
+// rootTypeName must be the role schema's actual root type name, since preset
+// keys are extracted from the permission SDL's type names. It clones the
+// operation to avoid mutating the original.
 func applyPresets(
 	operation *ast.OperationDefinition,
 	presets map[string][]presetArg,
 	sessionVariables map[string]any,
+	rootTypeName string,
 ) *ast.OperationDefinition {
-	if len(presets) == 0 {
+	if operation == nil || len(presets) == 0 {
 		return operation
 	}
 
 	cloned := cloneOperation(operation)
-	rootTypeName := getRootTypeName(cloned.Operation)
+	if rootTypeName == "" {
+		rootTypeName = defaultRootTypeName(cloned.Operation)
+	}
+
 	applyPresetsToSelectionSet(cloned.SelectionSet, rootTypeName, presets, sessionVariables)
 
 	return cloned
 }
 
-func getRootTypeName(op ast.Operation) string {
+func defaultRootTypeName(op ast.Operation) string {
 	switch op {
 	case ast.Query:
 		return "Query" //nolint:goconst,nolintlint

--- a/services/constellation/connector/remoteschema/execute_internal_test.go
+++ b/services/constellation/connector/remoteschema/execute_internal_test.go
@@ -145,7 +145,7 @@ func TestApplyPresets(t *testing.T) {
 			},
 		}
 
-		result := applyPresets(op, nil, nil)
+		result := applyPresets(op, nil, nil, "Query")
 		// When no presets, should return the original operation
 		if result != op {
 			t.Error("expected same operation when no presets")
@@ -172,7 +172,7 @@ func TestApplyPresets(t *testing.T) {
 			"x-hasura-user-id": "user-789",
 		}
 
-		result := applyPresets(op, presets, sessionVars)
+		result := applyPresets(op, presets, sessionVars, "Query")
 
 		// Should be a clone, not the original
 		if result == op {
@@ -213,7 +213,7 @@ func TestApplyPresets(t *testing.T) {
 			},
 		}
 
-		_ = applyPresets(op, presets, nil)
+		_ = applyPresets(op, presets, nil, "Query")
 
 		// Original operation should not have the injected argument
 		origField, ok := op.SelectionSet[0].(*ast.Field)
@@ -356,7 +356,7 @@ func TestBuildQueryString(t *testing.T) {
 	})
 }
 
-func TestGetRootTypeName(t *testing.T) {
+func TestDefaultRootTypeName(t *testing.T) {
 	t.Parallel()
 
 	tests := []struct {
@@ -369,8 +369,8 @@ func TestGetRootTypeName(t *testing.T) {
 	}
 
 	for _, tt := range tests {
-		if got := getRootTypeName(tt.op); got != tt.want {
-			t.Errorf("getRootTypeName(%v) = %s, want %s", tt.op, got, tt.want)
+		if got := defaultRootTypeName(tt.op); got != tt.want {
+			t.Errorf("defaultRootTypeName(%v) = %s, want %s", tt.op, got, tt.want)
 		}
 	}
 }


### PR DESCRIPTION
<!-- nhost-reviewer:start -->
### **What this PR solves**
Remote-schema permission presets were silently dropped whenever a role's SDL used a non-default root type name (e.g. `schema { query: query_root }`), because preset arguments were looked up under the operation-kind default (`Query`) rather than the schema's real root type. This change resolves the per-role root type name before applying presets, so session-variable presets are injected correctly for dashboard-style remote schemas. It also reworks the `services/storage/controller` `//nolint` directives into documented leading-comment form.

___

### **PR Type**
Bug fix

___

### **Description**
- Add `(*Connector).roleRootTypeName` to resolve a role's actual GraphQL root type name from its remote-schema SDL, falling back to the operation-kind default when the schema or root type is absent.
- Thread the resolved root type name into `applyPresets` so presets keyed by the SDL root type are matched; guard against a `nil` operation and rename `getRootTypeName` → `defaultRootTypeName`.
- Add regression test `TestExecute_AppliesPresetsWithNonDefaultRootType` covering the `query_root` SDL shape, and update internal tests for the new `applyPresets` signature.
- Convert every `//nolint` directive in `services/storage/controller` from a trailing inline comment to a leading directive with a written justification (no behavior change).

___

### Diagram Walkthrough

```mermaid
flowchart LR
  E["Execute(role, operation)"] --> R{"operation != nil?"}
  R -- no --> AP["applyPresets is a no-op"]
  R -- yes --> RT["roleRootTypeName(role, op)"]
  RT --> S{"role schema has<br/>matching root type?"}
  S -- yes --> N1["use SDL root type<br/>e.g. query_root"]
  S -- no --> N2["defaultRootTypeName<br/>Query / Mutation / Subscription"]
  N1 --> AP2["applyPresets(op, presets, vars, rootTypeName)"]
  N2 --> AP2
  AP2 --> Q["buildQueryString to upstream"]
```

<details> <summary><h3> File Walkthrough</h3></summary>

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody>
<tr><td><strong>Bug fix</strong></td><td><details><summary>2 files</summary><table>
<tr>
  <td><strong>connector.go</strong><dd><code>Resolve a role's real SDL root type name before applying presets.</code></dd></td>
  <td><a href="https://github.com/nhost/nhost/pull/XXX/files#diff-72077cda245f97e0692f1255d2d4a8dae399c6b86ec23bad501b6acd0285d308">+30/-1</a></td>
</tr>
<tr>
  <td><strong>execute.go</strong><dd><code>Accept an explicit rootTypeName, guard nil operation, rename helper to defaultRootTypeName.</code></dd></td>
  <td><a href="https://github.com/nhost/nhost/pull/XXX/files#diff-3b36684d0c2e069a7a80437af5e08e96088b3e33288d9a874eadab65953220c6">+10/-4</a></td>
</tr>
</table></details></td></tr>
<tr><td><strong>Tests</strong></td><td><details><summary>2 files</summary><table>
<tr>
  <td><strong>connector_test.go</strong><dd><code>Add regression test for presets under a non-default (query_root) root type.</code></dd></td>
  <td><a href="https://github.com/nhost/nhost/pull/XXX/files#diff-fc0d032b0120918dbd02b05ca68bc651eca18127d953ca60a21d67b1c017a0d2">+90/-0</a></td>
</tr>
<tr>
  <td><strong>execute_internal_test.go</strong><dd><code>Update applyPresets calls for the new signature; rename TestGetRootTypeName.</code></dd></td>
  <td><a href="https://github.com/nhost/nhost/pull/XXX/files#diff-a3e831bde4e4fc58bc64dd257ed85ed35ae8cf991d107169e33425582808b734">+6/-6</a></td>
</tr>
</table></details></td></tr>
<tr><td><strong>Lint directives</strong></td><td><details><summary>14 files</summary><table>
<tr>
  <td><strong>get_file.go</strong><dd><code>Move ireturn/dupl/funlen nolints to leading form with justifications (2 helpers + handler).</code></dd></td>
  <td><a href="https://github.com/nhost/nhost/pull/XXX/files#diff-d41af2374eb5382e529af51602911ab58609676b9d4226ae7634d7c76fe6b879">+6/-3</a></td>
</tr>
<tr>
  <td><strong>get_file_metadata_headers.go</strong><dd><code>Move three ireturn nolints to leading form with justifications.</code></dd></td>
  <td><a href="https://github.com/nhost/nhost/pull/XXX/files#diff-4acef768729223e34842615b51efd20001fdd0b5009410c3f2ef44408903cf32">+6/-3</a></td>
</tr>
<tr>
  <td><strong>get_file_with_presigned_url.go</strong><dd><code>Move ireturn/dupl/funlen nolints to leading form with justifications.</code></dd></td>
  <td><a href="https://github.com/nhost/nhost/pull/XXX/files#diff-ce2d278e0ef170950ebca532ab7776acd93d411223848bed724ea0c4333f7d31">+4/-2</a></td>
</tr>
<tr>
  <td><strong>delete_broken_metadata.go</strong><dd><code>Move handler ireturn nolint to leading form with justification.</code></dd></td>
  <td><a href="https://github.com/nhost/nhost/pull/XXX/files#diff-f7ce24e6a6280c12dde105cbf92158e27a8829b9998d297b52580f13dcebfc6f">+2/-1</a></td>
</tr>
<tr>
  <td><strong>delete_file.go</strong><dd><code>Move handler ireturn nolint to leading form with justification.</code></dd></td>
  <td><a href="https://github.com/nhost/nhost/pull/XXX/files#diff-e1fc38b0343f71bc47164f1662906a9f49f79d64ad54973e8d8e73f6d11f768b">+2/-1</a></td>
</tr>
<tr>
  <td><strong>delete_orphaned_files.go</strong><dd><code>Move handler ireturn nolint to leading form with justification.</code></dd></td>
  <td><a href="https://github.com/nhost/nhost/pull/XXX/files#diff-e07fe3e8b75ef3dee3ff710ef37628c369c3040ca827b1e5983aea71814981ad">+2/-1</a></td>
</tr>
<tr>
  <td><strong>get_file_presigned_url.go</strong><dd><code>Move handler ireturn nolint to leading form with justification.</code></dd></td>
  <td><a href="https://github.com/nhost/nhost/pull/XXX/files#diff-87af644ca0f439e771aa8cf4cad99dd277b8b8e3894a973563bc8906decef7c8">+2/-1</a></td>
</tr>
<tr>
  <td><strong>list_broken_metadata.go</strong><dd><code>Move handler ireturn nolint to leading form with justification.</code></dd></td>
  <td><a href="https://github.com/nhost/nhost/pull/XXX/files#diff-ff3707ec8c59e0ef0fc2b6bc9f51b2610dae9f867ffb9773b369bda5efd29a46">+2/-1</a></td>
</tr>
<tr>
  <td><strong>list_files_not_uploaded.go</strong><dd><code>Move handler ireturn nolint to leading form with justification.</code></dd></td>
  <td><a href="https://github.com/nhost/nhost/pull/XXX/files#diff-b98b04148a59a76db6fe781a508807b362038deb24efef7c686b3fbe14c4ae01">+2/-1</a></td>
</tr>
<tr>
  <td><strong>list_orphaned_files.go</strong><dd><code>Move handler ireturn nolint to leading form with justification.</code></dd></td>
  <td><a href="https://github.com/nhost/nhost/pull/XXX/files#diff-5609bca2bfb5793c81f684f5ba2782d48599e94654eb9b31c5379ded0dff2da4">+2/-1</a></td>
</tr>
<tr>
  <td><strong>openapi.go</strong><dd><code>Move handler ireturn nolint to leading form with justification.</code></dd></td>
  <td><a href="https://github.com/nhost/nhost/pull/XXX/files#diff-508f5b75cf6a545afac7fb2315c8b1bc60a7261d96c2ce3bc7037f8467001f14">+2/-1</a></td>
</tr>
<tr>
  <td><strong>replace_file.go</strong><dd><code>Move handler funlen/ireturn nolint to leading form with justification.</code></dd></td>
  <td><a href="https://github.com/nhost/nhost/pull/XXX/files#diff-84e7fa8c5de42c6235a27fef3d91dac72adf8328c9e6b4fd5a94ea6998346af4">+2/-1</a></td>
</tr>
<tr>
  <td><strong>upload_files.go</strong><dd><code>Move handler ireturn nolint to leading form with justification.</code></dd></td>
  <td><a href="https://github.com/nhost/nhost/pull/XXX/files#diff-d5ee48102be2048a4ca0976e3271f24f0172367a32b25d6f033c909b3659bef9">+2/-1</a></td>
</tr>
<tr>
  <td><strong>version.go</strong><dd><code>Move handler ireturn nolint to leading form with justification.</code></dd></td>
  <td><a href="https://github.com/nhost/nhost/pull/XXX/files#diff-c69ddf9cd8988198e765193664720924ceec3bd194bd603d097cca15ddd0599d">+2/-1</a></td>
</tr>
</table></details></td></tr>
</tbody></table>

</details>

___

<!-- nhost-reviewer:end -->