### PR TITLE
feat(constellation): expire JWT WebSocket sessions

### DIFF
--- a/services/constellation/controller/middleware/mock/jwt_authenticator.go
+++ b/services/constellation/controller/middleware/mock/jwt_authenticator.go
@@ -12,6 +12,7 @@ package mock
 import (
 	http "net/http"
 	reflect "reflect"
+	time "time"
 
 	jwt "github.com/nhost/nhost/services/constellation/internal/jwt"
 	gomock "go.uber.org/mock/gomock"
@@ -54,4 +55,20 @@ func (m *MockJWTAuthenticator) Authenticate(headers http.Header, roleOverride st
 func (mr *MockJWTAuthenticatorMockRecorder) Authenticate(headers, roleOverride any) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Authenticate", reflect.TypeOf((*MockJWTAuthenticator)(nil).Authenticate), headers, roleOverride)
+}
+
+// AuthenticateWithExpiration mocks base method.
+func (m *MockJWTAuthenticator) AuthenticateWithExpiration(headers http.Header, roleOverride string) (*jwt.SessionResult, *time.Time, error) {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "AuthenticateWithExpiration", headers, roleOverride)
+	ret0, _ := ret[0].(*jwt.SessionResult)
+	ret1, _ := ret[1].(*time.Time)
+	ret2, _ := ret[2].(error)
+	return ret0, ret1, ret2
+}
+
+// AuthenticateWithExpiration indicates an expected call of AuthenticateWithExpiration.
+func (mr *MockJWTAuthenticatorMockRecorder) AuthenticateWithExpiration(headers, roleOverride any) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "AuthenticateWithExpiration", reflect.TypeOf((*MockJWTAuthenticator)(nil).AuthenticateWithExpiration), headers, roleOverride)
 }

--- a/services/constellation/controller/middleware/session.go
+++ b/services/constellation/controller/middleware/session.go
@@ -19,10 +19,17 @@ import (
 )
 
 // JWTAuthenticator abstracts JWT authentication so callers can mock it in tests.
+// AuthenticateWithExpiration is part of the contract (not an optional capability)
+// because the WebSocket layer relies on the returned expiry to close
+// JWT-authenticated sockets at token expiry; declaring it here makes that control
+// compile-time enforced for every implementer.
 //
 //go:generate mockgen -package mock -destination mock/jwt_authenticator.go . JWTAuthenticator
 type JWTAuthenticator interface {
 	Authenticate(headers http.Header, roleOverride string) (*jwt.SessionResult, error)
+	AuthenticateWithExpiration(
+		headers http.Header, roleOverride string,
+	) (*jwt.SessionResult, *time.Time, error)
 }
 
 // noOpJWTAuthenticator implements JWTAuthenticator by always returning
@@ -33,6 +40,12 @@ func (noOpJWTAuthenticator) Authenticate(http.Header, string) (*jwt.SessionResul
 	return nil, nil //nolint:nilnil // (nil, nil) is the documented "no token found" signal of JWTAuthenticator
 }
 
+func (noOpJWTAuthenticator) AuthenticateWithExpiration(
+	http.Header, string,
+) (*jwt.SessionResult, *time.Time, error) {
+	return nil, nil, nil
+}
+
 // NewNoOpJWTAuthenticator returns a JWTAuthenticator that never finds a token.
 // Use this when JWT authentication is disabled and callers should fall through
 // to the public role.
@@ -40,25 +53,6 @@ func (noOpJWTAuthenticator) Authenticate(http.Header, string) (*jwt.SessionResul
 // concrete type is unexported; callers consume only the interface.
 func NewNoOpJWTAuthenticator() JWTAuthenticator { //nolint:ireturn,nolintlint
 	return noOpJWTAuthenticator{}
-}
-
-func authenticateJWT(
-	jwtAuth JWTAuthenticator,
-	headers http.Header,
-	roleOverride string,
-) (*jwt.SessionResult, *time.Time, error) {
-	if jwtAuthWithExpiration, ok := jwtAuth.(interface {
-		AuthenticateWithExpiration(http.Header, string) (*jwt.SessionResult, *time.Time, error)
-	}); ok {
-		return jwtAuthWithExpiration.AuthenticateWithExpiration(headers, roleOverride)
-	}
-
-	result, err := jwtAuth.Authenticate(headers, roleOverride)
-	if err != nil {
-		return nil, nil, err
-	}
-
-	return result, nil, nil
 }
 
 type sessionCtxKey struct{}
@@ -120,7 +114,7 @@ func ExtractSession(
 
 	roleOverride := headers.Get(sessionHeaderRole)
 
-	result, expiresAt, err := authenticateJWT(jwtAuth, headers, roleOverride)
+	result, expiresAt, err := jwtAuth.AuthenticateWithExpiration(headers, roleOverride)
 	if err != nil {
 		return nil, fmt.Errorf("jwt authentication: %w", err)
 	}
@@ -136,6 +130,7 @@ func ExtractSession(
 	return &SessionVariables{
 		Role:      publicRole,
 		Variables: map[string]any{"x-hasura-role": publicRole},
+		ExpiresAt: nil,
 	}, nil
 }
 
@@ -162,6 +157,7 @@ func extractAdminSession(headers http.Header) *SessionVariables {
 	return &SessionVariables{
 		Role:      role,
 		Variables: variables,
+		ExpiresAt: nil,
 	}
 }
 

--- a/services/constellation/controller/middleware/session.go
+++ b/services/constellation/controller/middleware/session.go
@@ -11,6 +11,7 @@ import (
 	"log/slog"
 	"net/http"
 	"strings"
+	"time"
 
 	"github.com/gin-gonic/gin"
 	"github.com/nhost/nhost/services/constellation/internal/jwt"
@@ -41,14 +42,35 @@ func NewNoOpJWTAuthenticator() JWTAuthenticator { //nolint:ireturn,nolintlint
 	return noOpJWTAuthenticator{}
 }
 
+func authenticateJWT(
+	jwtAuth JWTAuthenticator,
+	headers http.Header,
+	roleOverride string,
+) (*jwt.SessionResult, *time.Time, error) {
+	if jwtAuthWithExpiration, ok := jwtAuth.(interface {
+		AuthenticateWithExpiration(http.Header, string) (*jwt.SessionResult, *time.Time, error)
+	}); ok {
+		return jwtAuthWithExpiration.AuthenticateWithExpiration(headers, roleOverride)
+	}
+
+	result, err := jwtAuth.Authenticate(headers, roleOverride)
+	if err != nil {
+		return nil, nil, err
+	}
+
+	return result, nil, nil
+}
+
 type sessionCtxKey struct{}
 
 // SessionVariables carries the resolved role and the Hasura session variables
 // for the current request. The "x-hasura-role" key in Variables always matches
-// Role; downstream code can rely on either.
+// Role; downstream code can rely on either. ExpiresAt is set only for JWT-backed
+// sessions and is nil for admin-secret and public-role sessions.
 type SessionVariables struct {
 	Role      string
 	Variables map[string]any
+	ExpiresAt *time.Time
 }
 
 const (
@@ -98,7 +120,7 @@ func ExtractSession(
 
 	roleOverride := headers.Get(sessionHeaderRole)
 
-	result, err := jwtAuth.Authenticate(headers, roleOverride)
+	result, expiresAt, err := authenticateJWT(jwtAuth, headers, roleOverride)
 	if err != nil {
 		return nil, fmt.Errorf("jwt authentication: %w", err)
 	}
@@ -107,6 +129,7 @@ func ExtractSession(
 		return &SessionVariables{
 			Role:      result.Role,
 			Variables: result.Variables,
+			ExpiresAt: expiresAt,
 		}, nil
 	}
 

--- a/services/constellation/controller/middleware/session_test.go
+++ b/services/constellation/controller/middleware/session_test.go
@@ -343,8 +343,8 @@ func TestExtractSessionWithMockJWT(t *testing.T) {
 		//nolint:err113 // test sentinel error used to verify error propagation
 		sentinel := errors.New("token signature invalid")
 		auth.EXPECT().
-			Authenticate(gomock.Any(), "").
-			Return(nil, sentinel)
+			AuthenticateWithExpiration(gomock.Any(), "").
+			Return(nil, nil, sentinel)
 
 		_, err := middleware.ExtractSession("", auth, http.Header{
 			"Authorization": {"Bearer something"},
@@ -369,15 +369,16 @@ func TestExtractSessionWithMockJWT(t *testing.T) {
 		ctrl := gomock.NewController(t)
 		auth := mock.NewMockJWTAuthenticator(ctrl)
 
+		expiresAt := time.Unix(1893456000, 0).UTC()
 		auth.EXPECT().
-			Authenticate(gomock.Any(), "editor").
+			AuthenticateWithExpiration(gomock.Any(), "editor").
 			Return(&jwt.SessionResult{
 				Role: "editor",
 				Variables: map[string]any{
 					"x-hasura-role":    "editor",
 					"x-hasura-user-id": "u-7",
 				},
-			}, nil)
+			}, &expiresAt, nil)
 
 		session, err := middleware.ExtractSession("", auth, http.Header{
 			"Authorization": {"Bearer signed"},
@@ -393,6 +394,7 @@ func TestExtractSessionWithMockJWT(t *testing.T) {
 				"x-hasura-role":    "editor",
 				"x-hasura-user-id": "u-7",
 			},
+			ExpiresAt: &expiresAt,
 		}
 		if diff := cmp.Diff(want, session); diff != "" {
 			t.Errorf("session mismatch (-want +got):\n%s", diff)
@@ -406,8 +408,8 @@ func TestExtractSessionWithMockJWT(t *testing.T) {
 		auth := mock.NewMockJWTAuthenticator(ctrl)
 
 		auth.EXPECT().
-			Authenticate(gomock.Any(), "").
-			Return(nil, nil)
+			AuthenticateWithExpiration(gomock.Any(), "").
+			Return(nil, nil, nil)
 
 		session, err := middleware.ExtractSession("", auth, http.Header{})
 		if err != nil {

--- a/services/constellation/controller/middleware/session_test.go
+++ b/services/constellation/controller/middleware/session_test.go
@@ -12,6 +12,7 @@ import (
 	"github.com/gin-gonic/gin"
 	gojwt "github.com/golang-jwt/jwt/v5"
 	"github.com/google/go-cmp/cmp"
+	"github.com/google/go-cmp/cmp/cmpopts"
 	"github.com/nhost/nhost/services/constellation/controller/middleware"
 	"github.com/nhost/nhost/services/constellation/controller/middleware/mock"
 	"github.com/nhost/nhost/services/constellation/internal/jwt"
@@ -278,10 +279,38 @@ func TestExtractSession(t *testing.T) {
 				t.Fatalf("unexpected error: %v", err)
 			}
 
-			if diff := cmp.Diff(tc.expected, session); diff != "" {
+			if diff := cmp.Diff(
+				tc.expected,
+				session,
+				cmpopts.IgnoreFields(middleware.SessionVariables{}, "ExpiresAt"),
+			); diff != "" {
 				t.Errorf("session mismatch (-want +got):\n%s", diff)
 			}
 		})
+	}
+}
+
+func TestExtractSessionJWTExpiration(t *testing.T) {
+	t.Parallel()
+
+	jwtAuth := testAuthenticator(t)
+	expiresAt := time.Unix(1893456000, 0).UTC()
+	claims := validJWTClaims()
+	claims["exp"] = gojwt.NewNumericDate(expiresAt)
+
+	session, err := middleware.ExtractSession("", jwtAuth, http.Header{
+		"Authorization": {"Bearer " + signToken(t, claims)},
+	})
+	if err != nil {
+		t.Fatalf("ExtractSession() error = %v", err)
+	}
+
+	if session.ExpiresAt == nil {
+		t.Fatal("expected JWT expiration to be propagated")
+	}
+
+	if !session.ExpiresAt.Equal(expiresAt) {
+		t.Fatalf("expiration mismatch: want %s, got %s", expiresAt, *session.ExpiresAt)
 	}
 }
 

--- a/services/constellation/controller/middleware/session_test.go
+++ b/services/constellation/controller/middleware/session_test.go
@@ -294,7 +294,7 @@ func TestExtractSessionJWTExpiration(t *testing.T) {
 	t.Parallel()
 
 	jwtAuth := testAuthenticator(t)
-	expiresAt := time.Unix(1893456000, 0).UTC()
+	expiresAt := gojwt.NewNumericDate(time.Now().Add(time.Hour).UTC()).Time
 	claims := validJWTClaims()
 	claims["exp"] = gojwt.NewNumericDate(expiresAt)
 

--- a/services/constellation/controller/websocket.go
+++ b/services/constellation/controller/websocket.go
@@ -102,6 +102,17 @@ func (h *webSocketHandler) OnConnectionInit(
 	return nil
 }
 
+// ConnectionExpiresAt returns the JWT expiry bound for this WebSocket session.
+// The protocol layer uses it to close JWT-authenticated sockets when the access
+// token expires. Admin-secret and public-role sessions have no JWT expiry bound.
+func (h *webSocketHandler) ConnectionExpiresAt() (time.Time, bool) {
+	if h.session == nil || h.session.ExpiresAt == nil {
+		return time.Time{}, false
+	}
+
+	return *h.session.ExpiresAt, true
+}
+
 // OnSubscribe is called when client sends subscribe. It parses and validates
 // the subscription query, selects the owning subscription handler, registers
 // per-subscription state, and spawns a goroutine that forwards updates back

--- a/services/constellation/controller/websocket/errors.go
+++ b/services/constellation/controller/websocket/errors.go
@@ -5,6 +5,7 @@ import "errors"
 var (
 	errConnectionInitTimeout = errors.New("connection_init timeout")
 	errConnectionInitFailed  = errors.New("connection_init failed")
+	errConnectionExpired     = errors.New("connection expired")
 	errCouldNotReadMessage   = errors.New("could not read message")
 	errInvalidMessageFormat  = errors.New("invalid message format")
 )

--- a/services/constellation/controller/websocket/server.go
+++ b/services/constellation/controller/websocket/server.go
@@ -72,6 +72,10 @@ type Connection struct {
 	conn    wsConn
 	handler MessageHandler
 	sendCh  chan *Message
+	// connectionAckWriteCh lets the read pump wait until the write pump has
+	// flushed connection_ack before arming any post-init expiry deadline.
+	// White-box tests that drive readPump without writePump leave it nil.
+	connectionAckWriteCh chan error
 
 	initialized bool
 	expiresAt   time.Time
@@ -105,11 +109,12 @@ func NewConnection(
 	}
 
 	return &Connection{
-		conn:        conn,
-		handler:     handler,
-		sendCh:      sendCh,
-		initialized: false,
-		expiresAt:   time.Time{},
+		conn:                 conn,
+		handler:              handler,
+		sendCh:               sendCh,
+		connectionAckWriteCh: make(chan error, 1),
+		initialized:          false,
+		expiresAt:            time.Time{},
 	}, nil
 }
 
@@ -119,6 +124,7 @@ func (c *Connection) Loop(ctx context.Context, logger *slog.Logger) error {
 	rctx, cancel := context.WithCancel(ctx)
 
 	var closeOnce sync.Once
+
 	closeConn := func(message string) {
 		closeOnce.Do(func() {
 			if err := c.conn.Close(); err != nil {
@@ -160,12 +166,20 @@ func (c *Connection) Loop(ctx context.Context, logger *slog.Logger) error {
 	return errWrite
 }
 
+type readMessageStatus uint8
+
+const (
+	readMessageStatusContinue readMessageStatus = iota
+	readMessageStatusDone
+	readMessageStatusInitialized
+)
+
 // readPump reads messages from the WebSocket connection.
 func (c *Connection) readPump(ctx context.Context, logger *slog.Logger) error {
 	initTimer := time.NewTimer(connectionInitTimeout)
 	defer initTimer.Stop()
 
-	if err := c.conn.SetReadDeadline(time.Now().Add(connectionInitTimeout)); err != nil {
+	if err := c.setReadDeadline(ctx, time.Now().Add(connectionInitTimeout)); err != nil {
 		return fmt.Errorf("setting initial read deadline: %w", err)
 	}
 
@@ -182,37 +196,22 @@ func (c *Connection) readPump(ctx context.Context, logger *slog.Logger) error {
 			// ctx is not yet done and the init timer has not yet fired. Cancellation
 			// and the init timeout are observed by the next iteration's select once
 			// ReadMessage returns via a read deadline, close frame, or conn.Close.
-			_, message, err := c.conn.ReadMessage()
-			switch {
-			case ctx.Err() != nil:
-				return nil
-			case websocket.IsCloseError(
-				err, websocket.CloseNormalClosure, websocket.CloseGoingAway,
-			):
-				return nil
-			case isReadTimeout(err) && !c.initialized:
-				return errConnectionInitTimeout
-			case isReadTimeout(err) && c.isExpired(time.Now()):
-				return errConnectionExpired
-			case err != nil:
-				return fmt.Errorf("%w: %w", errCouldNotReadMessage, err)
-			}
-
-			var msg Message
-			if err := json.Unmarshal(message, &msg); err != nil {
-				return fmt.Errorf("%w: %w", errInvalidMessageFormat, err)
-			}
-
-			if err := c.handleMessage(ctx, &msg, logger); err != nil {
+			status, err := c.readAndHandleMessage(ctx, logger)
+			if err != nil {
 				return err
+			}
+
+			if status == readMessageStatusDone {
+				return nil
 			}
 
 			// Stop the init timeout once the handshake completes, then replace the
 			// pre-init read deadline with the JWT expiry bound (or no deadline for
 			// non-JWT sessions).
-			if msg.Type == messageTypeConnectionInit && c.initialized {
+			if status == readMessageStatusInitialized {
 				initTimer.Stop()
-				if err := c.setPostInitReadDeadline(); err != nil {
+
+				if err := c.setPostInitReadDeadline(ctx); err != nil {
 					return fmt.Errorf("setting post-init read deadline: %w", err)
 				}
 			}
@@ -220,12 +219,79 @@ func (c *Connection) readPump(ctx context.Context, logger *slog.Logger) error {
 	}
 }
 
-func (c *Connection) setPostInitReadDeadline() error {
-	if c.expiresAt.IsZero() {
-		return c.conn.SetReadDeadline(time.Time{})
+func (c *Connection) readAndHandleMessage(
+	ctx context.Context, logger *slog.Logger,
+) (readMessageStatus, error) {
+	_, message, err := c.conn.ReadMessage()
+	if err != nil {
+		return c.handleReadMessageError(ctx, err)
 	}
 
-	return c.conn.SetReadDeadline(c.expiresAt)
+	if contextDone(ctx) {
+		return readMessageStatusDone, nil
+	}
+
+	var msg Message
+	if err := json.Unmarshal(message, &msg); err != nil {
+		return readMessageStatusContinue, fmt.Errorf("%w: %w", errInvalidMessageFormat, err)
+	}
+
+	if err := c.handleMessage(ctx, &msg, logger); err != nil {
+		return readMessageStatusContinue, err
+	}
+
+	if msg.Type == messageTypeConnectionInit && c.initialized {
+		return readMessageStatusInitialized, nil
+	}
+
+	return readMessageStatusContinue, nil
+}
+
+func (c *Connection) handleReadMessageError(
+	ctx context.Context, readErr error,
+) (readMessageStatus, error) {
+	switch {
+	case contextDone(ctx):
+		return readMessageStatusDone, nil
+	case websocket.IsCloseError(readErr, websocket.CloseNormalClosure, websocket.CloseGoingAway):
+		return readMessageStatusDone, nil
+	case isReadTimeout(readErr) && !c.initialized:
+		return readMessageStatusContinue, errConnectionInitTimeout
+	case isReadTimeout(readErr) && c.isExpired(time.Now()):
+		return readMessageStatusContinue, errConnectionExpired
+	default:
+		return readMessageStatusContinue, fmt.Errorf("%w: %w", errCouldNotReadMessage, readErr)
+	}
+}
+
+func (c *Connection) setPostInitReadDeadline(ctx context.Context) error {
+	if c.expiresAt.IsZero() {
+		return c.setReadDeadline(ctx, time.Time{})
+	}
+
+	return c.setReadDeadline(ctx, c.expiresAt)
+}
+
+func (c *Connection) setReadDeadline(ctx context.Context, deadline time.Time) error {
+	if contextDone(ctx) {
+		return nil
+	}
+
+	if err := c.conn.SetReadDeadline(deadline); err != nil {
+		if contextDone(ctx) {
+			return nil
+		}
+
+		return fmt.Errorf("setting websocket read deadline: %w", err)
+	}
+
+	return nil
+}
+
+// contextDone reports that connection shutdown has started. Read/deadline
+// helpers treat transport errors after this point as graceful cancellation.
+func contextDone(ctx context.Context) bool {
+	return ctx.Err() != nil
 }
 
 func (c *Connection) isExpired(now time.Time) bool {
@@ -250,12 +316,20 @@ func (c *Connection) writePump(ctx context.Context, logger *slog.Logger) error {
 		case msg := <-c.sendCh:
 			data, err := json.Marshal(msg)
 			if err != nil {
-				return fmt.Errorf("could not marshal message: %w", err)
+				writeErr := fmt.Errorf("could not marshal message: %w", err)
+				c.notifyConnectionAckWrite(msg, writeErr)
+
+				return writeErr
 			}
 
 			if err := c.conn.WriteMessage(websocket.TextMessage, data); err != nil {
-				return fmt.Errorf("could not write message: %w", err)
+				writeErr := fmt.Errorf("could not write message: %w", err)
+				c.notifyConnectionAckWrite(msg, writeErr)
+
+				return writeErr
 			}
+
+			c.notifyConnectionAckWrite(msg, nil)
 		case <-ticker.C:
 			c.sendMessage(ctx, newPingMessage(), logger)
 		}
@@ -287,8 +361,7 @@ func (c *Connection) handleConnectionInit(
 	ctx context.Context, msg *Message, logger *slog.Logger,
 ) error {
 	if c.initialized {
-		c.sendMessage(ctx, newConnectionAckMessage(), logger)
-		return nil
+		return c.sendConnectionAck(ctx, logger)
 	}
 
 	if err := c.handler.OnConnectionInit(ctx, msg.Payload); err != nil {
@@ -303,9 +376,56 @@ func (c *Connection) handleConnectionInit(
 	}
 
 	logger.DebugContext(ctx, "connection initialized")
-	c.sendMessage(ctx, newConnectionAckMessage(), logger)
+
+	return c.sendConnectionAck(ctx, logger)
+}
+
+func (c *Connection) notifyConnectionAckWrite(msg *Message, err error) {
+	if c.connectionAckWriteCh == nil || msg == nil || msg.Type != messageTypeConnectionAck {
+		return
+	}
+
+	select {
+	case c.connectionAckWriteCh <- err:
+	default:
+	}
+}
+
+func (c *Connection) sendConnectionAck(ctx context.Context, logger *slog.Logger) error {
+	msg := newConnectionAckMessage()
+	if c.connectionAckWriteCh == nil {
+		c.sendMessage(ctx, msg, logger)
+
+		return nil
+	}
+
+	c.drainConnectionAckWriteNotifications()
+
+	select {
+	case c.sendCh <- msg:
+	case <-ctx.Done():
+		return nil
+	}
+
+	select {
+	case err := <-c.connectionAckWriteCh:
+		if err != nil {
+			return fmt.Errorf("writing connection_ack: %w", err)
+		}
+	case <-ctx.Done():
+	}
 
 	return nil
+}
+
+func (c *Connection) drainConnectionAckWriteNotifications() {
+	for {
+		select {
+		case <-c.connectionAckWriteCh:
+		default:
+			return
+		}
+	}
 }
 
 // handleSubscribe processes subscribe messages.

--- a/services/constellation/controller/websocket/server.go
+++ b/services/constellation/controller/websocket/server.go
@@ -401,10 +401,23 @@ func (c *Connection) sendConnectionAck(ctx context.Context, logger *slog.Logger)
 
 	c.drainConnectionAckWriteNotifications()
 
+	if c.isExpired(time.Now()) {
+		return errConnectionExpired
+	}
+
+	expiresCh, stopExpirationTimer := c.connectionExpirationTimer()
+	defer stopExpirationTimer()
+
 	select {
 	case c.sendCh <- msg:
+	case <-expiresCh:
+		return errConnectionExpired
 	case <-ctx.Done():
 		return nil
+	}
+
+	if c.isExpired(time.Now()) {
+		return errConnectionExpired
 	}
 
 	select {
@@ -412,10 +425,31 @@ func (c *Connection) sendConnectionAck(ctx context.Context, logger *slog.Logger)
 		if err != nil {
 			return fmt.Errorf("writing connection_ack: %w", err)
 		}
+	case <-expiresCh:
+		return errConnectionExpired
 	case <-ctx.Done():
 	}
 
 	return nil
+}
+
+func (c *Connection) connectionExpirationTimer() (<-chan time.Time, func()) {
+	if c.expiresAt.IsZero() {
+		return nil, func() {}
+	}
+
+	timer := time.NewTimer(time.Until(c.expiresAt))
+
+	return timer.C, func() {
+		if timer.Stop() {
+			return
+		}
+
+		select {
+		case <-timer.C:
+		default:
+		}
+	}
 }
 
 func (c *Connection) drainConnectionAckWriteNotifications() {

--- a/services/constellation/controller/websocket/server.go
+++ b/services/constellation/controller/websocket/server.go
@@ -4,9 +4,12 @@ import (
 	"context"
 	"encoding/json/jsontext"
 	json "encoding/json/v2"
+	"errors"
 	"fmt"
 	"log/slog"
+	"net"
 	"net/http"
+	"sync"
 	"time"
 
 	"github.com/gorilla/websocket"
@@ -53,7 +56,14 @@ type MessageHandler interface {
 type wsConn interface {
 	ReadMessage() (int, []byte, error)
 	WriteMessage(messageType int, data []byte) error
+	SetReadDeadline(t time.Time) error
 	Close() error
+}
+
+// connectionExpirationProvider is an optional capability for handlers that can
+// provide an absolute authentication expiry for the WebSocket connection.
+type connectionExpirationProvider interface {
+	ConnectionExpiresAt() (time.Time, bool)
 }
 
 // Connection represents an upgraded WebSocket connection.
@@ -64,6 +74,7 @@ type Connection struct {
 	sendCh  chan *Message
 
 	initialized bool
+	expiresAt   time.Time
 }
 
 // NewConnection upgrades an HTTP connection to WebSocket.
@@ -98,6 +109,7 @@ func NewConnection(
 		handler:     handler,
 		sendCh:      sendCh,
 		initialized: false,
+		expiresAt:   time.Time{},
 	}, nil
 }
 
@@ -106,10 +118,24 @@ func NewConnection(
 func (c *Connection) Loop(ctx context.Context, logger *slog.Logger) error {
 	rctx, cancel := context.WithCancel(ctx)
 
+	var closeOnce sync.Once
+	closeConn := func(message string) {
+		closeOnce.Do(func() {
+			if err := c.conn.Close(); err != nil {
+				logger.DebugContext(ctx, message, slog.String("error", err.Error()))
+			}
+		})
+	}
+
 	defer func() {
 		c.handler.OnClose(ctx)
-		c.conn.Close()
+		closeConn("websocket close failed")
 		cancel()
+	}()
+
+	go func() {
+		<-rctx.Done()
+		closeConn("websocket close after cancellation failed")
 	}()
 
 	errWriteCh := make(chan error, 1)
@@ -139,6 +165,10 @@ func (c *Connection) readPump(ctx context.Context, logger *slog.Logger) error {
 	initTimer := time.NewTimer(connectionInitTimeout)
 	defer initTimer.Stop()
 
+	if err := c.conn.SetReadDeadline(time.Now().Add(connectionInitTimeout)); err != nil {
+		return fmt.Errorf("setting initial read deadline: %w", err)
+	}
+
 	for {
 		select {
 		case <-ctx.Done():
@@ -151,13 +181,19 @@ func (c *Connection) readPump(ctx context.Context, logger *slog.Logger) error {
 			// `default` is used so each loop iteration reaches ReadMessage even when
 			// ctx is not yet done and the init timer has not yet fired. Cancellation
 			// and the init timeout are observed by the next iteration's select once
-			// ReadMessage returns (typically via the read deadline or a close frame).
+			// ReadMessage returns via a read deadline, close frame, or conn.Close.
 			_, message, err := c.conn.ReadMessage()
 			switch {
+			case ctx.Err() != nil:
+				return nil
 			case websocket.IsCloseError(
 				err, websocket.CloseNormalClosure, websocket.CloseGoingAway,
 			):
 				return nil
+			case isReadTimeout(err) && !c.initialized:
+				return errConnectionInitTimeout
+			case isReadTimeout(err) && c.isExpired(time.Now()):
+				return errConnectionExpired
 			case err != nil:
 				return fmt.Errorf("%w: %w", errCouldNotReadMessage, err)
 			}
@@ -171,12 +207,35 @@ func (c *Connection) readPump(ctx context.Context, logger *slog.Logger) error {
 				return err
 			}
 
-			// Stop the init timeout once the handshake completes.
+			// Stop the init timeout once the handshake completes, then replace the
+			// pre-init read deadline with the JWT expiry bound (or no deadline for
+			// non-JWT sessions).
 			if msg.Type == messageTypeConnectionInit && c.initialized {
 				initTimer.Stop()
+				if err := c.setPostInitReadDeadline(); err != nil {
+					return fmt.Errorf("setting post-init read deadline: %w", err)
+				}
 			}
 		}
 	}
+}
+
+func (c *Connection) setPostInitReadDeadline() error {
+	if c.expiresAt.IsZero() {
+		return c.conn.SetReadDeadline(time.Time{})
+	}
+
+	return c.conn.SetReadDeadline(c.expiresAt)
+}
+
+func (c *Connection) isExpired(now time.Time) bool {
+	return !c.expiresAt.IsZero() && !now.Before(c.expiresAt)
+}
+
+func isReadTimeout(err error) bool {
+	var netErr net.Error
+
+	return errors.As(err, &netErr) && netErr.Timeout()
 }
 
 // writePump writes messages to the WebSocket connection.
@@ -237,6 +296,11 @@ func (c *Connection) handleConnectionInit(
 	}
 
 	c.initialized = true
+	if provider, ok := c.handler.(connectionExpirationProvider); ok {
+		if expiresAt, ok := provider.ConnectionExpiresAt(); ok && !expiresAt.IsZero() {
+			c.expiresAt = expiresAt
+		}
+	}
 
 	logger.DebugContext(ctx, "connection initialized")
 	c.sendMessage(ctx, newConnectionAckMessage(), logger)

--- a/services/constellation/controller/websocket/server_internal_test.go
+++ b/services/constellation/controller/websocket/server_internal_test.go
@@ -302,6 +302,8 @@ func TestLoopWritesConnectionAckBeforeExpirationDeadline(t *testing.T) {
 	ackWritten := make(chan struct{})
 	postInitDeadlineSet := make(chan struct{})
 
+	var expiresAt time.Time
+
 	readCalls := 0
 	deadlineCalls := 0
 	fake := &fakeWSConn{
@@ -315,6 +317,14 @@ func TestLoopWritesConnectionAckBeforeExpirationDeadline(t *testing.T) {
 			case <-postInitDeadlineSet:
 			case <-time.After(2 * time.Second):
 				t.Fatal("post-init read deadline was not set")
+			}
+
+			if expiresAt.IsZero() {
+				t.Fatal("connection expiration was not captured")
+			}
+
+			if untilExpiry := time.Until(expiresAt); untilExpiry > 0 {
+				time.Sleep(untilExpiry + time.Millisecond)
 			}
 
 			return 0, nil, fakeTimeoutError{}
@@ -352,7 +362,11 @@ func TestLoopWritesConnectionAckBeforeExpirationDeadline(t *testing.T) {
 		conn: fake,
 		handler: &expiringNopHandler{
 			nopHandler: nopHandler{onInit: nil, onSub: nil, onComplete: nil, onClose: nil},
-			expiresAt:  time.Now,
+			expiresAt: func() time.Time {
+				expiresAt = time.Now().Add(100 * time.Millisecond)
+
+				return expiresAt
+			},
 		},
 		sendCh:               make(chan *Message, 1),
 		connectionAckWriteCh: make(chan error, 1),
@@ -367,6 +381,79 @@ func TestLoopWritesConnectionAckBeforeExpirationDeadline(t *testing.T) {
 
 	if deadlineCalls != 2 {
 		t.Fatalf("expected initial and post-init deadline calls, got %d", deadlineCalls)
+	}
+}
+
+func TestSendConnectionAckFullQueueReturnsExpired(t *testing.T) {
+	t.Parallel()
+
+	conn := &Connection{
+		conn:                 &fakeWSConn{},
+		handler:              &nopHandler{onInit: nil, onSub: nil, onComplete: nil, onClose: nil},
+		sendCh:               make(chan *Message, 1),
+		connectionAckWriteCh: make(chan error, 1),
+		initialized:          true,
+		expiresAt:            time.Time{},
+	}
+	conn.sendCh <- newPingMessage()
+
+	errCh := make(chan error, 1)
+	go func() {
+		conn.expiresAt = time.Now().Add(50 * time.Millisecond)
+		errCh <- conn.sendConnectionAck(t.Context(), slog.New(slog.DiscardHandler))
+	}()
+
+	select {
+	case err := <-errCh:
+		if !errors.Is(err, errConnectionExpired) {
+			t.Fatalf("expected errConnectionExpired, got %v", err)
+		}
+	case <-time.After(2 * time.Second):
+		t.Fatal("sendConnectionAck did not return after connection expiration")
+	}
+
+	msg := <-conn.sendCh
+	if msg.Type != messageTypePing {
+		t.Fatalf("expected queued ping to remain, got %q", msg.Type)
+	}
+}
+
+func TestSendConnectionAckBlockedWriteNotificationReturnsExpired(t *testing.T) {
+	t.Parallel()
+
+	conn := &Connection{
+		conn:                 &fakeWSConn{},
+		handler:              &nopHandler{onInit: nil, onSub: nil, onComplete: nil, onClose: nil},
+		sendCh:               make(chan *Message, 1),
+		connectionAckWriteCh: make(chan error, 1),
+		initialized:          true,
+		expiresAt:            time.Time{},
+	}
+
+	errCh := make(chan error, 1)
+	go func() {
+		conn.expiresAt = time.Now().Add(50 * time.Millisecond)
+		errCh <- conn.sendConnectionAck(t.Context(), slog.New(slog.DiscardHandler))
+	}()
+
+	select {
+	case msg := <-conn.sendCh:
+		if msg.Type != messageTypeConnectionAck {
+			t.Fatalf("expected connection_ack to be queued, got %q", msg.Type)
+		}
+	case err := <-errCh:
+		t.Fatalf("sendConnectionAck returned before queuing ack: %v", err)
+	case <-time.After(2 * time.Second):
+		t.Fatal("connection_ack was not queued")
+	}
+
+	select {
+	case err := <-errCh:
+		if !errors.Is(err, errConnectionExpired) {
+			t.Fatalf("expected errConnectionExpired, got %v", err)
+		}
+	case <-time.After(2 * time.Second):
+		t.Fatal("sendConnectionAck did not return after connection expiration")
 	}
 }
 

--- a/services/constellation/controller/websocket/server_internal_test.go
+++ b/services/constellation/controller/websocket/server_internal_test.go
@@ -60,6 +60,10 @@ func (f *fakeWSConn) WriteMessage(messageType int, data []byte) error {
 	return f.writeFn(messageType, data)
 }
 
+func (f *fakeWSConn) SetReadDeadline(time.Time) error {
+	return nil
+}
+
 func (f *fakeWSConn) Close() error {
 	f.mu.Lock()
 	f.closed = true

--- a/services/constellation/controller/websocket/server_internal_test.go
+++ b/services/constellation/controller/websocket/server_internal_test.go
@@ -20,9 +20,10 @@ import (
 // tests can script behavior (scripted reads, controlled write errors, blocking
 // reads, etc.) without needing a separate type per scenario.
 type fakeWSConn struct {
-	readFn  func() (int, []byte, error)
-	writeFn func(messageType int, data []byte) error
-	closeFn func() error
+	readFn            func() (int, []byte, error)
+	writeFn           func(messageType int, data []byte) error
+	setReadDeadlineFn func(time.Time) error
+	closeFn           func() error
 
 	mu       sync.Mutex
 	writes   [][]byte
@@ -43,6 +44,14 @@ func (f *fakeWSConn) ReadMessage() (int, []byte, error) {
 // but a nil-safe default is friendlier than a panic if the test is reorganised.
 var errFakeWSReadUnused = errors.New("fakeWSConn: ReadMessage called without a configured readFn")
 
+type fakeTimeoutError struct{}
+
+func (fakeTimeoutError) Error() string { return "fake timeout" }
+
+func (fakeTimeoutError) Timeout() bool { return true }
+
+func (fakeTimeoutError) Temporary() bool { return true }
+
 func (f *fakeWSConn) WriteMessage(messageType int, data []byte) error {
 	f.mu.Lock()
 	// Snapshot the bytes — gorilla's contract is that the buffer is reusable
@@ -60,8 +69,12 @@ func (f *fakeWSConn) WriteMessage(messageType int, data []byte) error {
 	return f.writeFn(messageType, data)
 }
 
-func (f *fakeWSConn) SetReadDeadline(time.Time) error {
-	return nil
+func (f *fakeWSConn) SetReadDeadline(t time.Time) error {
+	if f.setReadDeadlineFn == nil {
+		return nil
+	}
+
+	return f.setReadDeadlineFn(t)
 }
 
 func (f *fakeWSConn) Close() error {
@@ -129,6 +142,16 @@ func (h *nopHandler) OnClose(ctx context.Context) {
 	h.onClose(ctx)
 }
 
+type expiringNopHandler struct {
+	nopHandler
+
+	expiresAt func() time.Time
+}
+
+func (h *expiringNopHandler) ConnectionExpiresAt() (time.Time, bool) {
+	return h.expiresAt(), true
+}
+
 // withTimingOverrides installs short timing knobs for the duration of the test
 // and restores them via t.Cleanup. Without this, tests for the init timeout
 // and ping ticker would have to wait 10s / 30s of real time.
@@ -145,6 +168,263 @@ func withTimingOverrides(t *testing.T, initTimeout, pingInterval time.Duration) 
 		connectionInitTimeout = origInit
 		defaultPingInterval = origPing
 	})
+}
+
+func TestSetReadDeadlineSuppressesCancellation(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name           string
+		cancelBefore   bool
+		cancelInSetter bool
+		wantCalled     bool
+		wantErr        bool
+	}{
+		{
+			name:           "canceled before call skips websocket deadline",
+			cancelBefore:   true,
+			cancelInSetter: false,
+			wantCalled:     false,
+			wantErr:        false,
+		},
+		{
+			name:           "canceled during setter suppresses deadline error",
+			cancelBefore:   false,
+			cancelInSetter: true,
+			wantCalled:     true,
+			wantErr:        false,
+		},
+		{
+			name:           "active context returns deadline error",
+			cancelBefore:   false,
+			cancelInSetter: false,
+			wantCalled:     true,
+			wantErr:        true,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+
+			ctx, cancel := context.WithCancel(t.Context())
+			defer cancel()
+
+			if tt.cancelBefore {
+				cancel()
+			}
+
+			called := false
+			fake := &fakeWSConn{
+				setReadDeadlineFn: func(time.Time) error {
+					called = true
+
+					if tt.cancelInSetter {
+						cancel()
+					}
+
+					return context.Canceled
+				},
+			}
+			conn := &Connection{
+				conn:        fake,
+				handler:     &nopHandler{onInit: nil, onSub: nil, onComplete: nil, onClose: nil},
+				sendCh:      make(chan *Message, 1),
+				initialized: false,
+				expiresAt:   time.Time{},
+			}
+
+			err := conn.setReadDeadline(ctx, time.Now())
+
+			if called != tt.wantCalled {
+				t.Fatalf("expected SetReadDeadline called=%v, got %v", tt.wantCalled, called)
+			}
+
+			if tt.wantErr {
+				if !errors.Is(err, context.Canceled) {
+					t.Fatalf("expected context.Canceled error, got %v", err)
+				}
+
+				return
+			}
+
+			if err != nil {
+				t.Fatalf("expected nil error, got %v", err)
+			}
+		})
+	}
+}
+
+func TestReadPumpInitialDeadlineCancellationReturnsNil(t *testing.T) {
+	t.Parallel()
+
+	ctx, cancel := context.WithCancel(t.Context())
+	cancel()
+
+	deadlineCalled := false
+	fake := &fakeWSConn{
+		readFn: func() (int, []byte, error) {
+			t.Fatal("ReadMessage should not be called after context cancellation")
+
+			return 0, nil, nil
+		},
+		setReadDeadlineFn: func(time.Time) error {
+			deadlineCalled = true
+
+			return context.Canceled
+		},
+	}
+	conn := &Connection{
+		conn:        fake,
+		handler:     &nopHandler{onInit: nil, onSub: nil, onComplete: nil, onClose: nil},
+		sendCh:      make(chan *Message, 1),
+		initialized: false,
+		expiresAt:   time.Time{},
+	}
+
+	if err := conn.readPump(ctx, slog.New(slog.DiscardHandler)); err != nil {
+		t.Fatalf("expected nil error after context cancellation, got %v", err)
+	}
+
+	if deadlineCalled {
+		t.Fatal("SetReadDeadline should not be called after context cancellation")
+	}
+}
+
+func TestLoopWritesConnectionAckBeforeExpirationDeadline(t *testing.T) {
+	t.Parallel()
+
+	initBytes, err := json.Marshal(&Message{ID: "", Type: messageTypeConnectionInit, Payload: nil})
+	if err != nil {
+		t.Fatalf("could not marshal connection_init: %v", err)
+	}
+
+	ackWritten := make(chan struct{})
+	postInitDeadlineSet := make(chan struct{})
+
+	readCalls := 0
+	deadlineCalls := 0
+	fake := &fakeWSConn{
+		readFn: func() (int, []byte, error) {
+			readCalls++
+			if readCalls == 1 {
+				return websocket.TextMessage, initBytes, nil
+			}
+
+			select {
+			case <-postInitDeadlineSet:
+			case <-time.After(2 * time.Second):
+				t.Fatal("post-init read deadline was not set")
+			}
+
+			return 0, nil, fakeTimeoutError{}
+		},
+		writeFn: func(_ int, data []byte) error {
+			var msg Message
+			if err := json.Unmarshal(data, &msg); err != nil {
+				t.Errorf("could not unmarshal written message: %v", err)
+			}
+
+			if msg.Type != messageTypeConnectionAck {
+				t.Errorf("expected connection_ack write, got %q", msg.Type)
+			}
+
+			close(ackWritten)
+
+			return nil
+		},
+		setReadDeadlineFn: func(time.Time) error {
+			deadlineCalls++
+			if deadlineCalls == 2 {
+				select {
+				case <-ackWritten:
+				default:
+					t.Fatal("post-init read deadline was set before connection_ack was written")
+				}
+
+				close(postInitDeadlineSet)
+			}
+
+			return nil
+		},
+	}
+	conn := &Connection{
+		conn: fake,
+		handler: &expiringNopHandler{
+			nopHandler: nopHandler{onInit: nil, onSub: nil, onComplete: nil, onClose: nil},
+			expiresAt:  time.Now,
+		},
+		sendCh:               make(chan *Message, 1),
+		connectionAckWriteCh: make(chan error, 1),
+		initialized:          false,
+		expiresAt:            time.Time{},
+	}
+
+	err = conn.Loop(t.Context(), slog.New(slog.DiscardHandler))
+	if !errors.Is(err, errConnectionExpired) {
+		t.Fatalf("expected errConnectionExpired, got %v", err)
+	}
+
+	if deadlineCalls != 2 {
+		t.Fatalf("expected initial and post-init deadline calls, got %d", deadlineCalls)
+	}
+}
+
+func TestReadPumpPostInitDeadlineCancellationReturnsNil(t *testing.T) {
+	t.Parallel()
+
+	initBytes, err := json.Marshal(&Message{ID: "", Type: messageTypeConnectionInit, Payload: nil})
+	if err != nil {
+		t.Fatalf("could not marshal connection_init: %v", err)
+	}
+
+	ctx, cancel := context.WithCancel(t.Context())
+	defer cancel()
+
+	readCalls := 0
+	deadlineCalls := 0
+	fake := &fakeWSConn{
+		readFn: func() (int, []byte, error) {
+			readCalls++
+			if readCalls > 1 {
+				t.Fatal("ReadMessage should not be called again after context cancellation")
+			}
+
+			return websocket.TextMessage, initBytes, nil
+		},
+		setReadDeadlineFn: func(time.Time) error {
+			deadlineCalls++
+			if deadlineCalls > 1 {
+				return context.Canceled
+			}
+
+			return nil
+		},
+	}
+	conn := &Connection{
+		conn: fake,
+		handler: &nopHandler{
+			onInit: func(_ context.Context, _ jsontext.Value) error {
+				cancel()
+
+				return nil
+			},
+			onSub:      nil,
+			onComplete: nil,
+			onClose:    nil,
+		},
+		sendCh:      make(chan *Message, 1),
+		initialized: false,
+		expiresAt:   time.Time{},
+	}
+
+	if err := conn.readPump(ctx, slog.New(slog.DiscardHandler)); err != nil {
+		t.Fatalf("expected nil error after context cancellation, got %v", err)
+	}
+
+	if deadlineCalls != 1 {
+		t.Fatalf("expected only the initial deadline call, got %d", deadlineCalls)
+	}
 }
 
 // TestLoop_ConnectionInitTimeout covers M5 sub-item (1): the readPump's

--- a/services/constellation/controller/websocket/server_test.go
+++ b/services/constellation/controller/websocket/server_test.go
@@ -455,7 +455,7 @@ func TestProtocol_ConnectionClosesAtHandlerExpiration(t *testing.T) {
 	t.Parallel()
 
 	handler := &expiringHandler{
-		expiresAfter: 0,
+		expiresAfter: 50 * time.Millisecond,
 		closeCh:      make(chan struct{}),
 	}
 

--- a/services/constellation/controller/websocket/server_test.go
+++ b/services/constellation/controller/websocket/server_test.go
@@ -2,6 +2,7 @@ package websocket_test
 
 import (
 	"context"
+	"encoding/json/jsontext"
 	json "encoding/json/v2"
 	"errors"
 	"log/slog"
@@ -179,6 +180,31 @@ func writeMessage(t *testing.T, client *gorillaWS.Conn, msg wsMessage) {
 	if err := client.WriteMessage(gorillaWS.TextMessage, data); err != nil {
 		t.Fatalf("write message failed: %v", err)
 	}
+}
+
+type expiringHandler struct {
+	expiresAt time.Time
+	closeCh   chan struct{}
+}
+
+func (h *expiringHandler) OnConnectionInit(context.Context, jsontext.Value) error {
+	return nil
+}
+
+func (h *expiringHandler) OnSubscribe(context.Context, string, websocket.SubscribePayload) {
+	panic("unexpected subscribe")
+}
+
+func (h *expiringHandler) OnComplete(context.Context, string) {
+	panic("unexpected complete")
+}
+
+func (h *expiringHandler) OnClose(context.Context) {
+	close(h.closeCh)
+}
+
+func (h *expiringHandler) ConnectionExpiresAt() (time.Time, bool) {
+	return h.expiresAt, true
 }
 
 // protocolStep describes a single client->server interaction in a
@@ -422,6 +448,45 @@ func TestProtocol_ConnectionInit_Rejected(t *testing.T) {
 	case <-tc.loopDone:
 	case <-time.After(2 * time.Second):
 		t.Fatal("timed out waiting for server loop to exit")
+	}
+}
+
+func TestProtocol_ConnectionClosesAtHandlerExpiration(t *testing.T) {
+	t.Parallel()
+
+	handler := &expiringHandler{
+		expiresAt: time.Now().Add(50 * time.Millisecond),
+		closeCh:   make(chan struct{}),
+	}
+	tc := dialTestServerCapturingErr(t, handler)
+	defer tc.client.Close()
+
+	writeMessage(t, tc.client, wsMessage{Type: "connection_init"})
+
+	ack := readMessage(t, tc.client)
+	if ack.Type != "connection_ack" {
+		t.Fatalf("expected connection_ack, got %s", ack.Type)
+	}
+
+	tc.client.SetReadDeadline(time.Now().Add(2 * time.Second)) //nolint:errcheck
+	_, _, err := tc.client.ReadMessage()
+	if err == nil {
+		t.Fatal("expected connection to close at expiration")
+	}
+
+	select {
+	case err := <-tc.loopErr:
+		if err == nil || !strings.Contains(err.Error(), "connection expired") {
+			t.Fatalf("expected connection expired error, got %v", err)
+		}
+	case <-time.After(2 * time.Second):
+		t.Fatal("timed out waiting for server loop to exit")
+	}
+
+	select {
+	case <-handler.closeCh:
+	case <-time.After(2 * time.Second):
+		t.Fatal("OnClose was not called")
 	}
 }
 

--- a/services/constellation/controller/websocket/server_test.go
+++ b/services/constellation/controller/websocket/server_test.go
@@ -183,8 +183,8 @@ func writeMessage(t *testing.T, client *gorillaWS.Conn, msg wsMessage) {
 }
 
 type expiringHandler struct {
-	expiresAt time.Time
-	closeCh   chan struct{}
+	expiresAfter time.Duration
+	closeCh      chan struct{}
 }
 
 func (h *expiringHandler) OnConnectionInit(context.Context, jsontext.Value) error {
@@ -204,7 +204,7 @@ func (h *expiringHandler) OnClose(context.Context) {
 }
 
 func (h *expiringHandler) ConnectionExpiresAt() (time.Time, bool) {
-	return h.expiresAt, true
+	return time.Now().Add(h.expiresAfter), true
 }
 
 // protocolStep describes a single client->server interaction in a
@@ -455,9 +455,10 @@ func TestProtocol_ConnectionClosesAtHandlerExpiration(t *testing.T) {
 	t.Parallel()
 
 	handler := &expiringHandler{
-		expiresAt: time.Now().Add(50 * time.Millisecond),
-		closeCh:   make(chan struct{}),
+		expiresAfter: 0,
+		closeCh:      make(chan struct{}),
 	}
+
 	tc := dialTestServerCapturingErr(t, handler)
 	defer tc.client.Close()
 
@@ -469,6 +470,7 @@ func TestProtocol_ConnectionClosesAtHandlerExpiration(t *testing.T) {
 	}
 
 	tc.client.SetReadDeadline(time.Now().Add(2 * time.Second)) //nolint:errcheck
+
 	_, _, err := tc.client.ReadMessage()
 	if err == nil {
 		t.Fatal("expected connection to close at expiration")

--- a/services/constellation/controller/websocket_internal_test.go
+++ b/services/constellation/controller/websocket_internal_test.go
@@ -9,6 +9,7 @@ import (
 	"net/http"
 	"strings"
 	"testing"
+	"time"
 
 	"github.com/google/go-cmp/cmp"
 	"github.com/nhost/nhost/services/constellation/controller/middleware"
@@ -21,6 +22,29 @@ import (
 )
 
 // --- getConnectorForOperation tests ---------------------------------------
+
+func TestWebSocketHandlerConnectionExpiresAt(t *testing.T) {
+	t.Parallel()
+
+	expiresAt := time.Unix(1893456000, 0).UTC()
+	handler := &webSocketHandler{
+		session: &middleware.SessionVariables{ExpiresAt: &expiresAt},
+	}
+
+	got, ok := handler.ConnectionExpiresAt()
+	if !ok {
+		t.Fatal("expected expiration to be available")
+	}
+
+	if !got.Equal(expiresAt) {
+		t.Fatalf("expiration mismatch: want %s, got %s", expiresAt, got)
+	}
+
+	handler.session = &middleware.SessionVariables{}
+	if _, ok := handler.ConnectionExpiresAt(); ok {
+		t.Fatal("expected no expiration for non-JWT session")
+	}
+}
 
 func TestGetConnectorForOperation(t *testing.T) {
 	t.Parallel()

--- a/services/constellation/internal/jwt/jwt.go
+++ b/services/constellation/internal/jwt/jwt.go
@@ -20,6 +20,7 @@ import (
 	"fmt"
 	"log/slog"
 	"net/http"
+	"time"
 
 	"github.com/MicahParks/keyfunc/v3"
 	"github.com/nhost/nhost/services/constellation/internal/jwt/jwtconfig"
@@ -150,6 +151,24 @@ func newAuthenticator(
 func (a *Authenticator) Authenticate(
 	headers http.Header, roleOverride string,
 ) (*SessionResult, error) {
+	result, _, err := a.authenticate(headers, roleOverride)
+
+	return result, err
+}
+
+// AuthenticateWithExpiration is like [Authenticator.Authenticate] but also
+// returns the JWT exp claim for successfully authenticated bearer tokens. The
+// expiration pointer is nil when no token was found, matching Authenticate's
+// documented anonymous fall-through result.
+func (a *Authenticator) AuthenticateWithExpiration(
+	headers http.Header, roleOverride string,
+) (*SessionResult, *time.Time, error) {
+	return a.authenticate(headers, roleOverride)
+}
+
+func (a *Authenticator) authenticate(
+	headers http.Header, roleOverride string,
+) (*SessionResult, *time.Time, error) {
 	var lastErr error
 
 	sawToken := false
@@ -168,7 +187,7 @@ func (a *Authenticator) Authenticate(
 		// HASURA_GRAPHQL_JWT_SECRETS multi-IdP / key-rotation contract), so a
 		// token signed for a later secret must not be rejected just because an
 		// earlier secret reads the same header location.
-		claims, err := sv.parseAndValidate(token)
+		claims, expiresAt, err := sv.parseAndValidate(token)
 		if err != nil {
 			a.logger.Debug(
 				"jwt validation failed",
@@ -188,26 +207,26 @@ func (a *Authenticator) Authenticate(
 		// an authentication error, not a "try the next key" signal.
 		hasuraClaims, err := a.extractors[i].extractClaims(claims)
 		if err != nil {
-			return nil, fmt.Errorf("failed to extract hasura claims: %w", err)
+			return nil, nil, fmt.Errorf("failed to extract hasura claims: %w", err)
 		}
 
 		role, variables, err := buildSessionVariables(hasuraClaims, roleOverride)
 		if err != nil {
-			return nil, fmt.Errorf("failed to build session variables: %w", err)
+			return nil, nil, fmt.Errorf("failed to build session variables: %w", err)
 		}
 
 		return &SessionResult{
 			Role:      role,
 			Variables: variables,
-		}, nil
+		}, &expiresAt, nil
 	}
 
 	if sawToken {
 		// At least one secret extracted a token but none verified it.
-		return nil, fmt.Errorf("jwt authentication failed: %w", lastErr)
+		return nil, nil, fmt.Errorf("jwt authentication failed: %w", lastErr)
 	}
 
-	return nil, nil //nolint:nilnil // no token: caller falls through to anonymous, not an error
+	return nil, nil, nil //nolint:nilnil // no token: caller falls through to anonymous, not an error
 }
 
 // Close shuts down each configured secret validator, stopping any JWKS

--- a/services/constellation/internal/jwt/jwt.go
+++ b/services/constellation/internal/jwt/jwt.go
@@ -226,7 +226,7 @@ func (a *Authenticator) authenticate(
 		return nil, nil, fmt.Errorf("jwt authentication failed: %w", lastErr)
 	}
 
-	return nil, nil, nil //nolint:nilnil // no token: caller falls through to anonymous, not an error
+	return nil, nil, nil
 }
 
 // Close shuts down each configured secret validator, stopping any JWKS

--- a/services/constellation/internal/jwt/jwt_test.go
+++ b/services/constellation/internal/jwt/jwt_test.go
@@ -1596,6 +1596,57 @@ func TestAuthenticator(t *testing.T) { //nolint:maintidx
 	}
 }
 
+func TestAuthenticatorAuthenticateWithExpiration(t *testing.T) {
+	t.Parallel()
+
+	const hmacKey = "expiry-test-key"
+
+	expiresAt := time.Unix(1893456000, 0).UTC()
+	token := signHS256Token(t, hmacKey, gojwt.MapClaims{
+		"sub": "user-123",
+		"exp": gojwt.NewNumericDate(expiresAt),
+		"https://hasura.io/jwt/claims": hasuraClaims(
+			[]string{"user"}, "user", map[string]any{"x-hasura-user-id": "123"},
+		),
+	})
+
+	auth, err := jwt.NewAuthenticator(context.Background(), jwtconfig.Config{
+		Secrets: []jwtconfig.Secret{
+			{Type: jwtconfig.AlgorithmHS256, Key: hmacKey},
+		},
+	}, slog.Default())
+	if err != nil {
+		t.Fatalf("NewAuthenticator() error = %v", err)
+	}
+	defer auth.Close()
+
+	result, gotExpiresAt, err := auth.AuthenticateWithExpiration(
+		http.Header{"Authorization": {"Bearer " + token}},
+		"",
+	)
+	if err != nil {
+		t.Fatalf("AuthenticateWithExpiration() error = %v", err)
+	}
+
+	want := &jwt.SessionResult{
+		Role: "user",
+		Variables: expectedVars(
+			"user", []string{"user"}, "user", map[string]any{"x-hasura-user-id": "123"},
+		),
+	}
+	if diff := cmp.Diff(want, result); diff != "" {
+		t.Fatalf("session mismatch (-want +got):\n%s", diff)
+	}
+
+	if gotExpiresAt == nil {
+		t.Fatal("expected expiration to be returned")
+	}
+
+	if !gotExpiresAt.Equal(expiresAt) {
+		t.Fatalf("expiration mismatch: want %s, got %s", expiresAt, *gotExpiresAt)
+	}
+}
+
 func TestNewAuthenticatorErrorForEmptyConfig(t *testing.T) {
 	t.Parallel()
 

--- a/services/constellation/internal/jwt/jwt_test.go
+++ b/services/constellation/internal/jwt/jwt_test.go
@@ -1601,7 +1601,7 @@ func TestAuthenticatorAuthenticateWithExpiration(t *testing.T) {
 
 	const hmacKey = "expiry-test-key"
 
-	expiresAt := time.Unix(1893456000, 0).UTC()
+	expiresAt := gojwt.NewNumericDate(time.Now().Add(time.Hour).UTC()).Time
 
 	validClaims := func(exp time.Time) gojwt.MapClaims {
 		return gojwt.MapClaims{

--- a/services/constellation/internal/jwt/jwt_test.go
+++ b/services/constellation/internal/jwt/jwt_test.go
@@ -1602,48 +1602,115 @@ func TestAuthenticatorAuthenticateWithExpiration(t *testing.T) {
 	const hmacKey = "expiry-test-key"
 
 	expiresAt := time.Unix(1893456000, 0).UTC()
-	token := signHS256Token(t, hmacKey, gojwt.MapClaims{
-		"sub": "user-123",
-		"exp": gojwt.NewNumericDate(expiresAt),
-		"https://hasura.io/jwt/claims": hasuraClaims(
-			[]string{"user"}, "user", map[string]any{"x-hasura-user-id": "123"},
-		),
-	})
 
-	auth, err := jwt.NewAuthenticator(context.Background(), jwtconfig.Config{
-		Secrets: []jwtconfig.Secret{
-			{Type: jwtconfig.AlgorithmHS256, Key: hmacKey},
+	validClaims := func(exp time.Time) gojwt.MapClaims {
+		return gojwt.MapClaims{
+			"sub": "user-123",
+			"exp": gojwt.NewNumericDate(exp),
+			"https://hasura.io/jwt/claims": hasuraClaims(
+				[]string{"user"}, "user", map[string]any{"x-hasura-user-id": "123"},
+			),
+		}
+	}
+
+	cases := []struct {
+		name string
+		// headersFn builds the request headers; it receives the HMAC signing
+		// key so cases that need a token can sign one inline.
+		headersFn func(t *testing.T, key string) http.Header
+		// wantSession is the expected session result; nil means none expected.
+		wantSession *jwt.SessionResult
+		// wantExpiration is the expected exp pointer target; nil means the
+		// returned expiration pointer must itself be nil.
+		wantExpiration *time.Time
+		wantErr        bool
+	}{
+		{
+			name: "valid token returns session and expiration",
+			headersFn: func(t *testing.T, key string) http.Header {
+				t.Helper()
+
+				return http.Header{
+					"Authorization": {"Bearer " + signHS256Token(t, key, validClaims(expiresAt))},
+				}
+			},
+			wantSession: &jwt.SessionResult{
+				Role: "user",
+				Variables: expectedVars(
+					"user", []string{"user"}, "user", map[string]any{"x-hasura-user-id": "123"},
+				),
+			},
+			wantExpiration: &expiresAt,
+			wantErr:        false,
 		},
-	}, slog.Default())
-	if err != nil {
-		t.Fatalf("NewAuthenticator() error = %v", err)
-	}
-	defer auth.Close()
+		{
+			name: "no token returns nil session, nil expiration, nil error",
+			headersFn: func(t *testing.T, _ string) http.Header {
+				t.Helper()
 
-	result, gotExpiresAt, err := auth.AuthenticateWithExpiration(
-		http.Header{"Authorization": {"Bearer " + token}},
-		"",
-	)
-	if err != nil {
-		t.Fatalf("AuthenticateWithExpiration() error = %v", err)
+				return http.Header{}
+			},
+			wantSession:    nil,
+			wantExpiration: nil,
+			wantErr:        false,
+		},
+		{
+			name: "expired token returns nil session, nil expiration, error",
+			headersFn: func(t *testing.T, key string) http.Header {
+				t.Helper()
+
+				expired := time.Unix(1000000000, 0).UTC()
+
+				return http.Header{
+					"Authorization": {"Bearer " + signHS256Token(t, key, validClaims(expired))},
+				}
+			},
+			wantSession:    nil,
+			wantExpiration: nil,
+			wantErr:        true,
+		},
 	}
 
-	want := &jwt.SessionResult{
-		Role: "user",
-		Variables: expectedVars(
-			"user", []string{"user"}, "user", map[string]any{"x-hasura-user-id": "123"},
-		),
-	}
-	if diff := cmp.Diff(want, result); diff != "" {
-		t.Fatalf("session mismatch (-want +got):\n%s", diff)
-	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
 
-	if gotExpiresAt == nil {
-		t.Fatal("expected expiration to be returned")
-	}
+			auth, err := jwt.NewAuthenticator(context.Background(), jwtconfig.Config{
+				Secrets: []jwtconfig.Secret{
+					{Type: jwtconfig.AlgorithmHS256, Key: hmacKey},
+				},
+			}, slog.Default())
+			if err != nil {
+				t.Fatalf("NewAuthenticator() error = %v", err)
+			}
+			defer auth.Close()
 
-	if !gotExpiresAt.Equal(expiresAt) {
-		t.Fatalf("expiration mismatch: want %s, got %s", expiresAt, *gotExpiresAt)
+			result, gotExpiresAt, err := auth.AuthenticateWithExpiration(
+				tc.headersFn(t, hmacKey),
+				"",
+			)
+
+			if tc.wantErr {
+				if err == nil {
+					t.Errorf("expected error, got nil (result=%+v)", result)
+				}
+			} else if err != nil {
+				t.Fatalf("AuthenticateWithExpiration() unexpected error = %v", err)
+			}
+
+			if diff := cmp.Diff(tc.wantSession, result); diff != "" {
+				t.Errorf("session mismatch (-want +got):\n%s", diff)
+			}
+
+			switch {
+			case tc.wantExpiration == nil && gotExpiresAt != nil:
+				t.Errorf("expected nil expiration, got %s", *gotExpiresAt)
+			case tc.wantExpiration != nil && gotExpiresAt == nil:
+				t.Error("expected expiration to be returned, got nil")
+			case tc.wantExpiration != nil && !gotExpiresAt.Equal(*tc.wantExpiration):
+				t.Errorf("expiration mismatch: want %s, got %s", *tc.wantExpiration, *gotExpiresAt)
+			}
+		})
 	}
 }
 

--- a/services/constellation/internal/jwt/validator.go
+++ b/services/constellation/internal/jwt/validator.go
@@ -146,6 +146,11 @@ func (sv *secretValidator) parseAndValidate(tokenStr string) (map[string]any, ti
 		return nil, time.Time{}, fmt.Errorf("jwt expiration claim: %w", err)
 	}
 
+	// Defense-in-depth: GetExpirationTime returns (nil, nil) for an absent or
+	// zero exp claim, so this guard prevents a nil dereference at expiresAt.Time
+	// below. It is normally unreachable because buildParserOptions pins
+	// jwt.WithExpirationRequired(), making jwt.Parse reject exp-less tokens first;
+	// it survives as a backstop should that parser option ever change.
 	if expiresAt == nil {
 		return nil, time.Time{}, errMissingExpiration
 	}

--- a/services/constellation/internal/jwt/validator.go
+++ b/services/constellation/internal/jwt/validator.go
@@ -22,6 +22,8 @@ var (
 	ErrUnexpectedClaimsType = errors.New("unexpected claims type")
 	ErrPEMDecode            = errors.New("failed to decode PEM block")
 	ErrNotRSAPublicKey      = errors.New("key is not an RSA public key")
+
+	errMissingExpiration = errors.New("missing expiration claim")
 )
 
 // jwksProvider is the minimal contract this package needs from a JWKS-backed
@@ -128,18 +130,27 @@ func (sv *secretValidator) initStatic(secret jwtconfig.Secret, logger *slog.Logg
 	return nil
 }
 
-func (sv *secretValidator) parseAndValidate(tokenStr string) (map[string]any, error) {
+func (sv *secretValidator) parseAndValidate(tokenStr string) (map[string]any, time.Time, error) {
 	token, err := jwt.Parse(tokenStr, sv.keyFunc, sv.opts...)
 	if err != nil {
-		return nil, fmt.Errorf("jwt validation failed: %w", err)
+		return nil, time.Time{}, fmt.Errorf("jwt validation failed: %w", err)
 	}
 
 	claims, ok := token.Claims.(jwt.MapClaims)
 	if !ok {
-		return nil, ErrUnexpectedClaimsType
+		return nil, time.Time{}, ErrUnexpectedClaimsType
 	}
 
-	return claims, nil
+	expiresAt, err := claims.GetExpirationTime()
+	if err != nil {
+		return nil, time.Time{}, fmt.Errorf("jwt expiration claim: %w", err)
+	}
+
+	if expiresAt == nil {
+		return nil, time.Time{}, errMissingExpiration
+	}
+
+	return claims, expiresAt.Time, nil
 }
 
 // close shuts down any background goroutines (e.g. JWKS refresh).


### PR DESCRIPTION
<!-- nhost-reviewer:start -->
### **What this PR solves**
Ensures GraphQL WebSocket sessions authenticated by JWT do not outlive the token that authorized them. The change propagates JWT expiration through session extraction and arms WebSocket read deadlines so expired connections close automatically.

___

### **PR Type**
Enhancement

___

### **Description**
- Return JWT `exp` times from the Constellation JWT authenticator and session middleware.
- Expose session expiration from the WebSocket handler to the protocol layer.
- Add WebSocket read-deadline handling that enforces connection-init timeouts and JWT expiry after `connection_ack` is written.
- Cover expiration propagation and WebSocket close behavior with unit and protocol tests.

___

### Diagram Walkthrough

```mermaid
flowchart LR
  JWT["JWT validator"] --> Auth["Authenticator.AuthenticateWithExpiration"]
  Auth --> Session["middleware.ExtractSession"]
  Session --> Handler["webSocketHandler.ConnectionExpiresAt"]
  Handler --> Conn["websocket.Connection"]
  Conn --> Deadline["SetReadDeadline(exp)"]
  Deadline --> Close["close expired socket"]
```

<details> <summary><h3> File Walkthrough</h3></summary>

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody>
<tr><td><strong>Session middleware</strong></td><td><details><summary>3 files</summary><table>
<tr><td><strong>services/constellation/controller/middleware/mock/jwt_authenticator.go</strong><dd><code>Regenerates the JWTAuthenticator mock with AuthenticateWithExpiration support.</code></dd></td><td><a href="https://github.com/nhost/nhost/pull/4416/files#diff-e37a226c78a02bd8a92b98119e33cc72c6b6bbdf6155ead009a0c637965ed29a">+17/-0</a></td></tr>
<tr><td><strong>services/constellation/controller/middleware/session.go</strong><dd><code>Adds ExpiresAt to sessions and requires authenticators to return JWT expiration.</code></dd></td><td><a href="https://github.com/nhost/nhost/pull/4416/files#diff-7ca7fba1073a191d00882527390f0888cbd336633f15d90e2722d2938b61b087">+21/-2</a></td></tr>
<tr><td><strong>services/constellation/controller/middleware/session_test.go</strong><dd><code>Updates session tests for expiration propagation and mock authenticator calls.</code></dd></td><td><a href="https://github.com/nhost/nhost/pull/4416/files#diff-5659585994570e01adff56d9c2786ee2d250b1bce594341a9afbd2054f664461">+38/-7</a></td></tr>
</table></details></td></tr>
<tr><td><strong>WebSocket handler</strong></td><td><details><summary>2 files</summary><table>
<tr><td><strong>services/constellation/controller/websocket.go</strong><dd><code>Exposes the authenticated session expiration to the WebSocket protocol layer.</code></dd></td><td><a href="https://github.com/nhost/nhost/pull/4416/files#diff-4b479f1358f4840aa252cd12ef2ee2077c662afde304d2b6667a74a87324a52e">+11/-0</a></td></tr>
<tr><td><strong>services/constellation/controller/websocket_internal_test.go</strong><dd><code>Adds coverage for webSocketHandler expiration reporting.</code></dd></td><td><a href="https://github.com/nhost/nhost/pull/4416/files#diff-8751a7044415ffce7c79261d3038aea7461b7e635244590af6e708aae0adc66e">+24/-0</a></td></tr>
</table></details></td></tr>
<tr><td><strong>WebSocket protocol</strong></td><td><details><summary>4 files</summary><table>
<tr><td><strong>services/constellation/controller/websocket/errors.go</strong><dd><code>Adds an explicit connection-expired sentinel error.</code></dd></td><td><a href="https://github.com/nhost/nhost/pull/4416/files#diff-6cce189900c256c2dc2f88f02a4c5703d5e1506b22c6fcd0796e9bd9caac8a87">+1/-0</a></td></tr>
<tr><td><strong>services/constellation/controller/websocket/server.go</strong><dd><code>Enforces init and post-init JWT read deadlines and synchronizes connection_ack writes.</code></dd></td><td><a href="https://github.com/nhost/nhost/pull/4416/files#diff-baac4f8ab217e74b827ecba22651487e2ca5d6e6825ca1de304cc5518baeb1b6">+212/-28</a></td></tr>
<tr><td><strong>services/constellation/controller/websocket/server_internal_test.go</strong><dd><code>Adds deadline, cancellation, and ack-ordering tests for the WebSocket loop.</code></dd></td><td><a href="https://github.com/nhost/nhost/pull/4416/files#diff-f2a577c0ff2a52545b47f8f8b3e8da692b86f67ab38db0f626fdd8c02e004ecf">+287/-3</a></td></tr>
<tr><td><strong>services/constellation/controller/websocket/server_test.go</strong><dd><code>Adds a protocol-level test that closes a connection at handler expiration.</code></dd></td><td><a href="https://github.com/nhost/nhost/pull/4416/files#diff-5b8214e1bd200a42860a5e99232071c334727c08501c3ce72ccd6362299d7e8a">+67/-0</a></td></tr>
</table></details></td></tr>
<tr><td><strong>JWT validation</strong></td><td><details><summary>3 files</summary><table>
<tr><td><strong>services/constellation/internal/jwt/jwt.go</strong><dd><code>Adds AuthenticateWithExpiration while preserving existing Authenticate behavior.</code></dd></td><td><a href="https://github.com/nhost/nhost/pull/4416/files#diff-4b28dced7564fdd8e07cb38dde28ab4197a60244273c5da0a1248bb49397f416">+25/-6</a></td></tr>
<tr><td><strong>services/constellation/internal/jwt/jwt_test.go</strong><dd><code>Covers valid, absent, and expired tokens for AuthenticateWithExpiration.</code></dd></td><td><a href="https://github.com/nhost/nhost/pull/4416/files#diff-d6f448bcd3b3e968775ca18686553b09f9215b1804ce82a3cc329f8825f294a3">+118/-0</a></td></tr>
<tr><td><strong>services/constellation/internal/jwt/validator.go</strong><dd><code>Returns the validated JWT expiration time from token parsing.</code></dd></td><td><a href="https://github.com/nhost/nhost/pull/4416/files#diff-1740efcc5a2d5204cb05732ee8be202334ec1393e06620e5b4b8eb46d81a7e29">+20/-4</a></td></tr>
</table></details></td></tr>
</tbody></table>

</details>

___

<!-- nhost-reviewer:end -->