### PR TITLE
fix(ci): prevent script injection in release workflows

### DIFF
--- a/.github/workflows/ci_create_release.yaml
+++ b/.github/workflows/ci_create_release.yaml
@@ -33,9 +33,9 @@ jobs:
 
     - name: "Extract project and version from PR title"
       id: extract
+      env:
+        TITLE: ${{ github.event.pull_request.title }}
       run: |
-        TITLE="${{ github.event.pull_request.title }}"
-
         PROJECT=$(echo "${TITLE}" | sed 's/release(\([^)]*\)).*/\1/')
         if [ -z "$PROJECT" ]; then
           echo "Error: Could not extract project name from PR title"
@@ -74,8 +74,10 @@ jobs:
 
     - name: "Get unreleased changelog content"
       id: changelog
+      env:
+        PROJECT: ${{ steps.extract.outputs.project }}
       run: |
-        cd ${{ steps.extract.outputs.project }}
+        cd "$PROJECT"
         CHANGELOG_CONTENT=$(nix develop .#cliff -c make changelog-get-unreleased)
         DELIMITER="EOF_$(openssl rand -hex 16)"
         echo "content<<$DELIMITER" >> $GITHUB_OUTPUT

--- a/.github/workflows/ci_create_release.yaml
+++ b/.github/workflows/ci_create_release.yaml
@@ -77,16 +77,19 @@ jobs:
       run: |
         cd ${{ steps.extract.outputs.project }}
         CHANGELOG_CONTENT=$(nix develop .#cliff -c make changelog-get-unreleased)
-        echo "content<<EOF" >> $GITHUB_OUTPUT
+        DELIMITER="EOF_$(openssl rand -hex 16)"
+        echo "content<<$DELIMITER" >> $GITHUB_OUTPUT
         echo "$CHANGELOG_CONTENT" >> $GITHUB_OUTPUT
-        echo "EOF" >> $GITHUB_OUTPUT
+        echo "$DELIMITER" >> $GITHUB_OUTPUT
 
     - name: "Create GitHub Release"
-      run: |
-        gh release create "${{ steps.extract.outputs.tag }}" \
-          --title "${{ steps.extract.outputs.tag }}" \
-          --notes "${{ steps.changelog.outputs.content }}" \
-          --target main
       env:
         # We need a non-GITHUB_TOKEN here so the release event triggers downstream workflows
         GH_TOKEN: ${{ steps.app-token.outputs.token }}
+        TAG: ${{ steps.extract.outputs.tag }}
+        NOTES: ${{ steps.changelog.outputs.content }}
+      run: |
+        gh release create "$TAG" \
+          --title "$TAG" \
+          --notes "$NOTES" \
+          --target main

--- a/.github/workflows/ci_release.yaml
+++ b/.github/workflows/ci_release.yaml
@@ -14,9 +14,9 @@ jobs:
     steps:
       - name: "Extract project and version from tag"
         id: extract
+        env:
+          TAG: ${{ github.event.release.tag_name }}
         run: |
-          TAG="${{ github.event.release.tag_name }}"
-
           PROJECT=$(echo "${TAG}" | sed 's/@[^@]*$//')
           if [ -z "$PROJECT" ]; then
             echo "Error: Could not extract project name from tag"


### PR DESCRIPTION

  <!-- nhost-reviewer:start -->
  ### **What this PR solves**
  Three steps in the release workflows interpolated untrusted, user-controlled text (PR title, rendered changelog, release tag name)
  directly into `run:` shell blocks, allowing GitHub Actions script injection on a runner holding the release App token and AWS production
  credentials. This PR routes each value through an `env:` variable so it is treated as data, not shell code.

  ___

  ### **PR Type**
  Bug fix

  ___

  ### **Description**
  - Pass `github.event.pull_request.title` to the extract step via an `env:` variable and quote-expand it, instead of inlining it into the
  shell.
  - Pass the rendered changelog to `gh release create --notes` via an `env:` variable, and randomize the `$GITHUB_OUTPUT` heredoc delimiter
  so changelog content cannot smuggle fake step outputs.
  - Pass `github.event.release.tag_name` to the tag-extract step via an `env:` variable in `ci_release.yaml`.

  ___

  ### Diagram Walkthrough

  ```mermaid
  flowchart LR
    A["Untrusted input<br/>(PR title / changelog / tag)"] --> B["env: variable"]
    B --> C["Quoted shell var<br/>$TITLE / $NOTES / $TAG"]
    C --> D["run: block<br/>(no injection)"]
```
