### PR TITLE
feat(constellation): cap GraphQL request bodies

### DIFF
--- a/services/constellation/README.md
+++ b/services/constellation/README.md
@@ -177,6 +177,10 @@ All flags are also available as environment variables. The most common:
 | `--jwt-secret` | `CONSTELLATION_JWT_SECRET` | *(required)* |
 | `--cors-allowed-origins` | `CONSTELLATION_CORS_ALLOWED_ORIGINS` | *(empty — denies all cross-origin requests)*; entries may use `*` as a wildcard (e.g. `https://my-app-*-org.vercel.app`); a bare `*` cannot be combined with credentials and is rejected at startup |
 | `--subscription-poll-interval` | `CONSTELLATION_SUBSCRIPTION_POLL_INTERVAL` | `1s` |
+| `--graphql-request-body-limit-bytes` | `CONSTELLATION_GRAPHQL_REQUEST_BODY_LIMIT_BYTES` | `10485760` (10 MiB) |
+| `--http-read-timeout` | `CONSTELLATION_HTTP_READ_TIMEOUT` | `30s` — caps request header/body read time |
+| `--http-write-timeout` | `CONSTELLATION_HTTP_WRITE_TIMEOUT` | `5m0s` |
+| `--http-idle-timeout` | `CONSTELLATION_HTTP_IDLE_TIMEOUT` | `2m0s` |
 | `--enable-playground` | `CONSTELLATION_ENABLE_PLAYGROUND` | `false` |
 | `--debug` | `CONSTELLATION_DEBUG` | `false` |
 | `--log-format-text` | `CONSTELLATION_LOG_FORMAT_TEXT` | `false` — JSON logs by default |

--- a/services/constellation/cmd/serve.go
+++ b/services/constellation/cmd/serve.go
@@ -28,20 +28,27 @@ import (
 )
 
 const (
-	flagDebug                    = "debug"
-	flagLogFormatTEXT            = "log-format-text"
-	flagBindAddress              = "bind-address"
-	flagEnablePlayground         = "enable-playground"
-	flagMetadataPath             = "metadata-path"
-	flagAdminSecret              = "admin-secret"
-	flagJWTSecret                = "jwt-secret"
-	flagSubscriptionPollInterval = "subscription-poll-interval"
-	flagMetadataDatabaseURL      = "metadata-database-url"
-	flagProfileAddress           = "profile-address"
-	flagCORSAllowedOrigins       = "cors-allowed-origins"
-	flagDevMode                  = "dev-mode"
+	flagDebug                        = "debug"
+	flagLogFormatTEXT                = "log-format-text"
+	flagBindAddress                  = "bind-address"
+	flagEnablePlayground             = "enable-playground"
+	flagMetadataPath                 = "metadata-path"
+	flagAdminSecret                  = "admin-secret"
+	flagJWTSecret                    = "jwt-secret"
+	flagSubscriptionPollInterval     = "subscription-poll-interval"
+	flagMetadataDatabaseURL          = "metadata-database-url"
+	flagProfileAddress               = "profile-address"
+	flagCORSAllowedOrigins           = "cors-allowed-origins"
+	flagDevMode                      = "dev-mode"
+	flagGraphQLRequestBodyLimitBytes = "graphql-request-body-limit-bytes"
+	flagHTTPReadTimeout              = "http-read-timeout"
+	flagHTTPWriteTimeout             = "http-write-timeout"
+	flagHTTPIdleTimeout              = "http-idle-timeout"
 
-	shutdownTimeout = 30 * time.Second
+	defaultHTTPReadTimeout  = 30 * time.Second
+	defaultHTTPWriteTimeout = 5 * time.Minute
+	defaultHTTPIdleTimeout  = 120 * time.Second
+	shutdownTimeout         = 30 * time.Second
 )
 
 func generalFlags() []cli.Flag {
@@ -106,6 +113,35 @@ func serverFlags() []cli.Flag {
 				"enable in production, as it leaks internal schema and data values",
 			Category: "server",
 			Sources:  cli.EnvVars("CONSTELLATION_DEV_MODE"),
+		},
+		&cli.Int64Flag{ //nolint:exhaustruct
+			Name: flagGraphQLRequestBodyLimitBytes,
+			Usage: "maximum JSON request body size accepted by POST /v1/graphql " +
+				"and POST /v1, in bytes",
+			Value:    controller.DefaultMaxGraphQLRequestBodyBytes,
+			Category: "server",
+			Sources:  cli.EnvVars("CONSTELLATION_GRAPHQL_REQUEST_BODY_LIMIT_BYTES"),
+		},
+		&cli.DurationFlag{ //nolint:exhaustruct
+			Name:     flagHTTPReadTimeout,
+			Usage:    "maximum time allowed to read an HTTP request, including the body",
+			Value:    defaultHTTPReadTimeout,
+			Category: "server",
+			Sources:  cli.EnvVars("CONSTELLATION_HTTP_READ_TIMEOUT"),
+		},
+		&cli.DurationFlag{ //nolint:exhaustruct
+			Name:     flagHTTPWriteTimeout,
+			Usage:    "maximum time allowed to write an HTTP response",
+			Value:    defaultHTTPWriteTimeout,
+			Category: "server",
+			Sources:  cli.EnvVars("CONSTELLATION_HTTP_WRITE_TIMEOUT"),
+		},
+		&cli.DurationFlag{ //nolint:exhaustruct
+			Name:     flagHTTPIdleTimeout,
+			Usage:    "maximum time to keep idle HTTP keep-alive connections open",
+			Value:    defaultHTTPIdleTimeout,
+			Category: "server",
+			Sources:  cli.EnvVars("CONSTELLATION_HTTP_IDLE_TIMEOUT"),
 		},
 	}
 }
@@ -289,15 +325,30 @@ func getRouter(
 		router.GET("/", playgroundHandler("/v1/graphql"))
 	}
 
-	router.POST("/v1/graphql", ctrl.HandlerPost)
+	maxBodyBytes, err := getMaxGraphQLRequestBodyBytes(cmd)
+	if err != nil {
+		return nil, err
+	}
+
+	postHandler := ctrl.HandlerPostWithMaxBodyBytes(maxBodyBytes)
+	router.POST("/v1/graphql", postHandler)
 	router.GET("/v1/graphql", ctrl.HandlerGet)
 
 	// legacy endpoints for backward compatibility with hasura deployment
 	// to be removed when we do the one binary thing
-	router.POST("/v1", ctrl.HandlerPost)
+	router.POST("/v1", postHandler)
 	router.GET("/v1", ctrl.HandlerGet)
 
 	return router, nil
+}
+
+func getMaxGraphQLRequestBodyBytes(cmd *cli.Command) (int64, error) {
+	maxBodyBytes := cmd.Int64(flagGraphQLRequestBodyLimitBytes)
+	if maxBodyBytes <= 0 {
+		return 0, fmt.Errorf("%s must be greater than 0", flagGraphQLRequestBodyLimitBytes)
+	}
+
+	return maxBodyBytes, nil
 }
 
 // initJWTAuth builds a JWT authenticator from the configured secrets. At least
@@ -394,10 +445,9 @@ func runServer(
 		return fmt.Errorf("building HTTP router: %w", err)
 	}
 
-	server := &http.Server{ //nolint:exhaustruct
-		Addr:              cmd.String(flagBindAddress),
-		Handler:           router,
-		ReadHeaderTimeout: 5 * time.Second, //nolint:mnd
+	server, err := newHTTPServer(cmd, router)
+	if err != nil {
+		return fmt.Errorf("configuring HTTP server: %w", err)
 	}
 
 	ctx, cancel := context.WithCancel(ctx)
@@ -447,6 +497,41 @@ func runServer(
 	}
 
 	return nil
+}
+
+func newHTTPServer(cmd *cli.Command, handler http.Handler) (*http.Server, error) {
+	readTimeout, err := positiveDurationFlag(cmd, flagHTTPReadTimeout)
+	if err != nil {
+		return nil, err
+	}
+
+	writeTimeout, err := positiveDurationFlag(cmd, flagHTTPWriteTimeout)
+	if err != nil {
+		return nil, err
+	}
+
+	idleTimeout, err := positiveDurationFlag(cmd, flagHTTPIdleTimeout)
+	if err != nil {
+		return nil, err
+	}
+
+	return &http.Server{ //nolint:exhaustruct
+		Addr:              cmd.String(flagBindAddress),
+		Handler:           handler,
+		ReadHeaderTimeout: 5 * time.Second, //nolint:mnd
+		ReadTimeout:       readTimeout,
+		WriteTimeout:      writeTimeout,
+		IdleTimeout:       idleTimeout,
+	}, nil
+}
+
+func positiveDurationFlag(cmd *cli.Command, name string) (time.Duration, error) {
+	value := cmd.Duration(name)
+	if value <= 0 {
+		return 0, fmt.Errorf("%s must be greater than 0", name)
+	}
+
+	return value, nil
 }
 
 // startProfileServer starts a pprof profiling server if profileAddr is non-empty.

--- a/services/constellation/cmd/serve.go
+++ b/services/constellation/cmd/serve.go
@@ -42,14 +42,18 @@ const (
 	flagDevMode                      = "dev-mode"
 	flagGraphQLRequestBodyLimitBytes = "graphql-request-body-limit-bytes"
 	flagHTTPReadTimeout              = "http-read-timeout"
-	flagHTTPWriteTimeout             = "http-write-timeout"
-	flagHTTPIdleTimeout              = "http-idle-timeout"
+	//nolint:gosec // CLI flag name contains "write" but is not a credential.
+	flagHTTPWriteTimeout = "http-write-timeout"
+	flagHTTPIdleTimeout  = "http-idle-timeout"
 
-	defaultHTTPReadTimeout  = 30 * time.Second
-	defaultHTTPWriteTimeout = 5 * time.Minute
-	defaultHTTPIdleTimeout  = 120 * time.Second
-	shutdownTimeout         = 30 * time.Second
+	defaultHTTPReadTimeout   = 30 * time.Second
+	defaultHTTPWriteTimeout  = 5 * time.Minute
+	defaultHTTPIdleTimeout   = 120 * time.Second
+	maxHTTPReadHeaderTimeout = 5 * time.Second
+	shutdownTimeout          = 30 * time.Second
 )
+
+var errFlagMustBeGreaterThanZero = errors.New("must be greater than 0")
 
 func generalFlags() []cli.Flag {
 	return []cli.Flag{
@@ -330,6 +334,7 @@ func getRouter(
 		return nil, err
 	}
 
+	//nolint:contextcheck // handler uses per-request contexts; startup ctx must not be captured.
 	postHandler := ctrl.HandlerPostWithMaxBodyBytes(maxBodyBytes)
 	router.POST("/v1/graphql", postHandler)
 	router.GET("/v1/graphql", ctrl.HandlerGet)
@@ -345,7 +350,9 @@ func getRouter(
 func getMaxGraphQLRequestBodyBytes(cmd *cli.Command) (int64, error) {
 	maxBodyBytes := cmd.Int64(flagGraphQLRequestBodyLimitBytes)
 	if maxBodyBytes <= 0 {
-		return 0, fmt.Errorf("%s must be greater than 0", flagGraphQLRequestBodyLimitBytes)
+		return 0, fmt.Errorf(
+			"%s: %w", flagGraphQLRequestBodyLimitBytes, errFlagMustBeGreaterThanZero,
+		)
 	}
 
 	return maxBodyBytes, nil
@@ -378,8 +385,10 @@ func initJWTAuth(
 	return jwtAuth, nil
 }
 
-func newMetadataSource( //nolint:ireturn,nolintlint
-	ctx context.Context, cmd *cli.Command, logger *slog.Logger,
+func newMetadataSource( //nolint:ireturn // selected sources share the metadata.Source boundary.
+	ctx context.Context,
+	cmd *cli.Command,
+	logger *slog.Logger,
 ) (metadata.Source, error) {
 	if metaDBURL := cmd.String(flagMetadataDatabaseURL); metaDBURL != "" {
 		source, err := source.NewDatabaseMetadataSource(
@@ -518,7 +527,7 @@ func newHTTPServer(cmd *cli.Command, handler http.Handler) (*http.Server, error)
 	return &http.Server{ //nolint:exhaustruct
 		Addr:              cmd.String(flagBindAddress),
 		Handler:           handler,
-		ReadHeaderTimeout: 5 * time.Second, //nolint:mnd
+		ReadHeaderTimeout: min(readTimeout, maxHTTPReadHeaderTimeout),
 		ReadTimeout:       readTimeout,
 		WriteTimeout:      writeTimeout,
 		IdleTimeout:       idleTimeout,
@@ -528,7 +537,7 @@ func newHTTPServer(cmd *cli.Command, handler http.Handler) (*http.Server, error)
 func positiveDurationFlag(cmd *cli.Command, name string) (time.Duration, error) {
 	value := cmd.Duration(name)
 	if value <= 0 {
-		return 0, fmt.Errorf("%s must be greater than 0", name)
+		return 0, fmt.Errorf("%s: %w", name, errFlagMustBeGreaterThanZero)
 	}
 
 	return value, nil
@@ -550,7 +559,7 @@ func startProfileServer(
 	profileServer := &http.Server{ //nolint:exhaustruct
 		Addr:              profileAddr,
 		Handler:           http.DefaultServeMux,
-		ReadHeaderTimeout: 5 * time.Second, //nolint:mnd
+		ReadHeaderTimeout: maxHTTPReadHeaderTimeout,
 	}
 
 	go func() {

--- a/services/constellation/cmd/serve_internal_test.go
+++ b/services/constellation/cmd/serve_internal_test.go
@@ -5,9 +5,12 @@ import (
 	"context"
 	"errors"
 	"log/slog"
+	"net/http"
 	"strings"
 	"testing"
+	"time"
 
+	"github.com/nhost/nhost/services/constellation/controller"
 	oapicors "github.com/nhost/nhost/services/constellation/internal/lib/oapi/cors"
 	"github.com/urfave/cli/v3"
 )
@@ -147,6 +150,201 @@ func TestGetCorsOptionsAllowHeadersFunc(t *testing.T) {
 
 			if got := opts.AllowHeadersFunc(tc.header); got != tc.want {
 				t.Errorf("AllowHeadersFunc(%q) = %v; want %v", tc.header, got, tc.want)
+			}
+		})
+	}
+}
+
+func runGetMaxGraphQLRequestBodyBytes(t *testing.T, args []string) (int64, error) {
+	t.Helper()
+
+	var (
+		gotLimit int64
+		gotErr   error
+	)
+
+	cmd := &cli.Command{
+		Name:  "serve",
+		Flags: serverFlags(),
+		Action: func(_ context.Context, cmd *cli.Command) error {
+			gotLimit, gotErr = getMaxGraphQLRequestBodyBytes(cmd)
+
+			return nil
+		},
+	}
+
+	if err := cmd.Run(context.Background(), append([]string{"serve"}, args...)); err != nil {
+		t.Fatalf("running cli: %v", err)
+	}
+
+	return gotLimit, gotErr
+}
+
+func TestGetMaxGraphQLRequestBodyBytes(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name        string
+		args        []string
+		wantLimit   int64
+		wantErrText string
+	}{
+		{
+			name:      "default",
+			args:      nil,
+			wantLimit: controller.DefaultMaxGraphQLRequestBodyBytes,
+		},
+		{
+			name:      "explicit positive limit",
+			args:      []string{"--" + flagGraphQLRequestBodyLimitBytes, "1024"},
+			wantLimit: 1024,
+		},
+		{
+			name:        "zero rejected",
+			args:        []string{"--" + flagGraphQLRequestBodyLimitBytes, "0"},
+			wantErrText: flagGraphQLRequestBodyLimitBytes,
+		},
+		{
+			name:        "negative rejected",
+			args:        []string{"--" + flagGraphQLRequestBodyLimitBytes, "-1"},
+			wantErrText: flagGraphQLRequestBodyLimitBytes,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+
+			gotLimit, err := runGetMaxGraphQLRequestBodyBytes(t, tt.args)
+			if tt.wantErrText != "" {
+				if err == nil {
+					t.Fatalf("expected error containing %q", tt.wantErrText)
+				}
+
+				if !strings.Contains(err.Error(), tt.wantErrText) {
+					t.Fatalf("error %q does not contain %q", err, tt.wantErrText)
+				}
+
+				return
+			}
+
+			if err != nil {
+				t.Fatalf("getMaxGraphQLRequestBodyBytes unexpected error: %v", err)
+			}
+
+			if gotLimit != tt.wantLimit {
+				t.Errorf("limit = %d; want %d", gotLimit, tt.wantLimit)
+			}
+		})
+	}
+}
+
+func runNewHTTPServer(t *testing.T, args []string) (*http.Server, error) {
+	t.Helper()
+
+	var (
+		gotServer *http.Server
+		gotErr    error
+	)
+
+	cmd := &cli.Command{
+		Name:  "serve",
+		Flags: serverFlags(),
+		Action: func(_ context.Context, cmd *cli.Command) error {
+			gotServer, gotErr = newHTTPServer(cmd, http.NewServeMux())
+
+			return nil
+		},
+	}
+
+	if err := cmd.Run(context.Background(), append([]string{"serve"}, args...)); err != nil {
+		t.Fatalf("running cli: %v", err)
+	}
+
+	return gotServer, gotErr
+}
+
+func TestNewHTTPServerConfig(t *testing.T) {
+	t.Parallel()
+
+	const customReadTimeout = 45 * time.Second
+	const customWriteTimeout = 2 * time.Minute
+	const customIdleTimeout = 3 * time.Minute
+
+	tests := []struct {
+		name        string
+		args        []string
+		wantRead    time.Duration
+		wantWrite   time.Duration
+		wantIdle    time.Duration
+		wantErrText string
+	}{
+		{
+			name:      "default timeouts",
+			args:      nil,
+			wantRead:  defaultHTTPReadTimeout,
+			wantWrite: defaultHTTPWriteTimeout,
+			wantIdle:  defaultHTTPIdleTimeout,
+		},
+		{
+			name: "explicit positive timeouts",
+			args: []string{
+				"--" + flagHTTPReadTimeout, customReadTimeout.String(),
+				"--" + flagHTTPWriteTimeout, customWriteTimeout.String(),
+				"--" + flagHTTPIdleTimeout, customIdleTimeout.String(),
+			},
+			wantRead:  customReadTimeout,
+			wantWrite: customWriteTimeout,
+			wantIdle:  customIdleTimeout,
+		},
+		{
+			name:        "zero read timeout rejected",
+			args:        []string{"--" + flagHTTPReadTimeout, "0s"},
+			wantErrText: flagHTTPReadTimeout,
+		},
+		{
+			name:        "zero write timeout rejected",
+			args:        []string{"--" + flagHTTPWriteTimeout, "0s"},
+			wantErrText: flagHTTPWriteTimeout,
+		},
+		{
+			name:        "zero idle timeout rejected",
+			args:        []string{"--" + flagHTTPIdleTimeout, "0s"},
+			wantErrText: flagHTTPIdleTimeout,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+
+			server, err := runNewHTTPServer(t, tt.args)
+			if tt.wantErrText != "" {
+				if err == nil {
+					t.Fatalf("expected error containing %q", tt.wantErrText)
+				}
+
+				if !strings.Contains(err.Error(), tt.wantErrText) {
+					t.Fatalf("error %q does not contain %q", err, tt.wantErrText)
+				}
+
+				return
+			}
+
+			if err != nil {
+				t.Fatalf("newHTTPServer unexpected error: %v", err)
+			}
+
+			if server.ReadTimeout != tt.wantRead {
+				t.Errorf("ReadTimeout = %s; want %s", server.ReadTimeout, tt.wantRead)
+			}
+
+			if server.WriteTimeout != tt.wantWrite {
+				t.Errorf("WriteTimeout = %s; want %s", server.WriteTimeout, tt.wantWrite)
+			}
+
+			if server.IdleTimeout != tt.wantIdle {
+				t.Errorf("IdleTimeout = %s; want %s", server.IdleTimeout, tt.wantIdle)
 			}
 		})
 	}

--- a/services/constellation/cmd/serve_internal_test.go
+++ b/services/constellation/cmd/serve_internal_test.go
@@ -6,6 +6,7 @@ import (
 	"errors"
 	"log/slog"
 	"net/http"
+	"slices"
 	"strings"
 	"testing"
 	"time"
@@ -158,6 +159,20 @@ func TestGetCorsOptionsAllowHeadersFunc(t *testing.T) {
 func runGetMaxGraphQLRequestBodyBytes(t *testing.T, args []string) (int64, error) {
 	t.Helper()
 
+	return runGetMaxGraphQLRequestBodyBytesWithFlags(
+		t,
+		serverFlagsWithoutEnvVarsForTest(t, flagGraphQLRequestBodyLimitBytes),
+		args,
+	)
+}
+
+func runGetMaxGraphQLRequestBodyBytesWithFlags(
+	t *testing.T,
+	flags []cli.Flag,
+	args []string,
+) (int64, error) {
+	t.Helper()
+
 	var (
 		gotLimit int64
 		gotErr   error
@@ -165,7 +180,7 @@ func runGetMaxGraphQLRequestBodyBytes(t *testing.T, args []string) (int64, error
 
 	cmd := &cli.Command{
 		Name:  "serve",
-		Flags: serverFlags(),
+		Flags: flags,
 		Action: func(_ context.Context, cmd *cli.Command) error {
 			gotLimit, gotErr = getMaxGraphQLRequestBodyBytes(cmd)
 
@@ -239,7 +254,43 @@ func TestGetMaxGraphQLRequestBodyBytes(t *testing.T) {
 	}
 }
 
+func TestGetMaxGraphQLRequestBodyBytesFromEnv(t *testing.T) {
+	t.Setenv("CONSTELLATION_GRAPHQL_REQUEST_BODY_LIMIT_BYTES", "2048")
+
+	gotLimit, err := runGetMaxGraphQLRequestBodyBytesWithFlags(
+		t,
+		serverFlagsByNameForTest(t, flagGraphQLRequestBodyLimitBytes),
+		nil,
+	)
+	if err != nil {
+		t.Fatalf("getMaxGraphQLRequestBodyBytes unexpected error: %v", err)
+	}
+
+	if gotLimit != 2048 {
+		t.Errorf("limit = %d; want %d", gotLimit, 2048)
+	}
+}
+
 func runNewHTTPServer(t *testing.T, args []string) (*http.Server, error) {
+	t.Helper()
+
+	return runNewHTTPServerWithFlags(
+		t,
+		serverFlagsWithoutEnvVarsForTest(
+			t,
+			flagHTTPReadTimeout,
+			flagHTTPWriteTimeout,
+			flagHTTPIdleTimeout,
+		),
+		args,
+	)
+}
+
+func runNewHTTPServerWithFlags(
+	t *testing.T,
+	flags []cli.Flag,
+	args []string,
+) (*http.Server, error) {
 	t.Helper()
 
 	var (
@@ -249,7 +300,7 @@ func runNewHTTPServer(t *testing.T, args []string) (*http.Server, error) {
 
 	cmd := &cli.Command{
 		Name:  "serve",
-		Flags: serverFlags(),
+		Flags: flags,
 		Action: func(_ context.Context, cmd *cli.Command) error {
 			gotServer, gotErr = newHTTPServer(cmd, http.NewServeMux())
 
@@ -267,24 +318,29 @@ func runNewHTTPServer(t *testing.T, args []string) (*http.Server, error) {
 func TestNewHTTPServerConfig(t *testing.T) {
 	t.Parallel()
 
-	const customReadTimeout = 45 * time.Second
-	const customWriteTimeout = 2 * time.Minute
-	const customIdleTimeout = 3 * time.Minute
+	const (
+		customReadTimeout  = 45 * time.Second
+		shortReadTimeout   = 2 * time.Second
+		customWriteTimeout = 2 * time.Minute
+		customIdleTimeout  = 3 * time.Minute
+	)
 
 	tests := []struct {
-		name        string
-		args        []string
-		wantRead    time.Duration
-		wantWrite   time.Duration
-		wantIdle    time.Duration
-		wantErrText string
+		name           string
+		args           []string
+		wantRead       time.Duration
+		wantReadHeader time.Duration
+		wantWrite      time.Duration
+		wantIdle       time.Duration
+		wantErrText    string
 	}{
 		{
-			name:      "default timeouts",
-			args:      nil,
-			wantRead:  defaultHTTPReadTimeout,
-			wantWrite: defaultHTTPWriteTimeout,
-			wantIdle:  defaultHTTPIdleTimeout,
+			name:           "default timeouts",
+			args:           nil,
+			wantRead:       defaultHTTPReadTimeout,
+			wantReadHeader: maxHTTPReadHeaderTimeout,
+			wantWrite:      defaultHTTPWriteTimeout,
+			wantIdle:       defaultHTTPIdleTimeout,
 		},
 		{
 			name: "explicit positive timeouts",
@@ -293,9 +349,20 @@ func TestNewHTTPServerConfig(t *testing.T) {
 				"--" + flagHTTPWriteTimeout, customWriteTimeout.String(),
 				"--" + flagHTTPIdleTimeout, customIdleTimeout.String(),
 			},
-			wantRead:  customReadTimeout,
-			wantWrite: customWriteTimeout,
-			wantIdle:  customIdleTimeout,
+			wantRead:       customReadTimeout,
+			wantReadHeader: maxHTTPReadHeaderTimeout,
+			wantWrite:      customWriteTimeout,
+			wantIdle:       customIdleTimeout,
+		},
+		{
+			name: "short read timeout also caps header reads",
+			args: []string{
+				"--" + flagHTTPReadTimeout, shortReadTimeout.String(),
+			},
+			wantRead:       shortReadTimeout,
+			wantReadHeader: shortReadTimeout,
+			wantWrite:      defaultHTTPWriteTimeout,
+			wantIdle:       defaultHTTPIdleTimeout,
 		},
 		{
 			name:        "zero read timeout rejected",
@@ -339,6 +406,14 @@ func TestNewHTTPServerConfig(t *testing.T) {
 				t.Errorf("ReadTimeout = %s; want %s", server.ReadTimeout, tt.wantRead)
 			}
 
+			if server.ReadHeaderTimeout != tt.wantReadHeader {
+				t.Errorf(
+					"ReadHeaderTimeout = %s; want %s",
+					server.ReadHeaderTimeout,
+					tt.wantReadHeader,
+				)
+			}
+
 			if server.WriteTimeout != tt.wantWrite {
 				t.Errorf("WriteTimeout = %s; want %s", server.WriteTimeout, tt.wantWrite)
 			}
@@ -347,6 +422,104 @@ func TestNewHTTPServerConfig(t *testing.T) {
 				t.Errorf("IdleTimeout = %s; want %s", server.IdleTimeout, tt.wantIdle)
 			}
 		})
+	}
+}
+
+func TestNewHTTPServerConfigFromEnv(t *testing.T) {
+	const (
+		envReadTimeout  = 45 * time.Second
+		envWriteTimeout = 2 * time.Minute
+		envIdleTimeout  = 3 * time.Minute
+	)
+
+	t.Setenv("CONSTELLATION_HTTP_READ_TIMEOUT", envReadTimeout.String())
+	t.Setenv("CONSTELLATION_HTTP_WRITE_TIMEOUT", envWriteTimeout.String())
+	t.Setenv("CONSTELLATION_HTTP_IDLE_TIMEOUT", envIdleTimeout.String())
+
+	server, err := runNewHTTPServerWithFlags(
+		t,
+		serverFlagsByNameForTest(
+			t,
+			flagHTTPReadTimeout,
+			flagHTTPWriteTimeout,
+			flagHTTPIdleTimeout,
+		),
+		nil,
+	)
+	if err != nil {
+		t.Fatalf("newHTTPServer unexpected error: %v", err)
+	}
+
+	if server.ReadTimeout != envReadTimeout {
+		t.Errorf("ReadTimeout = %s; want %s", server.ReadTimeout, envReadTimeout)
+	}
+
+	if server.ReadHeaderTimeout != maxHTTPReadHeaderTimeout {
+		t.Errorf(
+			"ReadHeaderTimeout = %s; want %s",
+			server.ReadHeaderTimeout,
+			maxHTTPReadHeaderTimeout,
+		)
+	}
+
+	if server.WriteTimeout != envWriteTimeout {
+		t.Errorf("WriteTimeout = %s; want %s", server.WriteTimeout, envWriteTimeout)
+	}
+
+	if server.IdleTimeout != envIdleTimeout {
+		t.Errorf("IdleTimeout = %s; want %s", server.IdleTimeout, envIdleTimeout)
+	}
+}
+
+// serverFlagsWithoutEnvVarsForTest reuses the production flag definitions while
+// clearing process-environment sources so default-value tests are independent
+// from a developer or CI environment.
+func serverFlagsWithoutEnvVarsForTest(t *testing.T, names ...string) []cli.Flag {
+	t.Helper()
+
+	flags := serverFlagsByNameForTest(t, names...)
+	for _, flag := range flags {
+		clearFlagSourcesForTest(t, flag)
+	}
+
+	return flags
+}
+
+func serverFlagsByNameForTest(t *testing.T, names ...string) []cli.Flag {
+	t.Helper()
+
+	flags := make([]cli.Flag, 0, len(names))
+	for _, name := range names {
+		flags = append(flags, serverFlagByNameForTest(t, name))
+	}
+
+	return flags
+}
+
+func serverFlagByNameForTest(t *testing.T, name string) cli.Flag {
+	t.Helper()
+
+	for _, flag := range serverFlags() {
+		if slices.Contains(flag.Names(), name) {
+			return flag
+		}
+	}
+
+	t.Fatalf("server flag %q not found", name)
+
+	return nil
+}
+
+func clearFlagSourcesForTest(t *testing.T, flag cli.Flag) {
+	t.Helper()
+
+	switch typedFlag := flag.(type) {
+	case *cli.Int64Flag:
+		typedFlag.Sources = cli.ValueSourceChain{}
+	case *cli.DurationFlag:
+		typedFlag.Sources = cli.ValueSourceChain{}
+	default:
+		t.Fatalf("clearing env sources for %v: unsupported flag type %T", flag.Names(), flag)
 	}
 }
 

--- a/services/constellation/connector/sql/graphql/schema/table.go
+++ b/services/constellation/connector/sql/graphql/schema/table.go
@@ -8,6 +8,11 @@ import (
 	"github.com/nhost/nhost/services/constellation/metadata"
 )
 
+const (
+	scalarJSON  = "json"
+	scalarJSONB = "jsonb"
+)
+
 // generateForTable generates all GraphQL schema elements for a single table.
 func generateForTable( //nolint:funlen,cyclop
 	schema *graph.Schema,
@@ -338,7 +343,7 @@ func generateTableObjectType(
 
 		// jsonb/json columns expose a `path` argument so callers can drill
 		// into nested values without separate path-specific scalar types.
-		if col.Type == "jsonb" || col.Type == "json" {
+		if col.Type == scalarJSONB || col.Type == scalarJSON {
 			field.Arguments = []*graph.Argument{
 				{
 					Name:        "path",

--- a/services/constellation/controller/controller_test.go
+++ b/services/constellation/controller/controller_test.go
@@ -224,6 +224,7 @@ func TestHandlerPost_RejectsBodyLargerThanLimit(t *testing.T) {
 	t.Parallel()
 
 	const maxBodyBytes int64 = 16
+
 	body := []byte(`{"query":"{ users { id name } }"}`)
 
 	tests := []struct {

--- a/services/constellation/controller/controller_test.go
+++ b/services/constellation/controller/controller_test.go
@@ -6,6 +6,7 @@ import (
 	"encoding/json/jsontext"
 	json "encoding/json/v2"
 	"errors"
+	"io"
 	"log/slog"
 	"net/http"
 	"net/http/httptest"
@@ -90,6 +91,21 @@ func newTestRouter(t *testing.T, ctrl *controller.Controller) *gin.Engine {
 	router := gin.New()
 	router.Use(middleware.Session(testAdminSecret, middleware.NewNoOpJWTAuthenticator()))
 	router.POST("/graphql", ctrl.HandlerPost)
+	router.GET("/graphql", ctrl.HandlerGet)
+
+	return router
+}
+
+func newLimitedTestRouter(
+	t *testing.T, ctrl *controller.Controller, maxBodyBytes int64,
+) *gin.Engine {
+	t.Helper()
+
+	gin.SetMode(gin.TestMode)
+
+	router := gin.New()
+	router.Use(middleware.Session(testAdminSecret, middleware.NewNoOpJWTAuthenticator()))
+	router.POST("/graphql", ctrl.HandlerPostWithMaxBodyBytes(maxBodyBytes))
 	router.GET("/graphql", ctrl.HandlerGet)
 
 	return router
@@ -201,6 +217,54 @@ func TestHandlerPost_RejectsMalformedJSONBody(t *testing.T) {
 
 	if w.Code != http.StatusBadRequest {
 		t.Fatalf("expected 400, got %d: %s", w.Code, w.Body.String())
+	}
+}
+
+func TestHandlerPost_RejectsBodyLargerThanLimit(t *testing.T) {
+	t.Parallel()
+
+	const maxBodyBytes int64 = 16
+	body := []byte(`{"query":"{ users { id name } }"}`)
+
+	tests := []struct {
+		name          string
+		reader        io.Reader
+		contentLength int64
+	}{
+		{
+			name:          "known content length",
+			reader:        bytes.NewReader(body),
+			contentLength: int64(len(body)),
+		},
+		{
+			name:          "streaming body without content length",
+			reader:        io.NopCloser(bytes.NewReader(body)),
+			contentLength: -1,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+
+			router := newLimitedTestRouter(t, newTestController(t), maxBodyBytes)
+
+			req := httptest.NewRequest(http.MethodPost, "/graphql", tt.reader)
+			req.ContentLength = tt.contentLength
+			req.Header.Set("Content-Type", "application/json")
+			req.Header.Set("X-Hasura-Admin-Secret", testAdminSecret)
+
+			w := httptest.NewRecorder()
+			router.ServeHTTP(w, req)
+
+			if w.Code != http.StatusRequestEntityTooLarge {
+				t.Fatalf("expected 413, got %d: %s", w.Code, w.Body.String())
+			}
+
+			if !strings.Contains(w.Body.String(), "request body too large") {
+				t.Errorf("response body does not explain limit failure: %s", w.Body.String())
+			}
+		})
 	}
 }
 

--- a/services/constellation/controller/errors.go
+++ b/services/constellation/controller/errors.go
@@ -15,6 +15,7 @@ import (
 var (
 	errContentTypeNotJSON  = errors.New("Content-Type must be application/json")
 	errInvalidRequestBody  = errors.New("invalid request body")
+	errRequestBodyTooLarge = errors.New("request body too large")
 	errInternalServerError = errors.New("internal server error")
 	errNoSchemaForRole     = errors.New("no schema available for role")
 	errMultipleOperations  = errors.New("multiple operations found, operationName is required")

--- a/services/constellation/controller/handlers.go
+++ b/services/constellation/controller/handlers.go
@@ -13,6 +13,13 @@ import (
 	"github.com/nhost/nhost/services/constellation/internal/requestcontext"
 )
 
+const bytesPerMiB int64 = 1024 * 1024
+
+// DefaultMaxGraphQLRequestBodyBytes is the default JSON body cap for POST
+// GraphQL requests. Operators can override it on the serve command; direct
+// HandlerPost users get this safe default.
+const DefaultMaxGraphQLRequestBodyBytes int64 = 10 * bytesPerMiB
+
 // defaultSendBufferSize bounds the per-connection WebSocket outbound queue.
 // Frames are dropped when the buffer is full (see sendNext/sendError); the
 // sender goroutine is therefore decoupled from slow consumers without ever
@@ -25,6 +32,30 @@ var errMetadataReloaded = errors.New("metadata reloaded")
 // GraphQLRequest, dispatches it through Resolve, and writes the response —
 // taking the raw-bytes fast path when the connector returned pre-built JSON.
 func (c *Controller) HandlerPost(g *gin.Context) {
+	c.handlePost(g, DefaultMaxGraphQLRequestBodyBytes)
+}
+
+// HandlerPostWithMaxBodyBytes returns a Gin handler for POST /graphql that
+// rejects JSON request bodies larger than maxBodyBytes. Non-positive values use
+// DefaultMaxGraphQLRequestBodyBytes so direct callers cannot accidentally create
+// an unbounded handler.
+func (c *Controller) HandlerPostWithMaxBodyBytes(maxBodyBytes int64) gin.HandlerFunc {
+	return func(g *gin.Context) {
+		c.handlePost(g, maxBodyBytes)
+	}
+}
+
+func (c *Controller) handlePost(g *gin.Context, maxBodyBytes int64) {
+	maxBodyBytes = normalizeMaxGraphQLRequestBodyBytes(maxBodyBytes)
+	if g.Request.ContentLength > maxBodyBytes {
+		err := fmt.Errorf("%w: limit is %d bytes", errRequestBodyTooLarge, maxBodyBytes)
+		_ = g.Error(err)
+		g.JSON(http.StatusRequestEntityTooLarge, errorResponse(errRequestBodyTooLarge.Error()))
+
+		return
+	}
+
+	g.Request.Body = http.MaxBytesReader(g.Writer, g.Request.Body, maxBodyBytes)
 	// A missing Content-Type is treated as application/json. Otherwise the
 	// media type is parsed so that parameters such as "; charset=utf-8" and
 	// differing case are tolerated, matching what most GraphQL clients send.
@@ -40,6 +71,14 @@ func (c *Controller) HandlerPost(g *gin.Context) {
 
 	var reqBody GraphQLRequest
 	if err := json.UnmarshalRead(g.Request.Body, &reqBody); err != nil {
+		if requestBodyExceedsLimit(err) {
+			err = fmt.Errorf("%w: limit is %d bytes", errRequestBodyTooLarge, maxBodyBytes)
+			_ = g.Error(err)
+			g.JSON(http.StatusRequestEntityTooLarge, errorResponse(errRequestBodyTooLarge.Error()))
+
+			return
+		}
+
 		err = fmt.Errorf("%w: %w", errInvalidRequestBody, err)
 		_ = g.Error(err)
 		g.JSON(http.StatusBadRequest, errorResponse(err.Error()))
@@ -66,6 +105,20 @@ func (c *Controller) HandlerPost(g *gin.Context) {
 	}
 
 	g.JSON(http.StatusOK, resp)
+}
+
+func normalizeMaxGraphQLRequestBodyBytes(maxBodyBytes int64) int64 {
+	if maxBodyBytes <= 0 {
+		return DefaultMaxGraphQLRequestBodyBytes
+	}
+
+	return maxBodyBytes
+}
+
+func requestBodyExceedsLimit(err error) bool {
+	var maxBytesErr *http.MaxBytesError
+
+	return errors.As(err, &maxBytesErr)
 }
 
 // HandlerGet is the Gin handler for GET /graphql. It upgrades the connection

--- a/services/constellation/controller/handlers_internal_test.go
+++ b/services/constellation/controller/handlers_internal_test.go
@@ -1,0 +1,51 @@
+package controller
+
+import "testing"
+
+// TestNormalizeMaxGraphQLRequestBodyBytes pins the safety guarantee documented
+// on HandlerPostWithMaxBodyBytes: non-positive limits fall back to
+// DefaultMaxGraphQLRequestBodyBytes so a direct caller cannot create an
+// unbounded handler, while positive limits pass through untouched.
+func TestNormalizeMaxGraphQLRequestBodyBytes(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name      string
+		maxBytes  int64
+		wantBytes int64
+	}{
+		{
+			name:      "negative falls back to default",
+			maxBytes:  -1,
+			wantBytes: DefaultMaxGraphQLRequestBodyBytes,
+		},
+		{
+			name:      "zero falls back to default",
+			maxBytes:  0,
+			wantBytes: DefaultMaxGraphQLRequestBodyBytes,
+		},
+		{
+			name:      "positive is returned unchanged",
+			maxBytes:  16,
+			wantBytes: 16,
+		},
+		{
+			name:      "default value is returned unchanged",
+			maxBytes:  DefaultMaxGraphQLRequestBodyBytes,
+			wantBytes: DefaultMaxGraphQLRequestBodyBytes,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+
+			if got := normalizeMaxGraphQLRequestBodyBytes(tt.maxBytes); got != tt.wantBytes {
+				t.Errorf(
+					"normalizeMaxGraphQLRequestBodyBytes(%d) = %d, want %d",
+					tt.maxBytes, got, tt.wantBytes,
+				)
+			}
+		})
+	}
+}

--- a/services/constellation/docs/developers/architecture.md
+++ b/services/constellation/docs/developers/architecture.md
@@ -153,6 +153,7 @@ The controller never returns Go errors for user-visible failures from `Resolve`.
 
 The HTTP handler maps:
 
+- Request body over the configured cap → 413.
 - Parsing failure on the request body → 400.
 - Internal `Resolve` error → 500.
 - Everything else → 200 with `{data, errors}` shape.


### PR DESCRIPTION
<!-- nhost-reviewer:start -->
### **What this PR solves**
Adds bounded GraphQL HTTP request handling for Constellation so oversized request bodies and slow/stuck HTTP connections are rejected or timed out predictably. Operators can tune the new body-size and server timeout limits through CLI flags or environment variables.

___

### **PR Type**
Enhancement

___

### **Description**
- Adds configurable GraphQL POST body-size limits and HTTP read/write/idle timeouts to the Constellation serve command.
- Enforces POST body caps in the controller with 413 responses for requests over the configured limit.
- Covers the new limit and timeout behavior with unit tests and updates user/developer documentation.
- Refactors JSON scalar string literals in table schema generation into local constants.

___

### Diagram Walkthrough

```mermaid
flowchart LR
  A["CLI flags / env vars"] --> B["cmd.newHTTPServer"]
  A --> C["cmd.getRouter"]
  C --> D["controller.HandlerPostWithMaxBodyBytes"]
  D --> E["413 for oversized GraphQL JSON bodies"]
  B --> F["HTTP read/write/idle timeouts"]
```

<details> <summary><h3> File Walkthrough</h3></summary>

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody>
<tr><td><strong>Command and server configuration</strong></td><td><details><summary>2 files</summary><table>
<tr>
  <td><strong>services/constellation/cmd/serve.go</strong><dd><code>Adds body-limit and HTTP timeout flags/env vars, validates positive values, wires the POST handler limit, and configures http.Server timeouts.</code></dd></td>
  <td><a href="https://github.com/nhost/nhost/pull/XXX/files#diff-732ef1c9e66c28b12bfe756985c92d479209fe5fc4b627351c1b375799f6a8d0">+117/-23</a></td>
</tr>
<tr>
  <td><strong>services/constellation/cmd/serve_internal_test.go</strong><dd><code>Adds CLI/env/default validation tests for GraphQL body limits and HTTP timeout server configuration.</code></dd></td>
  <td><a href="https://github.com/nhost/nhost/pull/XXX/files#diff-652674658a2993769d177a7bd2c02caaf7b1f409b083bea3de97623c4d9f4d58">+371/-0</a></td>
</tr>
</table></details></td></tr>
<tr><td><strong>Controller request handling</strong></td><td><details><summary>4 files</summary><table>
<tr>
  <td><strong>services/constellation/controller/handlers.go</strong><dd><code>Adds default GraphQL request body cap enforcement and a configurable POST handler wrapper.</code></dd></td>
  <td><a href="https://github.com/nhost/nhost/pull/XXX/files#diff-79fd0b1bfbbb2b49cea46ae3f6cf6a402edb7d9d5d1d18057a9241cc97c4d4bb">+53/-0</a></td>
</tr>
<tr>
  <td><strong>services/constellation/controller/errors.go</strong><dd><code>Adds the request-body-too-large sentinel error used for 413 responses.</code></dd></td>
  <td><a href="https://github.com/nhost/nhost/pull/XXX/files#diff-e6f1c4bca0dd01fcaf8b30e788d3e5718e334efe7e5afcdbef9c4966f30f9cde">+1/-0</a></td>
</tr>
<tr>
  <td><strong>services/constellation/controller/controller_test.go</strong><dd><code>Adds request tests for known and streaming oversized GraphQL POST bodies.</code></dd></td>
  <td><a href="https://github.com/nhost/nhost/pull/XXX/files#diff-d8d20e54f239b7292609ca081ba2ced12340607c51829301fe8e211b60a5fce9">+65/-0</a></td>
</tr>
<tr>
  <td><strong>services/constellation/controller/handlers_internal_test.go</strong><dd><code>Pins normalization behavior for non-positive direct handler body-limit values.</code></dd></td>
  <td><a href="https://github.com/nhost/nhost/pull/XXX/files#diff-71e2de76648b88e123d240061f029e5ae4015a7aa6d854751d6f4f0234eec2f7">+51/-0</a></td>
</tr>
</table></details></td></tr>
<tr><td><strong>GraphQL schema cleanup</strong></td><td><details><summary>1 file</summary><table>
<tr>
  <td><strong>services/constellation/connector/sql/graphql/schema/table.go</strong><dd><code>Introduces local JSON/JSONB scalar constants for JSON path argument detection.</code></dd></td>
  <td><a href="https://github.com/nhost/nhost/pull/XXX/files#diff-9a00770c5281e293e778628f29c48d94175a1de4f8fbfd6204e25bc6917e08de">+6/-1</a></td>
</tr>
</table></details></td></tr>
<tr><td><strong>Documentation</strong></td><td><details><summary>2 files</summary><table>
<tr>
  <td><strong>services/constellation/README.md</strong><dd><code>Documents the new GraphQL request body and HTTP timeout configuration options.</code></dd></td>
  <td><a href="https://github.com/nhost/nhost/pull/XXX/files#diff-84a028508c3a75c60ec1b33705bbab8f84bee22345406912ad3fe789d4599b63">+4/-0</a></td>
</tr>
<tr>
  <td><strong>services/constellation/docs/developers/architecture.md</strong><dd><code>Documents the controller's 413 mapping for bodies over the configured cap.</code></dd></td>
  <td><a href="https://github.com/nhost/nhost/pull/XXX/files#diff-ea7299f8ce3e8c58503d08df7ce24ab58f3fa2eb54524686f0d861598b7ccb1c">+1/-0</a></td>
</tr>
</table></details></td></tr>
</tbody></table>

</details>

___

<!-- nhost-reviewer:end -->