### PR TITLE
fix(ci): gate pull_request_target on real write permission

### DIFF
--- a/.github/actions/check-permissions/action.yml
+++ b/.github/actions/check-permissions/action.yml
@@ -8,8 +8,27 @@ runs:
       run: |
         echo "github.event_name: ${{ github.event_name }}"
         echo "github.event.pull_request.author_association: ${{ github.event.pull_request.author_association }}"
-    - name: "This task will run and fail if user has no permissions and label safe_to_test isn't present"
-      if: 'github.event_name == ''pull_request_target'' && ! ( contains(github.event.pull_request.labels.*.name, ''safe_to_test'') || contains(fromJson(''["OWNER", "MEMBER", "COLLABORATOR"]''), github.event.pull_request.author_association) || contains(fromJson(''["nhost-helper-bot[bot]"]''), github.event.pull_request.user.login) )'
+    - name: "Fail if the PR author lacks write permission and the 'safe_to_test' label is not present"
+      if: >-
+        github.event_name == 'pull_request_target' &&
+        ! contains(github.event.pull_request.labels.*.name, 'safe_to_test') &&
+        ! contains(fromJson('["nhost-helper-bot[bot]"]'), github.event.pull_request.user.login)
       shell: bash
+      env:
+        GH_TOKEN: ${{ github.token }}
+        REPO: ${{ github.repository }}
+        PR_USER: ${{ github.event.pull_request.user.login }}
       run: |
-        exit 1
+        set -euo pipefail
+        permission=$(gh api "repos/${REPO}/collaborators/${PR_USER}/permission" --jq '.permission')
+        echo "Resolved repository permission for ${PR_USER}: ${permission}"
+        case "${permission}" in
+          admin | maintain | write)
+            echo "Author has write or higher permission; allowing checks to run."
+            ;;
+          *)
+            echo "::error::Author '${PR_USER}' has '${permission}' permission, which is below write."
+            echo "A maintainer must review the PR and add the 'safe_to_test' label to run secret-bearing checks."
+            exit 1
+            ;;
+        esac


### PR DESCRIPTION
  <!-- nhost-reviewer:start -->
  ### **What this PR solves**
  The shared `check-permissions` action gated secret-bearing `pull_request_target` jobs on `author_association`, which GitHub assigns as
  `COLLABORATOR` to read-only/triage collaborators and as `MEMBER` to any org member — so non-write users could run PR-controlled code with
  full repo secrets. This replaces that coarse check with a real per-user repository permission lookup, so only authors with write access
  (or a maintainer-applied `safe_to_test` label) can trigger those checks.

  ___

  ### **PR Type**
  Bug fix

  ___

  ### **Description**
  - Replaced the `author_association` allowlist (`OWNER`/`MEMBER`/`COLLABORATOR`) with a `gh api
  repos/{owner}/{repo}/collaborators/{user}/permission` lookup that only admits `admin`/`maintain`/`write`.
  - Made the gate fail-closed via `set -euo pipefail`: any API error, empty, or unexpected result blocks the secret-bearing jobs.
  - Preserved the `safe_to_test` label and `nhost-helper-bot[bot]` escape hatches, and aligned the action's description with its now-actual
  write-grade behavior.

  ___

  ### Diagram Walkthrough

  ```mermaid
  flowchart LR
    A["pull_request_target event"] --> B["check-permissions gate"]
    B --> C{"safe_to_test label<br/>or trusted bot?"}
    C -- "yes" --> E["Allow secret-bearing checks"]
    C -- "no" --> D["gh api collaborators/{user}/permission"]
    D --> F{"admin / maintain / write?"}
    F -- "yes" --> E
    F -- "no / error / empty" --> G["exit 1 — block (fail-closed)"]
```
