### PR TITLE
fix(dashboard): align schema diagram node selection border with card height

### DIFF
--- a/dashboard/src/features/orgs/projects/database/schema-diagram/useSchemaGraph.test.ts
+++ b/dashboard/src/features/orgs/projects/database/schema-diagram/useSchemaGraph.test.ts
@@ -1166,7 +1166,7 @@ describe('useSchemaGraph', () => {
       );
 
       const node = result.current.nodes.find((n) => n.id === 'public.users')!;
-      expect(node.height).toBe(computeNodeHeight(4));
+      expect(node.initialHeight).toBe(computeNodeHeight(4));
     });
 
     it('drops computed fields and sizes by columns only in postgres mode', () => {
@@ -1202,7 +1202,7 @@ describe('useSchemaGraph', () => {
 
       const node = result.current.nodes.find((n) => n.id === 'public.users')!;
       expect(node.data.computedFields).toEqual([]);
-      expect(node.height).toBe(computeNodeHeight(1));
+      expect(node.initialHeight).toBe(computeNodeHeight(1));
     });
   });
 

--- a/dashboard/src/features/orgs/projects/database/schema-diagram/useSchemaGraph.ts
+++ b/dashboard/src/features/orgs/projects/database/schema-diagram/useSchemaGraph.ts
@@ -494,8 +494,8 @@ export default function useSchemaGraph({
         id,
         type: 'tableNode',
         position: { x: 0, y: 0 },
-        width: TABLE_NODE_WIDTH,
-        height: computeNodeHeight(
+        initialWidth: TABLE_NODE_WIDTH,
+        initialHeight: computeNodeHeight(
           data.columns.length + data.computedFields.length,
         ),
         data,


### PR DESCRIPTION
| Before | After |
  |:------:|:-----:|
  | <img width="484" height="572" alt="Screenshot 2026-06-02 at 11 15 05" src="https://github.com/user-attachments/assets/7280bca2-1cdc-4057-8042-bff317425718" /> (notice the green line at the bottom going past the card) | <img width="484" height="572" alt="image" src="https://github.com/user-attachments/assets/d8ed8c63-00b1-4400-906a-9ae2dc86c435" /> |

### Checklist

- [X] No breaking changes
- [X] Tests pass
- [X] New features have new tests
- [X] Documentation is updated (if applicable)
- [X] Title of the PR is in the correct format (see below)

<!-- nhost-reviewer:start -->
### **What this PR solves**
In the database schema diagram, table nodes set their size via React Flow's *controlled* `width`/`height` props using a computed estimate (`computeNodeHeight`). When the actual rendered card was a different height, the selection border ran past the bottom of the card (the green line in the Before screenshot). Switching to `initialWidth`/`initialHeight` makes those values initial hints only, so React Flow measures the real DOM card and the selection border tracks the card's actual height.

___

### **PR Type**
Bug fix

___

### **Description**
- In `useSchemaGraph`, replace the controlled `width`/`height` React Flow node props with `initialWidth`/`initialHeight` so the rendered card is measured and the selection border aligns with its real height.
- Dagre layout is unaffected: positioning is derived from `rowCountByNodeId` + `computeNodeHeight`, not from the node's `width`/`height` props, and `layoutNodes` spreads the node through unchanged.
- Update the two `useSchemaGraph` unit tests to assert on `initialHeight` instead of `height`.

___

<details> <summary><h3> File Walkthrough</h3></summary>

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody>
<tr><td><strong>Bug fix</strong></td><td><details><summary>1 files</summary><table>
<tr>
  <td><strong>useSchemaGraph.ts</strong><dd><code>Use initialWidth/initialHeight so the node card is measured and the selection border matches its height</code></dd></td>
  <td><a href="https://github.com/nhost/nhost/pull/4425/files#diff-b001655e629263580d5aa81b1a3a962aef6b35368df233e63f71af83368b7119">+2/-2</a></td>
</tr>
</table></details></td></tr>
<tr><td><strong>Tests</strong></td><td><details><summary>1 files</summary><table>
<tr>
  <td><strong>useSchemaGraph.test.ts</strong><dd><code>Assert node.initialHeight instead of node.height</code></dd></td>
  <td><a href="https://github.com/nhost/nhost/pull/4425/files#diff-5f1487809654e8e2c955b9f2c1802aba04a9278f901327eced94c0f5dbab525e">+2/-2</a></td>
</tr>
</table></details></td></tr>
</tbody></table>

</details>

___

<!-- nhost-reviewer:end -->
