### PR TITLE
fix(auth): prevent JSON injection in turnstile siteverify request

### DIFF
--- a/services/auth/go/middleware/turnstile.go
+++ b/services/auth/go/middleware/turnstile.go
@@ -32,11 +32,19 @@ func makeTurnstileRequest(
 	secret string,
 	tokenResponse string,
 ) (*TurnstileResponse, error) {
+	body, err := json.Marshal(map[string]string{
+		"secret":   secret,
+		"response": tokenResponse,
+	})
+	if err != nil {
+		return nil, fmt.Errorf("failed to marshal turnstile request: %w", err)
+	}
+
 	request, err := http.NewRequestWithContext(
 		ctx,
 		http.MethodPost,
 		tunrstileURL,
-		bytes.NewBufferString(`{"secret": "`+secret+`","response":"`+tokenResponse+`"}`),
+		bytes.NewReader(body),
 	)
 	if err != nil {
 		return nil, fmt.Errorf("failed to create turnstile request: %w", err)

--- a/services/auth/go/middleware/turnstile_test.go
+++ b/services/auth/go/middleware/turnstile_test.go
@@ -1,6 +1,14 @@
 package middleware //nolint:testpackage
 
-import "testing"
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"io"
+	"net/http"
+	"strings"
+	"testing"
+)
 
 // turnstileCases lists every auth endpoint and whether Turnstile must gate
 // it. When a new endpoint is added to the OpenAPI spec, add a row here so we
@@ -98,6 +106,108 @@ func TestRequiresTurnstileWithAPIPrefix(t *testing.T) {
 				t.Errorf(
 					"requiresTurnstile(%q, %q) = %v, want %v",
 					prefix+tc.path, prefix, got, tc.want,
+				)
+			}
+		})
+	}
+}
+
+type roundTripFunc func(req *http.Request) (*http.Response, error)
+
+func (f roundTripFunc) RoundTrip(req *http.Request) (*http.Response, error) {
+	return f(req)
+}
+
+// siteverifyBody mirrors the JSON payload makeTurnstileRequest sends to
+// Cloudflare. Decoding the captured body into it asserts the secret and
+// response stay confined to their own fields.
+type siteverifyBody struct {
+	Secret   string `json:"secret"`
+	Response string `json:"response"`
+}
+
+// TestMakeTurnstileRequestBuildsSafeBody is the regression test for the JSON
+// injection fix. The siteverify body must be built with proper JSON encoding so
+// an attacker-controlled x-cf-turnstile-response token cannot close the
+// "response" string and smuggle a second "secret"/"response" pair. With the
+// previous string-concatenated body, the injection cases below either decoded to
+// the attacker's secret (last-wins parsing) or produced invalid JSON, failing
+// these assertions.
+func TestMakeTurnstileRequestBuildsSafeBody(t *testing.T) {
+	t.Parallel()
+
+	const secret = "real-secret"
+
+	cases := []struct {
+		name  string
+		token string
+	}{
+		{
+			name:  "plain token",
+			token: "valid-turnstile-token",
+		},
+		{
+			name:  "token closes response and injects secret",
+			token: `bogus","secret":"attacker-controlled-secret`,
+		},
+		{
+			name:  "token with quotes and braces",
+			token: `"}{"secret":"x"`,
+		},
+		{
+			name:  "token with backslash and newline",
+			token: "line1\\\"\n\"secret\":\"x",
+		},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+
+			var captured []byte
+
+			cl := &http.Client{
+				Transport: roundTripFunc(func(req *http.Request) (*http.Response, error) {
+					body, err := io.ReadAll(req.Body)
+					if err != nil {
+						return nil, fmt.Errorf("reading request body: %w", err)
+					}
+
+					captured = body
+
+					return &http.Response{
+						StatusCode: http.StatusOK,
+						Body:       io.NopCloser(strings.NewReader(`{"success":true}`)),
+						Header:     make(http.Header),
+					}, nil
+				}),
+			}
+
+			resp, err := makeTurnstileRequest(context.Background(), cl, secret, tc.token)
+			if err != nil {
+				t.Fatalf("makeTurnstileRequest returned error: %v", err)
+			}
+
+			if !resp.Success {
+				t.Fatalf("expected success response, got %+v", resp)
+			}
+
+			var got siteverifyBody
+			if err := json.Unmarshal(captured, &got); err != nil {
+				t.Fatalf("request body is not valid JSON: %v\nbody: %s", err, captured)
+			}
+
+			if got.Secret != secret {
+				t.Errorf(
+					"secret was altered by the token: got %q, want %q\nbody: %s",
+					got.Secret, secret, captured,
+				)
+			}
+
+			if got.Response != tc.token {
+				t.Errorf(
+					"response field does not match the token verbatim: got %q, want %q\nbody: %s",
+					got.Response, tc.token, captured,
 				)
 			}
 		})


### PR DESCRIPTION
<!-- nhost-reviewer:start -->
  ### **What this PR solves**
  The Cloudflare Turnstile verification request was assembled by string-concatenating the attacker-controlled `x-cf-turnstile-response`
  header into a JSON body. A crafted header could close the `response` string and append a second `secret`/`response` pair; Cloudflare's
  last-wins parsing then used the attacker's own sitekey, returned `success:true`, and bypassed the abuse gate on signup, passwordless,
  OTP, and password-reset endpoints. This builds the request with `json.Marshal`, so the header value is escaped and can no longer override
  the configured secret.

  ___

  ### **PR Type**
  Bug fix

  ___
  - Eliminates the JSON-injection (CWE-116) that smuggled a duplicate `secret` key and defeated the Turnstile abuse gate.
  - No API or contract change: valid tokens produce a semantically identical request; only malicious payloads are now correctly rejected
  (verified live against Cloudflare siteverify with their test secrets).

  ___

  ### Diagram Walkthrough

  ```mermaid
  flowchart LR
    A["Request with<br/>x-cf-turnstile-response header"] --> B["Turnstile middleware"]
    B --> C["makeTurnstileRequest<br/>json.Marshal(secret, response)"]
    C --> D["Cloudflare siteverify"]
    D --> E{"success?"}
    E -->|true| F["Protected handler"]
    E -->|false| G["403 Forbidden"]

```