### PR TITLE
fix(nhost-js): merge GraphQL request headers

### DIFF
--- a/packages/nhost-js/src/graphql/__tests__/client.test.ts
+++ b/packages/nhost-js/src/graphql/__tests__/client.test.ts
@@ -1,0 +1,39 @@
+import { beforeEach, describe, expect, jest, test } from '@jest/globals';
+import { createAPIClient } from '../client';
+
+const mockFetch = jest.fn();
+
+global.fetch = mockFetch as unknown as typeof global.fetch;
+
+describe('GraphQL client', () => {
+  beforeEach(() => {
+    mockFetch.mockReset();
+    mockFetch.mockImplementation(() =>
+      Promise.resolve(
+        new Response(JSON.stringify({ data: {} }), {
+          status: 200,
+          headers: { 'Content-Type': 'application/json' },
+        }),
+      ),
+    );
+  });
+
+  test('keeps the JSON content type when request options include headers', async () => {
+    const client = createAPIClient('https://api.example.com/graphql');
+
+    await client.request(
+      { query: 'query Test { test }' },
+      {
+        headers: {
+          Authorization: 'Bearer token',
+        },
+      },
+    );
+
+    const [, options] = mockFetch.mock.calls[0] as [string, RequestInit];
+    const headers = new Headers(options.headers);
+
+    expect(headers.get('Content-Type')).toBe('application/json');
+    expect(headers.get('Authorization')).toBe('Bearer token');
+  });
+});

--- a/packages/nhost-js/src/graphql/client.ts
+++ b/packages/nhost-js/src/graphql/client.ts
@@ -165,13 +165,16 @@ export const createAPIClient = (
     request: GraphQLRequest<TVariables>,
     options?: RequestInit,
   ): Promise<FetchResponse<GraphQLResponse<TResponseData>>> => {
+    const headers = new Headers(options?.headers);
+    if (!headers.has('Content-Type')) {
+      headers.set('Content-Type', 'application/json');
+    }
+
     const response = await enhancedFetch(`${url}`, {
-      method: 'POST',
-      headers: {
-        'Content-Type': 'application/json',
-      },
-      body: JSON.stringify(request),
       ...options,
+      method: 'POST',
+      headers,
+      body: JSON.stringify(request),
     });
 
     const body = await response.text();


### PR DESCRIPTION
<!-- nhost-reviewer:start -->
### **What this PR solves**
Fixes GraphQL requests that lost the default JSON content type when callers supplied custom headers, causing servers with strict content-type validation to reject the request. Adds regression coverage for preserving both the JSON content type and caller-provided headers.

___

### **PR Type**
Bug fix

___

### **Description**
- Merge GraphQL request headers with the default `Content-Type: application/json` header instead of replacing it.
- Preserve caller-supplied request options while forcing GraphQL operations to remain POST requests with the serialized GraphQL body.
- Add a Jest regression test covering custom authorization headers alongside the JSON content type.

___

<details> <summary><h3> File Walkthrough</h3></summary>

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody>
<tr><td><strong>Nhost JS GraphQL client</strong></td><td><details><summary>2 files</summary><table>
<tr>
  <td><strong>client.ts</strong><dd><code>Merges caller headers with the default JSON content type before executing GraphQL requests.</code></dd></td>
  <td><a href="https://github.com/nhost/nhost/pull/XXX/files#diff-cbd71dd3404704ff9d9c84273572fcac6f041532eef597de8a714249c08559c4">+7/-4</a></td>
</tr>
<tr>
  <td><strong>client.test.ts</strong><dd><code>Adds regression coverage ensuring custom headers do not remove the JSON content type.</code></dd></td>
  <td><a href="https://github.com/nhost/nhost/pull/XXX/files#diff-27ae39d143a4009eda5a6b0ab86ce143ffb2da3510f428c81ebd69d07bfd9a31">+39/-0</a></td>
</tr>
</table></details></td></tr>
</tbody></table>

</details>

___

<!-- nhost-reviewer:end -->