### PR TITLE
fix(constellation): emit enum types for mutation-only inputs

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -71,6 +71,7 @@ result
 .vitest
 
 **/.claude/settings.local.json
+.claude/PLAN*
 .review/
 
 letsencrypt/*

--- a/.pi/README.md
+++ b/.pi/README.md
@@ -4,7 +4,7 @@ This directory mirrors the repo's Claude Code review workflow with native Pi res
 
 ## What is included
 
-- `extensions/subagent/` — registers a `subagent` tool that launches isolated `pi` subprocesses for named agents.
+- `extensions/subagent/` — registers a `subagent` tool that launches isolated `pi` subprocesses for named agents. The tool supports top-level and per-task `modelOverride` values for temporarily replacing an agent's frontmatter model.
 - `agents/` — paired implementer/reviewer prompts per language: `go-implementer`/`go-reviewer`, `javascript-implementer`/`javascript-reviewer`, and `generic-implementer`/`generic-reviewer`. Implementers edit code; reviewers validate that proposed or applied changes were actually needed and adhere to the repo rules. Plus two model-diverse planning architects, `architect-a` (`gpt-5.5`) and `architect-b` (`claude-opus-4-7`), used by the `implement` skill.
 - `skills/nhost-review/` — branch/PR diff review workflow that writes `.review/` artifacts.
 - `skills/address-review/` — sequential implementer/reviewer workflow for addressing `.review/` findings.
@@ -17,6 +17,7 @@ From the repo root in Pi:
 
 ```text
 /skill:nhost-review origin/main
+/skill:nhost-review origin/main --reviewer-model gpt-5.5
 /skill:address-review PR_123_COMMENT_*.md
 /skill:implement add oauth pkce flow
 ```
@@ -25,6 +26,7 @@ Aliases are also available as prompt templates:
 
 ```text
 /nhost-review origin/main
+/nhost-review origin/main --reviewer-model gpt-5.5
 /nhost_review origin/main
 /address-review PR_123_COMMENT_*.md
 /implement add oauth pkce flow

--- a/.pi/extensions/subagent/index.ts
+++ b/.pi/extensions/subagent/index.ts
@@ -95,6 +95,12 @@ const taskItemSchema = Type.Object({
   cwd: Type.Optional(
     Type.String({ description: 'Working directory for this child agent' }),
   ),
+  modelOverride: Type.Optional(
+    Type.String({
+      description:
+        "Override this task's agent model. Takes precedence over top-level modelOverride and agent frontmatter.",
+    }),
+  ),
 });
 
 const subagentParamsSchema = Type.Object({
@@ -105,6 +111,12 @@ const subagentParamsSchema = Type.Object({
   ),
   task: Type.Optional(
     Type.String({ description: 'Task to delegate for single-agent mode' }),
+  ),
+  modelOverride: Type.Optional(
+    Type.String({
+      description:
+        'Override the model for this subagent invocation. Per-task modelOverride takes precedence in tasks/chain.',
+    }),
   ),
   tasks: Type.Optional(
     Type.Array(taskItemSchema, {
@@ -156,6 +168,17 @@ function formatAvailableModel(model: AvailableModel): string {
   if (!model.name || model.name === model.id) return label;
 
   return `${label} (${model.name})`;
+}
+
+function normalizeOptionalString(
+  value: string | undefined,
+): string | undefined {
+  const trimmed = value?.trim();
+  return trimmed ? trimmed : undefined;
+}
+
+function modelRequiresRegistryLookup(model: string | undefined): boolean {
+  return Boolean(model && !model.includes('/'));
 }
 
 function splitThinkingLevel(model: string): {
@@ -532,6 +555,7 @@ async function runAgent(params: {
   agentName: string;
   task: string;
   cwd?: string;
+  modelOverride?: string;
   step?: number;
   signal?: AbortSignal;
   onProgress?: ProgressCallback;
@@ -563,8 +587,10 @@ async function runAgent(params: {
     };
   }
 
+  const requestedModel =
+    normalizeOptionalString(params.modelOverride) ?? agent.model;
   const modelResolution = resolveAgentModel(
-    agent.model,
+    requestedModel,
     params.availableModels,
     params.availableModelsError,
   );
@@ -572,7 +598,7 @@ async function runAgent(params: {
     params.onProgress?.({
       agent: agent.name,
       agentSource: agent.source,
-      model: agent.model,
+      model: requestedModel,
       step: params.step,
       status: 'failed',
       activities: [],
@@ -588,7 +614,7 @@ async function runAgent(params: {
       exitCode: 1,
       output: '',
       stderr: modelResolution.error,
-      model: agent.model,
+      model: requestedModel,
       step: params.step,
     };
   }
@@ -617,7 +643,7 @@ async function runAgent(params: {
     exitCode: 0,
     output: '',
     stderr: '',
-    model: modelResolution.cliModel,
+    model: modelResolution.cliModel ?? requestedModel,
     step: params.step,
   };
 
@@ -921,6 +947,7 @@ export default function nhostSubagentExtension(pi: ExtensionAPI): void {
       'Delegate tasks to specialized Pi agents in isolated pi subprocesses.',
       'Supports single mode (agent + task), parallel mode (tasks array), and chain mode (chain array with {previous}).',
       'Project agents live in .pi/agents and require agentScope "project" or "both".',
+      'Use modelOverride to run an agent with a model other than its frontmatter default.',
     ].join(' '),
     promptSnippet:
       'Delegate work to project or user Pi agents with isolated context windows',
@@ -933,6 +960,9 @@ export default function nhostSubagentExtension(pi: ExtensionAPI): void {
 
     async execute(_toolCallId, params, signal, onUpdate, ctx) {
       const agentScope: AgentScope = params.agentScope ?? 'user';
+      const topLevelModelOverride = normalizeOptionalString(
+        params.modelOverride,
+      );
       const discovery = discoverAgents(ctx.cwd, agentScope);
       const agents = discovery.agents;
 
@@ -962,6 +992,20 @@ export default function nhostSubagentExtension(pi: ExtensionAPI): void {
       const requestedAgents = Array.from(requestedNames)
         .map((name) => agents.find((agent) => agent.name === name))
         .filter((agent): agent is AgentConfig => Boolean(agent));
+      const getEffectiveModel = (
+        agentName: string,
+        taskModelOverride?: string,
+      ): string | undefined => {
+        const taskOverride = normalizeOptionalString(taskModelOverride);
+        if (taskOverride) return taskOverride;
+        if (topLevelModelOverride) return topLevelModelOverride;
+
+        return agents.find((agent) => agent.name === agentName)?.model;
+      };
+      const getModelOverrideForTask = (
+        taskModelOverride?: string,
+      ): string | undefined =>
+        normalizeOptionalString(taskModelOverride) ?? topLevelModelOverride;
       const projectAgentsRequested = requestedAgents.filter(
         (agent) => agent.source === 'project',
       );
@@ -1002,11 +1046,21 @@ export default function nhostSubagentExtension(pi: ExtensionAPI): void {
 
       let availableModels: AvailableModel[] = [];
       let availableModelsError: string | undefined;
-      if (
-        requestedAgents.some((agent) =>
-          Boolean(agent.model && !agent.model.includes('/')),
-        )
-      ) {
+      const effectiveModels: string[] = [];
+      if (params.agent) {
+        const model = getEffectiveModel(params.agent);
+        if (model) effectiveModels.push(model);
+      }
+      for (const task of params.tasks ?? []) {
+        const model = getEffectiveModel(task.agent, task.modelOverride);
+        if (model) effectiveModels.push(model);
+      }
+      for (const task of params.chain ?? []) {
+        const model = getEffectiveModel(task.agent, task.modelOverride);
+        if (model) effectiveModels.push(model);
+      }
+
+      if (effectiveModels.some(modelRequiresRegistryLookup)) {
         try {
           const models = await ctx.modelRegistry.getAvailable();
           availableModels = models.map((model) => ({
@@ -1028,6 +1082,7 @@ export default function nhostSubagentExtension(pi: ExtensionAPI): void {
           agentName: params.agent,
           task: params.task,
           cwd: params.cwd,
+          modelOverride: topLevelModelOverride,
           signal,
           onProgress: (progress) => {
             emitUpdate(formatProgress(progress));
@@ -1077,6 +1132,7 @@ export default function nhostSubagentExtension(pi: ExtensionAPI): void {
             agentName: item.agent,
             task,
             cwd: item.cwd,
+            modelOverride: getModelOverrideForTask(item.modelOverride),
             step: index + 1,
             signal,
             onProgress: (progress) => {
@@ -1152,6 +1208,7 @@ export default function nhostSubagentExtension(pi: ExtensionAPI): void {
               agentName: item.agent,
               task: item.task,
               cwd: item.cwd,
+              modelOverride: getModelOverrideForTask(item.modelOverride),
               signal,
               onProgress: (progress) => {
                 parallelProgress[index] = progress;

--- a/.pi/prompts/nhost-review.md
+++ b/.pi/prompts/nhost-review.md
@@ -1,5 +1,5 @@
 ---
 description: Run the native Pi Nhost review skill
-argument-hint: "[base-ref]"
+argument-hint: "[base-ref] [--reviewer-model MODEL]"
 ---
 Load and execute the `nhost-review` skill with these arguments: $ARGUMENTS

--- a/.pi/prompts/nhost_review.md
+++ b/.pi/prompts/nhost_review.md
@@ -1,5 +1,5 @@
 ---
 description: Alias for the native Pi Nhost review skill
-argument-hint: "[base-ref]"
+argument-hint: "[base-ref] [--reviewer-model MODEL]"
 ---
 Load and execute the `nhost-review` skill with these arguments: $ARGUMENTS

--- a/.pi/skills/nhost-review/SKILL.md
+++ b/.pi/skills/nhost-review/SKILL.md
@@ -1,7 +1,7 @@
 ---
 name: nhost-review
 description: Review the current branch's diff in the Nhost monorepo using native Pi project agents. Generates `.review/` PR description, title suggestions, findings, and summary. Use automatically when the user asks to review, audit, critique, or check a branch, diff, PR, or code changes in this repo.
-argument-hint: [base-ref] [--reviewer-model MODEL]
+argument-hint: "[base-ref] [--reviewer-model MODEL]"
 ---
 
 # Nhost Review — Native Pi Workflow

--- a/.pi/skills/nhost-review/SKILL.md
+++ b/.pi/skills/nhost-review/SKILL.md
@@ -1,7 +1,7 @@
 ---
 name: nhost-review
 description: Review the current branch's diff in the Nhost monorepo using native Pi project agents. Generates `.review/` PR description, title suggestions, findings, and summary. Use automatically when the user asks to review, audit, critique, or check a branch, diff, PR, or code changes in this repo.
-argument-hint: [base-ref]
+argument-hint: [base-ref] [--reviewer-model MODEL]
 ---
 
 # Nhost Review — Native Pi Workflow
@@ -18,18 +18,28 @@ If the `subagent` tool is unavailable, perform the same review inline after read
 
 ## Inputs
 
-The skill argument is an optional base ref. If the user did not provide one, use `origin/main`.
+The skill arguments are an optional base ref and an optional reviewer model override:
+
+```text
+[base-ref] [--reviewer-model MODEL]
+```
+
+If the user did not provide a base ref, use `origin/main`. If `--reviewer-model MODEL` is present, pass `modelOverride: MODEL` to every reviewer `subagent` task and treat `MODEL` as the effective expected model for model-integrity checks in this run. Prefer an unqualified self-reportable model id such as `gpt-5.5`; if the override must be provider-qualified or include a thinking suffix for Pi routing, keep the full value for `modelOverride` and accept the full value, suffix-stripped value, or provider-stripped model id in the reviewer envelope.
 
 ## Phase 0 — Gather context
 
-1. Run this from the repo root, replacing `<base-ref>` with the provided argument or `origin/main`:
+1. Parse the arguments before gathering context:
+   - Walk tokens left-to-right; when you see `--reviewer-model`, consume the following token as `<reviewer-model-override>`; also accept `--reviewer-model=MODEL`.
+   - The first remaining non-flag token, if present, is `<base-ref>`.
+   - Ignore the model override and its value when choosing the base ref.
+2. Run this from the repo root, replacing `<base-ref>` with the parsed base ref or `origin/main`:
 
    ```bash
    bash .pi/skills/nhost-review/scripts/gather-context.sh <base-ref>
    ```
 
-2. Treat the output as pre-fetched review context. Do not re-fetch it unless it is incomplete or stale.
-3. Create `.review/` if it does not exist.
+3. Treat the output as pre-fetched review context. Do not re-fetch it unless it is incomplete or stale.
+4. Create `.review/` if it does not exist.
 
 The context contains PR number, repo, changed-file stats with GitHub diff hashes, and the diff excluding generated/vendor files.
 
@@ -73,14 +83,15 @@ Project grouping:
 - **Generic:** group by top-level project or cross-cutting concern.
 - Cross-language contract changes, env var renames, auth claims, metadata/schema drift, or workflow changes that must be traced end-to-end go to `generic-reviewer`.
 
-For each bucket, call the `subagent` tool with `agentScope: "project"`. Use parallel mode for independent review buckets; use a single call for a small PR or a single bucket.
+For each bucket, call the `subagent` tool with `agentScope: "project"`. Use parallel mode for independent review buckets; use a single call for a small PR or a single bucket. When `<reviewer-model-override>` is set, include `modelOverride: "<reviewer-model-override>"` on the top-level `subagent` call, or on each task item if different buckets intentionally use different overrides.
 
 Each delegated task must include:
 
 1. The full bucket file list and relevant diff hunks.
 2. The pre-fetched PR context: PR number, repo, base ref, changed-file stats.
-3. This exact instruction: **"Use output shape B (fresh-diff findings) from your reviewer prompt. Do not edit any files. Validate every finding before reporting it. Self-identify your model in the top-level `model` field of the response envelope — do not copy any model name from this prompt. Return a JSON object envelope with that `model` and a `findings` array of confirmed findings, even when the array is empty."**
-4. The expected return shape. The top-level `model` value is whatever the agent self-reported, **not** something the orchestrator fills in:
+3. The model context for this bucket: reviewer agent name, reviewer frontmatter model, optional reviewer model override, and effective expected self-report model for this run.
+4. This exact instruction: **"Use output shape B (fresh-diff findings) from your reviewer prompt. Do not edit any files. Validate every finding before reporting it. Self-identify your model in the top-level `model` field of the response envelope — do not copy any model name from this prompt. Return a JSON object envelope with that `model` and a `findings` array of confirmed findings, even when the array is empty."**
+5. The expected return shape. The top-level `model` value is whatever the agent self-reported, **not** something the orchestrator fills in:
 
    ```json
    {
@@ -95,13 +106,18 @@ When there are no confirmed findings, the reviewer must still return `{"model":"
 
 ### Model integrity check
 
-All three reviewer agents expect `claude-opus-4-7` per their frontmatter. After the bucket returns, validate the response envelope before trusting any findings:
+All three reviewer agents declare `claude-opus-4-7` in their frontmatter. For each bucket, compute the effective expected model before validating the response:
+
+- Without `--reviewer-model`: expected self-report is the agent frontmatter model (`claude-opus-4-7`).
+- With `--reviewer-model MODEL`: expected self-report is `MODEL`. If `MODEL` includes a Pi provider prefix or thinking suffix, also accept the provider-stripped / suffix-stripped model id as an exact match (for example, `openai/gpt-5.5:high` accepts `openai/gpt-5.5:high`, `openai/gpt-5.5`, and `gpt-5.5`).
+
+After the bucket returns, validate the response envelope before trusting any findings:
 
 1. Parse the response as a JSON object with a top-level string `model` and a `findings` array. A bare array, missing `model`, missing/non-array `findings`, or unparseable response is a bucket-level **model mismatch**. Discard any findings from that bucket, record the reported model as `missing` or `unparseable` as appropriate, and surface the mismatch in the final review summary.
-2. Compare the envelope `model` against the expected value:
-   - **Exact match**: proceed and carry the envelope model forward as each finding's reported model.
-   - **Same family, different version** (e.g. `claude-opus-4`): record a warning in the final review summary but keep the findings.
-   - **Different family** (e.g. `gpt-5.5`) or `unknown-<family>`: discard the bucket's findings, surface a **model mismatch** entry in the final review summary naming the agent, the expected model, and the reported model, and tell the user to investigate dispatch/config before trusting this PR's review.
+2. Compare the envelope `model` against the effective expected value for that bucket:
+   - **Exact match** to any accepted expected value: proceed and carry the envelope model forward as each finding's reported model.
+   - **Same family, different version** (e.g. expected `claude-opus-4-7`, reported `claude-opus-4`): record a warning in the final review summary but keep the findings.
+   - **Different family** (e.g. expected `claude-opus-4-7`, reported `gpt-5.5`) or `unknown-<family>`: discard the bucket's findings, surface a **model mismatch** entry in the final review summary naming the agent, the frontmatter model, any override, the effective expected model, and the reported model, and tell the user to investigate dispatch/config before trusting this PR's review.
 
 A bucket with `"findings": []` is valid only when the envelope model passes this check; otherwise an empty result cannot contribute to an approve decision. A cross-family mismatch is a configuration bug, not a content bug — re-running through the same channel will reproduce it. Do not silently retry.
 
@@ -145,7 +161,7 @@ For each confirmed finding, write `.review/PR_<PR_NUMBER>_COMMENT_<N>.md` with:
 - `**Question:**` for Go only (`placement`, `package-invariant`, `local-correctness`).
 - `**Severity:**` `blocking`, `warning`, or `suggestion`, plus one-sentence reason.
 - `**Plan:**` concrete fix.
-- `**Reviewer:**` the reviewer agent name, the expected model from its frontmatter, and the model it self-reported, e.g. `go-reviewer (expected claude-opus-4-7, reported claude-opus-4-7)`. When expected and reported differ, that mismatch belongs in the line so it travels with the comment.
+- `**Reviewer:**` the reviewer agent name, the frontmatter model, any override, the effective expected model, and the model it self-reported, e.g. `go-reviewer (frontmatter claude-opus-4-7, expected claude-opus-4-7, reported claude-opus-4-7)` or `go-reviewer (frontmatter claude-opus-4-7, override gpt-5.5, expected gpt-5.5, reported gpt-5.5)`. When expected and reported differ, that mismatch belongs in the line so it travels with the comment.
 
 Then write `.review/PR_<PR_NUMBER>_REVIEW.md` starting with:
 

--- a/services/constellation/connector/sql/graphql/schema/enum_writeonly_internal_test.go
+++ b/services/constellation/connector/sql/graphql/schema/enum_writeonly_internal_test.go
@@ -1,0 +1,317 @@
+package schema
+
+import (
+	"testing"
+
+	"github.com/nhost/nhost/services/constellation/connector/schemamerge"
+	"github.com/nhost/nhost/services/constellation/connector/sql/introspection"
+	"github.com/nhost/nhost/services/constellation/graph"
+	"github.com/nhost/nhost/services/constellation/metadata"
+)
+
+const enumWriteOnlyRole = "user"
+
+func TestGenerateForRole_WriteOnlyEnumFKEmitsEnumType(t *testing.T) {
+	t.Parallel()
+
+	md := enumWriteOnlyMetadata()
+	objects := enumWriteOnlyObjects()
+
+	sch, err := GenerateForRole(objects, enumWriteOnlyRole, md, Capabilities{
+		Kind: KindPostgres,
+	})
+	if err != nil {
+		t.Fatalf("GenerateForRole returned error: %v", err)
+	}
+
+	assertSchemaValid(t, sch, enumWriteOnlyRole)
+	assertEnumTypeExists(t, sch, "statuses_enum")
+	assertInputExists(t, sch, "statuses_enum_comparison_exp")
+	assertNullableInputFieldNamedType(t, sch, "tasks_insert_input", "status", "statuses_enum")
+	assertNullableInputFieldNamedType(t, sch, "tasks_set_input", "status", "statuses_enum")
+}
+
+func TestGenerateForRole_PKEnumFKMutationArgsEmitEnumType(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name        string
+		permissions func(*metadata.TableMetadata)
+		assert      func(*testing.T, *graph.Schema)
+	}{
+		{
+			name: "update pk_columns_input",
+			permissions: func(tableMeta *metadata.TableMetadata) {
+				tableMeta.UpdatePermissions = []metadata.UpdatePermission{
+					{
+						Role: enumWriteOnlyRole,
+						Permission: metadata.UpdatePermissionConfig{
+							Columns: []string{"note"},
+						},
+					},
+				}
+			},
+			assert: func(t *testing.T, sch *graph.Schema) {
+				t.Helper()
+
+				assertInputFieldType(
+					t, sch, "status_notes_pk_columns_input", "status", "statuses_enum",
+				)
+			},
+		},
+		{
+			name: "delete by pk argument",
+			permissions: func(tableMeta *metadata.TableMetadata) {
+				tableMeta.DeletePermissions = []metadata.DeletePermission{
+					{
+						Role:       enumWriteOnlyRole,
+						Permission: metadata.DeletePermissionConfig{},
+					},
+				}
+			},
+			assert: func(t *testing.T, sch *graph.Schema) {
+				t.Helper()
+
+				assertArgType(
+					t,
+					findObject(sch, "mutation_root"),
+					"delete_status_notes_by_pk",
+					"status",
+					"statuses_enum",
+				)
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+
+			md := enumPKMetadata(tt.permissions)
+			objects := enumPKObjects()
+
+			sch, err := GenerateForRole(objects, enumWriteOnlyRole, md, Capabilities{
+				Kind: KindPostgres,
+			})
+			if err != nil {
+				t.Fatalf("GenerateForRole returned error: %v", err)
+			}
+
+			assertSchemaValid(t, sch, enumWriteOnlyRole)
+			assertEnumTypeExists(t, sch, "statuses_enum")
+			tt.assert(t, sch)
+		})
+	}
+}
+
+func enumWriteOnlyMetadata() *metadata.DatabaseMetadata {
+	return &metadata.DatabaseMetadata{
+		Tables: []metadata.TableMetadata{
+			{
+				Table:  metadata.TableSource{Schema: "public", Name: "statuses"},
+				IsEnum: true,
+			},
+			{
+				Table: metadata.TableSource{Schema: "public", Name: "tasks"},
+				SelectPermissions: []metadata.SelectPermission{
+					{
+						Role: enumWriteOnlyRole,
+						Permission: metadata.SelectPermissionConfig{
+							Columns: []string{"id"},
+						},
+					},
+				},
+				InsertPermissions: []metadata.InsertPermission{
+					{
+						Role: enumWriteOnlyRole,
+						Permission: metadata.InsertPermissionConfig{
+							Columns: []string{"status"},
+						},
+					},
+				},
+				UpdatePermissions: []metadata.UpdatePermission{
+					{
+						Role: enumWriteOnlyRole,
+						Permission: metadata.UpdatePermissionConfig{
+							Columns: []string{"status"},
+						},
+					},
+				},
+			},
+		},
+	}
+}
+
+func enumPKMetadata(configure func(*metadata.TableMetadata)) *metadata.DatabaseMetadata {
+	statusNotes := metadata.TableMetadata{
+		Table: metadata.TableSource{Schema: "public", Name: "status_notes"},
+		SelectPermissions: []metadata.SelectPermission{
+			{
+				Role: enumWriteOnlyRole,
+				Permission: metadata.SelectPermissionConfig{
+					Columns: []string{"note"},
+				},
+			},
+		},
+	}
+	configure(&statusNotes)
+
+	return &metadata.DatabaseMetadata{
+		Tables: []metadata.TableMetadata{
+			{
+				Table:  metadata.TableSource{Schema: "public", Name: "statuses"},
+				IsEnum: true,
+			},
+			statusNotes,
+		},
+	}
+}
+
+func enumWriteOnlyObjects() *introspection.Objects {
+	objects := introspection.NewObjects()
+	objects.EnumValues["public.statuses"] = []introspection.EnumValue{
+		{Value: "open"},
+		{Value: "closed"},
+	}
+	objects.Schemas["public"] = &introspection.Schema{
+		Tables: map[string]*introspection.Table{
+			"statuses": enumTable("statuses"),
+			"tasks": {
+				Schema:       "public",
+				Name:         "tasks",
+				IsInsertable: true,
+				IsUpdatable:  true,
+				PrimaryKeys:  []string{"id"},
+				Columns: []introspection.Column{
+					{Name: "id", Type: "uuid"},
+					{Name: "status", Type: "text"},
+				},
+				ForeignKeys: []introspection.ForeignKey{
+					{
+						ColumnName:        "status",
+						ForeignSchema:     "public",
+						ForeignTable:      "statuses",
+						ForeignColumnName: "value",
+					},
+				},
+			},
+		},
+	}
+
+	return objects
+}
+
+func enumPKObjects() *introspection.Objects {
+	objects := introspection.NewObjects()
+	objects.EnumValues["public.statuses"] = []introspection.EnumValue{
+		{Value: "open"},
+		{Value: "closed"},
+	}
+	objects.Schemas["public"] = &introspection.Schema{
+		Tables: map[string]*introspection.Table{
+			"statuses": enumTable("statuses"),
+			"status_notes": {
+				Schema:       "public",
+				Name:         "status_notes",
+				IsInsertable: true,
+				IsUpdatable:  true,
+				PrimaryKeys:  []string{"status"},
+				Columns: []introspection.Column{
+					{Name: "status", Type: "text"},
+					{Name: "note", Type: "text"},
+				},
+				ForeignKeys: []introspection.ForeignKey{
+					{
+						ColumnName:        "status",
+						ForeignSchema:     "public",
+						ForeignTable:      "statuses",
+						ForeignColumnName: "value",
+					},
+				},
+			},
+		},
+	}
+
+	return objects
+}
+
+func enumTable(name string) *introspection.Table {
+	return &introspection.Table{
+		Schema:       "public",
+		Name:         name,
+		IsInsertable: true,
+		IsUpdatable:  true,
+		PrimaryKeys:  []string{"value"},
+		Columns: []introspection.Column{
+			{Name: "value", Type: "text"},
+		},
+	}
+}
+
+func assertSchemaValid(t *testing.T, sch *graph.Schema, role string) {
+	t.Helper()
+
+	if _, _, err := schemamerge.BuildValidatedSchema(sch, role); err != nil {
+		t.Fatalf("schema did not validate: %v", err)
+	}
+}
+
+func assertEnumTypeExists(t *testing.T, sch *graph.Schema, enumName string) {
+	t.Helper()
+
+	for _, enumType := range sch.Enums {
+		if enumType.Name == enumName {
+			return
+		}
+	}
+
+	t.Fatalf("schema has no enum type %q", enumName)
+}
+
+func assertInputExists(t *testing.T, sch *graph.Schema, inputName string) {
+	t.Helper()
+
+	for _, inputType := range sch.Inputs {
+		if inputType.Name == inputName {
+			return
+		}
+	}
+
+	t.Fatalf("schema has no input type %q", inputName)
+}
+
+func assertNullableInputFieldNamedType(
+	t *testing.T,
+	sch *graph.Schema,
+	inputName string,
+	fieldName string,
+	wantNamed string,
+) {
+	t.Helper()
+
+	for _, inputType := range sch.Inputs {
+		if inputType.Name != inputName {
+			continue
+		}
+
+		for _, field := range inputType.Fields {
+			if field.Name != fieldName {
+				continue
+			}
+
+			if field.Type == nil || field.Type.Elem != nil || field.Type.NonNull ||
+				field.Type.NamedType != wantNamed {
+				t.Fatalf(
+					"%s.%s: got %s, want %s",
+					inputName, fieldName, formatType(field.Type), wantNamed,
+				)
+			}
+
+			return
+		}
+
+		t.Fatalf("%s has no field %q", inputName, fieldName)
+	}
+
+	t.Fatalf("schema has no input type %q", inputName)
+}

--- a/services/constellation/connector/sql/graphql/schema/helpers.go
+++ b/services/constellation/connector/sql/graphql/schema/helpers.go
@@ -105,7 +105,8 @@ func getColumnDescription(col *introspection.Column) string {
 
 // getCustomColumnName returns the custom column name if configured, or realName otherwise.
 func getCustomColumnName(tableMeta *metadata.TableMetadata, realName string) string {
-	if colConfig, ok := tableMeta.Configuration.ColumnConfig[realName]; ok {
+	if colConfig, ok := tableMeta.Configuration.ColumnConfig[realName]; ok &&
+		colConfig.CustomName != "" {
 		return colConfig.CustomName
 	}
 
@@ -273,10 +274,8 @@ func normalizePostgresTypeToGraphQL(pgType string) string {
 	// Only map to built-in GraphQL types
 	//nolint:goconst,nolintlint
 	switch pgType {
-	case "integer", "int", "int4":
+	case "integer", "int", "int4", "int2", "smallint":
 		return "Int"
-	case "int2", "smallint":
-		return "smallint"
 	case "int8":
 		return "bigint"
 	case "boolean", "bool":

--- a/services/constellation/connector/sql/graphql/schema/helpers_internal_test.go
+++ b/services/constellation/connector/sql/graphql/schema/helpers_internal_test.go
@@ -20,8 +20,8 @@ func TestNormalizePostgresTypeToGraphQL(t *testing.T) {
 		{"integer", "Int"},
 		{"int", "Int"},
 		{"int4", "Int"},
-		{"int2", "smallint"},
-		{"smallint", "smallint"},
+		{"int2", "Int"},
+		{"smallint", "Int"},
 		{"int8", "bigint"},
 		{"boolean", "Boolean"},
 		{"bool", "Boolean"},
@@ -73,7 +73,6 @@ func TestIsCustomScalar(t *testing.T) {
 		{"jsonb", true},
 		{"citext", true},
 		{"bigint", true},
-		{"smallint", true},
 		{"numeric", true},
 	}
 
@@ -149,6 +148,57 @@ func TestGetColumnDescription(t *testing.T) {
 			got := getColumnDescription(&tt.col)
 			if got != tt.expected {
 				t.Errorf("getColumnDescription() = %q, want %q", got, tt.expected)
+			}
+		})
+	}
+}
+
+func TestGetCustomColumnName(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name       string
+		columnName string
+		config     map[string]metadata.ColumnConfig
+		expected   string
+	}{
+		{
+			name:       "no entry",
+			columnName: "email",
+			config:     nil,
+			expected:   "email",
+		},
+		{
+			name:       "comment-only entry falls back to real name",
+			columnName: "email",
+			config: map[string]metadata.ColumnConfig{
+				"email": {CustomName: ""},
+			},
+			expected: "email",
+		},
+		{
+			name:       "custom name set",
+			columnName: "email",
+			config: map[string]metadata.ColumnConfig{
+				"email": {CustomName: "emailAddress"},
+			},
+			expected: "emailAddress",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+
+			tableMeta := &metadata.TableMetadata{
+				Configuration: metadata.TableConfiguration{
+					ColumnConfig: tt.config,
+				},
+			}
+
+			got := getCustomColumnName(tableMeta, tt.columnName)
+			if got != tt.expected {
+				t.Errorf("getCustomColumnName() = %q, want %q", got, tt.expected)
 			}
 		})
 	}

--- a/services/constellation/connector/sql/graphql/schema/smallint_internal_test.go
+++ b/services/constellation/connector/sql/graphql/schema/smallint_internal_test.go
@@ -1,0 +1,152 @@
+package schema
+
+import (
+	"testing"
+
+	"github.com/nhost/nhost/services/constellation/connector/sql/introspection"
+	"github.com/nhost/nhost/services/constellation/graph"
+	"github.com/nhost/nhost/services/constellation/metadata"
+)
+
+func TestGenerateForRole_SmallintColumnsUseInt(t *testing.T) {
+	t.Parallel()
+
+	md := &metadata.DatabaseMetadata{
+		Tables: []metadata.TableMetadata{
+			{
+				Table: metadata.TableSource{Schema: "public", Name: "metrics"},
+			},
+		},
+	}
+
+	objects := introspection.NewObjects()
+	objects.Schemas["public"] = &introspection.Schema{
+		Tables: map[string]*introspection.Table{
+			"metrics": {
+				Schema:       "public",
+				Name:         "metrics",
+				IsInsertable: true,
+				IsUpdatable:  true,
+				PrimaryKeys:  []string{"id"},
+				Columns: []introspection.Column{
+					{Name: "id", Type: "int2"},
+					{Name: "rating", Type: "smallint"},
+				},
+			},
+		},
+	}
+
+	sch, err := GenerateForRole(objects, roleAdmin, md, Capabilities{
+		Kind: KindPostgres,
+	})
+	if err != nil {
+		t.Fatalf("GenerateForRole returned error: %v", err)
+	}
+
+	assertSchemaValid(t, sch, roleAdmin)
+	assertObjectFieldNamedType(t, sch, "metrics", "id", "Int")
+	assertObjectFieldNamedType(t, sch, "metrics", "rating", "Int")
+	assertInputFieldNamedType(t, sch, "metrics_bool_exp", "id", "Int_comparison_exp")
+	assertInputFieldNamedType(t, sch, "metrics_bool_exp", "rating", "Int_comparison_exp")
+	assertScalarMissing(t, sch, "smallint")
+	assertInputMissing(t, sch, "smallint_comparison_exp")
+}
+
+func assertObjectFieldNamedType(
+	t *testing.T,
+	sch *graph.Schema,
+	objectName string,
+	fieldName string,
+	wantNamed string,
+) {
+	t.Helper()
+
+	objectType := findObject(sch, objectName)
+	if objectType == nil {
+		t.Fatalf("schema has no object type %q", objectName)
+	}
+
+	for _, field := range objectType.Fields {
+		if field.Name != fieldName {
+			continue
+		}
+
+		if baseNamedTypeName(field.Type) != wantNamed {
+			t.Fatalf(
+				"%s.%s: got %s, want %s",
+				objectName, fieldName, formatType(field.Type), wantNamed,
+			)
+		}
+
+		return
+	}
+
+	t.Fatalf("%s has no field %q", objectName, fieldName)
+}
+
+func assertInputFieldNamedType(
+	t *testing.T,
+	sch *graph.Schema,
+	inputName string,
+	fieldName string,
+	wantNamed string,
+) {
+	t.Helper()
+
+	for _, inputType := range sch.Inputs {
+		if inputType.Name != inputName {
+			continue
+		}
+
+		for _, field := range inputType.Fields {
+			if field.Name != fieldName {
+				continue
+			}
+
+			if baseNamedTypeName(field.Type) != wantNamed {
+				t.Fatalf(
+					"%s.%s: got %s, want %s",
+					inputName, fieldName, formatType(field.Type), wantNamed,
+				)
+			}
+
+			return
+		}
+
+		t.Fatalf("%s has no field %q", inputName, fieldName)
+	}
+
+	t.Fatalf("schema has no input type %q", inputName)
+}
+
+func assertScalarMissing(t *testing.T, sch *graph.Schema, scalarName string) {
+	t.Helper()
+
+	for _, scalarType := range sch.Scalars {
+		if scalarType.Name == scalarName {
+			t.Fatalf("schema unexpectedly has scalar %q", scalarName)
+		}
+	}
+}
+
+func assertInputMissing(t *testing.T, sch *graph.Schema, inputName string) {
+	t.Helper()
+
+	for _, inputType := range sch.Inputs {
+		if inputType.Name == inputName {
+			t.Fatalf("schema unexpectedly has input type %q", inputName)
+		}
+	}
+}
+
+func baseNamedTypeName(typ *graph.Type) string {
+	if typ == nil {
+		return ""
+	}
+
+	for typ.Elem != nil {
+		typ = typ.Elem
+	}
+
+	return typ.NamedType
+}

--- a/services/constellation/connector/sql/graphql/schema/table.go
+++ b/services/constellation/connector/sql/graphql/schema/table.go
@@ -14,7 +14,7 @@ const (
 )
 
 // generateForTable generates all GraphQL schema elements for a single table.
-func generateForTable( //nolint:funlen,cyclop
+func generateForTable( //nolint:funlen
 	schema *graph.Schema,
 	tableMeta *metadata.TableMetadata,
 	tableInfo *introspection.Table,
@@ -38,46 +38,19 @@ func generateForTable( //nolint:funlen,cyclop
 	qualifiedName := getQualifiedName(tableMeta.Table.Schema, tableMeta.Table.Name)
 	allowedColumns := getAllowedColumns(tableMeta, tableInfo, role)
 
-	for _, col := range tableInfo.Columns {
-		if _, ok := allowedColumns[col.Name]; ok {
-			scalarType := getGraphQLScalarType(col.Type)
-			usedScalars[scalarType] = struct{}{}
-			selectUsedScalars[scalarType] = struct{}{}
-
-			if col.IsArray && caps.SupportsArrays {
-				selectUsedArrayElementTypes[scalarType] = struct{}{}
-			}
-
-			if is, enumKey := isEnumColumn(&col, tableInfo, md); is {
-				neededEnums[enumKey] = struct{}{}
-			}
-		}
-	}
-
-	// Also collect scalars from insert/update-allowed columns.
-	// These may not overlap with select-allowed columns, but their types
-	// are referenced in mutation input types (_insert_input, _set_input, etc.)
-	if role == roleAdmin ||
-		getInsertPermission(tableMeta, role) != nil ||
-		getUpdatePermission(tableMeta, role) != nil ||
-		getDeletePermission(tableMeta, role) != nil {
-		insertCols := getInsertAllowedColumns(tableMeta, tableInfo, role)
-		updateCols := getUpdateAllowedColumns(tableMeta, tableInfo, role)
-
-		for _, col := range tableInfo.Columns {
-			if _, ok := allowedColumns[col.Name]; ok {
-				continue // already tracked above
-			}
-
-			_, inInsert := insertCols[col.Name]
-			_, inUpdate := updateCols[col.Name]
-
-			if inInsert || inUpdate {
-				scalarType := getGraphQLScalarType(col.Type)
-				usedScalars[scalarType] = struct{}{}
-			}
-		}
-	}
+	collectSelectColumnTypeUses(
+		tableInfo,
+		allowedColumns,
+		md,
+		usedScalars,
+		selectUsedScalars,
+		selectUsedArrayElementTypes,
+		neededEnums,
+		caps,
+	)
+	collectMutationColumnTypeUses(
+		tableMeta, tableInfo, allowedColumns, role, md, usedScalars, neededEnums,
+	)
 
 	generateTableObjectType(
 		schema, tableMeta, tableInfo, customTableName, allowedColumns, role, md,
@@ -151,6 +124,135 @@ func generateForTable( //nolint:funlen,cyclop
 		qualifiedName,
 		allowedColumns,
 	)
+}
+
+func collectSelectColumnTypeUses(
+	tableInfo *introspection.Table,
+	allowedColumns map[string]struct{},
+	md *metadata.DatabaseMetadata,
+	usedScalars map[string]struct{},
+	selectUsedScalars map[string]struct{},
+	selectUsedArrayElementTypes map[string]struct{},
+	neededEnums map[string]struct{},
+	caps Capabilities,
+) {
+	for i := range tableInfo.Columns {
+		col := &tableInfo.Columns[i]
+		if _, ok := allowedColumns[col.Name]; !ok {
+			continue
+		}
+
+		scalarType := registerColumnTypeUse(col, tableInfo, md, usedScalars, neededEnums)
+		selectUsedScalars[scalarType] = struct{}{}
+
+		if col.IsArray && caps.SupportsArrays {
+			selectUsedArrayElementTypes[scalarType] = struct{}{}
+		}
+	}
+}
+
+func collectMutationColumnTypeUses(
+	tableMeta *metadata.TableMetadata,
+	tableInfo *introspection.Table,
+	allowedColumns map[string]struct{},
+	role string,
+	md *metadata.DatabaseMetadata,
+	usedScalars map[string]struct{},
+	neededEnums map[string]struct{},
+) {
+	insertPermission := hasInsertPermissionForRole(tableMeta, role)
+	updatePermission := hasUpdatePermissionForRole(tableMeta, role)
+	deletePermission := hasDeletePermissionForRole(tableMeta, role)
+
+	insertCols := getInsertAllowedColumns(tableMeta, tableInfo, role)
+	updateCols := getUpdateAllowedColumns(tableMeta, tableInfo, role)
+	pkColumns := primaryKeyColumns(tableInfo.PrimaryKeys)
+
+	setInputGenerated := tableInfo.IsUpdatable && updatePermission && len(updateCols) > 0
+	pkColumnsInputGenerated := setInputGenerated && len(tableInfo.PrimaryKeys) > 0
+	deleteByPKGenerated := tableInfo.IsUpdatable && deletePermission &&
+		len(tableInfo.PrimaryKeys) > 0
+
+	for i := range tableInfo.Columns {
+		col := &tableInfo.Columns[i]
+		if _, ok := allowedColumns[col.Name]; ok {
+			continue // already tracked by collectSelectColumnTypeUses
+		}
+
+		if mutationReferencesColumnType(
+			col,
+			tableInfo,
+			insertCols,
+			updateCols,
+			pkColumns,
+			insertPermission,
+			setInputGenerated,
+			pkColumnsInputGenerated || deleteByPKGenerated,
+		) {
+			registerColumnTypeUse(col, tableInfo, md, usedScalars, neededEnums)
+		}
+	}
+}
+
+func hasInsertPermissionForRole(tableMeta *metadata.TableMetadata, role string) bool {
+	return role == roleAdmin || getInsertPermission(tableMeta, role) != nil
+}
+
+func hasUpdatePermissionForRole(tableMeta *metadata.TableMetadata, role string) bool {
+	return role == roleAdmin || getUpdatePermission(tableMeta, role) != nil
+}
+
+func hasDeletePermissionForRole(tableMeta *metadata.TableMetadata, role string) bool {
+	return role == roleAdmin || getDeletePermission(tableMeta, role) != nil
+}
+
+func registerColumnTypeUse(
+	col *introspection.Column,
+	tableInfo *introspection.Table,
+	md *metadata.DatabaseMetadata,
+	usedScalars map[string]struct{},
+	neededEnums map[string]struct{},
+) string {
+	scalarType := getGraphQLScalarType(col.Type)
+	usedScalars[scalarType] = struct{}{}
+
+	if is, enumKey := isEnumColumn(col, tableInfo, md); is {
+		neededEnums[enumKey] = struct{}{}
+	}
+
+	return scalarType
+}
+
+func primaryKeyColumns(primaryKeys []string) map[string]struct{} {
+	columns := make(map[string]struct{}, len(primaryKeys))
+	for _, pkColName := range primaryKeys {
+		columns[pkColName] = struct{}{}
+	}
+
+	return columns
+}
+
+func mutationReferencesColumnType(
+	col *introspection.Column,
+	tableInfo *introspection.Table,
+	insertCols map[string]struct{},
+	updateCols map[string]struct{},
+	pkColumns map[string]struct{},
+	insertPermission bool,
+	setInputGenerated bool,
+	pkArgumentGenerated bool,
+) bool {
+	if _, inInsert := insertCols[col.Name]; tableInfo.IsInsertable && insertPermission && inInsert {
+		return true
+	}
+
+	if _, inUpdate := updateCols[col.Name]; setInputGenerated && inUpdate {
+		return true
+	}
+
+	_, isPK := pkColumns[col.Name]
+
+	return isPK && pkArgumentGenerated
 }
 
 // addGlobalEnums adds enums that are used globally across all tables.


### PR DESCRIPTION
<!-- nhost-reviewer:start -->
### **What this PR solves**
This PR fixes Constellation schema generation so mutation-only columns still register the GraphQL enum and scalar types they reference. It also aligns PostgreSQL smallint columns with the built-in GraphQL Int type and ignores empty custom column names.

___

### **PR Type**
Bug fix

___

### **Description**
- Register column enum and scalar type dependencies for insert/update/delete mutation inputs even when the role cannot select those columns.
- Normalize PostgreSQL `int2` and `smallint` to GraphQL `Int` instead of emitting a custom `smallint` scalar.
- Treat empty column custom names as absent and fall back to the real database column name.
- Add internal schema-generation tests for write-only enum foreign keys, enum primary-key mutation arguments, smallint fields, and column-name configuration.

___

<details> <summary><h3> File Walkthrough</h3></summary>

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody>
<tr><td><strong>Constellation schema generation</strong></td><td><details><summary>2 files</summary><table>
<tr>
  <td><strong>helpers.go</strong><dd><code>Fallback to the real column name when metadata custom names are empty and map smallint/int2 to GraphQL Int.</code></dd></td>
  <td><a href="https://github.com/nhost/nhost/pull/XXX/files#diff-3f36c3480124b418b265991f3c98b3f54fa2cac5da238ad620efeba876d78c89">+3/-4</a></td>
</tr>
<tr>
  <td><strong>table.go</strong><dd><code>Split column type-use collection into select and mutation paths so mutation-only inputs register needed scalars and enums.</code></dd></td>
  <td><a href="https://github.com/nhost/nhost/pull/XXX/files#diff-9a00770c5281e293e778628f29c48d94175a1de4f8fbfd6204e25bc6917e08de">+143/-41</a></td>
</tr>
</table></details></td></tr>
<tr><td><strong>Constellation tests</strong></td><td><details><summary>3 files</summary><table>
<tr>
  <td><strong>enum_writeonly_internal_test.go</strong><dd><code>Add tests covering enum types referenced by write-only mutation inputs and enum primary-key mutation arguments.</code></dd></td>
  <td><a href="https://github.com/nhost/nhost/pull/XXX/files#diff-4b8e61e11d6d1995b0bf65835c88f1924cad5607b03ce753c383de73be2f60f3">+317/-0</a></td>
</tr>
<tr>
  <td><strong>helpers_internal_test.go</strong><dd><code>Update smallint normalization expectations and add coverage for empty custom column names.</code></dd></td>
  <td><a href="https://github.com/nhost/nhost/pull/XXX/files#diff-931dd71129471ae892508a1bb6341628274e5dcb5fee54809830f04468a9bd13">+53/-3</a></td>
</tr>
<tr>
  <td><strong>smallint_internal_test.go</strong><dd><code>Add schema-generation coverage proving int2/smallint columns use Int comparisons without a custom smallint scalar.</code></dd></td>
  <td><a href="https://github.com/nhost/nhost/pull/XXX/files#diff-af49b08475ca5b2eb8536e89494236d1c3dfc445c115cc3305e791f39cb1660c">+152/-0</a></td>
</tr>
</table></details></td></tr>
<tr><td><strong>Repository configuration</strong></td><td><details><summary>1 file</summary><table>
<tr>
  <td><strong>.gitignore</strong><dd><code>Ignore generated Claude planning files.</code></dd></td>
  <td><a href="https://github.com/nhost/nhost/pull/XXX/files#diff-bc37d034bad564583790a46f19d807abfe519c5671395fd494d8cce506c42947">+1/-0</a></td>
</tr>
</table></details></td></tr>
</tbody></table>

</details>

___

<!-- nhost-reviewer:end -->