### PR TITLE
fix(dashboard): stabilize flaky e2e tests

### DIFF
--- a/dashboard/e2e/database/functions/functions.test.ts
+++ b/dashboard/e2e/database/functions/functions.test.ts
@@ -36,7 +36,7 @@ test.describe
 
       await expect(
         page.getByRole('link', { name: functionName, exact: true }),
-      ).toBeVisible();
+      ).toBeVisible({ timeout: 30000 });
 
       await page.getByRole('link', { name: functionName, exact: true }).click();
 
@@ -78,7 +78,7 @@ test.describe
         name: functionName,
         exact: true,
       });
-      await expect(functionLink).toBeVisible();
+      await expect(functionLink).toBeVisible({ timeout: 30000 });
 
       await functionLink.hover();
       await page

--- a/dashboard/e2e/database/permissions-graphql-verification.test.ts
+++ b/dashboard/e2e/database/permissions-graphql-verification.test.ts
@@ -4,6 +4,7 @@ import { TEST_ORGANIZATION_SLUG, TEST_PROJECT_SUBDOMAIN } from '@/e2e/env';
 import { expect, test } from '@/e2e/fixtures/auth-hook';
 import {
   clickPermissionButton,
+  getGraphQLResult,
   navigateToGraphQLPlayground,
   navigateToSQLEditor,
   prepareTable,
@@ -72,11 +73,14 @@ test.describe
         query: `query { ${tableName} { id title genre status } }`,
       });
 
-      const resultWindow = page.getByLabel('Result Window');
-      await expect(resultWindow).toContainText(
-        /error|not found in type|not exist|permission/i,
-        { timeout: 15000 },
-      );
+      const result = await getGraphQLResult({ page });
+
+      const hasError =
+        result.includes('error') ||
+        result.includes('not found in type') ||
+        result.includes('not exist') ||
+        result.includes('permission');
+      expect(hasError).toBe(true);
     });
 
     test('public role should only see books matching custom check', async ({
@@ -143,11 +147,10 @@ test.describe
         query: `query { ${tableName} { id title genre status } }`,
       });
 
-      const resultWindow = page.getByLabel('Result Window');
-      await expect(resultWindow).toContainText('The Great Gatsby', {
-        timeout: 15000,
-      });
-      await expect(resultWindow).not.toContainText('A Brief History of Time');
-      await expect(resultWindow).not.toContainText('Draft Novel');
+      const result = await getGraphQLResult({ page });
+
+      expect(result).toContain('The Great Gatsby');
+      expect(result).not.toContain('A Brief History of Time');
+      expect(result).not.toContain('Draft Novel');
     });
   });

--- a/dashboard/e2e/database/permissions-graphql-verification.test.ts
+++ b/dashboard/e2e/database/permissions-graphql-verification.test.ts
@@ -4,7 +4,6 @@ import { TEST_ORGANIZATION_SLUG, TEST_PROJECT_SUBDOMAIN } from '@/e2e/env';
 import { expect, test } from '@/e2e/fixtures/auth-hook';
 import {
   clickPermissionButton,
-  getGraphQLResult,
   navigateToGraphQLPlayground,
   navigateToSQLEditor,
   prepareTable,
@@ -73,14 +72,11 @@ test.describe
         query: `query { ${tableName} { id title genre status } }`,
       });
 
-      const result = await getGraphQLResult({ page });
-
-      const hasError =
-        result.includes('error') ||
-        result.includes('not found in type') ||
-        result.includes('not exist') ||
-        result.includes('permission');
-      expect(hasError).toBe(true);
+      const resultWindow = page.getByLabel('Result Window');
+      await expect(resultWindow).toContainText(
+        /error|not found in type|not exist|permission/i,
+        { timeout: 15000 },
+      );
     });
 
     test('public role should only see books matching custom check', async ({
@@ -105,20 +101,27 @@ test.describe
 
       await page.getByLabel('With custom check').click();
 
+      const columnSearch = page.locator(
+        'input[role="combobox"][placeholder="Search..."]',
+      );
+      const variableSearch = page.locator(
+        'input[role="combobox"][placeholder="Choose variable..."]',
+      );
+
       await page.getByText('Add check').click();
-      await page.locator('input[role="combobox"]').fill('genre');
-      await page.locator('input[role="combobox"]').press('Enter');
+      await columnSearch.fill('genre');
+      await columnSearch.press('Enter');
 
       await page.getByText('Select variable...').click();
-      await page.locator('input[role="combobox"]').fill('fiction');
+      await variableSearch.fill('fiction');
       await page.getByRole('option', { name: /fiction/i }).click();
 
-      await page.getByRole('button', { name: /add/i }).click();
-      await page.locator('input[role="combobox"]').fill('status');
-      await page.locator('input[role="combobox"]').press('Enter');
+      await page.getByRole('button', { name: /^add$/i }).click();
+      await columnSearch.fill('status');
+      await columnSearch.press('Enter');
 
       await page.getByText('Select variable...').click();
-      await page.locator('input[role="combobox"]').fill('published');
+      await variableSearch.fill('published');
       await page.getByRole('option', { name: /published/i }).click();
 
       await page.getByRole('button', { name: /select all/i }).click();
@@ -140,10 +143,11 @@ test.describe
         query: `query { ${tableName} { id title genre status } }`,
       });
 
-      const result = await getGraphQLResult({ page });
-
-      expect(result).toContain('The Great Gatsby');
-      expect(result).not.toContain('A Brief History of Time');
-      expect(result).not.toContain('Draft Novel');
+      const resultWindow = page.getByLabel('Result Window');
+      await expect(resultWindow).toContainText('The Great Gatsby', {
+        timeout: 15000,
+      });
+      await expect(resultWindow).not.toContainText('A Brief History of Time');
+      await expect(resultWindow).not.toContainText('Draft Novel');
     });
   });

--- a/dashboard/e2e/remote-schemas/create-remote-schema.test.ts
+++ b/dashboard/e2e/remote-schemas/create-remote-schema.test.ts
@@ -23,7 +23,11 @@ test.beforeEach(async ({ authenticatedNhostPage: page }) => {
 test('should create and delete a remote schema from URL', async ({
   authenticatedNhostPage: page,
 }) => {
-  await page.getByRole('button', { name: /new remote schema/i }).click();
+  const newSchemaButton = page.getByRole('button', {
+    name: /new remote schema/i,
+  });
+  await newSchemaButton.waitFor({ state: 'visible', timeout: 30000 });
+  await newSchemaButton.click();
   await expect(page.getByText(/create a new remote schema/i)).toBeVisible();
 
   const schemaName = snakeCase(`e2e ${faker.lorem.words(2)}`);

--- a/dashboard/e2e/run/run.test.ts
+++ b/dashboard/e2e/run/run.test.ts
@@ -33,6 +33,10 @@ test('should create and delete a run service', async ({
 
   await page.getByRole('button', { name: /confirm/i }).click();
 
+  await expect(
+    page.getByText('The service has been configured successfully.'),
+  ).toBeVisible({ timeout: 30000 });
+
   await expect(page.getByRole('heading', { name: serviceName })).toBeVisible();
 
   await page.getByLabel(/more options/i).click();

--- a/dashboard/e2e/utils.ts
+++ b/dashboard/e2e/utils.ts
@@ -609,6 +609,16 @@ export async function runGraphQLQuery({
   await page.getByRole('button', { name: 'Execute GraphQL query' }).click();
 }
 
+export async function getGraphQLResult({
+  page,
+}: {
+  page: Page;
+}): Promise<string> {
+  const resultWindow = page.getByLabel('Result Window');
+  await expect(resultWindow).not.toBeEmpty({ timeout: 15000 });
+  return resultWindow.innerText();
+}
+
 export async function deleteRelationship({
   page,
   relationshipName,

--- a/dashboard/e2e/utils.ts
+++ b/dashboard/e2e/utils.ts
@@ -609,16 +609,6 @@ export async function runGraphQLQuery({
   await page.getByRole('button', { name: 'Execute GraphQL query' }).click();
 }
 
-export async function getGraphQLResult({
-  page,
-}: {
-  page: Page;
-}): Promise<string> {
-  const resultWindow = page.getByLabel('Result Window');
-  await expect(resultWindow).not.toBeEmpty({ timeout: 5000 });
-  return resultWindow.innerText();
-}
-
 export async function deleteRelationship({
   page,
   relationshipName,

--- a/dashboard/playwright.config.ts
+++ b/dashboard/playwright.config.ts
@@ -32,7 +32,7 @@ export default defineConfig({
     trace: 'retain-on-failure',
     baseURL: process.env.NHOST_TEST_DASHBOARD_URL,
     launchOptions: {
-      slowMo: 100,
+      slowMo: 50,
     },
   },
   projects: [


### PR DESCRIPTION
### Checklist

- [X] No breaking changes
- [X] Tests pass
- [X] New features have new tests
- [X] Documentation is updated (if applicable)
- [X] Title of the PR is in the correct format (see below)

<!-- nhost-reviewer:start -->
### **What this PR solves**
The dashboard Playwright e2e suite was failing intermittently. Three root causes: (1) assertions on slow-loading async UI — function links, the "New Remote Schema" button, the Run service success toast — used the default timeout and fired before the elements rendered; (2) the permissions editor's shared `input[role="combobox"]` locator matched more than one field, so fills/presses could land on the wrong input; and (3) the GraphQL "Result Window" was sometimes read before a slow round-trip populated it. This change adds web-first waits and explicit timeouts, scopes the combobox locators by placeholder, and gives the Result Window read more headroom — making the permissions, functions, remote-schema, and run tests deterministic.

___

### **PR Type**
Tests

___

### **Description**
- Disambiguate the permission-editor comboboxes by binding separate `columnSearch` (`placeholder="Search..."`) and `variableSearch` (`placeholder="Choose variable..."`) locators instead of a shared `input[role="combobox"]` that matched multiple inputs, and tighten the row-commit button from `/add/i` to an exact `/^add$/i` match.
- Raise the `getGraphQLResult` "Result Window" non-empty timeout from 5s to 15s so result reads don't race a slow GraphQL round-trip (`e2e/utils.ts`).
- Add explicit 30s visibility waits to slow-loading elements: function links, the "New Remote Schema" button (now waited on before clicking), and a new wait on the Run service "configured successfully" toast before asserting the service heading.
- Halve global `slowMo` from 100ms to 50ms now that the suite relies on proper waits rather than artificial slowdown.

___

<details> <summary><h3> File Walkthrough</h3></summary>

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody>
<tr><td><strong>Tests</strong></td><td><details><summary>5 files</summary><table>
<tr>
  <td><strong>permissions-graphql-verification.test.ts</strong><dd><code>Scope combobox locators by placeholder; exact-match the Add button</code></dd></td>
  <td><a href="https://github.com/nhost/nhost/pull/4443/files#diff-03238bf6d86a7e8899c0902625adc616094300fac734fb6141403fd47474d179">+14/-7</a></td>
</tr>
<tr>
  <td><strong>utils.ts</strong><dd><code>Raise getGraphQLResult Result Window timeout 5s→15s</code></dd></td>
  <td><a href="https://github.com/nhost/nhost/pull/4443/files#diff-490448aa83585151d8c61d698273c43486fdcac6a5d28a9b7e5be2729bbffd12">+1/-1</a></td>
</tr>
<tr>
  <td><strong>functions.test.ts</strong><dd><code>Add 30s visibility timeout to function-link assertions</code></dd></td>
  <td><a href="https://github.com/nhost/nhost/pull/4443/files#diff-1f318b6a5d404d703dc8453496a6caa95c52090022708042fed99cd9941d0ac6">+2/-2</a></td>
</tr>
<tr>
  <td><strong>create-remote-schema.test.ts</strong><dd><code>Wait for the "New Remote Schema" button before clicking</code></dd></td>
  <td><a href="https://github.com/nhost/nhost/pull/4443/files#diff-5bb00c9b96fb26ea250f932648cf3fbaf1df2f40acb0e0b7171e1500c113c31e">+5/-1</a></td>
</tr>
<tr>
  <td><strong>run.test.ts</strong><dd><code>Assert success toast before checking the service heading</code></dd></td>
  <td><a href="https://github.com/nhost/nhost/pull/4443/files#diff-3b81821630a8e66e8f580609a834499bdfec9ac228ff07b99f398ec07c329095">+4/-0</a></td>
</tr>
</table></details></td></tr>
<tr><td><strong>Configuration</strong></td><td><details><summary>1 files</summary><table>
<tr>
  <td><strong>playwright.config.ts</strong><dd><code>Halve global slowMo from 100ms to 50ms</code></dd></td>
  <td><a href="https://github.com/nhost/nhost/pull/4443/files#diff-3ce7004405593146d0b9c501fc50a6a5ae2da8bb48b57dee2faf79ca9c09cf62">+1/-1</a></td>
</tr>
</table></details></td></tr>
</tbody></table>

</details>

___

<!-- nhost-reviewer:end -->
