### PR TITLE
fix(ci): stop trusting PR-supplied flake nixConfig in setup-nix

### DIFF
--- a/.github/actions/setup-nix/action.yml
+++ b/.github/actions/setup-nix/action.yml
@@ -27,13 +27,12 @@ runs:
         extra_nix_config: |
           download-buffer-size = 500000000
           experimental-features = nix-command flakes
-          sandbox = false
+          sandbox = relaxed
           access-tokens = github.com=${{ inputs.GITHUB_TOKEN }}
           substituters = https://cache.nixos.org/?priority=40 s3://nhost-nix-cache?endpoint=https://14bc02755b64adb7c8c62b5420d0a457.eu.r2.cloudflarestorage.com&region=auto&priority=50
           trusted-public-keys = cache.nixos.org-1:6NCHdD59X431o0gWypbMrAURkbJ16ZPMQFGspcDShjY= ${{ inputs.NIX_CACHE_PUB_KEY }}
           keep-env-derivations = true
           keep-outputs = true
-          accept-flake-config = true
 
     - name: "Forward R2 credentials to the Nix daemon"
       # The Nix daemon runs as root and doesn't inherit AWS_* env vars


### PR DESCRIPTION
  <!-- nhost-reviewer:start -->
  ### **What this PR solves**
  The `setup-nix` composite action installed Nix with `accept-flake-config = true`, so the daemon silently honored any `nixConfig` block declared in a PR-checked-out `flake.nix` — letting a PR extend the substituters / trusted-public-keys the CI daemon builds against. This drops that flag so the daemon trusts only its own configured substituters/keys, and pins `sandbox = relaxed` in the daemon config to preserve the build mode CI already ran under.

  ___

  ### **PR Type**
  Enhancement

  ___

  ### **Description**
  - Remove `accept-flake-config = true` from the `setup-nix` daemon config so Nix no longer honors a `nixConfig` block from a PR-supplied 
  `flake.nix` (non-interactive Nix warns and ignores it rather than prompting).
  - Pin `sandbox = relaxed` in the daemon config: the repo's own `flake.nix` already declares `sandbox = "relaxed"`, which is what every 
  `.#` flake build actually ran under while the flag was on — so this preserves the effective mode instead of silently widening it to a 
  fully disabled sandbox once the flag is gone.
  - No change to caching: the daemon config already lists the same substituters and trusted-public-keys (`cache.nixos.org` + the nhost R2 
  cache), so cache reads are unaffected; defense-in-depth hardening only, no functional change to builds.

  ___

  ### Diagram Walkthrough

  ```mermaid
  flowchart LR
    PR["PR flake.nix<br/>nixConfig { substituters, keys, sandbox }"]
    Daemon["Nix daemon<br/>(setup-nix)"]
    Trust["substituters + trusted-public-keys<br/>(daemon config only)"]
    SB["sandbox = relaxed"]
    PR -. "accept-flake-config removed:<br/>no longer honored" .-> Daemon
    Daemon --> Trust
    Daemon --> SB
  ```

  <details> <summary><h3> File Walkthrough</h3></summary>

  <table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody>
  <tr><td><strong>CI / GitHub Actions</strong></td><td><details><summary>1 file</summary><table>
  <tr>
    <td><strong>action.yml</strong><dd><code>Drop accept-flake-config; pin sandbox = relaxed in daemon config</code></dd></td>
    <td><a href="https://github.com/nhost/nhost/pull/NUMBER/files#diff-d6d03b00722cea2a21415f2e41951abebd36b521b485d7e4fc9fbb4a3c0195dc">+1
  /-2</a></td>
  </tr>
  </table></details></td></tr>
  </tbody></table>

  </details>

  ___

  <!-- nhost-reviewer:end -->