### PR TITLE
fix(storage): authorize file replace before reading request body

### DIFF
--- a/services/storage/controller/replace_file.go
+++ b/services/storage/controller/replace_file.go
@@ -77,13 +77,6 @@ func (ctrl *Controller) ReplaceFile( //nolint:funlen,ireturn
 	logger := oapimw.LoggerFromContext(ctx)
 	sessionHeaders := middleware.SessionHeadersFromContext(ctx)
 
-	file, form, apiErr := replaceFileParseRequest(request)
-	if apiErr != nil {
-		logger.ErrorContext(ctx, "problem parsing request", slog.String("error", apiErr.Error()))
-		return apiErr, nil
-	}
-	defer form.RemoveAll() //nolint:errcheck
-
 	originalMetadata, bucketMetadata, apiErr := ctrl.getFileMetadata(
 		ctx, request.Id, false, sessionHeaders,
 	)
@@ -94,6 +87,13 @@ func (ctrl *Controller) ReplaceFile( //nolint:funlen,ireturn
 
 		return apiErr, nil
 	}
+
+	file, form, apiErr := replaceFileParseRequest(request)
+	if apiErr != nil {
+		logger.ErrorContext(ctx, "problem parsing request", slog.String("error", apiErr.Error()))
+		return apiErr, nil
+	}
+	defer form.RemoveAll() //nolint:errcheck
 
 	if apiErr = checkFileSize(
 		file.header, bucketMetadata.MinUploadFile, bucketMetadata.MaxUploadFile,


### PR DESCRIPTION
<!-- nhost-reviewer:start -->
  ### **What this PR solves**
  The `PUT /v1/files/{id}` (replace file) handler read and buffered the **entire** multipart request body
  (`request.Body.ReadForm`) before it looked up the target file's metadata — which is also the authorization
  gate, since `GetFileByID` runs under the caller's session and is enforced by Hasura row permissions. An
  unauthenticated or unauthorized request with a bogus `id` therefore caused the full body to be ingested
  (and spilled to a temp file / kernel page cache) before the handler returned `403`/`404`, allowing a caller
  with no access to drive resource consumption on the storage host (CWE-770). This reorders the handler so the
  authorization/metadata lookup runs first and unauthorized requests are rejected without consuming the body.

  ___

  ### **PR Type**
  Bug fix

  ___

  ### **Description**
  - Move the `getFileMetadata` call ahead of `replaceFileParseRequest` in `ReplaceFile`, so the authorization
    gate (file lookup under the caller's session) runs **before** the multipart body is read and buffered.
  - Unauthenticated / unauthorized `PUT /v1/files/{id}` requests now return `403`/`404` without ingesting the
    request body, instead of buffering it to a temp file first.
  - No behavior change for valid requests: the metadata lookup uses only the URL `id` and session headers — not
    the body — and the two statements are independent, so a successful replace follows the exact same path and
    produces the same response.
  - Scope: this addresses the **replace (PUT)** vector only. The `POST /v1/files` upload vector is intentionally
    out of scope — its `bucket-id` lives inside the body and it accepts unbounded multi-file batches, so it
    cannot be fixed without either a breaking static body cap or a larger streaming rewrite (tracked as a
    follow-up).

  ___

  ### Diagram Walkthrough

  ```mermaid
  flowchart LR
    Req["PUT /v1/files/{id}<br/>large multipart body"]
    Auth["getFileMetadata<br/>(authz gate: file lookup<br/>under caller's session)"]
    Body["ReadForm<br/>(buffer body to temp file)"]
    Reject["403 / 404<br/>before body read"]
    OK["checkFileSize → scan → put"]
    Req --> Auth
    Auth -- "unauthorized" --> Reject
    Auth -- "authorized" --> Body --> OK
    ```