### PR TITLE
fix(constellation): expose smallint as scalar

### DIFF
--- a/services/constellation/KNOWN_DIFFERENCES.md
+++ b/services/constellation/KNOWN_DIFFERENCES.md
@@ -9,6 +9,31 @@
 
 3. If all columns of a table are non-aggregatable (e.g. only jsonb columns), the `max`/`min` fields are omitted from the `_aggregate_fields` type entirely rather than exposing empty types.
 
+# `smallint` / `int2` columns expose as `Int`
+
+PostgreSQL `smallint` (and its `int2` alias) columns are mapped to the built-in
+GraphQL `Int` scalar everywhere they appear in the generated schema — object
+fields, `_bool_exp`, `_set_input`, `_insert_input`, `_inc_input`,
+`_pk_columns_input`, `_by_pk` arguments, `_max_fields`, `_min_fields`,
+`_sum_fields`, `_stream_cursor_value_input`, and array element types
+(`smallint[]` becomes `[Int!]`). The `smallint` scalar and the
+`smallint_comparison_exp` input are not emitted at all.
+
+Hasura instead exposes a dedicated `smallint` custom scalar (plus
+`smallint_comparison_exp`), so the same column appears as `isoNumber: smallint`
+in Hasura and `isoNumber: Int` in Constellation, and `where: { isoNumber:
+{ _eq: 1 } }` is typed against `Int_comparison_exp` rather than
+`smallint_comparison_exp`.
+
+PostgreSQL `smallint` is a signed 16-bit integer, which fits losslessly inside
+GraphQL's signed 32-bit `Int`, so the value range and wire format are unchanged
+— the divergence is purely in the type name. Clients generated against the
+Hasura schema (typed GraphQL codegen, hand-written queries that name the
+`smallint` scalar, etc.) will need to be regenerated or updated to reference
+`Int` / `Int_comparison_exp` instead. Other narrower or wider integer types are
+unaffected: `int4`/`integer` still map to `Int` and `int8`/`bigint` still map
+to the custom `bigint` scalar, exactly as in Hasura.
+
 # Mutations with no update permissions
 
 Update mutations are not generated for tables where the role has no update column permissions (i.e. the `_update_column` enum only contains `_PLACEHOLDER`). Hasura generates these mutations but they cannot actually update any columns, making them no-ops.

--- a/services/constellation/KNOWN_DIFFERENCES.md
+++ b/services/constellation/KNOWN_DIFFERENCES.md
@@ -9,31 +9,6 @@
 
 3. If all columns of a table are non-aggregatable (e.g. only jsonb columns), the `max`/`min` fields are omitted from the `_aggregate_fields` type entirely rather than exposing empty types.
 
-# `smallint` / `int2` columns expose as `Int`
-
-PostgreSQL `smallint` (and its `int2` alias) columns are mapped to the built-in
-GraphQL `Int` scalar everywhere they appear in the generated schema — object
-fields, `_bool_exp`, `_set_input`, `_insert_input`, `_inc_input`,
-`_pk_columns_input`, `_by_pk` arguments, `_max_fields`, `_min_fields`,
-`_sum_fields`, `_stream_cursor_value_input`, and array element types
-(`smallint[]` becomes `[Int!]`). The `smallint` scalar and the
-`smallint_comparison_exp` input are not emitted at all.
-
-Hasura instead exposes a dedicated `smallint` custom scalar (plus
-`smallint_comparison_exp`), so the same column appears as `isoNumber: smallint`
-in Hasura and `isoNumber: Int` in Constellation, and `where: { isoNumber:
-{ _eq: 1 } }` is typed against `Int_comparison_exp` rather than
-`smallint_comparison_exp`.
-
-PostgreSQL `smallint` is a signed 16-bit integer, which fits losslessly inside
-GraphQL's signed 32-bit `Int`, so the value range and wire format are unchanged
-— the divergence is purely in the type name. Clients generated against the
-Hasura schema (typed GraphQL codegen, hand-written queries that name the
-`smallint` scalar, etc.) will need to be regenerated or updated to reference
-`Int` / `Int_comparison_exp` instead. Other narrower or wider integer types are
-unaffected: `int4`/`integer` still map to `Int` and `int8`/`bigint` still map
-to the custom `bigint` scalar, exactly as in Hasura.
-
 # Mutations with no update permissions
 
 Update mutations are not generated for tables where the role has no update column permissions (i.e. the `_update_column` enum only contains `_PLACEHOLDER`). Hasura generates these mutations but they cannot actually update any columns, making them no-ops.

--- a/services/constellation/connector/sql/graphql/schema/helpers.go
+++ b/services/constellation/connector/sql/graphql/schema/helpers.go
@@ -274,8 +274,10 @@ func normalizePostgresTypeToGraphQL(pgType string) string {
 	// Only map to built-in GraphQL types
 	//nolint:goconst,nolintlint
 	switch pgType {
-	case "integer", "int", "int4", "int2", "smallint":
+	case "integer", "int", "int4":
 		return "Int"
+	case "int2", "smallint":
+		return "smallint"
 	case "int8":
 		return "bigint"
 	case "boolean", "bool":

--- a/services/constellation/connector/sql/graphql/schema/helpers_internal_test.go
+++ b/services/constellation/connector/sql/graphql/schema/helpers_internal_test.go
@@ -20,8 +20,8 @@ func TestNormalizePostgresTypeToGraphQL(t *testing.T) {
 		{"integer", "Int"},
 		{"int", "Int"},
 		{"int4", "Int"},
-		{"int2", "Int"},
-		{"smallint", "Int"},
+		{"int2", "smallint"},
+		{"smallint", "smallint"},
 		{"int8", "bigint"},
 		{"boolean", "Boolean"},
 		{"bool", "Boolean"},
@@ -73,6 +73,7 @@ func TestIsCustomScalar(t *testing.T) {
 		{"jsonb", true},
 		{"citext", true},
 		{"bigint", true},
+		{"smallint", true},
 		{"numeric", true},
 	}
 

--- a/services/constellation/connector/sql/graphql/schema/smallint_internal_test.go
+++ b/services/constellation/connector/sql/graphql/schema/smallint_internal_test.go
@@ -8,7 +8,7 @@ import (
 	"github.com/nhost/nhost/services/constellation/metadata"
 )
 
-func TestGenerateForRole_SmallintColumnsUseInt(t *testing.T) {
+func TestGenerateForRole_SmallintColumnsUseCustomScalar(t *testing.T) {
 	t.Parallel()
 
 	md := &metadata.DatabaseMetadata{
@@ -29,8 +29,14 @@ func TestGenerateForRole_SmallintColumnsUseInt(t *testing.T) {
 				IsUpdatable:  true,
 				PrimaryKeys:  []string{"id"},
 				Columns: []introspection.Column{
-					{Name: "id", Type: "int2"},
-					{Name: "rating", Type: "smallint"},
+					{Name: "id", Type: "int2", SupportsMinMax: true},
+					{
+						Name:           "rating",
+						Type:           "smallint",
+						SupportsMinMax: true,
+						SupportsInc:    true,
+						SupportsAgg:    true,
+					},
 				},
 			},
 		},
@@ -44,12 +50,20 @@ func TestGenerateForRole_SmallintColumnsUseInt(t *testing.T) {
 	}
 
 	assertSchemaValid(t, sch, roleAdmin)
-	assertObjectFieldNamedType(t, sch, "metrics", "id", "Int")
-	assertObjectFieldNamedType(t, sch, "metrics", "rating", "Int")
-	assertInputFieldNamedType(t, sch, "metrics_bool_exp", "id", "Int_comparison_exp")
-	assertInputFieldNamedType(t, sch, "metrics_bool_exp", "rating", "Int_comparison_exp")
-	assertScalarMissing(t, sch, "smallint")
-	assertInputMissing(t, sch, "smallint_comparison_exp")
+	assertObjectFieldNamedType(t, sch, "metrics", "id", "smallint")
+	assertObjectFieldNamedType(t, sch, "metrics", "rating", "smallint")
+	assertInputFieldNamedType(t, sch, "metrics_bool_exp", "id", "smallint_comparison_exp")
+	assertInputFieldNamedType(t, sch, "metrics_bool_exp", "rating", "smallint_comparison_exp")
+	assertInputFieldNamedType(t, sch, "metrics_set_input", "rating", "smallint")
+	assertInputFieldNamedType(t, sch, "metrics_insert_input", "rating", "smallint")
+	assertInputFieldNamedType(t, sch, "metrics_inc_input", "rating", "smallint")
+	assertInputFieldNamedType(t, sch, "metrics_pk_columns_input", "id", "smallint")
+	assertInputFieldNamedType(
+		t, sch, "metrics_stream_cursor_value_input", "rating", "smallint",
+	)
+	assertObjectFieldNamedType(t, sch, "metrics_max_fields", "rating", "smallint")
+	assertScalarPresent(t, sch, "smallint")
+	assertInputExists(t, sch, "smallint_comparison_exp")
 }
 
 func assertObjectFieldNamedType(
@@ -119,24 +133,16 @@ func assertInputFieldNamedType(
 	t.Fatalf("schema has no input type %q", inputName)
 }
 
-func assertScalarMissing(t *testing.T, sch *graph.Schema, scalarName string) {
+func assertScalarPresent(t *testing.T, sch *graph.Schema, scalarName string) {
 	t.Helper()
 
 	for _, scalarType := range sch.Scalars {
 		if scalarType.Name == scalarName {
-			t.Fatalf("schema unexpectedly has scalar %q", scalarName)
+			return
 		}
 	}
-}
 
-func assertInputMissing(t *testing.T, sch *graph.Schema, inputName string) {
-	t.Helper()
-
-	for _, inputType := range sch.Inputs {
-		if inputType.Name == inputName {
-			t.Fatalf("schema unexpectedly has input type %q", inputName)
-		}
-	}
+	t.Fatalf("schema is missing expected scalar %q", scalarName)
 }
 
 func baseNamedTypeName(typ *graph.Type) string {


### PR DESCRIPTION
<!-- nhost-reviewer:start -->
### **What this PR solves**
Treats PostgreSQL `smallint`/`int2` columns as the distinct GraphQL `smallint` scalar instead of folding them into `Int`, preserving the database type in generated Constellation schemas.

___

### **PR Type**
Bug fix

___

### **Description**
- Maps PostgreSQL `int2` and `smallint` to the GraphQL `smallint` custom scalar.
- Updates helper coverage so `smallint` is recognized as a custom scalar with its own comparison input.
- Expands schema generation coverage for smallint object fields, filters, mutation inputs, primary-key inputs, cursor inputs, and aggregate fields.

___

<details> <summary><h3> File Walkthrough</h3></summary>

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody>
<tr><td><strong>Constellation schema generation</strong></td><td><details><summary>3 files</summary><table>
<tr>
  <td><strong>services/constellation/connector/sql/graphql/schema/helpers.go</strong><dd><code>Maps PostgreSQL smallint aliases to the custom smallint scalar.</code></dd></td>
  <td><a href="https://github.com/nhost/nhost/pull/XXX/files#diff-3f36c3480124b418b265991f3c98b3f54fa2cac5da238ad620efeba876d78c89">+3/-1</a></td>
</tr>
<tr>
  <td><strong>services/constellation/connector/sql/graphql/schema/helpers_internal_test.go</strong><dd><code>Adjusts type-normalization expectations and custom-scalar coverage for smallint.</code></dd></td>
  <td><a href="https://github.com/nhost/nhost/pull/XXX/files#diff-931dd71129471ae892508a1bb6341628274e5dcb5fee54809830f04468a9bd13">+3/-2</a></td>
</tr>
<tr>
  <td><strong>services/constellation/connector/sql/graphql/schema/smallint_internal_test.go</strong><dd><code>Verifies generated schemas expose smallint across fields, inputs, and aggregates.</code></dd></td>
  <td><a href="https://github.com/nhost/nhost/pull/XXX/files#diff-af49b08475ca5b2eb8536e89494236d1c3dfc445c115cc3305e791f39cb1660c">+26/-20</a></td>
</tr>
</table></details></td></tr>
</tbody></table>

</details>

___

<!-- nhost-reviewer:end -->