### PR TITLE
fix(constellation): hide unsupported introspection directives

### DIFF
--- a/services/constellation/controller/introspection/introspection.go
+++ b/services/constellation/controller/introspection/introspection.go
@@ -219,6 +219,10 @@ func executeDirectivesField(
 	directives := make([]map[string]any, 0, len(names))
 
 	for _, name := range names {
+		if !shouldAdvertiseDirective(name) {
+			continue
+		}
+
 		directiveInfo := executeDirectiveFields(
 			schema.Directives[name], field.SelectionSet, query, schema,
 		)
@@ -226,6 +230,17 @@ func executeDirectivesField(
 	}
 
 	return directives
+}
+
+// shouldAdvertiseDirective filters gqlparser prelude directives Constellation
+// does not support at execution time from __schema.directives output.
+func shouldAdvertiseDirective(name string) bool {
+	switch name {
+	case "defer", "oneOf":
+		return false
+	default:
+		return true
+	}
 }
 
 func executeDirectiveFields(
@@ -259,6 +274,8 @@ func fillDirectiveField(
 		result[key] = directive.Name
 	case kindDescription:
 		result[key] = stringOrNil(directive.Description)
+	case "isRepeatable":
+		result[key] = directive.IsRepeatable
 	case "locations":
 		locations := make([]string, 0, len(directive.Locations))
 		for _, location := range directive.Locations {

--- a/services/constellation/controller/introspection/introspection_test.go
+++ b/services/constellation/controller/introspection/introspection_test.go
@@ -11,6 +11,8 @@ import (
 )
 
 const sampleSchema = `
+directive @repeatableCustom repeatable on FIELD_DEFINITION
+
 "User account."
 type User {
 	id: ID!
@@ -768,6 +770,7 @@ func TestExecute(t *testing.T) { //nolint:gocognit,gocyclo,cyclop,maintidx
 				__schema {
 					directives {
 						name
+						isRepeatable
 						locations
 						args { name }
 					}
@@ -781,18 +784,18 @@ func TestExecute(t *testing.T) { //nolint:gocognit,gocyclo,cyclop,maintidx
 					t.Fatal("expected at least one directive")
 				}
 
-				// The "deprecated" built-in directive must be in the list with a
-				// "reason" argument and at least one location.
-				var deprecated map[string]any
-				for _, d := range dirs {
-					if d["name"] == "deprecated" {
-						deprecated = d
-						break
-					}
+				deprecated := findMapByName(t, dirs, "deprecated")
+
+				repeatable, ok := deprecated["isRepeatable"].(bool)
+				if !ok {
+					t.Fatalf(
+						"expected @deprecated.isRepeatable bool, got %T",
+						deprecated["isRepeatable"],
+					)
 				}
 
-				if deprecated == nil {
-					t.Fatal("expected built-in @deprecated directive in output")
+				if repeatable {
+					t.Errorf("@deprecated.isRepeatable = true, want false")
 				}
 
 				args, _ := deprecated["args"].([]map[string]any)
@@ -807,6 +810,49 @@ func TestExecute(t *testing.T) { //nolint:gocognit,gocyclo,cyclop,maintidx
 				locs := asStringSlice(t, deprecated["locations"])
 				if len(locs) == 0 {
 					t.Errorf("@deprecated locations empty")
+				}
+
+				custom := findMapByName(t, dirs, "repeatableCustom")
+				if repeatable, ok := custom["isRepeatable"].(bool); !ok || !repeatable {
+					t.Errorf(
+						"@repeatableCustom.isRepeatable = %v (ok=%v), want true",
+						custom["isRepeatable"], ok,
+					)
+				}
+			},
+		},
+		{
+			name:  "DirectiveListFilteredAndComplete",
+			query: `{ __schema { directives { name } } }`,
+			check: func(t *testing.T, got map[string]any) {
+				t.Helper()
+
+				dirs := asMapSlice(t, asMap(t, got["__schema"])["directives"])
+
+				names := make(map[string]bool, len(dirs))
+				for _, directive := range dirs {
+					name, ok := directive["name"].(string)
+					if !ok {
+						t.Fatalf("expected directive name string, got %T", directive["name"])
+					}
+
+					names[name] = true
+				}
+
+				for _, want := range []string{"include", "skip", "deprecated", "specifiedBy"} {
+					if !names[want] {
+						t.Errorf("expected built-in directive %q in output, got %v", want, names)
+					}
+				}
+
+				for _, banned := range []string{"defer", "oneOf"} {
+					if names[banned] {
+						t.Errorf(
+							"unexpected unsupported directive %q advertised: %v",
+							banned,
+							names,
+						)
+					}
 				}
 			},
 		},


### PR DESCRIPTION
<!-- nhost-reviewer:start -->
### **What this PR solves**
Completes the remaining Constellation introspection directive gaps by returning `__Directive.isRepeatable` and no longer advertising unsupported gqlparser prelude directives. This keeps introspection output closer to the GraphQL spec and Hasura-compatible server capabilities.

___

### **PR Type**
Bug fix

___

### **Description**
- Emits `isRepeatable` for directive introspection results from `ast.DirectiveDefinition.IsRepeatable`.
- Filters `defer` and `oneOf` from `__schema.directives` without mutating schema validation state.
- Extends introspection tests for built-in and repeatable custom directives plus directive list filtering.

___

<details> <summary><h3> File Walkthrough</h3></summary>

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody>
<tr><td><strong>Constellation introspection</strong></td><td><details><summary>2 files</summary><table>
<tr>
  <td><strong>introspection.go</strong><dd><code>Add directive repeatability output and filter unsupported advertised directives</code></dd></td>
  <td><a href="https://github.com/nhost/nhost/pull/XXX/files#diff-251618dfb353bdac9b5f6e9b1fd4a21aee74a035d832fca71af077411366513c">+17/-0</a></td>
</tr>
<tr>
  <td><strong>introspection_test.go</strong><dd><code>Cover directive repeatability and unsupported directive filtering</code></dd></td>
  <td><a href="https://github.com/nhost/nhost/pull/XXX/files#diff-df32eee5d2d39aab128a83ee92c8fb84c8ae6c498b6db49add8e7b61f0012338">+56/-10</a></td>
</tr>
</table></details></td></tr>
</tbody></table>

</details>

___

<!-- nhost-reviewer:end -->
