### PR TITLE
fix(constellation): harden WebSocket transport liveness

### DIFF
--- a/services/constellation/controller/websocket.go
+++ b/services/constellation/controller/websocket.go
@@ -121,11 +121,6 @@ func (h *webSocketHandler) ConnectionExpiresAt() (time.Time, bool) {
 func (h *webSocketHandler) OnSubscribe(
 	ctx context.Context, id string, payload websocket.SubscribePayload,
 ) {
-	if h.session == nil {
-		h.sendError(id, "session not available")
-		return
-	}
-
 	if _, exists := h.subs.Load(id); exists {
 		h.sendError(id, "subscription with ID already exists")
 		return

--- a/services/constellation/controller/websocket/errors.go
+++ b/services/constellation/controller/websocket/errors.go
@@ -3,9 +3,12 @@ package websocket
 import "errors"
 
 var (
-	errConnectionInitTimeout = errors.New("connection_init timeout")
-	errConnectionInitFailed  = errors.New("connection_init failed")
-	errConnectionExpired     = errors.New("connection expired")
-	errCouldNotReadMessage   = errors.New("could not read message")
-	errInvalidMessageFormat  = errors.New("invalid message format")
+	errConnectionInitTimeout     = errors.New("connection_init timeout")
+	errConnectionInitFailed      = errors.New("connection_init failed")
+	errConnectionExpired         = errors.New("connection expired")
+	errConnectionLivenessTimeout = errors.New("connection liveness timeout")
+	errDuplicateConnectionInit   = errors.New("duplicate connection_init")
+	errSubscribeBeforeInit       = errors.New("subscribe received before connection_init")
+	errCouldNotReadMessage       = errors.New("could not read message")
+	errInvalidMessageFormat      = errors.New("invalid message format")
 )

--- a/services/constellation/controller/websocket/protocol.go
+++ b/services/constellation/controller/websocket/protocol.go
@@ -23,6 +23,13 @@ const (
 	messageTypeError         = "error"
 )
 
+const (
+	closeCodeUnauthorized                    = 4401
+	closeCodeTooManyInitialisationRequests   = 4429
+	closeReasonUnauthorized                  = "Unauthorized"
+	closeReasonTooManyInitialisationRequests = "Too many initialisation requests"
+)
+
 // Message represents a graphql-ws protocol message.
 type Message struct {
 	ID      string         `json:"id,omitempty"`

--- a/services/constellation/controller/websocket/server.go
+++ b/services/constellation/controller/websocket/server.go
@@ -27,6 +27,10 @@ const (
 var (
 	connectionInitTimeout = 10 * time.Second
 	defaultPingInterval   = 30 * time.Second
+	// pongWait is a separate test-overridable knob. Tests that override the
+	// ping interval and depend on liveness timing should override pongWait too.
+	pongWait  = defaultPingInterval + 15*time.Second
+	writeWait = 10 * time.Second
 )
 
 // MessageHandler handles graphql-transport-ws protocol events.
@@ -57,6 +61,9 @@ type wsConn interface {
 	ReadMessage() (int, []byte, error)
 	WriteMessage(messageType int, data []byte) error
 	SetReadDeadline(t time.Time) error
+	SetWriteDeadline(t time.Time) error
+	SetPongHandler(h func(string) error)
+	WriteControl(messageType int, data []byte, deadline time.Time) error
 	Close() error
 }
 
@@ -183,6 +190,20 @@ func (c *Connection) readPump(ctx context.Context, logger *slog.Logger) error {
 		return fmt.Errorf("setting initial read deadline: %w", err)
 	}
 
+	// Gorilla invokes pong handlers from the read side while ReadMessage runs,
+	// so this closure observes initialized state on the readPump goroutine.
+	c.conn.SetPongHandler(func(string) error {
+		if !c.initialized {
+			return nil
+		}
+
+		if err := c.setPostInitReadDeadline(ctx); err != nil {
+			return fmt.Errorf("setting post-init read deadline from control pong: %w", err)
+		}
+
+		return nil
+	})
+
 	for {
 		select {
 		case <-ctx.Done():
@@ -205,12 +226,14 @@ func (c *Connection) readPump(ctx context.Context, logger *slog.Logger) error {
 				return nil
 			}
 
-			// Stop the init timeout once the handshake completes, then replace the
-			// pre-init read deadline with the JWT expiry bound (or no deadline for
-			// non-JWT sessions).
+			// Stop the init timeout once the handshake completes. Every successful
+			// initialized read then refreshes the post-init liveness deadline, capped
+			// by JWT expiry when present.
 			if status == readMessageStatusInitialized {
 				initTimer.Stop()
+			}
 
+			if c.initialized {
 				if err := c.setPostInitReadDeadline(ctx); err != nil {
 					return fmt.Errorf("setting post-init read deadline: %w", err)
 				}
@@ -259,17 +282,24 @@ func (c *Connection) handleReadMessageError(
 		return readMessageStatusContinue, errConnectionInitTimeout
 	case isReadTimeout(readErr) && c.isExpired(time.Now()):
 		return readMessageStatusContinue, errConnectionExpired
+	case isReadTimeout(readErr):
+		return readMessageStatusContinue, errConnectionLivenessTimeout
 	default:
 		return readMessageStatusContinue, fmt.Errorf("%w: %w", errCouldNotReadMessage, readErr)
 	}
 }
 
 func (c *Connection) setPostInitReadDeadline(ctx context.Context) error {
-	if c.expiresAt.IsZero() {
-		return c.setReadDeadline(ctx, time.Time{})
+	return c.setReadDeadline(ctx, c.nextReadDeadline(time.Now()))
+}
+
+func (c *Connection) nextReadDeadline(now time.Time) time.Time {
+	deadline := now.Add(pongWait)
+	if !c.expiresAt.IsZero() && c.expiresAt.Before(deadline) {
+		return c.expiresAt
 	}
 
-	return c.setReadDeadline(ctx, c.expiresAt)
+	return deadline
 }
 
 func (c *Connection) setReadDeadline(ctx context.Context, deadline time.Time) error {
@@ -283,6 +313,22 @@ func (c *Connection) setReadDeadline(ctx context.Context, deadline time.Time) er
 		}
 
 		return fmt.Errorf("setting websocket read deadline: %w", err)
+	}
+
+	return nil
+}
+
+func (c *Connection) setWriteDeadline(ctx context.Context, deadline time.Time) error {
+	if contextDone(ctx) {
+		return nil
+	}
+
+	if err := c.conn.SetWriteDeadline(deadline); err != nil {
+		if contextDone(ctx) {
+			return nil
+		}
+
+		return fmt.Errorf("setting websocket write deadline: %w", err)
 	}
 
 	return nil
@@ -322,6 +368,17 @@ func (c *Connection) writePump(ctx context.Context, logger *slog.Logger) error {
 				return writeErr
 			}
 
+			if err := c.setWriteDeadline(ctx, time.Now().Add(writeWait)); err != nil {
+				writeErr := fmt.Errorf("setting write deadline: %w", err)
+				c.notifyConnectionAckWrite(msg, writeErr)
+
+				return writeErr
+			}
+
+			if contextDone(ctx) {
+				return nil
+			}
+
 			if err := c.conn.WriteMessage(websocket.TextMessage, data); err != nil {
 				writeErr := fmt.Errorf("could not write message: %w", err)
 				c.notifyConnectionAckWrite(msg, writeErr)
@@ -346,7 +403,7 @@ func (c *Connection) handleMessage(ctx context.Context, msg *Message, logger *sl
 	case messageTypePong:
 		// Pongs acknowledge our pings; no further action required.
 	case messageTypeSubscribe:
-		c.handleSubscribe(ctx, msg, logger)
+		return c.handleSubscribe(ctx, msg, logger)
 	case messageTypeComplete:
 		c.handler.OnComplete(ctx, msg.ID)
 	default:
@@ -361,7 +418,14 @@ func (c *Connection) handleConnectionInit(
 	ctx context.Context, msg *Message, logger *slog.Logger,
 ) error {
 	if c.initialized {
-		return c.sendConnectionAck(ctx, logger)
+		if err := c.closeWithCode(
+			closeCodeTooManyInitialisationRequests,
+			closeReasonTooManyInitialisationRequests,
+		); err != nil {
+			return fmt.Errorf("%w: %w", errDuplicateConnectionInit, err)
+		}
+
+		return errDuplicateConnectionInit
 	}
 
 	if err := c.handler.OnConnectionInit(ctx, msg.Payload); err != nil {
@@ -462,20 +526,36 @@ func (c *Connection) drainConnectionAckWriteNotifications() {
 	}
 }
 
+func (c *Connection) closeWithCode(code int, reason string) error {
+	if err := c.conn.WriteControl(
+		websocket.CloseMessage,
+		websocket.FormatCloseMessage(code, reason),
+		time.Now().Add(writeWait),
+	); err != nil {
+		return fmt.Errorf("writing websocket close frame: %w", err)
+	}
+
+	return nil
+}
+
 // handleSubscribe processes subscribe messages.
-func (c *Connection) handleSubscribe(ctx context.Context, msg *Message, logger *slog.Logger) {
+func (c *Connection) handleSubscribe(ctx context.Context, msg *Message, logger *slog.Logger) error {
 	if !c.initialized {
-		c.sendError(ctx, msg.ID, "connection not initialized", logger)
-		return
+		if err := c.closeWithCode(closeCodeUnauthorized, closeReasonUnauthorized); err != nil {
+			return fmt.Errorf("%w: %w", errSubscribeBeforeInit, err)
+		}
+
+		return errSubscribeBeforeInit
 	}
 
 	var payload SubscribePayload
 	if err := json.Unmarshal(msg.Payload, &payload); err != nil {
 		c.sendError(ctx, msg.ID, "invalid subscribe payload: "+err.Error(), logger)
-		return
+	} else {
+		c.handler.OnSubscribe(ctx, msg.ID, payload)
 	}
 
-	c.handler.OnSubscribe(ctx, msg.ID, payload)
+	return nil
 }
 
 // sendMessage sends a message to the WebSocket connection.

--- a/services/constellation/controller/websocket/server_internal_test.go
+++ b/services/constellation/controller/websocket/server_internal_test.go
@@ -2,6 +2,7 @@ package websocket
 
 import (
 	"context"
+	"encoding/binary"
 	"encoding/json/jsontext"
 	json "encoding/json/v2"
 	"errors"
@@ -20,15 +21,29 @@ import (
 // tests can script behavior (scripted reads, controlled write errors, blocking
 // reads, etc.) without needing a separate type per scenario.
 type fakeWSConn struct {
-	readFn            func() (int, []byte, error)
-	writeFn           func(messageType int, data []byte) error
-	setReadDeadlineFn func(time.Time) error
-	closeFn           func() error
+	readFn             func() (int, []byte, error)
+	writeFn            func(messageType int, data []byte) error
+	setReadDeadlineFn  func(time.Time) error
+	setWriteDeadlineFn func(time.Time) error
+	setPongHandlerFn   func(func(string) error)
+	writeControlFn     func(messageType int, data []byte, deadline time.Time) error
+	closeFn            func() error
 
-	mu       sync.Mutex
-	writes   [][]byte
-	writeIDs []int
-	closed   bool
+	mu                sync.Mutex
+	writes            [][]byte
+	writeIDs          []int
+	readDeadlines     []time.Time
+	writeDeadlines    []time.Time
+	writeControlCalls []fakeWriteControlCall
+	pongHandler       func(string) error
+	events            []string
+	closed            bool
+}
+
+type fakeWriteControlCall struct {
+	messageType int
+	data        []byte
+	deadline    time.Time
 }
 
 func (f *fakeWSConn) ReadMessage() (int, []byte, error) {
@@ -43,6 +58,10 @@ func (f *fakeWSConn) ReadMessage() (int, []byte, error) {
 // installed. Tests that drive writePump in isolation never invoke ReadMessage,
 // but a nil-safe default is friendlier than a panic if the test is reorganised.
 var errFakeWSReadUnused = errors.New("fakeWSConn: ReadMessage called without a configured readFn")
+
+var errFakeWSPongHandlerUnused = errors.New(
+	"fakeWSConn: pong handler invoked before SetPongHandler",
+)
 
 type fakeTimeoutError struct{}
 
@@ -60,6 +79,7 @@ func (f *fakeWSConn) WriteMessage(messageType int, data []byte) error {
 	copy(buf, data)
 	f.writes = append(f.writes, buf)
 	f.writeIDs = append(f.writeIDs, messageType)
+	f.events = append(f.events, "write_message")
 	f.mu.Unlock()
 
 	if f.writeFn == nil {
@@ -70,11 +90,58 @@ func (f *fakeWSConn) WriteMessage(messageType int, data []byte) error {
 }
 
 func (f *fakeWSConn) SetReadDeadline(t time.Time) error {
+	f.mu.Lock()
+	f.readDeadlines = append(f.readDeadlines, t)
+	f.mu.Unlock()
+
 	if f.setReadDeadlineFn == nil {
 		return nil
 	}
 
 	return f.setReadDeadlineFn(t)
+}
+
+func (f *fakeWSConn) SetWriteDeadline(t time.Time) error {
+	f.mu.Lock()
+	f.writeDeadlines = append(f.writeDeadlines, t)
+	f.events = append(f.events, "set_write_deadline")
+	f.mu.Unlock()
+
+	if f.setWriteDeadlineFn == nil {
+		return nil
+	}
+
+	return f.setWriteDeadlineFn(t)
+}
+
+func (f *fakeWSConn) SetPongHandler(h func(string) error) {
+	f.mu.Lock()
+	f.pongHandler = h
+	f.mu.Unlock()
+
+	if f.setPongHandlerFn != nil {
+		f.setPongHandlerFn(h)
+	}
+}
+
+func (f *fakeWSConn) WriteControl(messageType int, data []byte, deadline time.Time) error {
+	buf := make([]byte, len(data))
+	copy(buf, data)
+
+	f.mu.Lock()
+	f.writeControlCalls = append(f.writeControlCalls, fakeWriteControlCall{
+		messageType: messageType,
+		data:        buf,
+		deadline:    deadline,
+	})
+	f.events = append(f.events, "write_control")
+	f.mu.Unlock()
+
+	if f.writeControlFn == nil {
+		return nil
+	}
+
+	return f.writeControlFn(messageType, data, deadline)
 }
 
 func (f *fakeWSConn) Close() error {
@@ -97,6 +164,58 @@ func (f *fakeWSConn) writtenMessages() [][]byte {
 	copy(out, f.writes)
 
 	return out
+}
+
+func (f *fakeWSConn) readDeadlineCalls() []time.Time {
+	f.mu.Lock()
+	defer f.mu.Unlock()
+
+	out := make([]time.Time, len(f.readDeadlines))
+	copy(out, f.readDeadlines)
+
+	return out
+}
+
+func (f *fakeWSConn) writeDeadlineCalls() []time.Time {
+	f.mu.Lock()
+	defer f.mu.Unlock()
+
+	out := make([]time.Time, len(f.writeDeadlines))
+	copy(out, f.writeDeadlines)
+
+	return out
+}
+
+func (f *fakeWSConn) writeControlRecords() []fakeWriteControlCall {
+	f.mu.Lock()
+	defer f.mu.Unlock()
+
+	out := make([]fakeWriteControlCall, len(f.writeControlCalls))
+	copy(out, f.writeControlCalls)
+
+	return out
+}
+
+func (f *fakeWSConn) eventRecords() []string {
+	f.mu.Lock()
+	defer f.mu.Unlock()
+
+	out := make([]string, len(f.events))
+	copy(out, f.events)
+
+	return out
+}
+
+func (f *fakeWSConn) invokePongHandler(data string) error {
+	f.mu.Lock()
+	handler := f.pongHandler
+	f.mu.Unlock()
+
+	if handler == nil {
+		return errFakeWSPongHandlerUnused
+	}
+
+	return handler(data)
 }
 
 // nopHandler is a MessageHandler that records calls but does nothing else.
@@ -158,15 +277,33 @@ func (h *expiringNopHandler) ConnectionExpiresAt() (time.Time, bool) {
 func withTimingOverrides(t *testing.T, initTimeout, pingInterval time.Duration) {
 	t.Helper()
 
+	withAllTimingOverrides(t, initTimeout, pingInterval, pongWait, writeWait)
+}
+
+func withAllTimingOverrides(
+	t *testing.T,
+	initTimeout time.Duration,
+	pingInterval time.Duration,
+	livenessTimeout time.Duration,
+	writeTimeout time.Duration,
+) {
+	t.Helper()
+
 	origInit := connectionInitTimeout
 	origPing := defaultPingInterval
+	origPong := pongWait
+	origWrite := writeWait
 
 	connectionInitTimeout = initTimeout
 	defaultPingInterval = pingInterval
+	pongWait = livenessTimeout
+	writeWait = writeTimeout
 
 	t.Cleanup(func() {
 		connectionInitTimeout = origInit
 		defaultPingInterval = origPing
+		pongWait = origPong
+		writeWait = origWrite
 	})
 }
 
@@ -514,6 +651,267 @@ func TestReadPumpPostInitDeadlineCancellationReturnsNil(t *testing.T) {
 	}
 }
 
+//nolint:paralleltest,cyclop // mutates timing knobs; keeping the scripted read flow inline is clearer.
+func TestReadPump_RefreshesLivenessOnPostInitAppFrames(t *testing.T) {
+	withAllTimingOverrides(t, time.Hour, time.Hour, 2*time.Second, time.Hour)
+
+	initBytes, err := json.Marshal(&Message{ID: "", Type: messageTypeConnectionInit, Payload: nil})
+	if err != nil {
+		t.Fatalf("could not marshal connection_init: %v", err)
+	}
+
+	pongBytes, err := json.Marshal(&Message{ID: "", Type: messageTypePong, Payload: nil})
+	if err != nil {
+		t.Fatalf("could not marshal pong: %v", err)
+	}
+
+	completeBytes, err := json.Marshal(
+		&Message{ID: "sub-1", Type: messageTypeComplete, Payload: nil},
+	)
+	if err != nil {
+		t.Fatalf("could not marshal complete: %v", err)
+	}
+
+	ctx, cancel := context.WithCancel(t.Context())
+	defer cancel()
+
+	reads := make(chan []byte, 3)
+	reads <- initBytes
+
+	reads <- pongBytes
+
+	reads <- completeBytes
+
+	deadlineRefreshed := make(chan struct{})
+
+	var closeDeadlineRefreshed sync.Once
+
+	var fake *fakeWSConn
+
+	fake = &fakeWSConn{
+		readFn: func() (int, []byte, error) {
+			select {
+			case data := <-reads:
+				return websocket.TextMessage, data, nil
+			case <-ctx.Done():
+				return 0, nil, ctx.Err()
+			}
+		},
+		setReadDeadlineFn: func(time.Time) error {
+			if len(fake.readDeadlineCalls()) >= 4 {
+				closeDeadlineRefreshed.Do(func() { close(deadlineRefreshed) })
+			}
+
+			return nil
+		},
+	}
+	conn := &Connection{
+		conn:        fake,
+		handler:     &nopHandler{onInit: nil, onSub: nil, onComplete: nil, onClose: nil},
+		sendCh:      make(chan *Message, 4),
+		initialized: false,
+		expiresAt:   time.Time{},
+	}
+
+	errCh := make(chan error, 1)
+	go func() {
+		errCh <- conn.readPump(ctx, slog.New(slog.DiscardHandler))
+	}()
+
+	select {
+	case <-deadlineRefreshed:
+	case <-time.After(2 * time.Second):
+		t.Fatal("post-init app frames did not refresh the read deadline")
+	}
+
+	cancel()
+
+	select {
+	case err := <-errCh:
+		if err != nil {
+			t.Fatalf("expected nil readPump error after cancellation, got %v", err)
+		}
+	case <-time.After(2 * time.Second):
+		t.Fatal("readPump did not exit after context cancellation")
+	}
+
+	deadlines := fake.readDeadlineCalls()
+	if len(deadlines) < 4 {
+		t.Fatalf(
+			"expected initial, post-init, pong, and complete deadlines, got %d",
+			len(deadlines),
+		)
+	}
+
+	lastDeadline := deadlines[len(deadlines)-1]
+	if lastDeadline.IsZero() {
+		t.Fatal("expected non-zero liveness deadline")
+	}
+
+	if until := time.Until(lastDeadline); until <= 0 || until > pongWait+time.Second {
+		t.Fatalf("expected last deadline within pongWait, got %v from now", until)
+	}
+}
+
+//nolint:paralleltest,cyclop // mutates timing knobs; keeping the scripted read flow inline is clearer.
+func TestReadPump_ControlPongRefreshesAfterInitOnly(t *testing.T) {
+	withAllTimingOverrides(t, time.Hour, time.Hour, 2*time.Second, time.Hour)
+
+	initBytes, err := json.Marshal(&Message{ID: "", Type: messageTypeConnectionInit, Payload: nil})
+	if err != nil {
+		t.Fatalf("could not marshal connection_init: %v", err)
+	}
+
+	ctx, cancel := context.WithCancel(t.Context())
+	defer cancel()
+
+	reads := make(chan []byte, 1)
+	pongHandlerRegistered := make(chan struct{})
+	postInitDeadlineSet := make(chan struct{})
+
+	var (
+		fake                  *fakeWSConn
+		closeRegistered       sync.Once
+		closePostInitDeadline sync.Once
+	)
+
+	fake = &fakeWSConn{
+		readFn: func() (int, []byte, error) {
+			select {
+			case data := <-reads:
+				return websocket.TextMessage, data, nil
+			case <-ctx.Done():
+				return 0, nil, ctx.Err()
+			}
+		},
+		setPongHandlerFn: func(func(string) error) {
+			closeRegistered.Do(func() { close(pongHandlerRegistered) })
+		},
+		setReadDeadlineFn: func(time.Time) error {
+			if len(fake.readDeadlineCalls()) >= 2 {
+				closePostInitDeadline.Do(func() { close(postInitDeadlineSet) })
+			}
+
+			return nil
+		},
+	}
+	conn := &Connection{
+		conn:        fake,
+		handler:     &nopHandler{onInit: nil, onSub: nil, onComplete: nil, onClose: nil},
+		sendCh:      make(chan *Message, 4),
+		initialized: false,
+		expiresAt:   time.Time{},
+	}
+
+	errCh := make(chan error, 1)
+	go func() {
+		errCh <- conn.readPump(ctx, slog.New(slog.DiscardHandler))
+	}()
+
+	select {
+	case <-pongHandlerRegistered:
+	case <-time.After(2 * time.Second):
+		t.Fatal("SetPongHandler was not registered")
+	}
+
+	if err := fake.invokePongHandler("pre-init"); err != nil {
+		t.Fatalf("pre-init control pong returned an error: %v", err)
+	}
+
+	if got := len(fake.readDeadlineCalls()); got != 1 {
+		t.Fatalf("pre-init control pong should not refresh deadline, got %d calls", got)
+	}
+
+	reads <- initBytes
+
+	select {
+	case <-postInitDeadlineSet:
+	case <-time.After(2 * time.Second):
+		t.Fatal("post-init deadline was not set")
+	}
+
+	if err := fake.invokePongHandler("post-init"); err != nil {
+		t.Fatalf("post-init control pong returned an error: %v", err)
+	}
+
+	if got := len(fake.readDeadlineCalls()); got < 3 {
+		t.Fatalf("post-init control pong should refresh deadline, got %d calls", got)
+	}
+
+	cancel()
+
+	select {
+	case err := <-errCh:
+		if err != nil {
+			t.Fatalf("expected nil readPump error after cancellation, got %v", err)
+		}
+	case <-time.After(2 * time.Second):
+		t.Fatal("readPump did not exit after context cancellation")
+	}
+}
+
+//nolint:paralleltest // mutates package-level timing knobs.
+func TestReadPump_LivenessTimeoutReturnsSentinel(t *testing.T) {
+	withAllTimingOverrides(t, time.Hour, time.Hour, 50*time.Millisecond, time.Hour)
+
+	initBytes, err := json.Marshal(&Message{ID: "", Type: messageTypeConnectionInit, Payload: nil})
+	if err != nil {
+		t.Fatalf("could not marshal connection_init: %v", err)
+	}
+
+	readCalls := 0
+	fake := &fakeWSConn{
+		readFn: func() (int, []byte, error) {
+			readCalls++
+			if readCalls == 1 {
+				return websocket.TextMessage, initBytes, nil
+			}
+
+			return 0, nil, fakeTimeoutError{}
+		},
+	}
+	conn := &Connection{
+		conn:        fake,
+		handler:     &nopHandler{onInit: nil, onSub: nil, onComplete: nil, onClose: nil},
+		sendCh:      make(chan *Message, 4),
+		initialized: false,
+		expiresAt:   time.Time{},
+	}
+
+	err = conn.readPump(t.Context(), slog.New(slog.DiscardHandler))
+	if !errors.Is(err, errConnectionLivenessTimeout) {
+		t.Fatalf("expected errConnectionLivenessTimeout, got %v", err)
+	}
+}
+
+//nolint:paralleltest // mutates package-level timing knobs.
+func TestPostInitReadDeadlineCappedByJWTExpiry(t *testing.T) {
+	withAllTimingOverrides(t, time.Hour, time.Hour, time.Hour, time.Hour)
+
+	expiresAt := time.Now().Add(50 * time.Millisecond)
+	fake := &fakeWSConn{}
+	conn := &Connection{
+		conn:        fake,
+		handler:     &nopHandler{onInit: nil, onSub: nil, onComplete: nil, onClose: nil},
+		sendCh:      make(chan *Message, 1),
+		initialized: true,
+		expiresAt:   expiresAt,
+	}
+
+	if err := conn.setPostInitReadDeadline(t.Context()); err != nil {
+		t.Fatalf("setPostInitReadDeadline returned an error: %v", err)
+	}
+
+	deadlines := fake.readDeadlineCalls()
+	if len(deadlines) != 1 {
+		t.Fatalf("expected one read deadline, got %d", len(deadlines))
+	}
+
+	if !deadlines[0].Equal(expiresAt) {
+		t.Fatalf("expected deadline capped at JWT expiry %v, got %v", expiresAt, deadlines[0])
+	}
+}
+
 // TestLoop_ConnectionInitTimeout covers M5 sub-item (1): the readPump's
 // init-timer branch. When the client opens the connection but never sends
 // connection_init, Loop must return errConnectionInitTimeout.
@@ -670,6 +1068,115 @@ func TestWritePump_WriteMessageFailureReturnsError(t *testing.T) {
 	}
 }
 
+//nolint:paralleltest // mutates package-level timing knobs.
+func TestWritePump_SetsWriteDeadlineBeforeWrite(t *testing.T) {
+	withAllTimingOverrides(t, time.Hour, time.Hour, time.Hour, 500*time.Millisecond)
+
+	ctx, cancel := context.WithCancel(t.Context())
+	defer cancel()
+
+	fake := &fakeWSConn{
+		writeFn: func(_ int, _ []byte) error {
+			cancel()
+
+			return nil
+		},
+	}
+	conn := &Connection{
+		conn:        fake,
+		handler:     &nopHandler{onInit: nil, onSub: nil, onComplete: nil, onClose: nil},
+		sendCh:      make(chan *Message, 1),
+		initialized: false,
+	}
+
+	errCh := make(chan error, 1)
+	go func() {
+		errCh <- conn.writePump(ctx, slog.New(slog.DiscardHandler))
+	}()
+
+	beforeSend := time.Now()
+
+	conn.sendCh <- newPongMessage()
+
+	select {
+	case err := <-errCh:
+		if err != nil {
+			t.Fatalf("expected nil writePump error, got %v", err)
+		}
+	case <-time.After(2 * time.Second):
+		t.Fatal("writePump did not exit after context cancellation")
+	}
+
+	events := fake.eventRecords()
+	if len(events) < 2 {
+		t.Fatalf("expected deadline and write events, got %v", events)
+	}
+
+	if events[0] != "set_write_deadline" || events[1] != "write_message" {
+		t.Fatalf("expected SetWriteDeadline before WriteMessage, got events %v", events)
+	}
+
+	deadlines := fake.writeDeadlineCalls()
+	if len(deadlines) != 1 {
+		t.Fatalf("expected one write deadline, got %d", len(deadlines))
+	}
+
+	if !deadlines[0].After(beforeSend) {
+		t.Fatalf("expected write deadline after send time, got %v <= %v", deadlines[0], beforeSend)
+	}
+
+	if deadlines[0].After(beforeSend.Add(writeWait + 2*time.Second)) {
+		t.Fatalf("write deadline %v was not bounded by writeWait from %v", deadlines[0], beforeSend)
+	}
+}
+
+//nolint:paralleltest // mutates package-level timing knobs.
+func TestWritePump_SetWriteDeadlineFailureReturnsError(t *testing.T) {
+	withAllTimingOverrides(t, time.Hour, time.Hour, time.Hour, time.Hour)
+
+	//nolint:err113 // test sentinel error used to verify error propagation
+	deadlineErr := errors.New("simulated write deadline failure")
+	fake := &fakeWSConn{
+		setWriteDeadlineFn: func(time.Time) error {
+			return deadlineErr
+		},
+		writeFn: func(_ int, _ []byte) error {
+			t.Fatal("WriteMessage should not be called after SetWriteDeadline fails")
+
+			return nil
+		},
+	}
+	conn := &Connection{
+		conn:        fake,
+		handler:     &nopHandler{onInit: nil, onSub: nil, onComplete: nil, onClose: nil},
+		sendCh:      make(chan *Message, 1),
+		initialized: false,
+	}
+
+	conn.sendCh <- newPongMessage()
+
+	ctx, cancel := context.WithCancel(t.Context())
+	defer cancel()
+
+	errCh := make(chan error, 1)
+	go func() {
+		errCh <- conn.writePump(ctx, slog.New(slog.DiscardHandler))
+	}()
+
+	select {
+	case err := <-errCh:
+		if !errors.Is(err, deadlineErr) {
+			t.Fatalf("expected error wrapping write deadline failure, got %v", err)
+		}
+	case <-time.After(2 * time.Second):
+		t.Fatal("writePump did not return after SetWriteDeadline failure")
+	}
+
+	if len(fake.writtenMessages()) != 0 {
+		t.Fatalf("expected no writes after deadline failure, got %d", len(fake.writtenMessages()))
+	}
+}
+
 // TestWritePump_PingTickerSendsPing covers M5 sub-item (4): the
 // defaultPingInterval ticker fires sendMessage(newPingMessage()). We crank
 // the interval down to ~10ms and assert a ping lands on sendCh.
@@ -738,6 +1245,134 @@ func TestWritePump_PingTickerSendsPing(t *testing.T) {
 
 			return
 		}
+	}
+}
+
+func TestHandleConnectionInit_DuplicateClosesWith4429(t *testing.T) {
+	t.Parallel()
+
+	fake := &fakeWSConn{}
+	conn := &Connection{
+		conn: fake,
+		handler: &nopHandler{
+			onInit: func(context.Context, jsontext.Value) error {
+				t.Fatal("OnConnectionInit should not be called for duplicate init")
+
+				return nil
+			},
+			onSub:      nil,
+			onComplete: nil,
+			onClose:    nil,
+		},
+		sendCh:      make(chan *Message, 1),
+		initialized: true,
+		expiresAt:   time.Time{},
+	}
+
+	err := conn.handleMessage(
+		t.Context(),
+		&Message{ID: "", Type: messageTypeConnectionInit, Payload: nil},
+		slog.New(slog.DiscardHandler),
+	)
+	if !errors.Is(err, errDuplicateConnectionInit) {
+		t.Fatalf("expected errDuplicateConnectionInit, got %v", err)
+	}
+
+	assertCloseControl(
+		t,
+		fake.writeControlRecords(),
+		closeCodeTooManyInitialisationRequests,
+		closeReasonTooManyInitialisationRequests,
+	)
+
+	if len(fake.writtenMessages()) != 0 {
+		t.Fatalf("expected no data writes for duplicate init, got %d", len(fake.writtenMessages()))
+	}
+}
+
+func TestHandleSubscribe_BeforeInitClosesWith4401(t *testing.T) {
+	t.Parallel()
+
+	payload, err := json.Marshal(SubscribePayload{Query: "{ users { id } }"})
+	if err != nil {
+		t.Fatalf("could not marshal subscribe payload: %v", err)
+	}
+
+	fake := &fakeWSConn{}
+	conn := &Connection{
+		conn: fake,
+		handler: &nopHandler{
+			onInit: nil,
+			onSub: func(context.Context, string, SubscribePayload) {
+				t.Fatal("OnSubscribe should not be called before init")
+			},
+			onComplete: nil,
+			onClose:    nil,
+		},
+		sendCh:      make(chan *Message, 1),
+		initialized: false,
+		expiresAt:   time.Time{},
+	}
+
+	err = conn.handleMessage(
+		t.Context(),
+		&Message{ID: "sub-1", Type: messageTypeSubscribe, Payload: payload},
+		slog.New(slog.DiscardHandler),
+	)
+	if !errors.Is(err, errSubscribeBeforeInit) {
+		t.Fatalf("expected errSubscribeBeforeInit, got %v", err)
+	}
+
+	assertCloseControl(
+		t,
+		fake.writeControlRecords(),
+		closeCodeUnauthorized,
+		closeReasonUnauthorized,
+	)
+
+	select {
+	case msg := <-conn.sendCh:
+		t.Fatalf("expected no operation error frame, got %s", msg.Type)
+	default:
+	}
+
+	if len(fake.writtenMessages()) != 0 {
+		t.Fatalf("expected no data writes before init, got %d", len(fake.writtenMessages()))
+	}
+}
+
+func assertCloseControl(
+	t *testing.T,
+	calls []fakeWriteControlCall,
+	wantCode int,
+	wantReason string,
+) {
+	t.Helper()
+
+	if len(calls) != 1 {
+		t.Fatalf("expected one close control frame, got %d", len(calls))
+	}
+
+	call := calls[0]
+	if call.messageType != websocket.CloseMessage {
+		t.Fatalf("expected CloseMessage control frame, got message type %d", call.messageType)
+	}
+
+	if call.deadline.IsZero() {
+		t.Fatal("expected close control frame deadline to be set")
+	}
+
+	if len(call.data) < 2 {
+		t.Fatalf("close frame payload too short: %d", len(call.data))
+	}
+
+	gotCode := int(binary.BigEndian.Uint16(call.data[:2]))
+	if gotCode != wantCode {
+		t.Fatalf("expected close code %d, got %d", wantCode, gotCode)
+	}
+
+	if gotReason := string(call.data[2:]); gotReason != wantReason {
+		t.Fatalf("expected close reason %q, got %q", wantReason, gotReason)
 	}
 }
 

--- a/services/constellation/controller/websocket/server_test.go
+++ b/services/constellation/controller/websocket/server_test.go
@@ -311,27 +311,6 @@ func TestProtocol(t *testing.T) {
 			},
 		},
 		{
-			name: "subscribe without init returns error",
-			setupHandler: func(_ *testing.T, _ *wsmock.MockMessageHandler) map[string]<-chan struct{} {
-				// OnSubscribe must NOT be called: no expectation set, gomock
-				// will fail the test if it is.
-				return nil
-			},
-			steps: func(_ map[string]<-chan struct{}) []protocolStep {
-				return []protocolStep{
-					{
-						send: wsMessage{
-							ID:      "sub-1",
-							Type:    "subscribe",
-							Payload: websocket.SubscribePayload{Query: "{ users { id } }"},
-						},
-						expectOutbound: "error",
-						expectID:       "sub-1",
-					},
-				}
-			},
-		},
-		{
 			name: "complete after init invokes OnComplete",
 			setupHandler: func(_ *testing.T, h *wsmock.MockMessageHandler) map[string]<-chan struct{} {
 				done := make(chan struct{})
@@ -351,20 +330,6 @@ func TestProtocol(t *testing.T) {
 						send:         wsMessage{ID: "sub-1", Type: "complete"},
 						awaitHandler: chans["sub-1"],
 					},
-				}
-			},
-		},
-		{
-			name: "second connection_init still produces ack but handler called once",
-			setupHandler: func(_ *testing.T, h *wsmock.MockMessageHandler) map[string]<-chan struct{} {
-				// OnConnectionInit should only fire on the first init.
-				h.EXPECT().OnConnectionInit(gomock.Any(), gomock.Any()).Return(nil).Times(1)
-				return nil
-			},
-			steps: func(_ map[string]<-chan struct{}) []protocolStep {
-				return []protocolStep{
-					{send: wsMessage{Type: "connection_init"}, expectOutbound: "connection_ack"},
-					{send: wsMessage{Type: "connection_init"}, expectOutbound: "connection_ack"},
 				}
 			},
 		},
@@ -415,6 +380,76 @@ func TestProtocol(t *testing.T) {
 
 			tc.close(t)
 		})
+	}
+}
+
+func TestProtocol_SubscribeBeforeInitCloses4401(t *testing.T) {
+	t.Parallel()
+
+	ctrl := gomock.NewController(t)
+	handler := wsmock.NewMockMessageHandler(ctrl)
+	handler.EXPECT().OnClose(gomock.Any())
+
+	tc := dialTestServerCapturingErr(t, handler)
+	defer tc.client.Close()
+
+	writeMessage(t, tc.client, wsMessage{
+		ID:      "sub-1",
+		Type:    "subscribe",
+		Payload: websocket.SubscribePayload{Query: "{ users { id } }"},
+	})
+
+	tc.client.SetReadDeadline(time.Now().Add(2 * time.Second)) //nolint:errcheck
+
+	_, _, err := tc.client.ReadMessage()
+	if !gorillaWS.IsCloseError(err, 4401) {
+		t.Fatalf("expected close code 4401, got %v", err)
+	}
+
+	select {
+	case loopErr := <-tc.loopErr:
+		if loopErr == nil {
+			t.Fatal("expected subscribe-before-init loop error, got nil")
+		}
+	case <-time.After(2 * time.Second):
+		t.Fatal("timed out waiting for server loop to exit")
+	}
+}
+
+func TestProtocol_DuplicateConnectionInitCloses4429(t *testing.T) {
+	t.Parallel()
+
+	ctrl := gomock.NewController(t)
+	handler := wsmock.NewMockMessageHandler(ctrl)
+	handler.EXPECT().OnConnectionInit(gomock.Any(), gomock.Any()).Return(nil).Times(1)
+	handler.EXPECT().OnClose(gomock.Any())
+
+	tc := dialTestServerCapturingErr(t, handler)
+	defer tc.client.Close()
+
+	writeMessage(t, tc.client, wsMessage{Type: "connection_init"})
+
+	ack := readMessage(t, tc.client)
+	if ack.Type != "connection_ack" {
+		t.Fatalf("expected connection_ack, got %s", ack.Type)
+	}
+
+	writeMessage(t, tc.client, wsMessage{Type: "connection_init"})
+
+	tc.client.SetReadDeadline(time.Now().Add(2 * time.Second)) //nolint:errcheck
+
+	_, _, err := tc.client.ReadMessage()
+	if !gorillaWS.IsCloseError(err, 4429) {
+		t.Fatalf("expected close code 4429, got %v", err)
+	}
+
+	select {
+	case loopErr := <-tc.loopErr:
+		if loopErr == nil {
+			t.Fatal("expected duplicate-init loop error, got nil")
+		}
+	case <-time.After(2 * time.Second):
+		t.Fatal("timed out waiting for server loop to exit")
 	}
 }
 

--- a/services/constellation/integration/subscription_protocol_test.go
+++ b/services/constellation/integration/subscription_protocol_test.go
@@ -57,7 +57,7 @@ func TestSubscriptionBadAdminSecret(t *testing.T) { //nolint:paralleltest
 }
 
 // TestSubscriptionSubscribeBeforeInit verifies that subscribing before sending
-// connection_init returns an error but keeps the connection open.
+// connection_init closes the connection.
 func TestSubscriptionSubscribeBeforeInit(t *testing.T) { //nolint:paralleltest
 	c, err := subtest.NewClient(t, wsURL)
 	if err != nil {
@@ -72,9 +72,28 @@ func TestSubscriptionSubscribeBeforeInit(t *testing.T) { //nolint:paralleltest
 				title
 			}
 		}`),
+	}).ExpectClosed()
+}
+
+// TestSubscriptionDuplicateConnectionInitClosesConnection verifies that a
+// second connection_init closes the connection after the first ack.
+func TestSubscriptionDuplicateConnectionInitClosesConnection(t *testing.T) { //nolint:paralleltest
+	c, err := subtest.NewClient(t, wsURL)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	c.Send(subtest.Message{
+		Type:    subtest.ConnectionInit,
+		Payload: initWithAdmin(),
 	}).Expect(func(msg subtest.Message) {
-		expectError(t, msg, "1", "connection not initialized")
-	}).Close()
+		if msg.Type != subtest.ConnectionAck {
+			t.Fatalf("expected connection_ack, got %s", msg.Type)
+		}
+	}).Send(subtest.Message{
+		Type:    subtest.ConnectionInit,
+		Payload: initWithAdmin(),
+	}).ExpectClosed()
 }
 
 // TestSubscriptionDuplicateID verifies that subscribing with an already-active


### PR DESCRIPTION
<!-- nhost-reviewer:start -->
### **What this PR solves**
Adds missing WebSocket transport hygiene for Constellation's graphql-transport-ws server. Connections now use bounded write deadlines, post-init liveness deadlines, and spec-compliant close codes for duplicate initialization or pre-init subscriptions.

___

### **PR Type**
Bug fix

___

### **Description**
- Add WebSocket read liveness and write deadline handling, including JWT-expiry-capped post-init deadlines.
- Close duplicate `connection_init` requests with code `4429` and pre-init `subscribe` requests with code `4401`.
- Update protocol/unit/integration tests for close-code behavior and transport deadline handling.

___

### Diagram Walkthrough

```mermaid
flowchart LR
  Client["graphql-transport-ws client"] -->|connection_init| ReadPump["websocket readPump"]
  ReadPump -->|ack after handler init| WritePump["writePump with writeWait"]
  WritePump -->|app ping| Client
  Client -->|app/control pong or app frame| ReadPump
  ReadPump -->|refresh deadline capped by JWT expiry| Deadline["post-init liveness deadline"]
  ReadPump -->|duplicate init| Close4429["close 4429"]
  ReadPump -->|subscribe before init| Close4401["close 4401"]
```

<details> <summary><h3> File Walkthrough</h3></summary>

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody>
<tr><td><strong>Controller handler</strong></td><td><details><summary>1 file</summary><table>
<tr>
  <td><strong>services/constellation/controller/websocket.go</strong><dd><code>Removes the now-unreachable nil-session subscribe error branch.</code></dd></td>
  <td><a href="https://github.com/nhost/nhost/pull/XXX/files#diff-4b479f1358f4840aa252cd12ef2ee2077c662afde304d2b6667a74a87324a52e">+0/-5</a></td>
</tr>
</table></details></td></tr>
<tr><td><strong>WebSocket protocol</strong></td><td><details><summary>5 files</summary><table>
<tr>
  <td><strong>services/constellation/controller/websocket/errors.go</strong><dd><code>Adds sentinel errors for liveness timeout and protocol close transitions.</code></dd></td>
  <td><a href="https://github.com/nhost/nhost/pull/XXX/files#diff-6cce189900c256c2dc2f88f02a4c5703d5e1506b22c6fcd0796e9bd9caac8a87">+8/-5</a></td>
</tr>
<tr>
  <td><strong>services/constellation/controller/websocket/protocol.go</strong><dd><code>Adds graphql-transport-ws close-code and reason constants.</code></dd></td>
  <td><a href="https://github.com/nhost/nhost/pull/XXX/files#diff-bd1408e8b8498643a103a7b7b49b8547ac44abd2e0cb3751bf9a36e3f3b7fec2">+7/-0</a></td>
</tr>
<tr>
  <td><strong>services/constellation/controller/websocket/server.go</strong><dd><code>Adds liveness deadlines, write deadlines, control-pong handling, and close-code behavior.</code></dd></td>
  <td><a href="https://github.com/nhost/nhost/pull/XXX/files#diff-baac4f8ab217e74b827ecba22651487e2ca5d6e6825ca1de304cc5518baeb1b6">+93/-13</a></td>
</tr>
<tr>
  <td><strong>services/constellation/controller/websocket/server_internal_test.go</strong><dd><code>Adds fake connection support and white-box deadline/close-code tests.</code></dd></td>
  <td><a href="https://github.com/nhost/nhost/pull/XXX/files#diff-f2a577c0ff2a52545b47f8f8b3e8da692b86f67ab38db0f626fdd8c02e004ecf">+643/-8</a></td>
</tr>
<tr>
  <td><strong>services/constellation/controller/websocket/server_test.go</strong><dd><code>Updates black-box protocol tests to assert 4401/4429 close behavior.</code></dd></td>
  <td><a href="https://github.com/nhost/nhost/pull/XXX/files#diff-5b8214e1bd200a42860a5e99232071c334727c08501c3ce72ccd6362299d7e8a">+70/-35</a></td>
</tr>
</table></details></td></tr>
<tr><td><strong>Integration tests</strong></td><td><details><summary>1 file</summary><table>
<tr>
  <td><strong>services/constellation/integration/subscription_protocol_test.go</strong><dd><code>Updates subscription protocol integration tests to expect connection closure.</code></dd></td>
  <td><a href="https://github.com/nhost/nhost/pull/XXX/files#diff-751c79bfc7cbe59cf0e5c341a6311ad81ddeefd02e1285ab585b9250444b1113">+22/-3</a></td>
</tr>
</table></details></td></tr>
</tbody></table>

</details>

___

<!-- nhost-reviewer:end -->