### PR TITLE
fix(dashboard): await metadata builder when tracking foreign keys locally

### DIFF
--- a/dashboard/src/features/orgs/projects/database/dataGrid/hooks/useTrackForeignKeyRelationsMutation/trackForeignKeyRelationsMigration.test.ts
+++ b/dashboard/src/features/orgs/projects/database/dataGrid/hooks/useTrackForeignKeyRelationsMutation/trackForeignKeyRelationsMigration.test.ts
@@ -1,0 +1,81 @@
+import { afterEach, beforeEach, vi } from 'vitest';
+import type { ForeignKeyRelation } from '@/features/orgs/projects/database/dataGrid/types/dataBrowser';
+import trackForeignKeyRelationsMigration from './trackForeignKeyRelationsMigration';
+
+const fetchMock = vi.fn();
+
+function ok(body: unknown) {
+  return { ok: true, json: async () => body } as Response;
+}
+
+function notOk(body: unknown) {
+  return { ok: false, json: async () => body } as Response;
+}
+
+const baseOptions = {
+  dataSource: 'default',
+  schema: 'public',
+  table: 'books',
+  appUrl: 'https://hasura.example',
+  adminSecret: 'test-secret',
+};
+
+const unTrackedForeignKeyRelations: ForeignKeyRelation[] = [
+  {
+    name: 'authors_author_id_fkey',
+    columnName: 'author_id',
+    referencedSchema: 'public',
+    referencedTable: 'authors',
+    referencedColumn: 'id',
+    updateAction: 'RESTRICT',
+    deleteAction: 'RESTRICT',
+  },
+];
+
+describe('trackForeignKeyRelationsMigration', () => {
+  beforeEach(() => {
+    vi.stubGlobal('fetch', fetchMock);
+  });
+
+  afterEach(() => {
+    vi.unstubAllGlobals();
+    fetchMock.mockReset();
+  });
+
+  it('serializes `up` as an array of relationship operations', async () => {
+    fetchMock.mockResolvedValueOnce(ok([{ message: 'success' }]));
+
+    await trackForeignKeyRelationsMigration({
+      ...baseOptions,
+      unTrackedForeignKeyRelations,
+    });
+
+    expect(fetchMock).toHaveBeenCalledTimes(1);
+
+    const [, requestInit] = fetchMock.mock.calls[0];
+    const body = JSON.parse(requestInit.body as string);
+
+    expect(Array.isArray(body.up)).toBe(true);
+    expect(body.up).toHaveLength(2);
+    expect(body.up[0]).toMatchObject({ type: 'pg_create_object_relationship' });
+    expect(body.up[1]).toMatchObject({ type: 'pg_create_array_relationship' });
+
+    expect(body).toMatchObject({
+      dataSource: 'default',
+      skip_execution: false,
+      name: 'track_foreign_key_relations_public_books',
+      down: [],
+    });
+  });
+
+  it('throws a normalized error when the response is not ok', async () => {
+    fetchMock.mockResolvedValueOnce(notOk({ error: 'boom' }));
+
+    await expect(
+      trackForeignKeyRelationsMigration({
+        ...baseOptions,
+        unTrackedForeignKeyRelations,
+      }),
+    ).rejects.toThrow('boom');
+  });
+});

--- a/dashboard/src/features/orgs/projects/database/dataGrid/hooks/useTrackForeignKeyRelationsMutation/trackForeignKeyRelationsMigration.ts
+++ b/dashboard/src/features/orgs/projects/database/dataGrid/hooks/useTrackForeignKeyRelationsMutation/trackForeignKeyRelationsMigration.ts
@@ -42,7 +42,7 @@ export default async function trackForeignKeyRelationsMigration({
   trackedForeignKeyRelations,
 }: TrackForeignKeyRelationsMigrationOptions &
   TrackForeignKeyRelationsMigrationVariables) {
-  const creatableRelationships = prepareTrackForeignKeyRelationsMetadata({
+  const creatableRelationships = await prepareTrackForeignKeyRelationsMetadata({
     dataSource,
     schema,
     table,


### PR DESCRIPTION
### Checklist

- [X] No breaking changes
- [X] Tests pass
- [X] New features have new tests
- [X] Documentation is updated (if applicable)
- [X] Title of the PR is in the correct format (see below)

<!-- nhost-reviewer:start -->
### **What this PR solves**
Tracking foreign-key relationships was failing because `prepareTrackForeignKeyRelationsMetadata` (an `async` function) was called without `await`, leaving `up` as a `Promise` that `JSON.stringify` serialized to `{}`. The Hasura migrate API rejected the request ("cannot unmarshal object into Go struct field Request.up of type `[]api.requestType`"). Adding `await` makes `up` serialize to the expected array of relationship operations, with a regression test to guard it.

___

### **PR Type**
Bug fix

___

### **Description**
- Await `prepareTrackForeignKeyRelationsMetadata` in `trackForeignKeyRelationsMigration` so the resolved array of relationship operations is assigned to `up` instead of an unresolved `Promise`.
- Add a regression test asserting `up` serializes to an array of `pg_create_object_relationship` / `pg_create_array_relationship` operations, and that a non-ok response throws a normalized error.

___

<details> <summary><h3> File Walkthrough</h3></summary>

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody>
<tr><td><strong>Bug fix</strong></td><td><details><summary>1 files</summary><table>
<tr>
  <td><strong>trackForeignKeyRelationsMigration.ts</strong><dd><code>Await the async metadata builder so `up` serializes as an array</code></dd></td>
  <td><a href="https://github.com/nhost/nhost/pull/4452/files#diff-8562c65950e2ff578d8db135790713bbff282ff6a61ff98bb5558a51944927d2">+1/-1</a></td>
</tr>
</table></details></td></tr>
<tr><td><strong>Tests</strong></td><td><details><summary>1 files</summary><table>
<tr>
  <td><strong>trackForeignKeyRelationsMigration.test.ts</strong><dd><code>Regression test asserting `up` serializes to a relationship-operations array</code></dd></td>
  <td><a href="https://github.com/nhost/nhost/pull/4452/files#diff-a4c788dcecb24050e72a0609899a08440ba3debc53bf8b8bc95fcd87983fd4c8">+86/-0</a></td>
</tr>
</table></details></td></tr>
</tbody></table>

</details>

___

<!-- nhost-reviewer:end -->
