### PR TITLE
feat(ghactivity): add reviewed activity bucket

### DIFF
--- a/tools/ghactivity/CLAUDE.md
+++ b/tools/ghactivity/CLAUDE.md
@@ -9,8 +9,8 @@
 ## Core Principles
 
 - **No new HTTP/auth stack** — always go through `internal/gh`, which wraps the `go-gh/v2` clients. The extension inherits whatever auth context `gh` resolves (the user's `gh auth` session, or `GH_TOKEN` / `GITHUB_TOKEN` in CI). Never instantiate `http.Client` or read tokens manually.
-- **The bucket classifier is the contract.** The five sections of the output (`InProgress`, `ReadyForReview`, `Blocked`, `ClosedOrMerged`, `Uncategorized`) are what users build their day around. Any change to `classifyPR` / `classifyIssue` must be accompanied by tests covering the moved cases.
-- **First-match-wins routing.** Each item lands in exactly one section. Priority order (top wins): `ClosedOrMerged` → `Blocked` → `ReadyForReview` → `InProgress` → `Uncategorized`. Preserve this order unless you have a clear reason.
+- **The bucket classifier is the contract.** The six activity sections of the output (`InProgress`, `ReadyForReview`, `Blocked`, `ClosedOrMerged`, `Reviewed`, `Uncategorized`) are what users build their day around. Any change to `classifyPR` / `classifyIssue` must be accompanied by tests covering the moved cases.
+- **First-match-wins routing.** Each item lands in exactly one section. Priority order (top wins): `ClosedOrMerged` → `Blocked` → `ReadyForReview` → `InProgress` → `Reviewed` → `Uncategorized`. Preserve this order unless you have a clear reason.
 - **Project status name is configurable.** Don't hardcode `"Waiting"` / `"Ready for review"`; route through `Params.WaitingStatus` / `Params.ReadyStatus` so teams with different column names can use the tool. The Projects v2 *field* itself is also configurable via `Params.StatusField` (default `activity.DefaultStatusField` = `"Status"`, CLI flag `--status-field`, env var `GHACTIVITY_STATUS_FIELD`) and is threaded into the GraphQL query as the `$statusField` variable — do not reintroduce a hardcoded `fieldValueByName(name: "Status")`.
 
 ## Directory Structure

--- a/tools/ghactivity/README.md
+++ b/tools/ghactivity/README.md
@@ -2,7 +2,7 @@
 
 A [`gh` CLI extension](https://docs.github.com/en/github-cli/github-cli/using-github-cli-extensions) that produces a markdown stand-up report of a GitHub user's activity in an organisation over a time window.
 
-It looks at every pull request and issue the user touched, sorts each one into one of five buckets, and prints a markdown report ready to paste into a stand-up channel.
+It looks at every pull request and issue the user touched, sorts each one into one of six buckets, and prints a markdown report ready to paste into a stand-up channel.
 
 ## Install
 
@@ -66,13 +66,13 @@ The tool runs three GitHub searches against the org and your window:
 - `reviewed-by:USER updated:SINCE..UNTIL`
 - `review-requested:USER updated:SINCE..UNTIL`
 
-It dedupes the union by URL, then routes each item into exactly one of five buckets. **Routing is first-match-wins**, in the priority order listed below — once a PR matches a bucket, no later rule can move it.
+It dedupes the union by URL, then routes each item into exactly one of six buckets. **Routing is first-match-wins**, in the priority order listed below — once a PR matches a bucket, no later rule can move it.
 
 ### Pull requests
 
 For each PR, in this order:
 
-1. **`ClosedOrMerged`** — the PR was merged or closed inside the window (`mergedAt` or `closedAt` falls between `--since` and `--until`).
+1. **`ClosedOrMerged`** — the user authored the PR **and** it was merged or closed inside the window (`mergedAt` or `closedAt` falls between `--since` and `--until`).
 2. **`Blocked`** — the user authored the PR **and** its Projects v2 status column was set to the `--waiting-status` value inside the window.
 3. **`ReadyForReview`** — the user authored the PR **and** either:
    - its Projects v2 status was set to the `--ready-status` value in the window, or
@@ -80,7 +80,7 @@ For each PR, in this order:
 4. **`InProgress`** — the user authored the PR **and** either:
    - the PR was opened in the window (`createdAt` is in range), or
    - the user pushed a commit in the window.
-5. **`Uncategorized`** — anything else where the user left a review or comment on the PR inside the window. The name is literal: the search's `updated:` qualifier is broad, so being merely returned by search isn't enough — there has to be an actual user action (a `PullRequestReview` submitted or an `IssueComment` posted by the user) inside the window.
+5. **`Reviewed`** — anything else where the user left a review or comment on the PR inside the window. The name is broad enough to include top-level PR comments as well as `PullRequestReview` submissions such as approvals or change requests. The search's `updated:` qualifier is broad, so being merely returned by search isn't enough — there has to be an actual user signal inside the window.
 
 PRs that don't match any of the above are dropped from the report.
 
@@ -94,7 +94,7 @@ All issue activity lands in `Uncategorized` today; if a richer issue taxonomy is
 
 ### Why "first-match-wins"
 
-The bucket order encodes how a stand-up reads top-to-bottom: things that wrapped up (`ClosedOrMerged`) lead, then the things blocking the user (`Blocked`), then what's awaiting review (`ReadyForReview`), then live work (`InProgress`), and finally context items (`Uncategorized`). A PR that was opened and then merged in the same window is reported as merged, not as in-progress — which is what you'd say in stand-up.
+The bucket order encodes how a stand-up reads top-to-bottom: things that wrapped up (`ClosedOrMerged`) lead, then the things blocking the user (`Blocked`), then what's awaiting review (`ReadyForReview`), then live work (`InProgress`), then review/comment activity (`Reviewed`), and finally issue or odd leftover context (`Uncategorized`). A PR that was opened and then merged in the same window is reported as merged, not as in-progress — which is what you'd say in stand-up.
 
 ### Why the status field is configurable
 
@@ -102,19 +102,24 @@ Different teams name their Projects v2 status field differently — `Status`, `W
 
 ## Output
 
-A markdown report with a fixed set of level-3 (`###`) sections, in this order:
+A markdown report starts with a level-2 heading for the report window and user, for example `## 2026-05-20 - meh`. If the window spans multiple dates, the heading uses a date range, for example `## 2026-04-25 to 2026-06-04 - meh`.
+
+It then emits a fixed set of level-3 (`###`) sections, in this order:
 
 1. `### 🟢 In progress`
 2. `### 👀 Moved to waiting for review`
 3. `### ⏸️ Blocked / waiting on something else`
 4. `### ✅ Closed / merged`
-5. `### 🎯 Today's focus` — scaffolding for the human to fill in.
-6. `### 📝 Other` — scaffolding for the human to fill in.
-7. `### Uncategorized` — items the user merely touched (reviewed/commented) inside the window.
+5. `### 🔍 Reviewed / commented`
+6. `### 🎯 Today's focus` — scaffolding for the human to fill in.
+7. `### 📝 Other` — scaffolding for the human to fill in.
+8. `### Uncategorized` — issue activity and any remaining context that does not fit the PR-specific buckets.
 
 Every heading is always emitted, even when its bucket is empty — the layout is designed to be pasted into a stand-up channel and filled in by hand, so the empty sections act as a checklist. Within a bucket, items are sorted by repository then PR/issue number for stable diffs day-to-day, and rendered as `- [PR #N](URL) Title` (or `- [Issue #N](URL) Title`).
 
 ```markdown
+## 2026-05-20 - meh
+
 ### 🟢 In progress
 
 - [PR #46](https://github.com/nhost/example/pull/46) WIP: baz refactor
@@ -128,6 +133,10 @@ Every heading is always emitted, even when its bucket is empty — the layout is
 ### ✅ Closed / merged
 
 - [PR #42](https://github.com/nhost/example/pull/42) Tidy up the foo handler
+
+### 🔍 Reviewed / commented
+
+- [PR #47](https://github.com/nhost/example/pull/47) Review teammate change
 
 ### 🎯 Today's focus
 

--- a/tools/ghactivity/internal/activity/activity.go
+++ b/tools/ghactivity/internal/activity/activity.go
@@ -38,10 +38,15 @@ const (
 
 // Report is the bucketed result of a collection run.
 type Report struct {
+	User  string
+	Since time.Time
+	Until time.Time
+
 	InProgress     []Item
 	ReadyForReview []Item
 	Blocked        []Item
 	ClosedOrMerged []Item
+	Reviewed       []Item
 	Uncategorized  []Item
 }
 
@@ -253,10 +258,14 @@ func runSearch(
 
 func categorise(nodes []searchNode, p Params) *Report {
 	r := &Report{
+		User:           p.User,
+		Since:          p.Since,
+		Until:          p.Until,
 		InProgress:     nil,
 		ReadyForReview: nil,
 		Blocked:        nil,
 		ClosedOrMerged: nil,
+		Reviewed:       nil,
 		Uncategorized:  nil,
 	}
 	for _, n := range nodes {
@@ -282,8 +291,8 @@ func classifyPR(n searchNode, p Params, r *Report) {
 
 	isAuthor := n.Author != nil && strings.EqualFold(n.Author.Login, p.User)
 
-	// 1. Closed or merged in window.
-	if inWindow(n.MergedAt, p) || inWindow(n.ClosedAt, p) {
+	// 1. Authored by user and closed or merged in window.
+	if isAuthor && (inWindow(n.MergedAt, p) || inWindow(n.ClosedAt, p)) {
 		r.ClosedOrMerged = append(r.ClosedOrMerged, item)
 		return
 	}
@@ -308,12 +317,12 @@ func classifyPR(n searchNode, p Params, r *Report) {
 		return
 	}
 
-	// 5. Uncategorized: any other in-window PR activity by the user (reviews
+	// 5. Reviewed: any other in-window PR activity by the user (reviews
 	// or comments). The search uses `updated:Since..Until`, which matches
 	// third-party updates too, so we require an actual user signal — being
 	// non-authored is not enough on its own.
 	if hasUserTimelineActivity(n.TimelineItems.Nodes, p) {
-		r.Uncategorized = append(r.Uncategorized, item)
+		r.Reviewed = append(r.Reviewed, item)
 	}
 }
 

--- a/tools/ghactivity/internal/activity/classify_internal_test.go
+++ b/tools/ghactivity/internal/activity/classify_internal_test.go
@@ -88,6 +88,7 @@ func onlyItem(t *testing.T, r *Report) (string, Item) {
 		"ReadyForReview": r.ReadyForReview,
 		"Blocked":        r.Blocked,
 		"ClosedOrMerged": r.ClosedOrMerged,
+		"Reviewed":       r.Reviewed,
 		"Uncategorized":  r.Uncategorized,
 	}
 
@@ -118,6 +119,7 @@ func bucketCounts(r *Report) map[string]int {
 		"ReadyForReview": len(r.ReadyForReview),
 		"Blocked":        len(r.Blocked),
 		"ClosedOrMerged": len(r.ClosedOrMerged),
+		"Reviewed":       len(r.Reviewed),
 		"Uncategorized":  len(r.Uncategorized),
 	}
 }
@@ -132,8 +134,8 @@ func TestClassifyPR_BucketPriority(t *testing.T) {
 
 	// Build a PR that satisfies every bucket's signal. Priority order
 	// (top wins): ClosedOrMerged > Blocked > ReadyForReview > InProgress >
-	// Uncategorized. We then peel signals off the top and check the next bucket
-	// fires.
+	// Reviewed > Uncategorized. We then peel signals off the top and check the
+	// next bucket fires.
 
 	full := authoredPR()
 	full.MergedAt = in
@@ -207,7 +209,7 @@ func TestClassifyPR_BucketPriority(t *testing.T) {
 			want: "InProgress",
 		},
 		{
-			name: "Uncategorized when only a timeline comment by the user remains",
+			name: "Reviewed when only a timeline comment by the user remains",
 			mut: func(n *searchNode) {
 				n.MergedAt = ""
 				n.ClosedAt = ""
@@ -217,7 +219,7 @@ func TestClassifyPR_BucketPriority(t *testing.T) {
 					{Typename: "IssueComment", CreatedAt: in, Author: &actor{Login: testUser}},
 				}
 			},
-			want: "Uncategorized",
+			want: "Reviewed",
 		},
 	}
 
@@ -259,7 +261,7 @@ func TestClassifyPR_NonAuthorRequiresInWindowSignal(t *testing.T) {
 		wantCount map[string]int
 	}{
 		{
-			name: "non-authored PR with no in-window user activity is NOT Uncategorized",
+			name: "non-authored PR with no in-window user activity is not bucketed",
 			node: func() searchNode {
 				n := nonAuthoredPR()
 				// Some third-party update bumped `updated`, but the user did
@@ -273,11 +275,11 @@ func TestClassifyPR_NonAuthorRequiresInWindowSignal(t *testing.T) {
 			},
 			wantCount: map[string]int{
 				"InProgress": 0, "ReadyForReview": 0, "Blocked": 0,
-				"ClosedOrMerged": 0, "Uncategorized": 0,
+				"ClosedOrMerged": 0, "Reviewed": 0, "Uncategorized": 0,
 			},
 		},
 		{
-			name: "non-authored PR with an in-window user review IS Uncategorized",
+			name: "non-authored PR with an in-window user review is Reviewed",
 			node: func() searchNode {
 				n := nonAuthoredPR()
 				n.TimelineItems.Nodes = []timelineItem{
@@ -293,7 +295,44 @@ func TestClassifyPR_NonAuthorRequiresInWindowSignal(t *testing.T) {
 			},
 			wantCount: map[string]int{
 				"InProgress": 0, "ReadyForReview": 0, "Blocked": 0,
-				"ClosedOrMerged": 0, "Uncategorized": 1,
+				"ClosedOrMerged": 0, "Reviewed": 1, "Uncategorized": 0,
+			},
+		},
+		{
+			name: "non-authored PR merged in window with no user activity is not bucketed",
+			node: func() searchNode {
+				n := nonAuthoredPR()
+				n.MergedAt = in
+				n.TimelineItems.Nodes = []timelineItem{
+					{Typename: "IssueComment", CreatedAt: in, Author: &actor{Login: "carol"}},
+				}
+
+				return n
+			},
+			wantCount: map[string]int{
+				"InProgress": 0, "ReadyForReview": 0, "Blocked": 0,
+				"ClosedOrMerged": 0, "Reviewed": 0, "Uncategorized": 0,
+			},
+		},
+		{
+			name: "non-authored PR merged in window with user review is Reviewed",
+			node: func() searchNode {
+				n := nonAuthoredPR()
+				n.MergedAt = in
+				n.TimelineItems.Nodes = []timelineItem{
+					{
+						Typename:    "PullRequestReview",
+						SubmittedAt: in,
+						State:       "APPROVED",
+						Author:      &actor{Login: testUser},
+					},
+				}
+
+				return n
+			},
+			wantCount: map[string]int{
+				"InProgress": 0, "ReadyForReview": 0, "Blocked": 0,
+				"ClosedOrMerged": 0, "Reviewed": 1, "Uncategorized": 0,
 			},
 		},
 		{
@@ -301,7 +340,7 @@ func TestClassifyPR_NonAuthorRequiresInWindowSignal(t *testing.T) {
 			node: authoredPR,
 			wantCount: map[string]int{
 				"InProgress": 0, "ReadyForReview": 0, "Blocked": 0,
-				"ClosedOrMerged": 0, "Uncategorized": 0,
+				"ClosedOrMerged": 0, "Reviewed": 0, "Uncategorized": 0,
 			},
 		},
 	}
@@ -360,7 +399,8 @@ func TestClassifyPR_EmptyProjectAndTimelineDoNotPanic(t *testing.T) {
 	classifyPR(authoredPR(), p, r)
 
 	if got := bucketCounts(r); got["InProgress"]+got["ReadyForReview"]+
-		got["Blocked"]+got["ClosedOrMerged"]+got["Uncategorized"] != 0 {
+		got["Blocked"]+got["ClosedOrMerged"]+got["Reviewed"]+
+		got["Uncategorized"] != 0 {
 		t.Fatalf("expected no buckets to fire for empty PR, got %v", got)
 	}
 }
@@ -608,6 +648,18 @@ func TestBuild_DedupesAndClassifies(t *testing.T) {
 
 	if len(got.ClosedOrMerged) != 1 {
 		t.Fatalf("expected one ClosedOrMerged item after dedupe, got %+v", got.ClosedOrMerged)
+	}
+
+	if got.User != p.User || !got.Since.Equal(p.Since) || !got.Until.Equal(p.Until) {
+		t.Fatalf(
+			"report metadata = user %q since %s until %s, want user %q since %s until %s",
+			got.User,
+			got.Since,
+			got.Until,
+			p.User,
+			p.Since,
+			p.Until,
+		)
 	}
 }
 

--- a/tools/ghactivity/internal/render/render.go
+++ b/tools/ghactivity/internal/render/render.go
@@ -12,6 +12,10 @@ import (
 
 // Markdown writes the report to w in the team's stand-up format.
 func Markdown(w io.Writer, r *activity.Report) error {
+	if err := writeHeader(w, r); err != nil {
+		return err
+	}
+
 	sections := []struct {
 		heading string
 		items   []activity.Item
@@ -20,6 +24,7 @@ func Markdown(w io.Writer, r *activity.Report) error {
 		{"### 👀 Moved to waiting for review", r.ReadyForReview},
 		{"### ⏸️ Blocked / waiting on something else", r.Blocked},
 		{"### ✅ Closed / merged", r.ClosedOrMerged},
+		{"### 🔍 Reviewed / commented", r.Reviewed},
 	}
 
 	for i, s := range sections {
@@ -59,6 +64,41 @@ Anything not tracked on GitHub, FYIs, heads-ups
 	}
 
 	return writeItems(w, r.Uncategorized)
+}
+
+func writeHeader(w io.Writer, r *activity.Report) error {
+	date := reportDate(r)
+	if date == "" && r.User == "" {
+		return nil
+	}
+
+	title := date
+	if r.User != "" {
+		if title != "" {
+			title += " - "
+		}
+
+		title += r.User
+	}
+
+	if _, err := fmt.Fprintf(w, "## %s\n\n", title); err != nil {
+		return wrap(err)
+	}
+
+	return nil
+}
+
+func reportDate(r *activity.Report) string {
+	if r.Since.IsZero() {
+		return ""
+	}
+
+	since := r.Since.Format("2006-01-02")
+	if r.Until.IsZero() || since == r.Until.Format("2006-01-02") {
+		return since
+	}
+
+	return since + " to " + r.Until.Format("2006-01-02")
 }
 
 func writeItems(w io.Writer, items []activity.Item) error {

--- a/tools/ghactivity/internal/render/render_test.go
+++ b/tools/ghactivity/internal/render/render_test.go
@@ -4,6 +4,7 @@ import (
 	"bytes"
 	"strings"
 	"testing"
+	"time"
 
 	"github.com/nhost/nhost/tools/ghactivity/internal/activity"
 	"github.com/nhost/nhost/tools/ghactivity/internal/render"
@@ -24,6 +25,7 @@ func TestMarkdownEmpty(t *testing.T) {
 		"### 👀 Moved to waiting for review",
 		"### ⏸️ Blocked / waiting on something else",
 		"### ✅ Closed / merged",
+		"### 🔍 Reviewed / commented",
 		"### 🎯 Today's focus",
 		"### 📝 Other",
 		"### Uncategorized",
@@ -32,6 +34,40 @@ func TestMarkdownEmpty(t *testing.T) {
 		if !strings.Contains(got, h) {
 			t.Errorf("missing heading %q in output:\n%s", h, got)
 		}
+	}
+}
+
+func TestMarkdownIncludesHeader(t *testing.T) {
+	t.Parallel()
+
+	var buf bytes.Buffer
+	if err := render.Markdown(&buf, &activity.Report{
+		User:  "meh",
+		Since: time.Date(2026, 5, 20, 9, 0, 0, 0, time.UTC),
+		Until: time.Date(2026, 5, 20, 17, 0, 0, 0, time.UTC),
+	}); err != nil {
+		t.Fatalf("render: %v", err)
+	}
+
+	if !strings.HasPrefix(buf.String(), "## 2026-05-20 - meh\n\n") {
+		t.Fatalf("expected report header, got:\n%s", buf.String())
+	}
+}
+
+func TestMarkdownIncludesDateRangeHeader(t *testing.T) {
+	t.Parallel()
+
+	var buf bytes.Buffer
+	if err := render.Markdown(&buf, &activity.Report{
+		User:  "meh",
+		Since: time.Date(2026, 4, 25, 11, 0, 0, 0, time.UTC),
+		Until: time.Date(2026, 6, 4, 9, 0, 0, 0, time.UTC),
+	}); err != nil {
+		t.Fatalf("render: %v", err)
+	}
+
+	if !strings.HasPrefix(buf.String(), "## 2026-04-25 to 2026-06-04 - meh\n\n") {
+		t.Fatalf("expected report date range header, got:\n%s", buf.String())
 	}
 }
 
@@ -49,10 +85,16 @@ func TestMarkdownItemsSortedAndFormatted(t *testing.T) {
 				URL: "https://example.com/pr/4319", Repository: "nhost/nhost",
 			},
 		},
+		Reviewed: []activity.Item{
+			{
+				Kind: activity.KindPR, Number: 12, Title: "a reviewed pr",
+				URL: "https://example.com/pr/12", Repository: "nhost/other",
+			},
+		},
 		Uncategorized: []activity.Item{
 			{
-				Kind: activity.KindIssue, Number: 12, Title: "an issue",
-				URL: "https://example.com/issue/12", Repository: "nhost/other",
+				Kind: activity.KindIssue, Number: 13, Title: "an issue",
+				URL: "https://example.com/issue/13", Repository: "nhost/other",
 			},
 		},
 	}
@@ -75,7 +117,11 @@ func TestMarkdownItemsSortedAndFormatted(t *testing.T) {
 		t.Errorf("expected PR #4319 before #4321; got:\n%s", got)
 	}
 
-	if !strings.Contains(got, "[Issue #12](https://example.com/issue/12) an issue") {
+	if !strings.Contains(got, "[PR #12](https://example.com/pr/12) a reviewed pr") {
+		t.Errorf("expected formatted reviewed PR line, got:\n%s", got)
+	}
+
+	if !strings.Contains(got, "[Issue #13](https://example.com/issue/13) an issue") {
 		t.Errorf("expected formatted issue line, got:\n%s", got)
 	}
 }


### PR DESCRIPTION
<!-- nhost-reviewer:start -->
### **What this PR solves**
This PR makes `gh activity` distinguish PRs the user reviewed or commented on from uncategorized issue/context activity. It also adds report metadata to the markdown output so stand-up reports identify the user and date window.

___

### **PR Type**
Enhancement

___

### **Description**
- Adds `Reviewed` as a first-match PR bucket for non-authored review/comment activity while keeping `Uncategorized` for issue and remaining context.
- Threads report metadata (`User`, `Since`, `Until`) from activity collection into markdown rendering.
- Emits a markdown report heading and a new reviewed/commented section, with classifier and renderer tests updated accordingly.
- Updates `ghactivity` documentation and project guidance to describe the six-bucket output.

___

### Diagram Walkthrough

```mermaid
flowchart LR
  S["GitHub searches"] --> C["activity.categorise"]
  C --> P["classifyPR first-match buckets"]
  P --> R["Reviewed bucket"]
  C --> I["classifyIssue Uncategorized"]
  R --> M["render.Markdown"]
  I --> M
```

<details> <summary><h3> File Walkthrough</h3></summary>

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody>
<tr><td><strong>Documentation</strong></td><td><details><summary>2 files</summary><table>
<tr>
  <td><strong>tools/ghactivity/CLAUDE.md</strong><dd><code>Documents the new Reviewed bucket and updated classifier priority.</code></dd></td>
  <td><a href="https://github.com/nhost/nhost/pull/XXX/files#diff-ec896d6788a8c9ef7ef8ce9547acb768317878f51766477cf90151de19f785b1">+2/-2</a></td>
</tr>
<tr>
  <td><strong>tools/ghactivity/README.md</strong><dd><code>Updates user-facing bucket descriptions, report headings, and output example.</code></dd></td>
  <td><a href="https://github.com/nhost/nhost/pull/XXX/files#diff-1f65fb927a272c7df2bd1f71d44d3f53b9a4cfefc77faa416e556345d842cdf1">+18/-9</a></td>
</tr>
</table></details></td></tr>
<tr><td><strong>Activity classification</strong></td><td><details><summary>2 files</summary><table>
<tr>
  <td><strong>tools/ghactivity/internal/activity/activity.go</strong><dd><code>Adds report metadata and routes user review/comment PR activity into Reviewed.</code></dd></td>
  <td><a href="https://github.com/nhost/nhost/pull/XXX/files#diff-c8629319d986ac38aaad480d4c22234a7454f17761691262e8d8388e254374ad">+13/-4</a></td>
</tr>
<tr>
  <td><strong>tools/ghactivity/internal/activity/classify_internal_test.go</strong><dd><code>Extends classifier tests for Reviewed routing and report metadata.</code></dd></td>
  <td><a href="https://github.com/nhost/nhost/pull/XXX/files#diff-b3a9a072b3ba2145fdfea450939a4be1c34876628035a244484f21dbbbeb2c21">+62/-10</a></td>
</tr>
</table></details></td></tr>
<tr><td><strong>Markdown rendering</strong></td><td><details><summary>2 files</summary><table>
<tr>
  <td><strong>tools/ghactivity/internal/render/render.go</strong><dd><code>Emits report headers and the Reviewed / commented section.</code></dd></td>
  <td><a href="https://github.com/nhost/nhost/pull/XXX/files#diff-563d8a25977e05b1061f768f046b74caaa0469f215362551bca5e6e30b06e262">+40/-0</a></td>
</tr>
<tr>
  <td><strong>tools/ghactivity/internal/render/render_test.go</strong><dd><code>Adds tests for report headers, reviewed items, and section headings.</code></dd></td>
  <td><a href="https://github.com/nhost/nhost/pull/XXX/files#diff-28b89dd685afba5d8e5ef6ac0dd6709f582001466ce6f0039a16509ce187a353">+49/-3</a></td>
</tr>
</table></details></td></tr>
</tbody></table>

</details>

___

<!-- nhost-reviewer:end -->