### PR TITLE
feat(constellation): align SQLite LIKE and constraints

### DIFF
--- a/services/constellation/CLAUDE.md
+++ b/services/constellation/CLAUDE.md
@@ -121,7 +121,7 @@ Golden file tests live in `testdata/` directories. Update them with the `-update
 
 - **`connector.Connector`** (5 methods): `GetSchema()`, `Execute()`, `ValidateOperation()`, `GetTypeName()`, `Close()`. Implemented by `sql.Connector`, `remoteschema.Connector`, the unexported `customizedConnector` wrapper, and the unexported `memconnector` type returned by `memconnector.New`.
 - **`connector/sql.Driver`** (5 methods): `Introspect()`, `ExecuteOperations()`, `ExecuteMultiplexedOperation()`, `Dialect()`, `Close()`. Implemented by `postgres.Client`, `sqlite.Client`.
-- **`Dialect`** (29 methods): Abstracts all SQL syntax differences. Implementations: `PostgresDialect`, `SQLiteDialect`.
+- **`Dialect`**: Abstracts all SQL syntax differences. Implementations: `PostgresDialect`, `SQLiteDialect`.
 - **`subscription.Handler`** (3 methods): `Start()`, `Stop()`, `Shutdown()`. Implemented by `sql/subscription.Handler`.
 - **`metadata.MetadataSource`** (3 methods): `InitialLoad()`, `Watch()`, `Close()`. Implementations: `FileMetadataSource` (one-time load), `DatabaseMetadataSource` (polls `hdb_catalog`).
 - **`websocket.MessageHandler`** (4 methods): `OnConnectionInit()`, `OnSubscribe()`, `OnComplete()`, `OnClose()`. Implemented by `controller.WebSocketHandler`.

--- a/services/constellation/connector/sql/graphql/queries/dialect/dialect.go
+++ b/services/constellation/connector/sql/graphql/queries/dialect/dialect.go
@@ -59,8 +59,8 @@ type Dialect interface { //nolint:interfacebloat
 	// PostgreSQL: to_jsonb(expr)    SQLite: json(expr)
 	ToJSON(expr string) string
 
-	// EmptyJSONArray returns an empty JSON array literal.
-	// PostgreSQL: '[]'::json    SQLite: '[]'
+	// EmptyJSONArray returns an empty JSON array expression.
+	// PostgreSQL: '[]'::json    SQLite: json_array()
 	EmptyJSONArray() string
 
 	// TableRef returns a schema-qualified table reference.
@@ -70,13 +70,21 @@ type Dialect interface { //nolint:interfacebloat
 	// SupportsLateral returns whether LEFT JOIN LATERAL is available.
 	SupportsLateral() bool
 
-	// ILike returns the case-insensitive LIKE operator.
-	// PostgreSQL: ILIKE    SQLite: LIKE
-	ILike() string
+	// Like returns the case-sensitive LIKE operator.
+	// PostgreSQL: LIKE    SQLite: LIKE (with PRAGMA case_sensitive_like=ON)
+	Like() string
 
-	// NotILike returns the negated case-insensitive LIKE operator.
-	// PostgreSQL: NOT ILIKE    SQLite: NOT LIKE
-	NotILike() string
+	// NotLike returns the negated case-sensitive LIKE operator.
+	// PostgreSQL: NOT LIKE    SQLite: NOT LIKE (with PRAGMA case_sensitive_like=ON)
+	NotLike() string
+
+	// WriteILikeCondition writes a case-insensitive LIKE predicate.
+	// PostgreSQL: source.column ILIKE $N    SQLite: LOWER(source.column) LIKE LOWER(?)
+	WriteILikeCondition(b *strings.Builder, source, column, placeholder string)
+
+	// WriteNotILikeCondition writes a negated case-insensitive LIKE predicate.
+	// PostgreSQL: source.column NOT ILIKE $N    SQLite: LOWER(source.column) NOT LIKE LOWER(?)
+	WriteNotILikeCondition(b *strings.Builder, source, column, placeholder string)
 
 	// SupportsRegex returns whether regex operators are available.
 	SupportsRegex() bool

--- a/services/constellation/connector/sql/graphql/queries/dialect/mock/dialect.go
+++ b/services/constellation/connector/sql/graphql/queries/dialect/mock/dialect.go
@@ -96,20 +96,6 @@ func (mr *MockDialectMockRecorder) EmptyJSONArray() *gomock.Call {
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "EmptyJSONArray", reflect.TypeOf((*MockDialect)(nil).EmptyJSONArray))
 }
 
-// ILike mocks base method.
-func (m *MockDialect) ILike() string {
-	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "ILike")
-	ret0, _ := ret[0].(string)
-	return ret0
-}
-
-// ILike indicates an expected call of ILike.
-func (mr *MockDialectMockRecorder) ILike() *gomock.Call {
-	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "ILike", reflect.TypeOf((*MockDialect)(nil).ILike))
-}
-
 // JSONAggQuotedAlias mocks base method.
 func (m *MockDialect) JSONAggQuotedAlias(alias string) string {
 	m.ctrl.T.Helper()
@@ -152,6 +138,20 @@ func (mr *MockDialectMockRecorder) JSONBuildObject() *gomock.Call {
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "JSONBuildObject", reflect.TypeOf((*MockDialect)(nil).JSONBuildObject))
 }
 
+// Like mocks base method.
+func (m *MockDialect) Like() string {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "Like")
+	ret0, _ := ret[0].(string)
+	return ret0
+}
+
+// Like indicates an expected call of Like.
+func (mr *MockDialectMockRecorder) Like() *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Like", reflect.TypeOf((*MockDialect)(nil).Like))
+}
+
 // MaterializedCTE mocks base method.
 func (m *MockDialect) MaterializedCTE() string {
 	m.ctrl.T.Helper()
@@ -166,18 +166,18 @@ func (mr *MockDialectMockRecorder) MaterializedCTE() *gomock.Call {
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "MaterializedCTE", reflect.TypeOf((*MockDialect)(nil).MaterializedCTE))
 }
 
-// NotILike mocks base method.
-func (m *MockDialect) NotILike() string {
+// NotLike mocks base method.
+func (m *MockDialect) NotLike() string {
 	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "NotILike")
+	ret := m.ctrl.Call(m, "NotLike")
 	ret0, _ := ret[0].(string)
 	return ret0
 }
 
-// NotILike indicates an expected call of NotILike.
-func (mr *MockDialectMockRecorder) NotILike() *gomock.Call {
+// NotLike indicates an expected call of NotLike.
+func (mr *MockDialectMockRecorder) NotLike() *gomock.Call {
 	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "NotILike", reflect.TypeOf((*MockDialect)(nil).NotILike))
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "NotLike", reflect.TypeOf((*MockDialect)(nil).NotLike))
 }
 
 // Placeholder mocks base method.
@@ -483,6 +483,18 @@ func (mr *MockDialectMockRecorder) WriteGroupKeysFrom(b, keysAlias, colAlias, sq
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "WriteGroupKeysFrom", reflect.TypeOf((*MockDialect)(nil).WriteGroupKeysFrom), b, keysAlias, colAlias, sqlType, values, params, paramIndex)
 }
 
+// WriteILikeCondition mocks base method.
+func (m *MockDialect) WriteILikeCondition(b *strings.Builder, source, column, placeholder string) {
+	m.ctrl.T.Helper()
+	m.ctrl.Call(m, "WriteILikeCondition", b, source, column, placeholder)
+}
+
+// WriteILikeCondition indicates an expected call of WriteILikeCondition.
+func (mr *MockDialectMockRecorder) WriteILikeCondition(b, source, column, placeholder any) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "WriteILikeCondition", reflect.TypeOf((*MockDialect)(nil).WriteILikeCondition), b, source, column, placeholder)
+}
+
 // WriteJSONRowColumn mocks base method.
 func (m *MockDialect) WriteJSONRowColumn(b *strings.Builder, alias, expr string) {
 	m.ctrl.T.Helper()
@@ -529,6 +541,18 @@ func (m *MockDialect) WriteJSONRowSuffixNoAlias(b *strings.Builder) {
 func (mr *MockDialectMockRecorder) WriteJSONRowSuffixNoAlias(b any) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "WriteJSONRowSuffixNoAlias", reflect.TypeOf((*MockDialect)(nil).WriteJSONRowSuffixNoAlias), b)
+}
+
+// WriteNotILikeCondition mocks base method.
+func (m *MockDialect) WriteNotILikeCondition(b *strings.Builder, source, column, placeholder string) {
+	m.ctrl.T.Helper()
+	m.ctrl.Call(m, "WriteNotILikeCondition", b, source, column, placeholder)
+}
+
+// WriteNotILikeCondition indicates an expected call of WriteNotILikeCondition.
+func (mr *MockDialectMockRecorder) WriteNotILikeCondition(b, source, column, placeholder any) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "WriteNotILikeCondition", reflect.TypeOf((*MockDialect)(nil).WriteNotILikeCondition), b, source, column, placeholder)
 }
 
 // WriteOnConflictTarget mocks base method.

--- a/services/constellation/connector/sql/graphql/queries/dialect/postgres.go
+++ b/services/constellation/connector/sql/graphql/queries/dialect/postgres.go
@@ -98,12 +98,28 @@ func (d *PostgresDialect) SupportsLateral() bool {
 	return true
 }
 
-func (d *PostgresDialect) ILike() string {
-	return "ILIKE"
+func (d *PostgresDialect) Like() string {
+	return "LIKE"
 }
 
-func (d *PostgresDialect) NotILike() string {
-	return "NOT ILIKE"
+func (d *PostgresDialect) NotLike() string {
+	return "NOT LIKE"
+}
+
+func (d *PostgresDialect) WriteILikeCondition(
+	b *strings.Builder, source, column, placeholder string,
+) {
+	core.WriteQualifiedColumn(b, source, column)
+	b.WriteString(" ILIKE ")
+	b.WriteString(placeholder)
+}
+
+func (d *PostgresDialect) WriteNotILikeCondition(
+	b *strings.Builder, source, column, placeholder string,
+) {
+	core.WriteQualifiedColumn(b, source, column)
+	b.WriteString(" NOT ILIKE ")
+	b.WriteString(placeholder)
 }
 
 func (d *PostgresDialect) SupportsRegex() bool {

--- a/services/constellation/connector/sql/graphql/queries/dialect/postgres_test.go
+++ b/services/constellation/connector/sql/graphql/queries/dialect/postgres_test.go
@@ -173,12 +173,26 @@ func TestPostgresDialect_LikeOps(t *testing.T) {
 	t.Parallel()
 
 	d := &dialect.PostgresDialect{}
-	if d.ILike() != "ILIKE" {
-		t.Fatalf("ILike = %q, want ILIKE", d.ILike())
+	if d.Like() != "LIKE" {
+		t.Fatalf("Like = %q, want LIKE", d.Like())
 	}
 
-	if d.NotILike() != "NOT ILIKE" {
-		t.Fatalf("NotILike = %q, want NOT ILIKE", d.NotILike())
+	if d.NotLike() != "NOT LIKE" {
+		t.Fatalf("NotLike = %q, want NOT LIKE", d.NotLike())
+	}
+
+	var b strings.Builder
+	d.WriteILikeCondition(&b, `"t"`, "name", "$1")
+
+	if got := b.String(); got != `"t"."name" ILIKE $1` {
+		t.Fatalf("WriteILikeCondition = %q, want qualified ILIKE", got)
+	}
+
+	b.Reset()
+	d.WriteNotILikeCondition(&b, `"t"`, "name", "$1")
+
+	if got := b.String(); got != `"t"."name" NOT ILIKE $1` {
+		t.Fatalf("WriteNotILikeCondition = %q, want qualified NOT ILIKE", got)
 	}
 }
 

--- a/services/constellation/connector/sql/graphql/queries/dialect/sqlite.go
+++ b/services/constellation/connector/sql/graphql/queries/dialect/sqlite.go
@@ -131,8 +131,10 @@ func (d *SQLiteDialect) ToJSON(expr string) string {
 	return "json(" + expr + ")"
 }
 
+// EmptyJSONArray returns json_array() instead of a string literal, so SQLite
+// treats the value as JSON when it is nested into json_object/json_array calls.
 func (d *SQLiteDialect) EmptyJSONArray() string {
-	return "'[]'"
+	return "json_array()"
 }
 
 // TableRef drops the schema argument: SQLite has a single per-database
@@ -146,12 +148,32 @@ func (d *SQLiteDialect) SupportsLateral() bool {
 	return false
 }
 
-func (d *SQLiteDialect) ILike() string {
+func (d *SQLiteDialect) Like() string {
 	return "LIKE"
 }
 
-func (d *SQLiteDialect) NotILike() string {
+func (d *SQLiteDialect) NotLike() string {
 	return "NOT LIKE"
+}
+
+func (d *SQLiteDialect) WriteILikeCondition(
+	b *strings.Builder, source, column, placeholder string,
+) {
+	b.WriteString("LOWER(")
+	core.WriteQualifiedColumn(b, source, column)
+	b.WriteString(") LIKE LOWER(")
+	b.WriteString(placeholder)
+	b.WriteByte(')')
+}
+
+func (d *SQLiteDialect) WriteNotILikeCondition(
+	b *strings.Builder, source, column, placeholder string,
+) {
+	b.WriteString("LOWER(")
+	core.WriteQualifiedColumn(b, source, column)
+	b.WriteString(") NOT LIKE LOWER(")
+	b.WriteString(placeholder)
+	b.WriteByte(')')
 }
 
 func (d *SQLiteDialect) SupportsRegex() bool {

--- a/services/constellation/connector/sql/graphql/queries/dialect/sqlite_test.go
+++ b/services/constellation/connector/sql/graphql/queries/dialect/sqlite_test.go
@@ -151,7 +151,7 @@ func TestSQLiteDialect_JSONHelpers(t *testing.T) {
 		},
 		{"JSONBuildObject", d.JSONBuildObject(), "json_object"},
 		{"ToJSON", d.ToJSON("x"), "json(x)"},
-		{"EmptyJSONArray", d.EmptyJSONArray(), "'[]'"},
+		{"EmptyJSONArray", d.EmptyJSONArray(), "json_array()"},
 	}
 
 	for _, tt := range tests {
@@ -179,13 +179,26 @@ func TestSQLiteDialect_LikeOps(t *testing.T) {
 	t.Parallel()
 
 	d := &dialect.SQLiteDialect{}
-	// SQLite LIKE is already case-insensitive for ASCII.
-	if d.ILike() != "LIKE" {
-		t.Fatalf("ILike = %q, want LIKE", d.ILike())
+	if d.Like() != "LIKE" {
+		t.Fatalf("Like = %q, want LIKE", d.Like())
 	}
 
-	if d.NotILike() != "NOT LIKE" {
-		t.Fatalf("NotILike = %q, want NOT LIKE", d.NotILike())
+	if d.NotLike() != "NOT LIKE" {
+		t.Fatalf("NotLike = %q, want NOT LIKE", d.NotLike())
+	}
+
+	var b strings.Builder
+	d.WriteILikeCondition(&b, `"t"`, "name", "?")
+
+	if got := b.String(); got != `LOWER("t"."name") LIKE LOWER(?)` {
+		t.Fatalf("WriteILikeCondition = %q, want LOWER LIKE", got)
+	}
+
+	b.Reset()
+	d.WriteNotILikeCondition(&b, `"t"`, "name", "?")
+
+	if got := b.String(); got != `LOWER("t"."name") NOT LIKE LOWER(?)` {
+		t.Fatalf("WriteNotILikeCondition = %q, want LOWER NOT LIKE", got)
 	}
 }
 

--- a/services/constellation/connector/sql/graphql/queries/permissions/permissions_test.go
+++ b/services/constellation/connector/sql/graphql/queries/permissions/permissions_test.go
@@ -1,11 +1,13 @@
 package permissions_test
 
 import (
+	"strings"
 	"testing"
 
 	"github.com/vektah/gqlparser/v2/ast"
 
 	"github.com/nhost/nhost/services/constellation/connector/sql/graphql/queries/core"
+	"github.com/nhost/nhost/services/constellation/connector/sql/graphql/queries/dialect"
 	"github.com/nhost/nhost/services/constellation/connector/sql/graphql/queries/permissions"
 	"github.com/nhost/nhost/services/constellation/connector/sql/graphql/queries/where"
 	"github.com/nhost/nhost/services/constellation/metadata"
@@ -44,6 +46,118 @@ func (t hasInsertCheckTable) ParseWhere(
 	}
 
 	return where.Clause{where.NewRawFilter("true")}, nil
+}
+
+type permissionLikeTable struct {
+	columns map[string]*core.Column
+	d       dialect.Dialect
+}
+
+func (t permissionLikeTable) Name() string { return "users" }
+func (t permissionLikeTable) Dialect() dialect.Dialect {
+	return t.d
+}
+func (t permissionLikeTable) SchemaName() string      { return "" }
+func (t permissionLikeTable) TableFromClause() string { return `"users"` }
+
+func (t permissionLikeTable) ColumnFromSQLName(name string) *core.Column {
+	return t.columns[name]
+}
+
+func (t permissionLikeTable) ColumnFromGraphqlName(name string) *core.Column {
+	return t.columns[name]
+}
+
+func (t permissionLikeTable) LookupRelationship(_ string) permissions.Relationship {
+	return nil
+}
+
+func (t permissionLikeTable) RelationshipFromGraphqlName(_ string) where.Relationship {
+	return nil
+}
+
+func (t permissionLikeTable) SiblingTable(_, _ string) permissions.Table { return nil }
+func (t permissionLikeTable) TableBySchemaName(_, _ string) where.Table  { return nil }
+func (t permissionLikeTable) HasRowLevelPermissions(string) bool         { return false }
+
+func (t permissionLikeTable) WriteRowLevelPermissions(
+	_ *strings.Builder,
+	params []any,
+	paramIndex int,
+	_ string,
+	_ map[string]any,
+	_ string,
+) ([]any, int, error) {
+	return params, paramIndex, nil
+}
+
+func (t permissionLikeTable) ParseWhere(
+	whereArg *ast.Value,
+	variables map[string]any,
+	role string,
+	sessionVariables map[string]any,
+	nestingLevel int,
+	aliases where.Aliases,
+) (where.Clause, error) {
+	//nolint:wrapcheck // test stub: forward parser error verbatim.
+	return where.Parse(t, whereArg, variables, role, sessionVariables, nestingLevel, aliases)
+}
+
+func (t permissionLikeTable) ParseFieldComparison(
+	column *core.Column,
+	value *ast.Value,
+	variables map[string]any,
+) (where.Statement, error) {
+	//nolint:wrapcheck // test stub: forward parser error verbatim.
+	return where.ParseFieldComparison(t, column, value, variables)
+}
+
+func TestSelectPermissionLikeIsCaseSensitiveOnSQLite(t *testing.T) {
+	t.Parallel()
+
+	table := permissionLikeTable{
+		d: dialect.NewSQLiteDialect(),
+		columns: map[string]*core.Column{
+			"name": {SQLName: "name", GraphqlName: "name", SQLType: "text"},
+		},
+	}
+	store := permissions.NewStore()
+
+	if err := permissions.Initialize(table, store, metadata.TableMetadata{
+		SelectPermissions: []metadata.SelectPermission{
+			{
+				Role: "user",
+				Permission: metadata.SelectPermissionConfig{
+					Columns: []string{"name"},
+					Filter: map[string]any{
+						"name": map[string]any{"_like": "Foo%"},
+					},
+					AllowAggregations: false,
+				},
+			},
+		},
+	}); err != nil {
+		t.Fatalf("Initialize() error = %v", err)
+	}
+
+	var b strings.Builder
+
+	params, paramIndex, err := store.WriteRowLevel(&b, nil, 1, "user", nil, `"t"`)
+	if err != nil {
+		t.Fatalf("WriteRowLevel() error = %v", err)
+	}
+
+	if got, want := b.String(), `"t"."name" LIKE ?`; got != want {
+		t.Fatalf("WriteRowLevel() SQL = %q, want %q", got, want)
+	}
+
+	if paramIndex != 2 {
+		t.Fatalf("paramIndex = %d, want 2", paramIndex)
+	}
+
+	if len(params) != 1 || params[0] != "Foo%" {
+		t.Fatalf("params = %v, want [Foo%%]", params)
+	}
 }
 
 func TestStoreHasNonEmptyInsertCheck(t *testing.T) {

--- a/services/constellation/connector/sql/graphql/queries/sqlite_query_test.go
+++ b/services/constellation/connector/sql/graphql/queries/sqlite_query_test.go
@@ -115,6 +115,37 @@ func testBuildQuerySQLite( //nolint:gocognit
 	}
 }
 
+func TestBuildMutationDeleteSQL_SQLite(t *testing.T) { //nolint:paralleltest
+	cases := []buildQueryTestCase{
+		{
+			// Regression guard for SQLITE_MEDIUM_5: when a SQLite mutation returns no
+			// rows, the top-level returning selection must default through
+			// dialect.EmptyJSONArray() -> json_array(), not the bare string literal
+			// '[]'. Nesting a bare literal under json_object would serialize as the
+			// JSON string "[]" instead of the array []. Keeping an array relationship
+			// in the returning shape preserves the production path that originally
+			// exposed the mismatch.
+			name: "delete returning array relationship uses JSON empty array",
+			query: query{
+				Query: `
+					mutation {
+						delete_departments(where: {name: {_eq: "No match"}}) {
+							affected_rows
+							returning {
+								id
+								employees {
+									user_id
+								}
+							}
+						}
+					}`,
+			},
+		},
+	}
+
+	testBuildQuerySQLite(t, cases)
+}
+
 func TestBuildSelectionSQL_SQLite(t *testing.T) { //nolint:paralleltest
 	cases := []buildQueryTestCase{
 		{

--- a/services/constellation/connector/sql/graphql/queries/testdata/TestBuildMutationDeleteSQL_SQLite/delete_returning_array_relationship_uses_JSON_empty_array.json
+++ b/services/constellation/connector/sql/graphql/queries/testdata/TestBuildMutationDeleteSQL_SQLite/delete_returning_array_relationship_uses_JSON_empty_array.json
@@ -1,0 +1,10 @@
+[
+  {
+    "Name": "delete_departments",
+    "SQL": "WITH mutation_result AS (DELETE FROM \"departments\" WHERE departments.\"name\" = ? RETURNING *) SELECT json_object('affected_rows', (SELECT COUNT(*) FROM mutation_result), 'returning', (SELECT COALESCE(json_group_array(json_object('id', mutation_result.\"id\", 'employees', (SELECT coalesce(json_group_array(json(\"mutation_result.r.employees\")), '[]') AS \"employees\" FROM (WITH \"mutation_result.r.employees.base\" AS (SELECT * FROM \"user_departments\" WHERE \"department_id\" = \"mutation_result\".\"id\") SELECT json_object('user_id', \"mutation_result.r.employees.base\".\"user_id\") AS \"mutation_result.r.employees\" FROM \"mutation_result.r.employees.base\") AS \"mutation_result.r.employees\"))), json_array()) FROM mutation_result) AS \"_e\"))",
+    "Parameters": [
+      "No match"
+    ],
+    "StreamCursors": null
+  }
+]

--- a/services/constellation/connector/sql/graphql/queries/where/filters.go
+++ b/services/constellation/connector/sql/graphql/queries/where/filters.go
@@ -190,17 +190,17 @@ func (f *likeFilter) WriteCondition(
 	params []any,
 	paramIndex int,
 ) ([]any, int, error) {
-	core.WriteQualifiedColumn(b, source, f.column)
+	placeholder := f.dialect.Placeholder(paramIndex)
 
 	if f.caseSensitive {
-		b.WriteString(" LIKE ")
+		core.WriteQualifiedColumn(b, source, f.column)
+		b.WriteByte(' ')
+		b.WriteString(f.dialect.Like())
+		b.WriteByte(' ')
+		b.WriteString(placeholder)
 	} else {
-		b.WriteByte(' ')
-		b.WriteString(f.dialect.ILike())
-		b.WriteByte(' ')
+		f.dialect.WriteILikeCondition(b, source, f.column, placeholder)
 	}
-
-	b.WriteString(f.dialect.Placeholder(paramIndex))
 
 	params = append(params, f.pattern)
 
@@ -220,17 +220,17 @@ func (f *notLikeFilter) WriteCondition(
 	params []any,
 	paramIndex int,
 ) ([]any, int, error) {
-	core.WriteQualifiedColumn(b, source, f.column)
+	placeholder := f.dialect.Placeholder(paramIndex)
 
 	if f.caseSensitive {
-		b.WriteString(" NOT LIKE ")
+		core.WriteQualifiedColumn(b, source, f.column)
+		b.WriteByte(' ')
+		b.WriteString(f.dialect.NotLike())
+		b.WriteByte(' ')
+		b.WriteString(placeholder)
 	} else {
-		b.WriteByte(' ')
-		b.WriteString(f.dialect.NotILike())
-		b.WriteByte(' ')
+		f.dialect.WriteNotILikeCondition(b, source, f.column, placeholder)
 	}
-
-	b.WriteString(f.dialect.Placeholder(paramIndex))
 
 	params = append(params, f.pattern)
 

--- a/services/constellation/connector/sql/graphql/queries/where/filters_internal_test.go
+++ b/services/constellation/connector/sql/graphql/queries/where/filters_internal_test.go
@@ -7,6 +7,7 @@ import (
 	"go.uber.org/mock/gomock"
 
 	"github.com/nhost/nhost/services/constellation/connector/sql/graphql/queries/core"
+	"github.com/nhost/nhost/services/constellation/connector/sql/graphql/queries/dialect"
 	dialectmock "github.com/nhost/nhost/services/constellation/connector/sql/graphql/queries/dialect/mock"
 )
 
@@ -112,30 +113,35 @@ func TestLikeFilters_CaseSensitiveVsInsensitive(t *testing.T) {
 	t.Parallel()
 
 	cases := []struct {
-		name string
-		// makeFilter constructs the filter; primeDialect sets up dialect mock
-		// expectations for the case-insensitive branch.
+		name          string
 		makeFilter    func(d *dialectmock.MockDialect, caseSensitive bool) Statement
 		primeDialect  func(d *dialectmock.MockDialect)
 		caseSensitive bool
-		wantOp        string
+		wantSQL       string
 	}{
 		{
 			name: "like sensitive",
 			makeFilter: func(d *dialectmock.MockDialect, cs bool) Statement {
 				return &likeFilter{column: "name", pattern: "%foo%", caseSensitive: cs, dialect: d}
 			},
+			primeDialect:  func(d *dialectmock.MockDialect) { d.EXPECT().Like().Return("LIKE") },
 			caseSensitive: true,
-			wantOp:        " LIKE ",
+			wantSQL:       `"t"."name" LIKE $1`,
 		},
 		{
 			name: "like insensitive",
 			makeFilter: func(d *dialectmock.MockDialect, cs bool) Statement {
 				return &likeFilter{column: "name", pattern: "%foo%", caseSensitive: cs, dialect: d}
 			},
-			primeDialect:  func(d *dialectmock.MockDialect) { d.EXPECT().ILike().Return("ILIKE") },
+			primeDialect: func(d *dialectmock.MockDialect) {
+				d.EXPECT().
+					WriteILikeCondition(gomock.Any(), `"t"`, "name", "$1").
+					Do(func(b *strings.Builder, _, _, _ string) {
+						b.WriteString(`"t"."name" ILIKE $1`)
+					})
+			},
 			caseSensitive: false,
-			wantOp:        " ILIKE ",
+			wantSQL:       `"t"."name" ILIKE $1`,
 		},
 		{
 			name: "not like sensitive",
@@ -147,8 +153,9 @@ func TestLikeFilters_CaseSensitiveVsInsensitive(t *testing.T) {
 					dialect:       d,
 				}
 			},
+			primeDialect:  func(d *dialectmock.MockDialect) { d.EXPECT().NotLike().Return("NOT LIKE") },
 			caseSensitive: true,
-			wantOp:        " NOT LIKE ",
+			wantSQL:       `"t"."name" NOT LIKE $1`,
 		},
 		{
 			name: "not like insensitive",
@@ -160,9 +167,15 @@ func TestLikeFilters_CaseSensitiveVsInsensitive(t *testing.T) {
 					dialect:       d,
 				}
 			},
-			primeDialect:  func(d *dialectmock.MockDialect) { d.EXPECT().NotILike().Return("NOT ILIKE") },
+			primeDialect: func(d *dialectmock.MockDialect) {
+				d.EXPECT().
+					WriteNotILikeCondition(gomock.Any(), `"t"`, "name", "$1").
+					Do(func(b *strings.Builder, _, _, _ string) {
+						b.WriteString(`"t"."name" NOT ILIKE $1`)
+					})
+			},
 			caseSensitive: false,
-			wantOp:        " NOT ILIKE ",
+			wantSQL:       `"t"."name" NOT ILIKE $1`,
 		},
 	}
 
@@ -179,8 +192,64 @@ func TestLikeFilters_CaseSensitiveVsInsensitive(t *testing.T) {
 			}
 
 			sql, _ := runStatement(t, tc.makeFilter(d, tc.caseSensitive), `"t"`)
-			if !strings.Contains(sql, tc.wantOp) {
-				t.Errorf("expected %q in %q", tc.wantOp, sql)
+			if sql != tc.wantSQL {
+				t.Errorf("sql = %q, want %q", sql, tc.wantSQL)
+			}
+		})
+	}
+}
+
+func TestLikeFilters_SQLiteRendering(t *testing.T) {
+	t.Parallel()
+
+	d := dialect.NewSQLiteDialect()
+
+	tests := []struct {
+		name string
+		stmt Statement
+		want string
+	}{
+		{
+			name: "_like is case-sensitive",
+			stmt: &likeFilter{
+				column: "name", pattern: "%Foo%", caseSensitive: true, dialect: d,
+			},
+			want: `"t"."name" LIKE ?`,
+		},
+		{
+			name: "_ilike lowers both operands",
+			stmt: &likeFilter{
+				column: "name", pattern: "%Foo%", caseSensitive: false, dialect: d,
+			},
+			want: `LOWER("t"."name") LIKE LOWER(?)`,
+		},
+		{
+			name: "_nlike is case-sensitive",
+			stmt: &notLikeFilter{
+				column: "name", pattern: "%Foo%", caseSensitive: true, dialect: d,
+			},
+			want: `"t"."name" NOT LIKE ?`,
+		},
+		{
+			name: "_nilike lowers both operands",
+			stmt: &notLikeFilter{
+				column: "name", pattern: "%Foo%", caseSensitive: false, dialect: d,
+			},
+			want: `LOWER("t"."name") NOT LIKE LOWER(?)`,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+
+			sql, params := runStatement(t, tt.stmt, `"t"`)
+			if sql != tt.want {
+				t.Errorf("sql = %q, want %q", sql, tt.want)
+			}
+
+			if len(params) != 1 || params[0] != "%Foo%" {
+				t.Errorf("params = %v, want [%%Foo%%]", params)
 			}
 		})
 	}

--- a/services/constellation/connector/sql/graphql/schema/testdata/TestGenerateForRole_SQLite/admin.graphqls
+++ b/services/constellation/connector/sql/graphql/schema/testdata/TestGenerateForRole_SQLite/admin.graphqls
@@ -59,10 +59,6 @@ enum authOauth2AuthRequests_constraint {
   unique or primary key constraint on columns "id"
   """
   oauth2_auth_requests_pkey
-  """
-  unique or primary key constraint on columns "id"
-  """
-  sqlite_autoindex_oauth2_auth_requests_1
 }
 """
 update columns of table "oauth2_auth_requests"
@@ -206,10 +202,6 @@ enum authOauth2AuthorizationCodes_constraint {
   unique or primary key constraint on columns "code_hash"
   """
   oauth2_authorization_codes_code_hash_key
-  """
-  unique or primary key constraint on columns "id"
-  """
-  sqlite_autoindex_oauth2_authorization_codes_1
 }
 """
 update columns of table "oauth2_authorization_codes"
@@ -287,10 +279,6 @@ enum authOauth2Clients_constraint {
   unique or primary key constraint on columns "client_id"
   """
   oauth2_clients_pkey
-  """
-  unique or primary key constraint on columns "client_id"
-  """
-  sqlite_autoindex_oauth2_clients_1
 }
 """
 update columns of table "oauth2_clients"
@@ -394,10 +382,6 @@ enum authOauth2RefreshTokens_constraint {
   unique or primary key constraint on columns "token_hash"
   """
   oauth2_refresh_tokens_token_hash_key
-  """
-  unique or primary key constraint on columns "id"
-  """
-  sqlite_autoindex_oauth2_refresh_tokens_1
 }
 """
 update columns of table "oauth2_refresh_tokens"
@@ -481,10 +465,6 @@ enum authProviderRequests_constraint {
   unique or primary key constraint on columns "id"
   """
   provider_requests_pkey
-  """
-  unique or primary key constraint on columns "id"
-  """
-  sqlite_autoindex_provider_requests_1
 }
 """
 update columns of table "provider_requests"
@@ -520,10 +500,6 @@ enum authProviders_constraint {
   unique or primary key constraint on columns "id"
   """
   providers_pkey
-  """
-  unique or primary key constraint on columns "id"
-  """
-  sqlite_autoindex_providers_1
 }
 """
 update columns of table "providers"
@@ -551,10 +527,6 @@ enum authRefreshTokenTypes_constraint {
   unique or primary key constraint on columns "value"
   """
   refresh_token_types_pkey
-  """
-  unique or primary key constraint on columns "value"
-  """
-  sqlite_autoindex_refresh_token_types_1
 }
 """
 update columns of table "refresh_token_types"
@@ -590,10 +562,6 @@ enum authRefreshTokens_constraint {
   unique or primary key constraint on columns "id"
   """
   refresh_tokens_pkey
-  """
-  unique or primary key constraint on columns "id"
-  """
-  sqlite_autoindex_refresh_tokens_1
 }
 """
 update columns of table "refresh_tokens"
@@ -711,10 +679,6 @@ enum authRoles_constraint {
   unique or primary key constraint on columns "role"
   """
   roles_pkey
-  """
-  unique or primary key constraint on columns "role"
-  """
-  sqlite_autoindex_roles_1
 }
 """
 update columns of table "roles"
@@ -746,10 +710,6 @@ enum authUserProviders_constraint {
   unique or primary key constraint on columns "provider_id", "provider_user_id"
   """
   user_providers_provider_id_provider_user_id_key
-  """
-  unique or primary key constraint on columns "id"
-  """
-  sqlite_autoindex_user_providers_1
 }
 """
 update columns of table "user_providers"
@@ -837,10 +797,6 @@ enum authUserRoles_constraint {
   unique or primary key constraint on columns "user_id", "role"
   """
   user_roles_user_id_role_key
-  """
-  unique or primary key constraint on columns "id"
-  """
-  sqlite_autoindex_user_roles_1
 }
 """
 update columns of table "user_roles"
@@ -896,10 +852,6 @@ enum authUserSecurityKeys_constraint {
   unique or primary key constraint on columns "credential_id"
   """
   user_security_key_credential_id_key
-  """
-  unique or primary key constraint on columns "id"
-  """
-  sqlite_autoindex_user_security_keys_1
 }
 """
 update columns of table "user_security_keys"
@@ -1019,10 +971,6 @@ enum users_constraint {
   unique or primary key constraint on columns "email"
   """
   users_email_key
-  """
-  unique or primary key constraint on columns "id"
-  """
-  sqlite_autoindex_users_1
 }
 """
 update columns of table "users"
@@ -1267,10 +1215,6 @@ enum department_files_constraint {
   unique or primary key constraint on columns "id"
   """
   department_files_pkey
-  """
-  unique or primary key constraint on columns "id"
-  """
-  sqlite_autoindex_department_files_1
 }
 """
 update columns of table "department_files"
@@ -1322,10 +1266,6 @@ enum department_roles_constraint {
   unique or primary key constraint on columns "value"
   """
   department_roles_pkey
-  """
-  unique or primary key constraint on columns "value"
-  """
-  sqlite_autoindex_department_roles_1
 }
 """
 update columns of table "department_roles"
@@ -1365,10 +1305,6 @@ enum departments_constraint {
   unique or primary key constraint on columns "name"
   """
   departments_name_key
-  """
-  unique or primary key constraint on columns "id"
-  """
-  sqlite_autoindex_departments_1
 }
 """
 update columns of table "departments"
@@ -1440,10 +1376,6 @@ enum exercise_log_sets_constraint {
   unique or primary key constraint on columns "id"
   """
   exercise_log_sets_pkey
-  """
-  unique or primary key constraint on columns "id"
-  """
-  sqlite_autoindex_exercise_log_sets_1
 }
 """
 update columns of table "exercise_log_sets"
@@ -1499,10 +1431,6 @@ enum exercise_logs_constraint {
   unique or primary key constraint on columns "id", "kind"
   """
   sqlite_autoindex_exercise_logs_2
-  """
-  unique or primary key constraint on columns "id"
-  """
-  sqlite_autoindex_exercise_logs_1
 }
 """
 update columns of table "exercise_logs"
@@ -1589,10 +1517,6 @@ enum kb_entries_constraint {
   unique or primary key constraint on columns "id"
   """
   kb_entries_pkey
-  """
-  unique or primary key constraint on columns "id"
-  """
-  sqlite_autoindex_kb_entries_1
 }
 """
 update columns of table "kb_entries"
@@ -1688,10 +1612,6 @@ enum kb_entry_departments_constraint {
   unique or primary key constraint on columns "kb_entry_id", "department_id"
   """
   kb_entry_departments_kb_entry_id_department_id_key
-  """
-  unique or primary key constraint on columns "id"
-  """
-  sqlite_autoindex_kb_entry_departments_1
 }
 """
 update columns of table "kb_entry_departments"
@@ -1739,10 +1659,6 @@ enum news_constraint {
   unique or primary key constraint on columns "title"
   """
   news_title_key
-  """
-  unique or primary key constraint on columns "id"
-  """
-  sqlite_autoindex_news_1
 }
 """
 update columns of table "news"
@@ -1826,10 +1742,6 @@ enum note_replies_constraint {
   unique or primary key constraint on columns "id"
   """
   note_replies_pkey
-  """
-  unique or primary key constraint on columns "id"
-  """
-  sqlite_autoindex_note_replies_1
 }
 """
 update columns of table "note_replies"
@@ -1881,10 +1793,6 @@ enum notes_constraint {
   unique or primary key constraint on columns "id"
   """
   notes_pkey
-  """
-  unique or primary key constraint on columns "id"
-  """
-  sqlite_autoindex_notes_1
 }
 """
 update columns of table "notes"
@@ -1961,10 +1869,6 @@ enum user_departments_constraint {
   unique or primary key constraint on columns "user_id", "department_id"
   """
   user_departments_pkey
-  """
-  unique or primary key constraint on columns "user_id", "department_id"
-  """
-  sqlite_autoindex_user_departments_1
 }
 """
 update columns of table "user_departments"
@@ -2042,10 +1946,6 @@ enum buckets_constraint {
   unique or primary key constraint on columns "id"
   """
   buckets_pkey
-  """
-  unique or primary key constraint on columns "id"
-  """
-  sqlite_autoindex_buckets_1
 }
 """
 update columns of table "buckets"
@@ -2129,10 +2029,6 @@ enum files_constraint {
   unique or primary key constraint on columns "id"
   """
   files_pkey
-  """
-  unique or primary key constraint on columns "id"
-  """
-  sqlite_autoindex_files_1
 }
 """
 update columns of table "files"
@@ -2240,10 +2136,6 @@ enum virus_constraint {
   unique or primary key constraint on columns "id"
   """
   virus_pkey
-  """
-  unique or primary key constraint on columns "id"
-  """
-  sqlite_autoindex_virus_1
 }
 """
 update columns of table "virus"

--- a/services/constellation/connector/sql/graphql/schema/testdata/TestGenerateForRole_SQLite/mixed_permissions.graphqls
+++ b/services/constellation/connector/sql/graphql/schema/testdata/TestGenerateForRole_SQLite/mixed_permissions.graphqls
@@ -152,10 +152,6 @@ enum user_departments_constraint {
   unique or primary key constraint on columns "user_id", "department_id"
   """
   user_departments_pkey
-  """
-  unique or primary key constraint on columns "user_id", "department_id"
-  """
-  sqlite_autoindex_user_departments_1
 }
 """
 update columns of table "user_departments"

--- a/services/constellation/connector/sql/graphql/schema/testdata/TestGenerateForRole_SQLite/queries_relationships.graphqls
+++ b/services/constellation/connector/sql/graphql/schema/testdata/TestGenerateForRole_SQLite/queries_relationships.graphqls
@@ -99,10 +99,6 @@ enum authRoles_constraint {
   unique or primary key constraint on columns "role"
   """
   roles_pkey
-  """
-  unique or primary key constraint on columns "role"
-  """
-  sqlite_autoindex_roles_1
 }
 """
 update columns of table "roles"
@@ -134,10 +130,6 @@ enum authUserRoles_constraint {
   unique or primary key constraint on columns "user_id", "role"
   """
   user_roles_user_id_role_key
-  """
-  unique or primary key constraint on columns "id"
-  """
-  sqlite_autoindex_user_roles_1
 }
 """
 update columns of table "user_roles"
@@ -197,10 +189,6 @@ enum users_constraint {
   unique or primary key constraint on columns "email"
   """
   users_email_key
-  """
-  unique or primary key constraint on columns "id"
-  """
-  sqlite_autoindex_users_1
 }
 """
 update columns of table "users"
@@ -424,10 +412,6 @@ enum departments_constraint {
   unique or primary key constraint on columns "name"
   """
   departments_name_key
-  """
-  unique or primary key constraint on columns "id"
-  """
-  sqlite_autoindex_departments_1
 }
 """
 update columns of table "departments"
@@ -495,10 +479,6 @@ enum user_departments_constraint {
   unique or primary key constraint on columns "user_id", "department_id"
   """
   user_departments_pkey
-  """
-  unique or primary key constraint on columns "user_id", "department_id"
-  """
-  sqlite_autoindex_user_departments_1
 }
 """
 update columns of table "user_departments"

--- a/services/constellation/connector/sql/graphql/schema/testdata/TestGenerateForRole_SQLite/queries_relationships_enum.graphqls
+++ b/services/constellation/connector/sql/graphql/schema/testdata/TestGenerateForRole_SQLite/queries_relationships_enum.graphqls
@@ -56,10 +56,6 @@ enum authRefreshTokenTypes_constraint {
   unique or primary key constraint on columns "value"
   """
   refresh_token_types_pkey
-  """
-  unique or primary key constraint on columns "value"
-  """
-  sqlite_autoindex_refresh_token_types_1
 }
 """
 update columns of table "refresh_token_types"
@@ -95,10 +91,6 @@ enum authRefreshTokens_constraint {
   unique or primary key constraint on columns "id"
   """
   refresh_tokens_pkey
-  """
-  unique or primary key constraint on columns "id"
-  """
-  sqlite_autoindex_refresh_tokens_1
 }
 """
 update columns of table "refresh_tokens"
@@ -182,10 +174,6 @@ enum users_constraint {
   unique or primary key constraint on columns "email"
   """
   users_email_key
-  """
-  unique or primary key constraint on columns "id"
-  """
-  sqlite_autoindex_users_1
 }
 """
 update columns of table "users"

--- a/services/constellation/connector/sql/graphql/schema/testdata/TestGenerateForRole_SQLite/queries_relationships_enum_no_perms.graphqls
+++ b/services/constellation/connector/sql/graphql/schema/testdata/TestGenerateForRole_SQLite/queries_relationships_enum_no_perms.graphqls
@@ -56,10 +56,6 @@ enum authRefreshTokens_constraint {
   unique or primary key constraint on columns "id"
   """
   refresh_tokens_pkey
-  """
-  unique or primary key constraint on columns "id"
-  """
-  sqlite_autoindex_refresh_tokens_1
 }
 """
 update columns of table "refresh_tokens"
@@ -143,10 +139,6 @@ enum users_constraint {
   unique or primary key constraint on columns "email"
   """
   users_email_key
-  """
-  unique or primary key constraint on columns "id"
-  """
-  sqlite_autoindex_users_1
 }
 """
 update columns of table "users"

--- a/services/constellation/connector/sql/graphql/schema/testdata/TestGenerateForRole_SQLite/simplequeries.graphqls
+++ b/services/constellation/connector/sql/graphql/schema/testdata/TestGenerateForRole_SQLite/simplequeries.graphqls
@@ -64,10 +64,6 @@ enum users_constraint {
   unique or primary key constraint on columns "email"
   """
   users_email_key
-  """
-  unique or primary key constraint on columns "id"
-  """
-  sqlite_autoindex_users_1
 }
 """
 update columns of table "users"

--- a/services/constellation/connector/sql/graphql/schema/testdata/TestGenerateForRole_SQLite/simplequeries_aggregation.graphqls
+++ b/services/constellation/connector/sql/graphql/schema/testdata/TestGenerateForRole_SQLite/simplequeries_aggregation.graphqls
@@ -64,10 +64,6 @@ enum users_constraint {
   unique or primary key constraint on columns "email"
   """
   users_email_key
-  """
-  unique or primary key constraint on columns "id"
-  """
-  sqlite_autoindex_users_1
 }
 """
 update columns of table "users"

--- a/services/constellation/connector/sql/graphql/schema/testdata/TestGenerateForRole_SQLite/user.graphqls
+++ b/services/constellation/connector/sql/graphql/schema/testdata/TestGenerateForRole_SQLite/user.graphqls
@@ -205,10 +205,6 @@ enum department_files_constraint {
   unique or primary key constraint on columns "id"
   """
   department_files_pkey
-  """
-  unique or primary key constraint on columns "id"
-  """
-  sqlite_autoindex_department_files_1
 }
 """
 placeholder for update columns of table "department_files" (current role has no relevant permissions)
@@ -282,10 +278,6 @@ enum exercise_log_sets_constraint {
   unique or primary key constraint on columns "id"
   """
   exercise_log_sets_pkey
-  """
-  unique or primary key constraint on columns "id"
-  """
-  sqlite_autoindex_exercise_log_sets_1
 }
 """
 placeholder for update columns of table "exercise_log_sets" (current role has no relevant permissions)
@@ -325,10 +317,6 @@ enum exercise_logs_constraint {
   unique or primary key constraint on columns "id", "kind"
   """
   sqlite_autoindex_exercise_logs_2
-  """
-  unique or primary key constraint on columns "id"
-  """
-  sqlite_autoindex_exercise_logs_1
 }
 """
 placeholder for update columns of table "exercise_logs" (current role has no relevant permissions)
@@ -399,10 +387,6 @@ enum kb_entries_constraint {
   unique or primary key constraint on columns "id"
   """
   kb_entries_pkey
-  """
-  unique or primary key constraint on columns "id"
-  """
-  sqlite_autoindex_kb_entries_1
 }
 """
 update columns of table "kb_entries"
@@ -466,10 +450,6 @@ enum kb_entry_departments_constraint {
   unique or primary key constraint on columns "kb_entry_id", "department_id"
   """
   kb_entry_departments_kb_entry_id_department_id_key
-  """
-  unique or primary key constraint on columns "id"
-  """
-  sqlite_autoindex_kb_entry_departments_1
 }
 """
 placeholder for update columns of table "kb_entry_departments" (current role has no relevant permissions)
@@ -509,10 +489,6 @@ enum news_constraint {
   unique or primary key constraint on columns "title"
   """
   news_title_key
-  """
-  unique or primary key constraint on columns "id"
-  """
-  sqlite_autoindex_news_1
 }
 """
 update columns of table "news"
@@ -568,10 +544,6 @@ enum note_replies_constraint {
   unique or primary key constraint on columns "id"
   """
   note_replies_pkey
-  """
-  unique or primary key constraint on columns "id"
-  """
-  sqlite_autoindex_note_replies_1
 }
 """
 placeholder for update columns of table "note_replies" (current role has no relevant permissions)
@@ -611,10 +583,6 @@ enum notes_constraint {
   unique or primary key constraint on columns "id"
   """
   notes_pkey
-  """
-  unique or primary key constraint on columns "id"
-  """
-  sqlite_autoindex_notes_1
 }
 """
 update columns of table "notes"
@@ -683,10 +651,6 @@ enum user_departments_constraint {
   unique or primary key constraint on columns "user_id", "department_id"
   """
   user_departments_pkey
-  """
-  unique or primary key constraint on columns "user_id", "department_id"
-  """
-  sqlite_autoindex_user_departments_1
 }
 """
 update columns of table "user_departments"
@@ -734,10 +698,6 @@ enum files_constraint {
   unique or primary key constraint on columns "id"
   """
   files_pkey
-  """
-  unique or primary key constraint on columns "id"
-  """
-  sqlite_autoindex_files_1
 }
 """
 update columns of table "files"

--- a/services/constellation/connector/sql/sqlite/introspect.go
+++ b/services/constellation/connector/sql/sqlite/introspect.go
@@ -11,6 +11,11 @@ import (
 	"github.com/nhost/nhost/services/constellation/metadata"
 )
 
+const (
+	sqliteTypeInt4 = "int4"
+	sqliteTypeInt2 = "int2"
+)
+
 // Introspect returns the database objects (tables, columns, primary keys,
 // foreign keys, unique constraints) for the relations listed in dbMeta.
 // Introspection is metadata-scoped: untracked tables and views in
@@ -622,10 +627,11 @@ func getForeignKeys(
 // indexes must repeat the index predicate, which this metadata model cannot
 // represent, so partial indexes are deliberately not exposed as upsert
 // constraints. Expression and rowid unique indexes are also skipped because the
-// GraphQL upsert metadata can only render column-list conflict targets. The
-// origin column (pk/u/c) is unused: any non-partial unique index counts,
-// regardless of whether it was created implicitly for a UNIQUE column, a
-// PRIMARY KEY, or an explicit CREATE UNIQUE INDEX.
+// GraphQL upsert metadata can only render column-list conflict targets. Indexes
+// with origin=pk are deliberately excluded: the primary-key constraint is
+// already represented separately, and exposing SQLite's PK-backed autoindex as a
+// unique constraint would add a duplicate upsert target that PostgreSQL
+// introspection does not produce.
 func getUniqueConstraints(
 	ctx context.Context, q Querier, tableName string,
 ) ([]introspection.UniqueConstraint, error) {
@@ -652,7 +658,7 @@ func getUniqueConstraints(
 			return nil, fmt.Errorf("failed to scan index entry: %w", err)
 		}
 
-		if unique && !partial {
+		if unique && !partial && origin != "pk" {
 			indexNames = append(indexNames, name)
 		}
 	}
@@ -871,9 +877,12 @@ func mapSQLiteType(sqliteType string) string { //nolint:gocyclo,cyclop
 	upper := strings.ToUpper(strings.TrimSpace(sqliteType))
 
 	switch {
-	case upper == "INTEGER" || upper == "INT" || upper == "BIGINT" ||
-		upper == "SMALLINT" || upper == "TINYINT" || upper == "MEDIUMINT":
+	case upper == "INTEGER" || upper == "BIGINT":
 		return "int8" //nolint:goconst // matches sibling type cases that also nolint goconst
+	case upper == "INT" || upper == "MEDIUMINT":
+		return sqliteTypeInt4
+	case upper == "SMALLINT" || upper == "TINYINT":
+		return sqliteTypeInt2
 	case upper == "REAL" || upper == "FLOAT" || upper == "DOUBLE" ||
 		strings.HasPrefix(upper, "DOUBLE "):
 		return "float8" //nolint:goconst
@@ -906,7 +915,15 @@ func mapSQLiteType(sqliteType string) string { //nolint:gocyclo,cyclop
 // typeSupportsMinMax returns whether a mapped type supports min/max aggregation.
 func typeSupportsMinMax(mappedType string) bool {
 	switch mappedType {
-	case "int8", "float8", "numeric", "text", "date", "timestamptz", "uuid":
+	case "int8",
+		sqliteTypeInt4,
+		sqliteTypeInt2,
+		"float8",
+		"numeric",
+		"text",
+		"date",
+		"timestamptz",
+		"uuid":
 		return true
 	default:
 		return false
@@ -916,7 +933,7 @@ func typeSupportsMinMax(mappedType string) bool {
 // typeSupportsInc returns whether a mapped type supports increment (+) operations.
 func typeSupportsInc(mappedType string) bool {
 	switch mappedType {
-	case "int8", "float8", "numeric":
+	case "int8", sqliteTypeInt4, sqliteTypeInt2, "float8", "numeric":
 		return true
 	default:
 		return false
@@ -926,7 +943,7 @@ func typeSupportsInc(mappedType string) bool {
 // typeSupportsAgg returns whether a mapped type supports numeric aggregation (sum, avg, etc.).
 func typeSupportsAgg(mappedType string) bool {
 	switch mappedType {
-	case "int8", "float8", "numeric":
+	case "int8", sqliteTypeInt4, sqliteTypeInt2, "float8", "numeric":
 		return true
 	default:
 		return false

--- a/services/constellation/connector/sql/sqlite/introspect_internal_test.go
+++ b/services/constellation/connector/sql/sqlite/introspect_internal_test.go
@@ -11,11 +11,11 @@ func TestMapSQLiteType(t *testing.T) {
 	}{
 		// Integer types
 		{"INTEGER", "int8"},
-		{"INT", "int8"},
+		{"INT", "int4"},
 		{"BIGINT", "int8"},
-		{"SMALLINT", "int8"},
-		{"TINYINT", "int8"},
-		{"MEDIUMINT", "int8"},
+		{"SMALLINT", "int2"},
+		{"TINYINT", "int2"},
+		{"MEDIUMINT", "int4"},
 		{"integer", "int8"},
 
 		// Real types
@@ -88,6 +88,8 @@ func TestTypeSupportsMinMax(t *testing.T) {
 		want   bool
 	}{
 		{"int8", true},
+		{"int4", true},
+		{"int2", true},
 		{"float8", true},
 		{"numeric", true},
 		{"text", true},
@@ -119,6 +121,8 @@ func TestTypeSupportsInc(t *testing.T) {
 		want   bool
 	}{
 		{"int8", true},
+		{"int4", true},
+		{"int2", true},
 		{"float8", true},
 		{"numeric", true},
 		{"bool", false},
@@ -149,6 +153,8 @@ func TestTypeSupportsAgg(t *testing.T) {
 		want   bool
 	}{
 		{"int8", true},
+		{"int4", true},
+		{"int2", true},
 		{"float8", true},
 		{"numeric", true},
 		{"bool", false},

--- a/services/constellation/connector/sql/sqlite/introspect_test.go
+++ b/services/constellation/connector/sql/sqlite/introspect_test.go
@@ -168,6 +168,82 @@ CREATE UNIQUE INDEX users_lower_email_key ON users(lower(email));
 	assertPlainUniqueAndSkippedIndex(t, users, "users_lower_email_key", "expression")
 }
 
+func TestIntrospectSkipsPrimaryKeyAutoindexesAsUniqueConstraints(t *testing.T) {
+	t.Parallel()
+
+	dbPath := filepath.Join(t.TempDir(), "pk_autoindexes.db")
+
+	db, err := sql.Open("sqlite3", dbPath)
+	if err != nil {
+		t.Fatalf("failed to open database: %v", err)
+	}
+
+	if _, err := db.ExecContext(t.Context(), `
+CREATE TABLE rowid_alias (
+    id INTEGER PRIMARY KEY,
+    name TEXT
+);
+
+CREATE TABLE composite_pk (
+    tenant_id TEXT NOT NULL,
+    id INTEGER NOT NULL,
+    name TEXT,
+    PRIMARY KEY (tenant_id, id)
+);
+
+CREATE TABLE without_rowid_pk (
+    tenant_id TEXT NOT NULL,
+    id INTEGER NOT NULL,
+    name TEXT,
+    PRIMARY KEY (tenant_id, id)
+) WITHOUT ROWID;
+`); err != nil {
+		t.Fatalf("failed to create schema: %v", err)
+	}
+
+	if err := db.Close(); err != nil {
+		t.Fatalf("failed to close setup database: %v", err)
+	}
+
+	sqlDB, err := sqlite.Open(t.Context(), dbPath)
+	if err != nil {
+		t.Fatalf("failed to open sqlite: %v", err)
+	}
+
+	client := sqlite.NewClient(sqlDB)
+	t.Cleanup(func() { client.Close() })
+
+	got, err := client.Introspect(t.Context(), &metadata.DatabaseMetadata{
+		Tables: []metadata.TableMetadata{
+			{Table: metadata.TableSource{Name: "rowid_alias"}},
+			{Table: metadata.TableSource{Name: "composite_pk"}},
+			{Table: metadata.TableSource{Name: "without_rowid_pk"}},
+		},
+	})
+	if err != nil {
+		t.Fatalf("failed to introspect: %v", err)
+	}
+
+	for _, tableName := range []string{"rowid_alias", "composite_pk", "without_rowid_pk"} {
+		table := got.Schemas[""].Tables[tableName]
+		if table == nil {
+			t.Fatalf("missing table %s", tableName)
+		}
+
+		if len(table.PrimaryKeys) == 0 {
+			t.Fatalf("%s primary key was not introspected", tableName)
+		}
+
+		if len(table.UniqueConstraints) != 0 {
+			t.Fatalf(
+				"%s PK-backed autoindex exposed as unique constraint: %+v",
+				tableName,
+				table.UniqueConstraints,
+			)
+		}
+	}
+}
+
 func introspectUsersTable(
 	t *testing.T, dbFileName string, schema string,
 ) *introspection.Table {

--- a/services/constellation/connector/sql/sqlite/pragma_cgo.go
+++ b/services/constellation/connector/sql/sqlite/pragma_cgo.go
@@ -1,0 +1,18 @@
+//go:build cgo
+
+package sqlite
+
+import (
+	"fmt"
+
+	sqlite3 "github.com/mattn/go-sqlite3"
+)
+
+func execConnectionPragma(conn *sqlite3.SQLiteConn, pragma string) error {
+	_, err := conn.Exec(pragma, nil)
+	if err != nil {
+		return fmt.Errorf("executing sqlite connection pragma: %w", err)
+	}
+
+	return nil
+}

--- a/services/constellation/connector/sql/sqlite/pragma_nocgo.go
+++ b/services/constellation/connector/sql/sqlite/pragma_nocgo.go
@@ -1,0 +1,13 @@
+//go:build !cgo
+
+package sqlite
+
+import sqlite3 "github.com/mattn/go-sqlite3"
+
+func execConnectionPragma(_ *sqlite3.SQLiteConn, _ string) error {
+	// The Nhost CLI imports Constellation schema-building code but is built with
+	// CGO disabled for static cross-platform artifacts. go-sqlite3's no-CGO stub
+	// exposes SQLiteConn without Exec, and SQLite cannot open at runtime in that
+	// mode anyway, so this path exists only to keep no-CGO CLI builds compiling.
+	return nil
+}

--- a/services/constellation/connector/sql/sqlite/sqlite.go
+++ b/services/constellation/connector/sql/sqlite/sqlite.go
@@ -11,10 +11,11 @@
 // # Client lifecycle
 //
 // A *Client owns its underlying DB exclusively: [Client.Close] is one-shot and
-// the receiver must not be reused after closing. [Open] enables WAL journal
-// mode and foreign-key enforcement on the connection; both PRAGMAs are
-// idempotent so reopening a database returned by an earlier [Client.Close] is
-// safe.
+// the receiver must not be reused after closing. [Open] uses this package's
+// private go-sqlite3 driver registration, whose per-connection hook enables WAL
+// journal mode, foreign-key enforcement, and case-sensitive LIKE for every new
+// physical database/sql connection. The PRAGMAs are idempotent, so reopening a
+// database returned by an earlier [Client.Close] is safe.
 //
 // # Scope
 //
@@ -32,8 +33,9 @@ import (
 	"errors"
 	"fmt"
 	"log/slog"
+	"sync"
 
-	_ "github.com/mattn/go-sqlite3" // database/sql driver registration
+	sqlite3 "github.com/mattn/go-sqlite3"
 
 	csql "github.com/nhost/nhost/services/constellation/connector/sql"
 	"github.com/nhost/nhost/services/constellation/connector/sql/graphql/queries/core"
@@ -41,7 +43,40 @@ import (
 	"github.com/nhost/nhost/services/constellation/metadata"
 )
 
-var errSequentialNonJSONResult = errors.New("sequential operation returned non-JSON result")
+const sqliteDriverName = "sqlite3_constellation"
+
+var (
+	errSequentialNonJSONResult = errors.New("sequential operation returned non-JSON result")
+	// registerSQLiteDriverOnce guards database/sql's process-wide driver registry.
+	registerSQLiteDriverOnce sync.Once //nolint:gochecknoglobals
+)
+
+func registerSQLiteDriver() {
+	registerSQLiteDriverOnce.Do(func() {
+		sql.Register(
+			sqliteDriverName,
+			&sqlite3.SQLiteDriver{ //nolint:exhaustruct // optional external driver fields stay zero.
+				ConnectHook: func(conn *sqlite3.SQLiteConn) error {
+					for _, pragma := range []string{
+						"PRAGMA foreign_keys=ON",
+						"PRAGMA case_sensitive_like=ON",
+						"PRAGMA journal_mode=WAL",
+					} {
+						if _, err := conn.Exec(pragma, nil); err != nil {
+							return fmt.Errorf(
+								"running sqlite connection pragma %q: %w",
+								pragma,
+								err,
+							)
+						}
+					}
+
+					return nil
+				},
+			},
+		)
+	})
+}
 
 // Querier abstracts SQLite query execution. Both DB and Tx satisfy this
 // interface, which lets unexported helpers run against either a connection
@@ -136,6 +171,10 @@ func (a *dbAdapter) Close() error {
 	return a.db.Close() //nolint:wrapcheck
 }
 
+func (a *dbAdapter) SetMaxOpenConns(n int) {
+	a.db.SetMaxOpenConns(n)
+}
+
 // txAdapter wraps *sql.Tx so it satisfies the local Tx interface.
 type txAdapter struct {
 	tx *sql.Tx
@@ -182,36 +221,34 @@ func NewClient(db DB) *Client {
 	return &Client{db: db}
 }
 
-// Open opens a SQLite database against connStr and enables WAL journal mode
-// plus foreign-key enforcement on the connection. The returned DB is ready to
-// pass to [NewClient].
+// Open opens a SQLite database against connStr with the package's private
+// go-sqlite3 driver registration. Every physical database/sql connection opened
+// through the returned pool has WAL journal mode, foreign-key enforcement, and
+// case-sensitive LIKE enabled before use. The returned DB is ready to pass to
+// [NewClient].
 //
 // Production code goes through [New]; Open is exported so [internal/lib/testdb]
 // and integration-style tests in sibling packages can build the DB and Client
 // in two steps.
 //
-// Failure handling: if either PRAGMA fails the underlying *sql.DB is closed
-// before returning, and the close error (if any) is joined onto the returned
-// error via [errors.Join]. Callers therefore must not Close the returned DB on
-// error — it is already closed. On success, the caller owns [DB.Close].
+// Failure handling: if the initial connection or per-connection PRAGMA hook
+// fails, the underlying *sql.DB is closed before returning, and the close error
+// (if any) is joined onto the returned error via [errors.Join]. Callers
+// therefore must not Close the returned DB on error — it is already closed. On
+// success, the caller owns [DB.Close].
 //
 // see package-level interface seam note.
 func Open(ctx context.Context, connStr string) (DB, error) { //nolint:ireturn,nolintlint
-	rawDB, err := sql.Open("sqlite3", connStr)
+	registerSQLiteDriver()
+
+	rawDB, err := sql.Open(sqliteDriverName, connStr)
 	if err != nil {
 		return nil, fmt.Errorf("opening sqlite database: %w", err)
 	}
 
-	if _, execErr := rawDB.ExecContext(ctx, "PRAGMA journal_mode=WAL"); execErr != nil {
+	if err := rawDB.PingContext(ctx); err != nil {
 		return nil, errors.Join(
-			fmt.Errorf("enabling WAL mode: %w", execErr),
-			rawDB.Close(),
-		)
-	}
-
-	if _, execErr := rawDB.ExecContext(ctx, "PRAGMA foreign_keys=ON"); execErr != nil {
-		return nil, errors.Join(
-			fmt.Errorf("enabling foreign keys: %w", execErr),
+			fmt.Errorf("opening sqlite connection: %w", err),
 			rawDB.Close(),
 		)
 	}

--- a/services/constellation/connector/sql/sqlite/sqlite.go
+++ b/services/constellation/connector/sql/sqlite/sqlite.go
@@ -62,7 +62,7 @@ func registerSQLiteDriver() {
 						"PRAGMA case_sensitive_like=ON",
 						"PRAGMA journal_mode=WAL",
 					} {
-						if _, err := conn.Exec(pragma, nil); err != nil {
+						if err := execConnectionPragma(conn, pragma); err != nil {
 							return fmt.Errorf(
 								"running sqlite connection pragma %q: %w",
 								pragma,

--- a/services/constellation/connector/sql/sqlite/sqlite_test.go
+++ b/services/constellation/connector/sql/sqlite/sqlite_test.go
@@ -169,6 +169,80 @@ func TestOpen(t *testing.T) {
 	})
 }
 
+func TestOpenEnablesCaseSensitiveLikeOnEveryConnection(t *testing.T) {
+	t.Parallel()
+
+	dbPath := filepath.Join(t.TempDir(), "case-sensitive-like.db")
+
+	db, err := sqlite.Open(t.Context(), dbPath)
+	if err != nil {
+		t.Fatalf("failed to open sqlite: %v", err)
+	}
+
+	t.Cleanup(func() {
+		if err := db.Close(); err != nil {
+			t.Errorf("failed to close database: %v", err)
+		}
+	})
+
+	pool, ok := db.(interface{ SetMaxOpenConns(n int) })
+	if !ok {
+		t.Fatalf("expected sqlite.Open DB to allow configuring max open conns, got %T", db)
+	}
+
+	pool.SetMaxOpenConns(2)
+
+	tx1, err := db.BeginTx(t.Context())
+	if err != nil {
+		t.Fatalf("failed to begin first transaction: %v", err)
+	}
+
+	t.Cleanup(func() {
+		if err := tx1.Rollback(); err != nil && !errors.Is(err, sql.ErrTxDone) {
+			t.Errorf("first transaction rollback during cleanup: %v", err)
+		}
+	})
+
+	tx2, err := db.BeginTx(t.Context())
+	if err != nil {
+		t.Fatalf("failed to begin second transaction: %v", err)
+	}
+
+	t.Cleanup(func() {
+		if err := tx2.Rollback(); err != nil && !errors.Is(err, sql.ErrTxDone) {
+			t.Errorf("second transaction rollback during cleanup: %v", err)
+		}
+	})
+
+	assertLikeSemantics := func(t *testing.T, tx sqlite.Tx) {
+		t.Helper()
+
+		var caseSensitive, lowerRewrite int
+		if err := tx.QueryRowContext(
+			t.Context(),
+			"SELECT 'Foo' LIKE 'foo%', LOWER('Foo') LIKE LOWER('foo%')",
+		).Scan(&caseSensitive, &lowerRewrite); err != nil {
+			t.Fatalf("failed to query LIKE semantics: %v", err)
+		}
+
+		if caseSensitive != 0 {
+			t.Fatalf("case-sensitive LIKE matched different case: got %d, want 0", caseSensitive)
+		}
+
+		if lowerRewrite != 1 {
+			t.Fatalf("LOWER rewrite did not match case-insensitively: got %d, want 1", lowerRewrite)
+		}
+	}
+
+	assertLikeSemantics(t, tx2)
+
+	if err := tx2.Rollback(); err != nil && !errors.Is(err, sql.ErrTxDone) {
+		t.Fatalf("failed to roll back second transaction: %v", err)
+	}
+
+	assertLikeSemantics(t, tx1)
+}
+
 func TestOpenEnforcesForeignKeysOnEveryConnection(t *testing.T) {
 	t.Parallel()
 

--- a/services/constellation/connector/sql/sqlite/sqlite_test.go
+++ b/services/constellation/connector/sql/sqlite/sqlite_test.go
@@ -169,6 +169,88 @@ func TestOpen(t *testing.T) {
 	})
 }
 
+func TestOpenEnforcesForeignKeysOnEveryConnection(t *testing.T) {
+	t.Parallel()
+
+	dbPath := filepath.Join(t.TempDir(), "foreign-keys.db")
+
+	db, err := sqlite.Open(t.Context(), dbPath)
+	if err != nil {
+		t.Fatalf("failed to open sqlite: %v", err)
+	}
+
+	t.Cleanup(func() {
+		if err := db.Close(); err != nil {
+			t.Errorf("failed to close database: %v", err)
+		}
+	})
+
+	pool, ok := db.(interface{ SetMaxOpenConns(n int) })
+	if !ok {
+		t.Fatalf("expected sqlite.Open DB to allow configuring max open conns, got %T", db)
+	}
+
+	pool.SetMaxOpenConns(2)
+
+	if err := db.ExecContext(t.Context(), `
+		CREATE TABLE parents (id INTEGER PRIMARY KEY);
+		CREATE TABLE children (
+			id INTEGER PRIMARY KEY,
+			parent_id INTEGER NOT NULL REFERENCES parents(id)
+		);
+	`); err != nil {
+		t.Fatalf("failed to create schema: %v", err)
+	}
+
+	tx1, err := db.BeginTx(t.Context())
+	if err != nil {
+		t.Fatalf("failed to begin first transaction: %v", err)
+	}
+
+	t.Cleanup(func() {
+		if err := tx1.Rollback(); err != nil && !errors.Is(err, sql.ErrTxDone) {
+			t.Errorf("first transaction rollback during cleanup: %v", err)
+		}
+	})
+
+	tx2, err := db.BeginTx(t.Context())
+	if err != nil {
+		t.Fatalf("failed to begin second transaction: %v", err)
+	}
+
+	t.Cleanup(func() {
+		if err := tx2.Rollback(); err != nil && !errors.Is(err, sql.ErrTxDone) {
+			t.Errorf("second transaction rollback during cleanup: %v", err)
+		}
+	})
+
+	assertForeignKeyViolation := func(t *testing.T, tx sqlite.Tx, childID int) {
+		t.Helper()
+
+		err := tx.ExecContext(
+			t.Context(),
+			"INSERT INTO children (id, parent_id) VALUES (?, ?)",
+			childID,
+			999,
+		)
+		if err == nil {
+			t.Fatal("expected foreign-key violation")
+		}
+
+		if !strings.Contains(err.Error(), "FOREIGN KEY constraint failed") {
+			t.Fatalf("expected foreign-key violation, got %v", err)
+		}
+	}
+
+	assertForeignKeyViolation(t, tx2, 2)
+
+	if err := tx2.Rollback(); err != nil && !errors.Is(err, sql.ErrTxDone) {
+		t.Fatalf("failed to roll back second transaction: %v", err)
+	}
+
+	assertForeignKeyViolation(t, tx1, 1)
+}
+
 func TestDialect(t *testing.T) {
 	t.Parallel()
 

--- a/services/constellation/connector/sql/sqlite/testdata/TestIntrospect/success.golden.json
+++ b/services/constellation/connector/sql/sqlite/testdata/TestIntrospect/success.golden.json
@@ -97,12 +97,6 @@
               "Columns": [
                 "email"
               ]
-            },
-            {
-              "Name": "sqlite_autoindex_users_1",
-              "Columns": [
-                "id"
-              ]
             }
           ],
           "IsView": false,
@@ -146,14 +140,7 @@
           ],
           "PrimaryKeyConstraintName": "",
           "ForeignKeys": null,
-          "UniqueConstraints": [
-            {
-              "Name": "sqlite_autoindex_department_roles_1",
-              "Columns": [
-                "type"
-              ]
-            }
-          ],
+          "UniqueConstraints": null,
           "IsView": false,
           "IsInsertable": true,
           "IsUpdatable": true
@@ -317,12 +304,6 @@
               "Name": "departments_name_key",
               "Columns": [
                 "name"
-              ]
-            },
-            {
-              "Name": "sqlite_autoindex_departments_1",
-              "Columns": [
-                "id"
               ]
             }
           ],
@@ -507,15 +488,7 @@
               "ForeignColumnName": "id"
             }
           ],
-          "UniqueConstraints": [
-            {
-              "Name": "sqlite_autoindex_user_departments_1",
-              "Columns": [
-                "user_id",
-                "department_id"
-              ]
-            }
-          ],
+          "UniqueConstraints": null,
           "IsView": false,
           "IsInsertable": true,
           "IsUpdatable": true

--- a/services/constellation/docs/user/postgres-features.md
+++ b/services/constellation/docs/user/postgres-features.md
@@ -430,7 +430,7 @@ See [`remote-schema.md`](./remote-schema.md). Remote schemas are configured per 
 | JSONB comparison operators | yes | no |
 | JSONB mutation operators (`_append`, etc.) | yes | no |
 | Array columns and `_contains` / `_contained_in` | yes | no |
-| `ILIKE` | yes | LIKE fallback |
+| `ILIKE` | yes | yes (ASCII case-folding via `LOWER(...) LIKE LOWER(...)`) |
 | Generated columns | yes | no |
 | Identity columns | yes (`GENERATED AS IDENTITY`) | yes (`INTEGER PRIMARY KEY` rowid alias) |
 | `gen_random_uuid()` / sequence defaults | yes | partial |
@@ -446,7 +446,7 @@ See [`remote-schema.md`](./remote-schema.md). Remote schemas are configured per 
 | `RETURNING` | yes | no |
 | Data-modifying CTEs (`WITH ... AS (INSERT/UPDATE/DELETE ... RETURNING)`) | yes | no |
 | Stream subscriptions | yes | yes |
-| Aggregates (`avg`, `sum`, `stddev*`, `var*`, `variance`) | yes | partial |
+| Aggregates | yes (`count`, `min`, `max`, `avg`, `sum`, `stddev*`, `var*`, `variance`) | partial (`count`, `min`, `max`, `avg`, `sum`; no `stddev*` / `var*` / `variance`) |
 | Object / array / remote relationships | yes | yes |
 | Per-role permissions with session variables | yes | yes |
 | Enum-mapping tables (`is_enum`) | yes | yes |

--- a/services/storage/controller/get_file.go
+++ b/services/storage/controller/get_file.go
@@ -18,7 +18,8 @@ import (
 	"github.com/nhost/nhost/services/storage/middleware"
 )
 
-func deptr[T any](v *T) T { //nolint:ireturn
+//nolint:ireturn // generic helper returns the caller-selected type parameter.
+func deptr[T any](v *T) T {
 	if v == nil {
 		var zero T
 		return zero
@@ -279,7 +280,7 @@ func (ctrl *Controller) processFileToDownload(
 	}, nil
 }
 
-func (ctrl *Controller) getFileResponse( //nolint: ireturn,dupl,funlen
+func (ctrl *Controller) getFileResponse( //nolint:dupl,funlen,ireturn
 	ctx context.Context,
 	file *processedFile,
 	logger *slog.Logger,

--- a/services/storage/controller/get_file_metadata_headers.go
+++ b/services/storage/controller/get_file_metadata_headers.go
@@ -147,7 +147,8 @@ func (ctrl *Controller) getFileMetadataHeadersResponseObject( //nolint:ireturn
 }
 
 func (ctrl *Controller) getFileMetadataHeaders( //nolint:ireturn
-	ctx context.Context, request api.GetFileMetadataHeadersRequestObject,
+	ctx context.Context,
+	request api.GetFileMetadataHeadersRequestObject,
 ) (api.GetFileMetadataHeadersResponseObject, *APIError) {
 	sessionHeaders := middleware.SessionHeadersFromContext(ctx)
 	acceptHeader := middleware.AcceptHeaderFromContext(ctx)
@@ -195,7 +196,8 @@ func (ctrl *Controller) getFileMetadataHeaders( //nolint:ireturn
 }
 
 func (ctrl *Controller) GetFileMetadataHeaders( //nolint:ireturn
-	ctx context.Context, request api.GetFileMetadataHeadersRequestObject,
+	ctx context.Context,
+	request api.GetFileMetadataHeadersRequestObject,
 ) (api.GetFileMetadataHeadersResponseObject, error) {
 	response, apiErr := ctrl.getFileMetadataHeaders(ctx, request)
 	if apiErr != nil {

--- a/services/storage/controller/get_file_presigned_url.go
+++ b/services/storage/controller/get_file_presigned_url.go
@@ -23,7 +23,8 @@ type GetFilePresignedURLRequest struct {
 }
 
 func (ctrl *Controller) GetFilePresignedURL( //nolint:ireturn
-	ctx context.Context, request api.GetFilePresignedURLRequestObject,
+	ctx context.Context,
+	request api.GetFilePresignedURLRequestObject,
 ) (api.GetFilePresignedURLResponseObject, error) {
 	logger := oapimw.LoggerFromContext(ctx)
 	logger = logger.With("file_id", request.Id)

--- a/services/storage/controller/get_file_with_presigned_url.go
+++ b/services/storage/controller/get_file_with_presigned_url.go
@@ -81,7 +81,7 @@ func getAmazonSignature(request api.GetFileWithPresignedURLRequestObject) string
 	)
 }
 
-func (ctrl *Controller) getFileWithPresignedURLResponseObject( //nolint: ireturn,dupl,funlen
+func (ctrl *Controller) getFileWithPresignedURLResponseObject( //nolint:dupl,funlen,ireturn
 	ctx context.Context,
 	file *processedFile,
 	logger *slog.Logger,
@@ -154,7 +154,7 @@ func (ctrl *Controller) getFileWithPresignedURLResponseObject( //nolint: ireturn
 	}
 }
 
-func (ctrl *Controller) GetFileWithPresignedURL( //nolint: ireturn
+func (ctrl *Controller) GetFileWithPresignedURL( //nolint:ireturn
 	ctx context.Context,
 	request api.GetFileWithPresignedURLRequestObject,
 ) (api.GetFileWithPresignedURLResponseObject, error) {

--- a/services/storage/controller/list_broken_metadata.go
+++ b/services/storage/controller/list_broken_metadata.go
@@ -69,7 +69,8 @@ func fileListSummary(files []FileSummary) *[]api.FileSummary {
 }
 
 func (ctrl *Controller) ListBrokenMetadata( //nolint:ireturn
-	ctx context.Context, _ api.ListBrokenMetadataRequestObject,
+	ctx context.Context,
+	_ api.ListBrokenMetadataRequestObject,
 ) (api.ListBrokenMetadataResponseObject, error) {
 	logger := oapimw.LoggerFromContext(ctx)
 

--- a/services/storage/controller/list_files_not_uploaded.go
+++ b/services/storage/controller/list_files_not_uploaded.go
@@ -50,7 +50,8 @@ func (ctrl *Controller) ListNotUploaded(ctx *gin.Context) {
 }
 
 func (ctrl *Controller) ListFilesNotUploaded( //nolint:ireturn
-	ctx context.Context, _ api.ListFilesNotUploadedRequestObject,
+	ctx context.Context,
+	_ api.ListFilesNotUploadedRequestObject,
 ) (api.ListFilesNotUploadedResponseObject, error) {
 	logger := oapimw.LoggerFromContext(ctx)
 

--- a/services/storage/controller/list_orphaned_files.go
+++ b/services/storage/controller/list_orphaned_files.go
@@ -45,7 +45,8 @@ func (ctrl *Controller) listOrphans(ctx context.Context) ([]string, *APIError) {
 }
 
 func (ctrl *Controller) ListOrphanedFiles( //nolint:ireturn
-	ctx context.Context, _ api.ListOrphanedFilesRequestObject,
+	ctx context.Context,
+	_ api.ListOrphanedFilesRequestObject,
 ) (api.ListOrphanedFilesResponseObject, error) {
 	logger := oapimw.LoggerFromContext(ctx)
 

--- a/services/storage/controller/upload_files.go
+++ b/services/storage/controller/upload_files.go
@@ -252,7 +252,8 @@ func parseUploadRequest(form *multipart.Form) (uploadFileRequest, *APIError) {
 }
 
 func (ctrl *Controller) UploadFiles( //nolint:ireturn
-	ctx context.Context, request api.UploadFilesRequestObject,
+	ctx context.Context,
+	request api.UploadFilesRequestObject,
 ) (api.UploadFilesResponseObject, error) {
 	logger := oapimw.LoggerFromContext(ctx)
 	sessionHeaders := middleware.SessionHeadersFromContext(ctx)

--- a/services/storage/storage/s3.go
+++ b/services/storage/storage/s3.go
@@ -18,7 +18,8 @@ import (
 	"github.com/nhost/nhost/services/storage/controller"
 )
 
-func deptr[T any](p *T) T { //nolint:ireturn
+//nolint:ireturn // generic helper returns the caller-selected type parameter.
+func deptr[T any](p *T) T {
 	if p == nil {
 		return *new(T)
 	}


### PR DESCRIPTION
<!-- nhost-reviewer:start -->
### **What this PR solves**
This PR tightens SQLite parity in Constellation by making LIKE semantics explicit per connection, rendering case-insensitive LIKE through dialect-aware predicates, and removing duplicate SQLite primary-key autoindexes from exposed upsert constraints. It also updates SQLite type introspection, generated goldens, docs, and mechanical storage lint formatting.

___

### **PR Type**
Enhancement

___

### **Description**
- Adds dialect-level case-sensitive LIKE operators and full case-insensitive LIKE condition writers for PostgreSQL and SQLite.
- Ensures SQLite connections consistently enable foreign keys, WAL, and case-sensitive LIKE through a private driver hook.
- Excludes SQLite PK-backed autoindexes from unique constraint introspection and refreshes schema/introspection goldens.
- Refines SQLite integer type mapping and updates user-facing feature documentation.
- Cleans up storage Go formatting and `nolint` directives without functional changes.

___

### Diagram Walkthrough

```mermaid
flowchart LR
  A["SQLite Open"] --> B["Private driver ConnectHook"]
  B --> C["PRAGMA foreign_keys / case_sensitive_like / WAL"]
  D["GraphQL where filters"] --> E["Dialect LIKE APIs"]
  E --> F["Postgres ILIKE"]
  E --> G["SQLite LOWER(...) LIKE LOWER(...)"]
  H["SQLite introspection"] --> I["Skip PK autoindexes"]
  I --> J["Updated GraphQL schema goldens"]
```

<details> <summary><h3> File Walkthrough</h3></summary>

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody>
<tr><td><strong>Constellation dialect and query generation</strong></td><td><details><summary>11 files</summary><table>
<tr><td><strong>services/constellation/connector/sql/graphql/queries/dialect/dialect.go</strong><dd><code>Replaces operator-only ILIKE APIs with LIKE operators plus full ILIKE condition writers.</code></dd></td><td><a href="https://github.com/nhost/nhost/pull/XXX/files#diff-c0ba41687cc1d508a197295df4108a8d67da574f6980c0ec687470fe439c4fd5">+16/-8</a></td></tr>
<tr><td><strong>services/constellation/connector/sql/graphql/queries/dialect/mock/dialect.go</strong><dd><code>Regenerates the dialect mock for the updated interface.</code></dd></td><td><a href="https://github.com/nhost/nhost/pull/XXX/files#diff-031b8b9256c10b6a2d6276eb0162539a2ce3c62574c6f4c78f22696f1ebd1486">+44/-20</a></td></tr>
<tr><td><strong>services/constellation/connector/sql/graphql/queries/dialect/postgres.go</strong><dd><code>Implements PostgreSQL LIKE and ILIKE condition rendering.</code></dd></td><td><a href="https://github.com/nhost/nhost/pull/XXX/files#diff-9021cdac5425b03b83359911e0b777034ca6fcc50c43aeb8e7a2cc20c66d63b5">+20/-4</a></td></tr>
<tr><td><strong>services/constellation/connector/sql/graphql/queries/dialect/postgres_test.go</strong><dd><code>Adds coverage for PostgreSQL LIKE and ILIKE dialect output.</code></dd></td><td><a href="https://github.com/nhost/nhost/pull/XXX/files#diff-e1ac0354cc544109486f7eaf62f1209748f7b918a734458b6b9abd663e17942b">+18/-4</a></td></tr>
<tr><td><strong>services/constellation/connector/sql/graphql/queries/dialect/sqlite.go</strong><dd><code>Implements SQLite LIKE and LOWER-based case-insensitive LIKE rendering.</code></dd></td><td><a href="https://github.com/nhost/nhost/pull/XXX/files#diff-cb0045eda25c927316e3ddff5d802b6386b9dd9e43f2e3c98def8701ffc27131">+25/-3</a></td></tr>
<tr><td><strong>services/constellation/connector/sql/graphql/queries/dialect/sqlite_test.go</strong><dd><code>Adds SQLite dialect assertions for JSON arrays and LIKE conditions.</code></dd></td><td><a href="https://github.com/nhost/nhost/pull/XXX/files#diff-ded64688f692c2dc8b7a5fc9d70ffa01e225e0916543f9e1e4e5b16f62dbfd3b">+19/-6</a></td></tr>
<tr><td><strong>services/constellation/connector/sql/graphql/queries/permissions/permissions_test.go</strong><dd><code>Adds SQLite row-level permission coverage for case-sensitive LIKE predicates.</code></dd></td><td><a href="https://github.com/nhost/nhost/pull/XXX/files#diff-a2e8df46484d99a82aca00cd3569e217bf1b6e8f623a4ef2416d9ce22aa1f704">+114/-0</a></td></tr>
<tr><td><strong>services/constellation/connector/sql/graphql/queries/sqlite_query_test.go</strong><dd><code>Adds a delete mutation regression for SQLite JSON empty arrays.</code></dd></td><td><a href="https://github.com/nhost/nhost/pull/XXX/files#diff-68faf6e048a40dc3244a6d490acca6664e89362e9d40455320919490374a63a3">+31/-0</a></td></tr>
<tr><td><strong>services/constellation/connector/sql/graphql/queries/testdata/TestBuildMutationDeleteSQL_SQLite/delete_returning_array_relationship_uses_JSON_empty_array.json</strong><dd><code>Adds the expected SQLite delete mutation SQL golden using json_array().</code></dd></td><td><a href="https://github.com/nhost/nhost/pull/XXX/files#diff-3c167464643edf613d8b73296e1e36adb97c60fc2f52f747244e2acfc0654a2f">+10/-0</a></td></tr>
<tr><td><strong>services/constellation/connector/sql/graphql/queries/where/filters.go</strong><dd><code>Routes LIKE filters through the new dialect condition writers.</code></dd></td><td><a href="https://github.com/nhost/nhost/pull/XXX/files#diff-365459e4fcf733ed67695d4194b45e1a06e014cef0e7aac9a7e13c2aebb4304e">+12/-12</a></td></tr>
<tr><td><strong>services/constellation/connector/sql/graphql/queries/where/filters_internal_test.go</strong><dd><code>Expands filter tests for case-sensitive and case-insensitive LIKE rendering.</code></dd></td><td><a href="https://github.com/nhost/nhost/pull/XXX/files#diff-fffd7f83a6245b0f51ba33725109e42ac78f005575ec358c0ab0b191e2540eef">+81/-12</a></td></tr>
</table></details></td></tr>
<tr><td><strong>Constellation SQLite introspection and driver</strong></td><td><details><summary>6 files</summary><table>
<tr><td><strong>services/constellation/connector/sql/sqlite/introspect.go</strong><dd><code>Skips PK-backed autoindexes and maps SQLite integer affinities more precisely.</code></dd></td><td><a href="https://github.com/nhost/nhost/pull/XXX/files#diff-f1377d09a939a200b7d8f0de7483760a60f45c27003d6c65c4ada115809cc318">+27/-10</a></td></tr>
<tr><td><strong>services/constellation/connector/sql/sqlite/introspect_internal_test.go</strong><dd><code>Updates type-support tests for int2 and int4 mappings.</code></dd></td><td><a href="https://github.com/nhost/nhost/pull/XXX/files#diff-f77a76d256d34155a8ea1086bf0d8be7e23ef529bc1697f041ee002389bd02db">+10/-4</a></td></tr>
<tr><td><strong>services/constellation/connector/sql/sqlite/introspect_test.go</strong><dd><code>Adds coverage proving PK autoindexes are not exposed as unique constraints.</code></dd></td><td><a href="https://github.com/nhost/nhost/pull/XXX/files#diff-f0f5d7517157781eb965301ef81ba6184b81ce90c5f33c45cf6a64ff8c364761">+76/-0</a></td></tr>
<tr><td><strong>services/constellation/connector/sql/sqlite/sqlite.go</strong><dd><code>Registers a private SQLite driver hook to apply connection PRAGMAs on every connection.</code></dd></td><td><a href="https://github.com/nhost/nhost/pull/XXX/files#diff-db22725c234abc5fd30320c993cfa3557049c77eb960254752a52738dde53dea">+60/-23</a></td></tr>
<tr><td><strong>services/constellation/connector/sql/sqlite/sqlite_test.go</strong><dd><code>Adds multi-connection tests for case-sensitive LIKE and foreign-key enforcement.</code></dd></td><td><a href="https://github.com/nhost/nhost/pull/XXX/files#diff-26a7670b127eeb03b3f08cc2d09f99c22eff80e7d2ce5a821360b243937dda3b">+156/-0</a></td></tr>
<tr><td><strong>services/constellation/connector/sql/sqlite/testdata/TestIntrospect/success.golden.json</strong><dd><code>Refreshes SQLite introspection golden output after removing PK autoindex unique constraints.</code></dd></td><td><a href="https://github.com/nhost/nhost/pull/XXX/files#diff-a3ead7c3b71d477d4ce7e606c630eb48e6e866738b40d3240deb98851778e066">+2/-29</a></td></tr>
</table></details></td></tr>
<tr><td><strong>Generated GraphQL schema goldens and docs</strong></td><td><details><summary>10 files</summary><table>
<tr><td><strong>services/constellation/CLAUDE.md</strong><dd><code>Removes a brittle method count from the Dialect interface note.</code></dd></td><td><a href="https://github.com/nhost/nhost/pull/XXX/files#diff-9b18f251928cc18a41691831743f3f42bde9187a6c5d87d8b9bb3024fa2a28cb">+1/-1</a></td></tr>
<tr><td><strong>services/constellation/connector/sql/graphql/schema/testdata/TestGenerateForRole_SQLite/admin.graphqls</strong><dd><code>Removes PK-backed sqlite_autoindex constraints from the admin SQLite schema golden.</code></dd></td><td><a href="https://github.com/nhost/nhost/pull/XXX/files#diff-9155c4b9ed67a0a2ae69a64173b7f3ceceb37ab8eaa7a9243aec2c5bdb57dafc">+0/-108</a></td></tr>
<tr><td><strong>services/constellation/connector/sql/graphql/schema/testdata/TestGenerateForRole_SQLite/mixed_permissions.graphqls</strong><dd><code>Updates mixed-permission SQLite constraint output.</code></dd></td><td><a href="https://github.com/nhost/nhost/pull/XXX/files#diff-3b16e62e9a2e23e9582a72486451b5c1a4d22d7963f71d94636ed8ceab4c5bbe">+0/-4</a></td></tr>
<tr><td><strong>services/constellation/connector/sql/graphql/schema/testdata/TestGenerateForRole_SQLite/queries_relationships.graphqls</strong><dd><code>Updates relationship schema golden constraint enums.</code></dd></td><td><a href="https://github.com/nhost/nhost/pull/XXX/files#diff-cd54bfc70a052d449ad7242765e8ea7a73308a1ff40542cb2e8472fd8f5bb1d7">+0/-20</a></td></tr>
<tr><td><strong>services/constellation/connector/sql/graphql/schema/testdata/TestGenerateForRole_SQLite/queries_relationships_enum.graphqls</strong><dd><code>Updates enum relationship schema golden constraint enums.</code></dd></td><td><a href="https://github.com/nhost/nhost/pull/XXX/files#diff-7b4237ba521572cbf400b1aa5eeb465b4ecde2a8b5b2d4de45e301c91c8796a2">+0/-12</a></td></tr>
<tr><td><strong>services/constellation/connector/sql/graphql/schema/testdata/TestGenerateForRole_SQLite/queries_relationships_enum_no_perms.graphqls</strong><dd><code>Updates no-permission enum relationship schema golden constraints.</code></dd></td><td><a href="https://github.com/nhost/nhost/pull/XXX/files#diff-82eb95cf3da870a162f28c250ae2013e55f19d90c090f28d94dc37e6665cc833">+0/-8</a></td></tr>
<tr><td><strong>services/constellation/connector/sql/graphql/schema/testdata/TestGenerateForRole_SQLite/simplequeries.graphqls</strong><dd><code>Updates simple query schema golden constraints.</code></dd></td><td><a href="https://github.com/nhost/nhost/pull/XXX/files#diff-8c3c745ed0a1da5bfe13549bc3883ec87aa02d5ebd7ffcf69f2a9afd584e9214">+0/-4</a></td></tr>
<tr><td><strong>services/constellation/connector/sql/graphql/schema/testdata/TestGenerateForRole_SQLite/simplequeries_aggregation.graphqls</strong><dd><code>Updates aggregation schema golden constraints.</code></dd></td><td><a href="https://github.com/nhost/nhost/pull/XXX/files#diff-c7228672c2cad3367e68eb0cc71900228dc774e8d4fa77979b50d307bce732bf">+0/-4</a></td></tr>
<tr><td><strong>services/constellation/connector/sql/graphql/schema/testdata/TestGenerateForRole_SQLite/user.graphqls</strong><dd><code>Updates user role schema golden constraints.</code></dd></td><td><a href="https://github.com/nhost/nhost/pull/XXX/files#diff-7bd4e33094c4613681b288202e4fc3651592b89ddda1227124fa2c0ec296ec68">+0/-40</a></td></tr>
<tr><td><strong>services/constellation/docs/user/postgres-features.md</strong><dd><code>Documents SQLite ILIKE behavior and aggregate support more precisely.</code></dd></td><td><a href="https://github.com/nhost/nhost/pull/XXX/files#diff-b2d33657db29fbf0cc12de1a45ddb33055cfbc069b63a7e6854df0af9b1fbc78">+2/-2</a></td></tr>
</table></details></td></tr>
<tr><td><strong>Storage lint cleanup</strong></td><td><details><summary>9 files</summary><table>
<tr><td><strong>services/storage/controller/get_file.go</strong><dd><code>Normalizes generic helper nolint justification and response nolint formatting.</code></dd></td><td><a href="https://github.com/nhost/nhost/pull/XXX/files#diff-d41af2374eb5382e529af51602911ab58609676b9d4226ae7634d7c76fe6b879">+3/-2</a></td></tr>
<tr><td><strong>services/storage/controller/get_file_metadata_headers.go</strong><dd><code>Applies golines formatting to OpenAPI handler signatures.</code></dd></td><td><a href="https://github.com/nhost/nhost/pull/XXX/files#diff-4acef768729223e34842615b51efd20001fdd0b5009410c3f2ef44408903cf32">+4/-2</a></td></tr>
<tr><td><strong>services/storage/controller/get_file_presigned_url.go</strong><dd><code>Splits the presigned URL handler signature across lines.</code></dd></td><td><a href="https://github.com/nhost/nhost/pull/XXX/files#diff-87af644ca0f439e771aa8cf4cad99dd277b8b8e3894a973563bc8906decef7c8">+2/-1</a></td></tr>
<tr><td><strong>services/storage/controller/get_file_with_presigned_url.go</strong><dd><code>Normalizes nolint directive spacing and ordering.</code></dd></td><td><a href="https://github.com/nhost/nhost/pull/XXX/files#diff-ce2d278e0ef170950ebca532ab7776acd93d411223848bed724ea0c4333f7d31">+2/-2</a></td></tr>
<tr><td><strong>services/storage/controller/list_broken_metadata.go</strong><dd><code>Applies golines formatting to the broken metadata handler signature.</code></dd></td><td><a href="https://github.com/nhost/nhost/pull/XXX/files#diff-ff3707ec8c59e0ef0fc2b6bc9f51b2610dae9f867ffb9773b369bda5efd29a46">+2/-1</a></td></tr>
<tr><td><strong>services/storage/controller/list_files_not_uploaded.go</strong><dd><code>Applies golines formatting to the not-uploaded files handler signature.</code></dd></td><td><a href="https://github.com/nhost/nhost/pull/XXX/files#diff-b98b04148a59a76db6fe781a508807b362038deb24efef7c686b3fbe14c4ae01">+2/-1</a></td></tr>
<tr><td><strong>services/storage/controller/list_orphaned_files.go</strong><dd><code>Applies golines formatting to the orphaned files handler signature.</code></dd></td><td><a href="https://github.com/nhost/nhost/pull/XXX/files#diff-5609bca2bfb5793c81f684f5ba2782d48599e94654eb9b31c5379ded0dff2da4">+2/-1</a></td></tr>
<tr><td><strong>services/storage/controller/upload_files.go</strong><dd><code>Applies golines formatting to the upload handler signature.</code></dd></td><td><a href="https://github.com/nhost/nhost/pull/XXX/files#diff-d5ee48102be2048a4ca0976e3271f24f0172367a32b25d6f033c909b3659bef9">+2/-1</a></td></tr>
<tr><td><strong>services/storage/storage/s3.go</strong><dd><code>Adds a justification for the generic helper ireturn nolint directive.</code></dd></td><td><a href="https://github.com/nhost/nhost/pull/XXX/files#diff-6cdefe76cc412b7d6a5daf67961ca72e2389507c82cb13b42957a578558d2488">+2/-1</a></td></tr>
</table></details></td></tr>
</tbody></table>

</details>

___

<!-- nhost-reviewer:end -->