### PR TITLE
fix(constellation): handle phantom field alias collisions in remote relationships

### DIFF
--- a/services/constellation/controller/planner/analyzer.go
+++ b/services/constellation/controller/planner/analyzer.go
@@ -1,10 +1,15 @@
 package planner
 
 import (
+	"fmt"
+	"strings"
+
 	"github.com/nhost/nhost/services/constellation/controller/planner/transform"
 	"github.com/nhost/nhost/services/constellation/internal/jsonpath"
 	"github.com/vektah/gqlparser/v2/ast"
 )
+
+const phantomAliasPrefix = "_constellation_phantom_"
 
 // analyzer walks a GraphQL AST and detects remote relationships.
 type analyzer struct {
@@ -261,14 +266,22 @@ func (a *analyzer) processPhantomFields(
 		return
 	}
 
-	// Check which fields are already selected
-	selectedFields := a.collectSelectedFields(field)
+	// Check which fields are already available under their own response key.
+	selectedFields := a.collectOwnResponseKeyFields(field)
+	responseKeys := a.collectResponseKeys(field)
 
 	// Determine which phantom fields need to be added
 	var phantomFields []string
+
+	phantomAliases := make(map[string]string)
 	for col := range neededPhantoms {
-		if _, ok := selectedFields[col]; !ok {
-			phantomFields = append(phantomFields, col)
+		if _, ok := selectedFields[col]; ok {
+			continue
+		}
+
+		phantomFields = append(phantomFields, col)
+		if _, collides := responseKeys[col]; collides {
+			phantomAliases[col] = makePhantomAlias(col, responseKeys)
 		}
 	}
 
@@ -276,10 +289,15 @@ func (a *analyzer) processPhantomFields(
 		return
 	}
 
+	if len(phantomAliases) == 0 {
+		phantomAliases = nil
+	}
+
 	// Record phantom field spec
 	pfs := &PhantomFieldSpec{
 		Path:            path,
 		Fields:          phantomFields,
+		Aliases:         phantomAliases,
 		ForRelationship: phantomForRel,
 	}
 	result.PhantomFields = append(result.PhantomFields, pfs)
@@ -325,6 +343,89 @@ func (a *analyzer) collectSelectedFieldsFromSelections(
 			a.collectSelectedFieldsFromSelections(s.SelectionSet, selectedFields)
 		}
 	}
+}
+
+// collectOwnResponseKeyFields returns fields selected with the same response
+// key as their underlying field name. Only these fields make a join column
+// available at parentRow[column] without an injected phantom.
+func (a *analyzer) collectOwnResponseKeyFields(field *ast.Field) map[string]struct{} {
+	selectedFields := make(map[string]struct{})
+	a.collectOwnResponseKeyFieldsFromSelections(field.SelectionSet, selectedFields)
+
+	return selectedFields
+}
+
+func (a *analyzer) collectOwnResponseKeyFieldsFromSelections(
+	selections ast.SelectionSet,
+	selectedFields map[string]struct{},
+) {
+	for _, sel := range selections {
+		switch s := sel.(type) {
+		case *ast.Field:
+			if s.Alias == "" || s.Alias == s.Name {
+				selectedFields[s.Name] = struct{}{}
+			}
+		case *ast.FragmentSpread:
+			if frag := a.fragments.ForName(s.Name); frag != nil {
+				a.collectOwnResponseKeyFieldsFromSelections(frag.SelectionSet, selectedFields)
+			}
+		case *ast.InlineFragment:
+			a.collectOwnResponseKeyFieldsFromSelections(s.SelectionSet, selectedFields)
+		}
+	}
+}
+
+// collectResponseKeys returns every response key in the field's selection set.
+func (a *analyzer) collectResponseKeys(field *ast.Field) map[string]struct{} {
+	responseKeys := make(map[string]struct{})
+	a.collectResponseKeysFromSelections(field.SelectionSet, responseKeys)
+
+	return responseKeys
+}
+
+func (a *analyzer) collectResponseKeysFromSelections(
+	selections ast.SelectionSet,
+	responseKeys map[string]struct{},
+) {
+	for _, sel := range selections {
+		switch s := sel.(type) {
+		case *ast.Field:
+			responseKeys[fieldResponseKey(s)] = struct{}{}
+		case *ast.FragmentSpread:
+			if frag := a.fragments.ForName(s.Name); frag != nil {
+				a.collectResponseKeysFromSelections(frag.SelectionSet, responseKeys)
+			}
+		case *ast.InlineFragment:
+			a.collectResponseKeysFromSelections(s.SelectionSet, responseKeys)
+		}
+	}
+}
+
+func makePhantomAlias(fieldName string, responseKeys map[string]struct{}) string {
+	base := phantomAliasPrefix + sanitizePhantomAliasPart(fieldName)
+	alias := base
+
+	for i := 1; ; i++ {
+		if _, exists := responseKeys[alias]; !exists {
+			responseKeys[alias] = struct{}{}
+
+			return alias
+		}
+
+		alias = fmt.Sprintf("%s_%d", base, i)
+	}
+}
+
+func sanitizePhantomAliasPart(fieldName string) string {
+	return strings.NewReplacer(".", "_", "-", "_").Replace(fieldName)
+}
+
+func fieldResponseKey(field *ast.Field) string {
+	if field.Alias != "" {
+		return field.Alias
+	}
+
+	return field.Name
 }
 
 // recurseIntoNestedFields recursively analyzes non-relationship fields.

--- a/services/constellation/controller/planner/analyzer.go
+++ b/services/constellation/controller/planner/analyzer.go
@@ -311,40 +311,6 @@ func (a *analyzer) processPhantomFields(
 	}
 }
 
-// collectSelectedFields returns a set of field names already selected in the field's selection set.
-// It expands fragment spreads and inline fragments to detect fields selected through fragments.
-func (a *analyzer) collectSelectedFields(field *ast.Field) map[string]struct{} {
-	selectedFields := make(map[string]struct{})
-	a.collectSelectedFieldsFromSelections(field.SelectionSet, selectedFields)
-
-	return selectedFields
-}
-
-// collectSelectedFieldsFromSelections recursively collects field names from a selection set,
-// expanding fragment spreads and inline fragments.
-func (a *analyzer) collectSelectedFieldsFromSelections(
-	selections ast.SelectionSet,
-	selectedFields map[string]struct{},
-) {
-	for _, sel := range selections {
-		switch s := sel.(type) {
-		case *ast.Field:
-			name := s.Name
-			if s.Alias != "" {
-				name = s.Alias
-			}
-
-			selectedFields[name] = struct{}{}
-		case *ast.FragmentSpread:
-			if frag := a.fragments.ForName(s.Name); frag != nil {
-				a.collectSelectedFieldsFromSelections(frag.SelectionSet, selectedFields)
-			}
-		case *ast.InlineFragment:
-			a.collectSelectedFieldsFromSelections(s.SelectionSet, selectedFields)
-		}
-	}
-}
-
 // collectOwnResponseKeyFields returns fields selected with the same response
 // key as their underlying field name. Only these fields make a join column
 // available at parentRow[column] without an injected phantom.

--- a/services/constellation/controller/planner/analyzer_internal_test.go
+++ b/services/constellation/controller/planner/analyzer_internal_test.go
@@ -619,6 +619,48 @@ func TestAnalyzeField_SkipsPhantomWhenColumnAlreadySelected(t *testing.T) {
 	}
 }
 
+func TestAnalyzeField_AliasedUnrelatedFieldDoesNotSuppressPhantom(t *testing.T) {
+	t.Parallel()
+
+	rel := analyzerTestRelationship()
+	a := newAnalyzer("db1", analyzerTestSchema(), []*RelationshipMetadata{rel}, ast.Query, nil)
+
+	field := &ast.Field{
+		Name: "users",
+		SelectionSet: ast.SelectionSet{
+			&ast.Field{Name: "id", Alias: "department_id"},
+			&ast.Field{
+				Name:         "department",
+				SelectionSet: ast.SelectionSet{&ast.Field{Name: "name"}},
+			},
+		},
+	}
+
+	result := &analysisResult{
+		PhantomFields: []*PhantomFieldSpec{},
+		RemoteQueries: []*RemoteQueryPlan{},
+	}
+
+	a.analyzeField(field, "users", jsonpath.Parse("users"), result)
+
+	if len(result.PhantomFields) != 1 {
+		t.Fatalf("expected one phantom field spec, got %+v", result.PhantomFields)
+	}
+
+	spec := result.PhantomFields[0]
+	if len(spec.Fields) != 1 || spec.Fields[0] != "department_id" {
+		t.Fatalf("expected department_id phantom, got %+v", spec.Fields)
+	}
+
+	if got := spec.Aliases["department_id"]; got != "_constellation_phantom_department_id" {
+		t.Fatalf("expected internal alias for colliding phantom, got %q", got)
+	}
+
+	if result.RemoteQueries[0].SourcePhantomFields != spec {
+		t.Fatalf("expected remote query to reference source phantom spec")
+	}
+}
+
 // ---------- analyzer.collectSelectedFields ----------
 
 func TestAnalyzer_CollectSelectedFields_ExpandsFragments(t *testing.T) {

--- a/services/constellation/controller/planner/analyzer_internal_test.go
+++ b/services/constellation/controller/planner/analyzer_internal_test.go
@@ -661,9 +661,11 @@ func TestAnalyzeField_AliasedUnrelatedFieldDoesNotSuppressPhantom(t *testing.T) 
 	}
 }
 
-// ---------- analyzer.collectSelectedFields ----------
+// ---------- analyzer.collectOwnResponseKeyFields / collectResponseKeys ----------
 
-func TestAnalyzer_CollectSelectedFields_ExpandsFragments(t *testing.T) {
+func TestAnalyzer_CollectOwnResponseKeyFields_ExpandsFragmentsAndIgnoresRenamedFields(
+	t *testing.T,
+) {
 	t.Parallel()
 
 	frag := &ast.FragmentDefinition{
@@ -671,6 +673,7 @@ func TestAnalyzer_CollectSelectedFields_ExpandsFragments(t *testing.T) {
 		TypeCondition: "users",
 		SelectionSet: ast.SelectionSet{
 			&ast.Field{Name: "email", Alias: "user_email"},
+			&ast.Field{Name: "created_at", Alias: "created_at"},
 		},
 	}
 
@@ -696,11 +699,27 @@ func TestAnalyzer_CollectSelectedFields_ExpandsFragments(t *testing.T) {
 		},
 	}
 
-	got := a.collectSelectedFields(field)
+	ownResponseKeys := a.collectOwnResponseKeyFields(field)
+	for _, want := range []string{"id", "created_at", "name"} {
+		if _, ok := ownResponseKeys[want]; !ok {
+			t.Errorf("expected %q in own-response-key fields, got %v", want, ownResponseKeys)
+		}
+	}
 
-	for _, want := range []string{"id", "user_email", "name"} {
-		if _, ok := got[want]; !ok {
-			t.Errorf("expected %q in selected fields, got %v", want, got)
+	for _, unwanted := range []string{"email", "user_email"} {
+		if _, ok := ownResponseKeys[unwanted]; ok {
+			t.Errorf(
+				"did not expect %q in own-response-key fields, got %v",
+				unwanted,
+				ownResponseKeys,
+			)
+		}
+	}
+
+	responseKeys := a.collectResponseKeys(field)
+	for _, want := range []string{"id", "user_email", "created_at", "name"} {
+		if _, ok := responseKeys[want]; !ok {
+			t.Errorf("expected %q in response keys, got %v", want, responseKeys)
 		}
 	}
 }

--- a/services/constellation/controller/planner/planner.go
+++ b/services/constellation/controller/planner/planner.go
@@ -157,8 +157,9 @@ func toPhantomSpecs(specs []*PhantomFieldSpec) []transform.PhantomSpec {
 	out := make([]transform.PhantomSpec, 0, len(specs))
 	for _, s := range specs {
 		out = append(out, transform.PhantomSpec{
-			Path:   s.Path,
-			Fields: s.Fields,
+			Path:    s.Path,
+			Fields:  s.Fields,
+			Aliases: s.Aliases,
 		})
 	}
 

--- a/services/constellation/controller/planner/transform/transform.go
+++ b/services/constellation/controller/planner/transform/transform.go
@@ -37,6 +37,10 @@ type PhantomSpec struct {
 
 	// Fields are the field names to add (e.g. ["user_id", "department_id"]).
 	Fields []string
+
+	// Aliases maps field names to the internal response key to use when
+	// injecting a phantom field. An absent entry means no alias is needed.
+	Aliases map[string]string
 }
 
 // Transformer transforms GraphQL operations to strip relationship fields
@@ -413,13 +417,18 @@ func InjectPhantomFields(operation *ast.OperationDefinition, specs []PhantomSpec
 	}
 
 	for _, spec := range specs {
-		injectFieldsAtPath(operation.SelectionSet, []string(spec.Path), spec.Fields)
+		injectFieldsAtPath(operation.SelectionSet, []string(spec.Path), spec.Fields, spec.Aliases)
 	}
 }
 
 // injectFieldsAtPath injects fields at the given path in the selection set.
 // Path is like ["users", "profile"] meaning inject into users -> profile's selection.
-func injectFieldsAtPath(ss ast.SelectionSet, path []string, fields []string) {
+func injectFieldsAtPath(
+	ss ast.SelectionSet,
+	path []string,
+	fields []string,
+	aliases map[string]string,
+) {
 	if len(path) == 0 || len(fields) == 0 {
 		return
 	}
@@ -440,13 +449,13 @@ func injectFieldsAtPath(ss ast.SelectionSet, path []string, fields []string) {
 		}
 
 		if len(path) == 1 {
-			injectFieldsIntoSelectionSet(field, fields)
+			injectFieldsIntoSelectionSet(field, fields, aliases)
 
 			return
 		}
 
 		if field.SelectionSet != nil {
-			injectFieldsAtPath(field.SelectionSet, path[1:], fields)
+			injectFieldsAtPath(field.SelectionSet, path[1:], fields, aliases)
 		}
 
 		return
@@ -454,7 +463,11 @@ func injectFieldsAtPath(ss ast.SelectionSet, path []string, fields []string) {
 }
 
 // injectFieldsIntoSelectionSet adds fields to a field's selection set if not already present.
-func injectFieldsIntoSelectionSet(field *ast.Field, fieldNames []string) {
+func injectFieldsIntoSelectionSet(
+	field *ast.Field,
+	fieldNames []string,
+	aliases map[string]string,
+) {
 	if field.SelectionSet == nil {
 		field.SelectionSet = make(ast.SelectionSet, 0)
 	}
@@ -462,12 +475,7 @@ func injectFieldsIntoSelectionSet(field *ast.Field, fieldNames []string) {
 	existing := make(map[string]struct{})
 	for _, sel := range field.SelectionSet {
 		if f, ok := sel.(*ast.Field); ok {
-			name := f.Name
-			if f.Alias != "" {
-				name = f.Alias
-			}
-
-			existing[name] = struct{}{}
+			existing[f.Name] = struct{}{}
 		}
 	}
 
@@ -477,7 +485,8 @@ func injectFieldsIntoSelectionSet(field *ast.Field, fieldNames []string) {
 		}
 
 		field.SelectionSet = append(field.SelectionSet, &ast.Field{ //nolint:exhaustruct
-			Name: name,
+			Alias: aliases[name],
+			Name:  name,
 		})
 	}
 }

--- a/services/constellation/controller/planner/transform/transform.go
+++ b/services/constellation/controller/planner/transform/transform.go
@@ -475,12 +475,13 @@ func injectFieldsIntoSelectionSet(
 	existing := make(map[string]struct{})
 	for _, sel := range field.SelectionSet {
 		if f, ok := sel.(*ast.Field); ok {
-			existing[f.Name] = struct{}{}
+			existing[fieldResponseKey(f)] = struct{}{}
 		}
 	}
 
 	for _, name := range fieldNames {
-		if _, ok := existing[name]; ok {
+		responseKey := phantomResponseKey(name, aliases)
+		if _, ok := existing[responseKey]; ok {
 			continue
 		}
 
@@ -488,5 +489,22 @@ func injectFieldsIntoSelectionSet(
 			Alias: aliases[name],
 			Name:  name,
 		})
+		existing[responseKey] = struct{}{}
 	}
+}
+
+func fieldResponseKey(field *ast.Field) string {
+	if field.Alias != "" {
+		return field.Alias
+	}
+
+	return field.Name
+}
+
+func phantomResponseKey(fieldName string, aliases map[string]string) string {
+	if alias := aliases[fieldName]; alias != "" {
+		return alias
+	}
+
+	return fieldName
 }

--- a/services/constellation/controller/planner/transform/transform_test.go
+++ b/services/constellation/controller/planner/transform/transform_test.go
@@ -798,6 +798,49 @@ func TestInjectPhantomFields_DeduplicatesExistingFields(t *testing.T) {
 	}
 }
 
+func TestInjectPhantomFields_InjectsUnaliasedPhantomWhenExistingFieldUsesDifferentAlias(
+	t *testing.T,
+) {
+	t.Parallel()
+
+	op := &ast.OperationDefinition{
+		Operation: ast.Query,
+		Name:      "GetUsers",
+		SelectionSet: ast.SelectionSet{
+			&ast.Field{
+				Name: "users",
+				SelectionSet: ast.SelectionSet{
+					&ast.Field{Name: "id"},
+					&ast.Field{Name: "department_id", Alias: "dep_id"},
+				},
+			},
+		},
+	}
+
+	specs := []transform.PhantomSpec{
+		{
+			Path:   jsonpath.Parse("users"),
+			Fields: []string{"department_id"},
+		},
+	}
+
+	transform.InjectPhantomFields(op, specs)
+
+	usersField, ok := op.SelectionSet[0].(*ast.Field)
+	if !ok {
+		t.Fatal("expected root selection to be *ast.Field")
+	}
+
+	responseKeys := fieldNames(usersField.SelectionSet)
+	if !containsString(responseKeys, "dep_id") {
+		t.Fatalf("expected original aliased field to remain, got %v", responseKeys)
+	}
+
+	if !containsString(responseKeys, "department_id") {
+		t.Fatalf("expected unaliased phantom field to be injected, got %v", responseKeys)
+	}
+}
+
 func TestInjectPhantomFields_AliasCollisionUsesPhantomAlias(t *testing.T) {
 	t.Parallel()
 

--- a/services/constellation/controller/planner/transform/transform_test.go
+++ b/services/constellation/controller/planner/transform/transform_test.go
@@ -798,6 +798,47 @@ func TestInjectPhantomFields_DeduplicatesExistingFields(t *testing.T) {
 	}
 }
 
+func TestInjectPhantomFields_AliasCollisionUsesPhantomAlias(t *testing.T) {
+	t.Parallel()
+
+	op := &ast.OperationDefinition{
+		Operation: ast.Query,
+		Name:      "GetUsers",
+		SelectionSet: ast.SelectionSet{
+			&ast.Field{
+				Name: "users",
+				SelectionSet: ast.SelectionSet{
+					&ast.Field{Name: "id", Alias: "department_id"},
+				},
+			},
+		},
+	}
+
+	specs := []transform.PhantomSpec{
+		{
+			Path:    jsonpath.Parse("users"),
+			Fields:  []string{"department_id"},
+			Aliases: map[string]string{"department_id": "_constellation_phantom_department_id"},
+		},
+	}
+
+	transform.InjectPhantomFields(op, specs)
+
+	usersField, ok := op.SelectionSet[0].(*ast.Field)
+	if !ok {
+		t.Fatal("expected root selection to be *ast.Field")
+	}
+
+	responseKeys := fieldNames(usersField.SelectionSet)
+	if !containsString(responseKeys, "department_id") {
+		t.Fatalf("expected original aliased field to remain, got %v", responseKeys)
+	}
+
+	if !containsString(responseKeys, "_constellation_phantom_department_id") {
+		t.Fatalf("expected aliased phantom field to be injected, got %v", responseKeys)
+	}
+}
+
 func TestInjectPhantomFields_NoOpWithEmptySpecs(t *testing.T) {
 	t.Parallel()
 

--- a/services/constellation/controller/planner/types.go
+++ b/services/constellation/controller/planner/types.go
@@ -90,6 +90,11 @@ type PhantomFieldSpec struct {
 	// Fields are the field names to add (e.g., ["user_id", "department_id"]).
 	Fields []string
 
+	// Aliases maps field names to the internal response key that should be used
+	// when injecting the phantom field. An absent entry means the field can be
+	// injected without an alias.
+	Aliases map[string]string
+
 	// ForRelationship identifies which relationship needs these phantom fields.
 	ForRelationship string
 }

--- a/services/constellation/controller/resolver/aggregate_resolver.go
+++ b/services/constellation/controller/resolver/aggregate_resolver.go
@@ -101,7 +101,7 @@ func (r *RemoteRelationshipResolver) executeAndStitchAggregate(
 // aggregate execution.
 func uniqueJoinValues(joinArgs []*remoteJoinArgument, sourceCol string) []any {
 	joinValues := make([]any, 0, len(joinArgs))
-	seen := make(map[any]struct{}, len(joinArgs))
+	seen := make(map[string]struct{}, len(joinArgs))
 
 	for _, arg := range joinArgs {
 		v := arg.values[sourceCol]
@@ -109,11 +109,12 @@ func uniqueJoinValues(joinArgs []*remoteJoinArgument, sourceCol string) []any {
 			continue
 		}
 
-		if _, ok := seen[v]; ok {
+		key := joinValueDedupKey(v)
+		if _, ok := seen[key]; ok {
 			continue
 		}
 
-		seen[v] = struct{}{}
+		seen[key] = struct{}{}
 
 		joinValues = append(joinValues, v)
 	}

--- a/services/constellation/controller/resolver/aggregate_resolver.go
+++ b/services/constellation/controller/resolver/aggregate_resolver.go
@@ -138,8 +138,13 @@ func stitchAggregateResults(
 
 	outputName := rq.alias
 
+	lookupKey := sourceCol
+	if alias, ok := rq.localJoinAliases[sourceCol]; ok {
+		lookupKey = alias
+	}
+
 	parentPath.ForEach(results, func(parentRow map[string]any) {
-		v := parentRow[sourceCol]
+		v := parentRow[lookupKey]
 		if v == nil {
 			parentRow[outputName] = nil
 

--- a/services/constellation/controller/resolver/aggregate_resolver_internal_test.go
+++ b/services/constellation/controller/resolver/aggregate_resolver_internal_test.go
@@ -417,6 +417,27 @@ func TestUniqueJoinValues_DedupesAndSkipsNil(t *testing.T) {
 // TestUniqueJoinValues_EmptyInput returns an empty slice (not nil) for empty
 // join arguments, satisfying the early-return contract in
 // executeAndStitchAggregate.
+func TestUniqueJoinValues_HandlesNonComparable(t *testing.T) {
+	t.Parallel()
+
+	sliceValue := []any{"a", "b"}
+	mapValue := map[string]any{"k": "v"}
+	joinArgs := []*remoteJoinArgument{
+		newRemoteJoinArgument(map[string]any{"deptId": sliceValue}),
+		newRemoteJoinArgument(map[string]any{"deptId": []any{"a", "b"}}),
+		newRemoteJoinArgument(map[string]any{"deptId": mapValue}),
+		newRemoteJoinArgument(map[string]any{"deptId": map[string]any{"k": "v"}}),
+		newRemoteJoinArgument(map[string]any{"deptId": "d1"}),
+	}
+
+	got := uniqueJoinValues(joinArgs, "deptId")
+
+	want := []any{sliceValue, mapValue, "d1"}
+	if diff := cmp.Diff(want, got); diff != "" {
+		t.Errorf("uniqueJoinValues mismatch (-want +got):\n%s", diff)
+	}
+}
+
 func TestUniqueJoinValues_EmptyInput(t *testing.T) {
 	t.Parallel()
 

--- a/services/constellation/controller/resolver/aggregate_resolver_internal_test.go
+++ b/services/constellation/controller/resolver/aggregate_resolver_internal_test.go
@@ -176,6 +176,63 @@ func TestExecuteAndStitchAggregate_HappyPath(t *testing.T) {
 	}
 }
 
+func TestStitchAggregateResults_UsesLocalJoinAlias(t *testing.T) {
+	t.Parallel()
+
+	aggregateResult := map[string]any{
+		"d1": map[string]any{
+			"aggregate": map[string]any{"count": 3},
+			"nodes":     []any{map[string]any{"id": "m1"}},
+		},
+	}
+
+	results := map[string]any{
+		"teams": []any{
+			map[string]any{
+				"name":                           "Engineering",
+				"dept_id":                        "shadow-value",
+				"_constellation_phantom_dept_id": "d1",
+			},
+		},
+	}
+
+	rq := &remoteQuery{
+		alias:      "members_aggregate",
+		parentPath: jsonpath.Parse("teams"),
+		localJoinAliases: map[string]string{
+			"dept_id": "_constellation_phantom_dept_id",
+		},
+		sourceField: &ast.Field{
+			Name: "members_aggregate",
+			SelectionSet: ast.SelectionSet{
+				&ast.Field{
+					Name: "aggregate",
+					SelectionSet: ast.SelectionSet{
+						&ast.Field{Name: "count"},
+					},
+				},
+				&ast.Field{Name: "nodes"},
+			},
+		},
+	}
+
+	stitchAggregateResults(rq, results, aggregateResult, "dept_id")
+
+	teams, ok := results["teams"].([]any)
+	if !ok {
+		t.Fatal("teams missing or wrong type")
+	}
+
+	team0, ok := teams[0].(map[string]any)
+	if !ok {
+		t.Fatal("teams[0] wrong type")
+	}
+
+	if diff := cmp.Diff(aggregateResult["d1"], team0["members_aggregate"]); diff != "" {
+		t.Errorf("team[0] aliased aggregate mismatch (-want +got):\n%s", diff)
+	}
+}
+
 // TestExecuteAndStitchAggregate_NilSourceColumnEmits stitches a nil result for
 // parent rows whose join column is itself nil. This guards the
 // stitchAggregateResults early-return for v == nil.

--- a/services/constellation/controller/resolver/database_resolver.go
+++ b/services/constellation/controller/resolver/database_resolver.go
@@ -31,23 +31,41 @@ func (r *databaseResolver) BuildOperation(rq *remoteQuery) *ast.OperationDefinit
 	}
 
 	whereArg := r.buildWhereArgument(rq)
+	if userWhere := findWhereArgument(rq.sourceField.Arguments); rq.isArray && userWhere != nil {
+		whereArg.Value = andMergeWhereValues(whereArg.Value, userWhere.Value)
+	}
 
 	// We need the remote join columns in the result to match against parent rows.
 	selectionSet := make(ast.SelectionSet, 0, len(rq.sourceField.SelectionSet)+len(r.joinColumns))
 	selectionSet = append(selectionSet, rq.sourceField.SelectionSet...)
 
-	// Add remote join columns if not already in selection and track which ones we inject
+	// Add remote join columns if not already in selection and track which ones we inject.
+	responseKeys := collectSelectionResponseKeys(rq.sourceField.SelectionSet, rq.fragments)
 	for _, remoteCol := range r.joinColumns {
-		// Check if field is already selected (including within fragments)
-		found := selectionContainsField(rq.sourceField.SelectionSet, rq.fragments, remoteCol)
-
-		if !found {
-			selectionSet = append(selectionSet, &ast.Field{ //nolint:exhaustruct
-				Name: remoteCol,
-			})
-			// Mark as phantom field to remove later since user didn't request it
-			rq.remotePhantomFields = append(rq.remotePhantomFields, remoteCol)
+		if selectionContainsField(rq.sourceField.SelectionSet, rq.fragments, remoteCol) {
+			continue
 		}
+
+		alias := ""
+
+		phantomResponseKey := remoteCol
+		if _, collides := responseKeys[remoteCol]; collides {
+			alias = makeRemotePhantomAlias(remoteCol, responseKeys)
+			phantomResponseKey = alias
+
+			if rq.remoteJoinAliases == nil {
+				rq.remoteJoinAliases = make(map[string]string)
+			}
+
+			rq.remoteJoinAliases[remoteCol] = alias
+		}
+
+		selectionSet = append(selectionSet, &ast.Field{ //nolint:exhaustruct
+			Alias: alias,
+			Name:  remoteCol,
+		})
+		// Mark as phantom response key to remove later since user didn't request it.
+		rq.remotePhantomFields = append(rq.remotePhantomFields, phantomResponseKey)
 	}
 
 	// Create a new field for the remote query
@@ -78,7 +96,7 @@ func (r *databaseResolver) buildWhereArgument(rq *remoteQuery) *ast.Argument {
 	for localCol, remoteCol := range r.joinColumns {
 		// Collect unique values for this column
 		values := make([]any, 0, len(rq.joinArguments))
-		seen := make(map[any]struct{})
+		seen := make(map[string]struct{})
 
 		for _, arg := range rq.joinArguments {
 			val := arg.values[localCol]
@@ -86,11 +104,13 @@ func (r *databaseResolver) buildWhereArgument(rq *remoteQuery) *ast.Argument {
 				continue
 			}
 
-			if _, ok := seen[val]; ok {
+			key := joinValueDedupKey(val)
+			if _, ok := seen[key]; ok {
 				continue
 			}
 
-			seen[val] = struct{}{}
+			seen[key] = struct{}{}
+
 			values = append(values, val)
 		}
 
@@ -186,9 +206,11 @@ func (r *databaseResolver) BuildResultLookup(rq *remoteQuery, results []any) map
 
 		for _, localCol := range localCols {
 			remoteCol := r.joinColumns[localCol]
-			// Try the alias first, then fall back to the column name
+			// Try an injected phantom alias first, then a user alias, then the column name.
 			lookupKey := remoteCol
-			if alias, hasAlias := colToAlias[remoteCol]; hasAlias {
+			if alias, hasAlias := rq.remoteJoinAliases[remoteCol]; hasAlias {
+				lookupKey = alias
+			} else if alias, hasAlias := colToAlias[remoteCol]; hasAlias {
 				lookupKey = alias
 			}
 
@@ -204,7 +226,7 @@ func (r *databaseResolver) BuildResultLookup(rq *remoteQuery, results []any) map
 }
 
 // GetJoinKeyFromParent extracts join key from a parent row for stitching.
-func (r *databaseResolver) GetJoinKeyFromParent(_ *remoteQuery, parentRow map[string]any) string {
+func (r *databaseResolver) GetJoinKeyFromParent(rq *remoteQuery, parentRow map[string]any) string {
 	// Sort local columns for consistent key building (must match BuildResultLookup)
 	localCols := make([]string, 0, len(r.joinColumns))
 	for localCol := range r.joinColumns {
@@ -217,7 +239,12 @@ func (r *databaseResolver) GetJoinKeyFromParent(_ *remoteQuery, parentRow map[st
 	keyParts := make([]string, 0, len(localCols))
 
 	for _, localCol := range localCols {
-		val := parentRow[localCol]
+		lookupKey := localCol
+		if alias, ok := rq.localJoinAliases[localCol]; ok {
+			lookupKey = alias
+		}
+
+		val := parentRow[lookupKey]
 		keyParts = append(keyParts, fmt.Sprintf("%v", val))
 	}
 
@@ -266,6 +293,38 @@ func buildColumnAliasMapRecursive(
 	}
 }
 
+func findWhereArgument(args ast.ArgumentList) *ast.Argument {
+	for _, arg := range args {
+		if arg.Name == "where" {
+			return arg
+		}
+	}
+
+	return nil
+}
+
+func andMergeWhereValues(generated, user *ast.Value) *ast.Value {
+	if user == nil || user.Kind == ast.NullValue {
+		return generated
+	}
+
+	return &ast.Value{ //nolint:exhaustruct
+		Kind: ast.ObjectValue,
+		Children: ast.ChildValueList{
+			{
+				Name: "_and",
+				Value: &ast.Value{ //nolint:exhaustruct
+					Kind: ast.ListValue,
+					Children: ast.ChildValueList{
+						{Value: generated},
+						{Value: user},
+					},
+				},
+			},
+		},
+	}
+}
+
 // selectionContainsField checks if the selection set contains a field with the given name,
 // including fields within fragment spreads and inline fragments.
 func selectionContainsField(
@@ -276,12 +335,10 @@ func selectionContainsField(
 	for _, sel := range selectionSet {
 		switch s := sel.(type) {
 		case *ast.Field:
-			// Check if this field matches (by name or alias)
-			if s.Name == fieldName || s.Alias == fieldName {
+			if s.Name == fieldName {
 				return true
 			}
 		case *ast.FragmentSpread:
-			// Find and check the fragment definition
 			for _, frag := range fragments {
 				if frag.Name == s.Name {
 					if selectionContainsField(frag.SelectionSet, fragments, fieldName) {
@@ -292,7 +349,6 @@ func selectionContainsField(
 				}
 			}
 		case *ast.InlineFragment:
-			// Check the inline fragment's selection set
 			if selectionContainsField(s.SelectionSet, fragments, fieldName) {
 				return true
 			}
@@ -300,6 +356,70 @@ func selectionContainsField(
 	}
 
 	return false
+}
+
+func collectSelectionResponseKeys(
+	selectionSet ast.SelectionSet,
+	fragments ast.FragmentDefinitionList,
+) map[string]struct{} {
+	responseKeys := make(map[string]struct{})
+	collectSelectionResponseKeysRecursive(selectionSet, fragments, responseKeys)
+
+	return responseKeys
+}
+
+func collectSelectionResponseKeysRecursive(
+	selectionSet ast.SelectionSet,
+	fragments ast.FragmentDefinitionList,
+	responseKeys map[string]struct{},
+) {
+	for _, sel := range selectionSet {
+		switch s := sel.(type) {
+		case *ast.Field:
+			responseKeys[responseKey(s)] = struct{}{}
+		case *ast.FragmentSpread:
+			for _, frag := range fragments {
+				if frag.Name == s.Name {
+					collectSelectionResponseKeysRecursive(
+						frag.SelectionSet,
+						fragments,
+						responseKeys,
+					)
+
+					break
+				}
+			}
+		case *ast.InlineFragment:
+			collectSelectionResponseKeysRecursive(s.SelectionSet, fragments, responseKeys)
+		}
+	}
+}
+
+func makeRemotePhantomAlias(fieldName string, responseKeys map[string]struct{}) string {
+	base := "_constellation_remote_phantom_" + fieldName
+	alias := base
+
+	for i := 1; ; i++ {
+		if _, exists := responseKeys[alias]; !exists {
+			responseKeys[alias] = struct{}{}
+
+			return alias
+		}
+
+		alias = fmt.Sprintf("%s_%d", base, i)
+	}
+}
+
+func responseKey(field *ast.Field) string {
+	if field.Alias != "" {
+		return field.Alias
+	}
+
+	return field.Name
+}
+
+func joinValueDedupKey(v any) string {
+	return fmt.Sprintf("%#v", v)
 }
 
 // valueKindForType returns the appropriate AST value kind for a Go value.

--- a/services/constellation/controller/resolver/database_resolver_internal_test.go
+++ b/services/constellation/controller/resolver/database_resolver_internal_test.go
@@ -9,7 +9,7 @@ import (
 	"github.com/vektah/gqlparser/v2/ast"
 )
 
-func TestDatabaseResolverBuildOperation(t *testing.T) {
+func TestDatabaseResolverBuildOperation(t *testing.T) { //nolint:gocognit,cyclop,maintidx
 	t.Parallel()
 
 	joinCols := map[string]string{"id": "userId"}
@@ -105,7 +105,7 @@ func TestDatabaseResolverBuildOperation(t *testing.T) {
 			},
 		},
 		{
-			name: "forwards user arguments but discards user where",
+			name: "forwards user arguments and merges user where",
 			joinArgs: []*remoteJoinArgument{
 				newRemoteJoinArgument(map[string]any{"id": "u1"}),
 			},
@@ -113,8 +113,12 @@ func TestDatabaseResolverBuildOperation(t *testing.T) {
 				Name: "orders",
 				Arguments: ast.ArgumentList{
 					{Name: "limit", Value: &ast.Value{Kind: ast.IntValue, Raw: "10"}},
-					// User-supplied "where" must be discarded — databaseResolver builds its own.
-					{Name: "where", Value: &ast.Value{Kind: ast.ObjectValue}},
+					{
+						Name: "where",
+						Value: &ast.Value{Kind: ast.ObjectValue, Children: ast.ChildValueList{
+							{Name: "status", Value: &ast.Value{Kind: ast.ObjectValue}},
+						}},
+					},
 				},
 				SelectionSet: ast.SelectionSet{&ast.Field{Name: "id"}},
 			},
@@ -126,15 +130,71 @@ func TestDatabaseResolverBuildOperation(t *testing.T) {
 				}
 
 				field, _ := op.SelectionSet[0].(*ast.Field)
-
 				argNames := argumentNames(field.Arguments)
 
 				if countOccurrences(argNames, "where") != 1 {
-					t.Errorf("expected exactly one 'where' (the generated one), got %v", argNames)
+					t.Errorf("expected exactly one merged 'where', got %v", argNames)
+				}
+
+				whereArg := findWhereArgument(field.Arguments)
+
+				andChild := whereArg.Value.Children.ForName("_and")
+				if andChild == nil || andChild.Kind != ast.ListValue {
+					t.Fatalf("expected _and list in merged where, got %+v", whereArg.Value)
+				}
+
+				if got := len(andChild.Children); got != 2 {
+					t.Fatalf("expected generated and user where under _and, got %d", got)
 				}
 
 				if !slices.Contains(argNames, "limit") {
 					t.Errorf("expected user 'limit' argument forwarded, got %v", argNames)
+				}
+			},
+		},
+		{
+			name: "dedupes slice join values without panic",
+			joinArgs: []*remoteJoinArgument{
+				newRemoteJoinArgument(map[string]any{"id": []any{"a", "b"}}),
+				newRemoteJoinArgument(map[string]any{"id": []any{"a", "b"}}),
+				newRemoteJoinArgument(map[string]any{"id": []any{"c"}}),
+			},
+			sourceField: &ast.Field{
+				Name:         "orders",
+				SelectionSet: ast.SelectionSet{&ast.Field{Name: "id"}},
+			},
+			check: func(t *testing.T, op *ast.OperationDefinition, _ *remoteQuery) {
+				t.Helper()
+
+				field, _ := op.SelectionSet[0].(*ast.Field)
+				whereArg := findWhereArgument(field.Arguments)
+
+				inList := whereArg.Value.Children.ForName("userId").Children.ForName("_in")
+				if got := len(inList.Children); got != 2 {
+					t.Errorf("expected 2 deduped values, got %d", got)
+				}
+			},
+		},
+		{
+			name: "dedupes map join values without panic",
+			joinArgs: []*remoteJoinArgument{
+				newRemoteJoinArgument(map[string]any{"id": map[string]any{"k": "v"}}),
+				newRemoteJoinArgument(map[string]any{"id": map[string]any{"k": "v"}}),
+				newRemoteJoinArgument(map[string]any{"id": map[string]any{"k": "w"}}),
+			},
+			sourceField: &ast.Field{
+				Name:         "orders",
+				SelectionSet: ast.SelectionSet{&ast.Field{Name: "id"}},
+			},
+			check: func(t *testing.T, op *ast.OperationDefinition, _ *remoteQuery) {
+				t.Helper()
+
+				field, _ := op.SelectionSet[0].(*ast.Field)
+				whereArg := findWhereArgument(field.Arguments)
+
+				inList := whereArg.Value.Children.ForName("userId").Children.ForName("_in")
+				if got := len(inList.Children); got != 2 {
+					t.Errorf("expected 2 deduped values, got %d", got)
 				}
 			},
 		},
@@ -311,6 +371,65 @@ func TestDatabaseResolverBuildResultLookupAndJoinKey(t *testing.T) {
 			)
 		}
 	})
+
+	t.Run("parent join key uses local phantom alias", func(t *testing.T) {
+		t.Parallel()
+
+		rqAliased := &remoteQuery{
+			resolver:         dr,
+			localJoinAliases: map[string]string{"id": "_constellation_phantom_id"},
+		}
+
+		key := dr.GetJoinKeyFromParent(rqAliased, map[string]any{
+			"id":                        "wrong-user-alias-value",
+			"_constellation_phantom_id": "u1",
+		})
+		if key != "u1" {
+			t.Errorf("expected key from phantom alias 'u1', got %q", key)
+		}
+	})
+
+	t.Run("remote phantom alias is honoured when building lookup", func(t *testing.T) {
+		t.Parallel()
+
+		rqAliased := &remoteQuery{
+			resolver:          dr,
+			remoteJoinAliases: map[string]string{"userId": "_constellation_remote_phantom_userId"},
+			sourceField: &ast.Field{
+				SelectionSet: ast.SelectionSet{&ast.Field{Name: "product", Alias: "userId"}},
+			},
+		}
+
+		results := []any{
+			map[string]any{
+				"userId":                               "wrong-product-alias-value",
+				"_constellation_remote_phantom_userId": "u1",
+			},
+		}
+
+		got := dr.BuildResultLookup(rqAliased, results)
+		if len(got["u1"]) != 1 {
+			t.Errorf("expected 1 result under remote phantom alias key, got %v", got)
+		}
+	})
+}
+
+func TestRemoteQueryGetLocalPhantomFields_UsesEffectiveResponseKeys(t *testing.T) {
+	t.Parallel()
+
+	rq := &remoteQuery{
+		localPhantomFields: []string{"department_id", "org_id"},
+		localJoinAliases: map[string]string{
+			"department_id": "_constellation_phantom_department_id",
+		},
+	}
+
+	got := rq.getLocalPhantomFields()
+
+	want := []string{"_constellation_phantom_department_id", "org_id"}
+	if diff := cmp.Diff(want, got); diff != "" {
+		t.Errorf("local phantom fields mismatch (-want +got):\n%s", diff)
+	}
 }
 
 func TestSchemaResolverExtractResults(t *testing.T) {

--- a/services/constellation/controller/resolver/remote_query.go
+++ b/services/constellation/controller/resolver/remote_query.go
@@ -37,9 +37,15 @@ type remoteQuery struct {
 
 	// parentPath is where localPhantomFields live (e.g. "games.homeTeam" for
 	// a "games.homeTeam.department" relationship).
-	parentPath          jsonpath.Path
-	localPhantomFields  []string
+	parentPath jsonpath.Path
+	// localPhantomFields stores source join columns; localJoinAliases maps any
+	// column injected under an internal alias to the actual response key.
+	localPhantomFields []string
+	localJoinAliases   map[string]string
+	// remotePhantomFields stores response keys to remove from remote results;
+	// remoteJoinAliases maps remote join columns to injected response keys.
 	remotePhantomFields []string
+	remoteJoinAliases   map[string]string
 
 	// resolver carries the strategy for type-specific operations. For
 	// grouped-aggregate queries this is nil; the executor uses the
@@ -162,9 +168,20 @@ func (rq *remoteQuery) removePhantomFieldsFromRemoteResults(results []any) {
 	}
 }
 
-// getLocalPhantomFields returns the local phantom fields.
+// getLocalPhantomFields returns the local phantom response keys to delete.
 func (rq *remoteQuery) getLocalPhantomFields() []string {
-	return rq.localPhantomFields
+	fields := make([]string, 0, len(rq.localPhantomFields))
+	for _, field := range rq.localPhantomFields {
+		if alias, ok := rq.localJoinAliases[field]; ok {
+			fields = append(fields, alias)
+
+			continue
+		}
+
+		fields = append(fields, field)
+	}
+
+	return fields
 }
 
 // getParentPath returns the parent path used to locate parent rows for stitching.

--- a/services/constellation/controller/resolver/remote_query_builder.go
+++ b/services/constellation/controller/resolver/remote_query_builder.go
@@ -51,9 +51,14 @@ func buildRemoteQueryFromPlan(
 		return nil
 	}
 
-	var localPhantomFields []string
+	var (
+		localPhantomFields []string
+		localJoinAliases   map[string]string
+	)
+
 	if rqp.SourcePhantomFields != nil {
 		localPhantomFields = rqp.SourcePhantomFields.Fields
+		localJoinAliases = rqp.SourcePhantomFields.Aliases
 	}
 
 	// Grouped-aggregate cross-DB relationships bypass the resolver/operation
@@ -69,7 +74,9 @@ func buildRemoteQueryFromPlan(
 			fragments:           fragments,
 			parentPath:          rqp.SourcePath,
 			localPhantomFields:  localPhantomFields,
+			localJoinAliases:    localJoinAliases,
 			remotePhantomFields: nil,
+			remoteJoinAliases:   nil,
 			resolver:            nil,
 			aggregateInfo: &aggregateInfo{
 				targetTableSchema: rqp.TargetTableSchema,
@@ -95,7 +102,9 @@ func buildRemoteQueryFromPlan(
 		fragments:           fragments,
 		parentPath:          rqp.SourcePath,
 		localPhantomFields:  localPhantomFields,
+		localJoinAliases:    localJoinAliases,
 		remotePhantomFields: nil, // Set by resolver during BuildOperation.
+		remoteJoinAliases:   nil, // Set by resolver during BuildOperation when needed.
 		resolver:            resolver,
 		aggregateInfo:       nil,
 	}
@@ -119,7 +128,15 @@ func extractJoinArgumentsFromPlan(
 	sourceColumns := getSourceColumns(rqp)
 	sort.Strings(sourceColumns)
 
-	return buildJoinArguments(rows, sourceColumns)
+	return buildJoinArguments(rows, sourceColumns, sourceColumnAliases(rqp))
+}
+
+func sourceColumnAliases(rqp *planner.RemoteQueryPlan) map[string]string {
+	if rqp.SourcePhantomFields == nil || len(rqp.SourcePhantomFields.Aliases) == 0 {
+		return nil
+	}
+
+	return rqp.SourcePhantomFields.Aliases
 }
 
 // getSourceColumns returns the source columns for join key building.
@@ -144,6 +161,7 @@ func getSourceColumns(rqp *planner.RemoteQueryPlan) []string {
 func buildJoinArguments(
 	rows []map[string]any,
 	sourceColumns []string,
+	sourceColumnAliases map[string]string,
 ) []*remoteJoinArgument {
 	seen := make(map[string]struct{})
 
@@ -155,7 +173,12 @@ func buildJoinArguments(
 		hasNull := false
 
 		for _, sourceCol := range sourceColumns {
-			val := row[sourceCol]
+			lookupKey := sourceCol
+			if alias, ok := sourceColumnAliases[sourceCol]; ok {
+				lookupKey = alias
+			}
+
+			val := row[lookupKey]
 			if val == nil {
 				hasNull = true
 

--- a/services/constellation/controller/resolver/remote_relationship_resolver.go
+++ b/services/constellation/controller/resolver/remote_relationship_resolver.go
@@ -83,6 +83,7 @@ import (
 
 	"github.com/nhost/nhost/services/constellation/connector"
 	"github.com/nhost/nhost/services/constellation/connector/groupedaggregate"
+	"github.com/nhost/nhost/services/constellation/internal/jsonpath"
 	"github.com/vektah/gqlparser/v2/ast"
 )
 
@@ -304,8 +305,8 @@ func (r *RemoteRelationshipResolver) removeAllLocalPhantomFields(
 	results map[string]any,
 	remoteQueries []*remoteQuery,
 ) {
-	// Track which paths we've already processed to avoid duplicate work
-	seen := make(map[string]struct{})
+	fieldsByPath := make(map[string]map[string]struct{})
+	pathsByKey := make(map[string]jsonpath.Path)
 
 	for _, rq := range remoteQueries {
 		parentPath := rq.getParentPath()
@@ -315,16 +316,25 @@ func (r *RemoteRelationshipResolver) removeAllLocalPhantomFields(
 			continue
 		}
 
-		// Create a unique key for this path
 		key := parentPath.String()
-		if _, ok := seen[key]; ok {
-			continue
+
+		pathsByKey[key] = parentPath
+		if fieldsByPath[key] == nil {
+			fieldsByPath[key] = make(map[string]struct{})
 		}
 
-		seen[key] = struct{}{}
+		for _, field := range phantomFields {
+			fieldsByPath[key][field] = struct{}{}
+		}
+	}
 
-		// Remove the phantom fields at this path
-		parentPath.Delete(results, phantomFields...)
+	for key, fieldSet := range fieldsByPath {
+		phantomFields := make([]string, 0, len(fieldSet))
+		for field := range fieldSet {
+			phantomFields = append(phantomFields, field)
+		}
+
+		pathsByKey[key].Delete(results, phantomFields...)
 	}
 }
 

--- a/services/constellation/controller/resolver/schema_resolver.go
+++ b/services/constellation/controller/resolver/schema_resolver.go
@@ -227,7 +227,7 @@ func mergeSourceFieldArguments(remoteField *ast.Field, sourceArgs ast.ArgumentLi
 }
 
 // GetJoinKeyFromParent extracts join key from a parent row for stitching.
-func (r *schemaResolver) GetJoinKeyFromParent(_ *remoteQuery, parentRow map[string]any) string {
+func (r *schemaResolver) GetJoinKeyFromParent(rq *remoteQuery, parentRow map[string]any) string {
 	// Sort LHS fields for consistent key building
 	lhsFields := make([]string, len(r.lhsFields))
 	copy(lhsFields, r.lhsFields)
@@ -237,7 +237,12 @@ func (r *schemaResolver) GetJoinKeyFromParent(_ *remoteQuery, parentRow map[stri
 	keyParts := make([]string, 0, len(lhsFields))
 
 	for _, field := range lhsFields {
-		val := parentRow[field]
+		lookupKey := field
+		if alias, ok := rq.localJoinAliases[field]; ok {
+			lookupKey = alias
+		}
+
+		val := parentRow[lookupKey]
 		keyParts = append(keyParts, fmt.Sprintf("%v", val))
 	}
 

--- a/services/constellation/controller/resolver/variable_resolution.go
+++ b/services/constellation/controller/resolver/variable_resolution.go
@@ -27,13 +27,28 @@ func resolveVariableReferences(selections ast.SelectionSet, variables map[string
 // resolveArgumentVariables replaces variable references in arguments with literal values.
 func resolveArgumentVariables(args ast.ArgumentList, variables map[string]any) {
 	for _, arg := range args {
-		if arg.Value != nil && arg.Value.Kind == ast.Variable {
-			varName := arg.Value.Raw
-			if val, ok := variables[varName]; ok {
-				arg.Value = toLiteralValue(val)
-			}
-		}
+		arg.Value = resolveValueVariables(arg.Value, variables)
 	}
+}
+
+func resolveValueVariables(value *ast.Value, variables map[string]any) *ast.Value {
+	if value == nil {
+		return nil
+	}
+
+	if value.Kind == ast.Variable {
+		if val, ok := variables[value.Raw]; ok {
+			return toLiteralValue(val)
+		}
+
+		return value
+	}
+
+	for _, child := range value.Children {
+		child.Value = resolveValueVariables(child.Value, variables)
+	}
+
+	return value
 }
 
 // toLiteralValue converts a Go value to an AST literal value.

--- a/services/constellation/controller/resolver/variable_resolution_internal_test.go
+++ b/services/constellation/controller/resolver/variable_resolution_internal_test.go
@@ -1,0 +1,88 @@
+package resolver
+
+import (
+	"testing"
+
+	"github.com/vektah/gqlparser/v2/ast"
+)
+
+func TestResolveArgumentVariables_NestedObject(t *testing.T) {
+	t.Parallel()
+
+	args := ast.ArgumentList{
+		{
+			Name: "where",
+			Value: &ast.Value{Kind: ast.ObjectValue, Children: ast.ChildValueList{
+				{
+					Name: "name",
+					Value: &ast.Value{Kind: ast.ObjectValue, Children: ast.ChildValueList{
+						{Name: "_eq", Value: &ast.Value{Kind: ast.Variable, Raw: "name"}},
+					}},
+				},
+			}},
+		},
+	}
+
+	resolveArgumentVariables(args, map[string]any{"name": "Ada"})
+
+	value := args[0].Value.Children.ForName("name").Children.ForName("_eq")
+	if value.Kind != ast.StringValue || value.Raw != "Ada" {
+		t.Fatalf("expected nested variable to resolve to string Ada, got %+v", value)
+	}
+}
+
+func TestResolveArgumentVariables_NestedList(t *testing.T) {
+	t.Parallel()
+
+	args := ast.ArgumentList{
+		{
+			Name: "tags",
+			Value: &ast.Value{Kind: ast.ListValue, Children: ast.ChildValueList{
+				{Value: &ast.Value{Kind: ast.Variable, Raw: "first"}},
+				{Value: &ast.Value{Kind: ast.StringValue, Raw: "literal"}},
+				{Value: &ast.Value{Kind: ast.Variable, Raw: "second"}},
+			}},
+		},
+	}
+
+	resolveArgumentVariables(args, map[string]any{"first": "a", "second": "b"})
+
+	children := args[0].Value.Children
+	if children[0].Value.Raw != "a" || children[1].Value.Raw != "literal" ||
+		children[2].Value.Raw != "b" {
+		t.Fatalf("unexpected resolved list: %+v", children)
+	}
+}
+
+func TestResolveArgumentVariables_MissingVariableLeftUnchanged(t *testing.T) {
+	t.Parallel()
+
+	args := ast.ArgumentList{
+		{Name: "id", Value: &ast.Value{Kind: ast.Variable, Raw: "missing"}},
+	}
+
+	resolveArgumentVariables(args, nil)
+
+	if args[0].Value.Kind != ast.Variable || args[0].Value.Raw != "missing" {
+		t.Fatalf("expected missing variable unchanged, got %+v", args[0].Value)
+	}
+}
+
+func TestResolveArgumentVariables_TopLevelVariableStillWorks(t *testing.T) {
+	t.Parallel()
+
+	args := ast.ArgumentList{
+		{Name: "id", Value: &ast.Value{Kind: ast.Variable, Raw: "id"}},
+	}
+
+	resolveArgumentVariables(args, map[string]any{"id": "u1"})
+
+	arg := args.ForName("id")
+	if arg == nil {
+		t.Fatal("expected id argument")
+	}
+
+	if arg.Value.Kind != ast.StringValue || arg.Value.Raw != "u1" {
+		t.Fatalf("expected top-level variable to resolve, got %+v", arg.Value)
+	}
+}

--- a/services/constellation/controller/results.go
+++ b/services/constellation/controller/results.go
@@ -6,6 +6,7 @@ import (
 	"fmt"
 
 	"github.com/nhost/nhost/services/constellation/controller/planner"
+	"github.com/nhost/nhost/services/constellation/internal/jsonpath"
 )
 
 // unmarshalRawResults converts any [jsontext.Value] entries in results to
@@ -35,16 +36,34 @@ func removePhantomFieldsFromPlan(results map[string]any, plan *planner.QueryPlan
 		return
 	}
 
-	seen := make(map[string]struct{})
+	fieldsByPath := make(map[string]map[string]struct{})
+	pathsByKey := make(map[string]jsonpath.Path)
 
 	for _, pfs := range plan.AllPhantomFieldSpecs() {
 		key := pfs.Path.String()
-		if _, ok := seen[key]; ok {
-			continue
+
+		pathsByKey[key] = pfs.Path
+		if fieldsByPath[key] == nil {
+			fieldsByPath[key] = make(map[string]struct{})
 		}
 
-		seen[key] = struct{}{}
+		for _, field := range pfs.Fields {
+			if alias, ok := pfs.Aliases[field]; ok {
+				fieldsByPath[key][alias] = struct{}{}
 
-		pfs.Path.Delete(results, pfs.Fields...)
+				continue
+			}
+
+			fieldsByPath[key][field] = struct{}{}
+		}
+	}
+
+	for key, fieldSet := range fieldsByPath {
+		fields := make([]string, 0, len(fieldSet))
+		for field := range fieldSet {
+			fields = append(fields, field)
+		}
+
+		pathsByKey[key].Delete(results, fields...)
 	}
 }

--- a/services/constellation/controller/results_internal_test.go
+++ b/services/constellation/controller/results_internal_test.go
@@ -159,6 +159,55 @@ func TestRemovePhantomFieldsFromPlan(t *testing.T) {
 		}
 	})
 
+	t.Run(
+		"removes aliased phantom response keys without deleting user aliases",
+		func(t *testing.T) {
+			t.Parallel()
+
+			results := map[string]any{
+				"users": []any{
+					map[string]any{
+						"user_id":                        "user-visible-alias",
+						"_constellation_phantom_user_id": "real-user-id",
+						"name":                           "Alice",
+					},
+				},
+			}
+
+			plan := &planner.QueryPlan{
+				PrimaryQueries: []*planner.PrimaryQuery{
+					{
+						Connector:      "db1",
+						CleanOperation: nil,
+						CleanFragments: nil,
+						PhantomFields: []*planner.PhantomFieldSpec{
+							{
+								Path:   jsonpath.Parse("users"),
+								Fields: []string{"user_id"},
+								Aliases: map[string]string{
+									"user_id": "_constellation_phantom_user_id",
+								},
+								ForRelationship: "departments",
+							},
+						},
+					},
+				},
+				RemoteQueries: nil,
+			}
+
+			removePhantomFieldsFromPlan(results, plan)
+
+			want := map[string]any{
+				"users": []any{
+					map[string]any{"user_id": "user-visible-alias", "name": "Alice"},
+				},
+			}
+			if diff := cmp.Diff(want, results); diff != "" {
+				t.Errorf("results mismatch (-want +got):\n%s", diff)
+			}
+		},
+	)
+
 	t.Run("de-duplicates phantom paths", func(t *testing.T) {
 		t.Parallel()
 

--- a/services/constellation/docs/developers/remote-relationships.md
+++ b/services/constellation/docs/developers/remote-relationships.md
@@ -130,17 +130,18 @@ The analyzer expands `*ast.FragmentSpread` and `*ast.InlineFragment` so relation
 
 ### Phantom field specification
 
-After detecting relationships, the analyzer subtracts fields the user already selected (`collectSelectedFields`) from `neededPhantoms` and records the remainder as a `PhantomFieldSpec`:
+After detecting relationships, the analyzer compares `neededPhantoms` against fields already selected with their own response key (`collectOwnResponseKeyFields`). Aliased user fields still occupy response keys, so `collectResponseKeys` is used to choose an internal alias when an injected phantom would collide with the user's response shape. The remaining fields are recorded as a `PhantomFieldSpec`:
 
 ```go
 type PhantomFieldSpec struct {
     Path            jsonpath.Path     // e.g. ["users", "profile"]
     Fields          []string          // e.g. ["department_id"]
+    Aliases         map[string]string // optional internal response keys for colliding phantoms
     ForRelationship string
 }
 ```
 
-The spec is referenced from every `RemoteQueryPlan` that shares the same source path, so the resolver can later look up which phantom fields belong to which relationship.
+The spec is referenced from every `RemoteQueryPlan` that shares the same source path, so the resolver can later look up which phantom fields belong to which relationship and which internal response key to read for aliased phantoms.
 
 ### AST transformer
 

--- a/services/constellation/integration/query_remote_relationships_test.go
+++ b/services/constellation/integration/query_remote_relationships_test.go
@@ -126,6 +126,23 @@ func TestQueryRemoteRelationships(t *testing.T) { //nolint:paralleltest,maintidx
 			},
 		},
 
+		{
+			name: "db to db array remote relationship resolves when join column is user-aliased",
+			query: query{
+				Query: `query {
+					userProfiles(order_by: { id: asc }) {
+						id
+						uid: user_id
+						departments(order_by: [{ department_id: asc }]) {
+							department_id
+							role
+						}
+					}
+				}`,
+				Role: "admin",
+			},
+		},
+
 		// Query only from remote source without crossing databases
 		{
 			name: "query from other database only",

--- a/services/constellation/integration/query_remote_relationships_test.go
+++ b/services/constellation/integration/query_remote_relationships_test.go
@@ -88,6 +88,44 @@ func TestQueryRemoteRelationships(t *testing.T) { //nolint:paralleltest,maintidx
 			},
 		},
 
+		{
+			name: "db to db array remote relationship honors user where",
+			query: query{
+				Query: `query {
+					userProfiles(order_by: { id: asc }) {
+						id
+						user_id
+						departments(
+							where: { role: { _eq: manager } }
+							order_by: [{ department_id: asc }]
+						) {
+							user_id
+							department_id
+							role
+						}
+					}
+				}`,
+				Role: "admin",
+			},
+		},
+
+		{
+			name: "db to db array remote relationship ignores unrelated alias collision with join column",
+			query: query{
+				Query: `query {
+					userProfiles(order_by: { id: asc }) {
+						user_id: id
+						departments(order_by: [{ department_id: asc }]) {
+							user_id
+							department_id
+							role
+						}
+					}
+				}`,
+				Role: "admin",
+			},
+		},
+
 		// Query only from remote source without crossing databases
 		{
 			name: "query from other database only",


### PR DESCRIPTION
<!-- nhost-reviewer:start -->
### **What this PR solves**
Fixes remote relationship stitching when user aliases collide with join columns or variables/where clauses are nested in relationship arguments. The change preserves user-visible response keys while injecting, reading, and removing internal phantom fields safely across planning, transformation, and resolution.

___

### **PR Type**
Bug fix

___

### **Description**
- Tracks internal aliases for local and remote phantom join fields to avoid response-key collisions with user selections.
- Propagates phantom alias metadata from planner specs through operation transformation, remote query construction, stitching, and result cleanup.
- Merges user `where` filters with generated join predicates and resolves nested variable references.
- Adds unit and integration coverage plus developer documentation for aliased phantom fields.

___

### Diagram Walkthrough

```mermaid
flowchart LR
  A["Planner detects needed join columns"] --> B["Transformer injects phantom fields with safe aliases"]
  B --> C["Resolver reads alias-aware join keys"]
  C --> D["Remote results are stitched"]
  D --> E["Controller removes internal phantom response keys"]
```

<details> <summary><h3> File Walkthrough</h3></summary>

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody>
<tr><td><strong>Planner</strong></td><td><details><summary>4 files</summary><table>
<tr><td><strong>services/constellation/controller/planner/analyzer.go</strong><dd><code>Detects own-response-key selections, response-key collisions, and safe phantom aliases.</code></dd></td><td><a href="https://github.com/nhost/nhost/pull/XXX/files#diff-d77e6502a8fd1c41aaa0a507fa537b931f8e1a7dced7ecaa126a4a65151a5fb4">+84/-17</a></td></tr>
<tr><td><strong>services/constellation/controller/planner/analyzer_internal_test.go</strong><dd><code>Adds analyzer coverage for aliased selections and fragment response keys.</code></dd></td><td><a href="https://github.com/nhost/nhost/pull/XXX/files#diff-610f9191e6f428f246c08013d31353c11260facba494046299b93de6b34e1bcf">+67/-6</a></td></tr>
<tr><td><strong>services/constellation/controller/planner/planner.go</strong><dd><code>Copies phantom alias metadata into transform specs.</code></dd></td><td><a href="https://github.com/nhost/nhost/pull/XXX/files#diff-fa386b3273c3e383093f192324fb1fa38f06983517ffdecf31708446d65a19b9">+3/-2</a></td></tr>
<tr><td><strong>services/constellation/controller/planner/types.go</strong><dd><code>Adds alias metadata to phantom field specs.</code></dd></td><td><a href="https://github.com/nhost/nhost/pull/XXX/files#diff-186788b552906c7aebf9f40a1da6316fd7ea394a77378569b3aa0cce486dab2e">+5/-0</a></td></tr>
</table></details></td></tr>
<tr><td><strong>Planner transform</strong></td><td><details><summary>2 files</summary><table>
<tr><td><strong>services/constellation/controller/planner/transform/transform.go</strong><dd><code>Injects phantom fields using alias-aware response-key deduplication.</code></dd></td><td><a href="https://github.com/nhost/nhost/pull/XXX/files#diff-c6598c5e54b4d90c21e5c769c71417b22b13617b6e069ac9f81a40ca664060d9">+40/-13</a></td></tr>
<tr><td><strong>services/constellation/controller/planner/transform/transform_test.go</strong><dd><code>Covers phantom injection when aliases differ or collide.</code></dd></td><td><a href="https://github.com/nhost/nhost/pull/XXX/files#diff-08bee43a73e81012f01d13eefe710c9e9fb6671a4c7a0f28c745e620500cc4b1">+84/-0</a></td></tr>
</table></details></td></tr>
<tr><td><strong>Resolver</strong></td><td><details><summary>10 files</summary><table>
<tr><td><strong>services/constellation/controller/resolver/aggregate_resolver.go</strong><dd><code>Uses alias-aware local join lookup and comparable-safe dedup keys for aggregate stitching.</code></dd></td><td><a href="https://github.com/nhost/nhost/pull/XXX/files#diff-a0b4da3519a737b5d45720e956b4945c797906ce1a7ca69286550fb37372dad5">+10/-4</a></td></tr>
<tr><td><strong>services/constellation/controller/resolver/aggregate_resolver_internal_test.go</strong><dd><code>Adds aggregate stitching and non-comparable join-value dedupe tests.</code></dd></td><td><a href="https://github.com/nhost/nhost/pull/XXX/files#diff-f0c4a16f98e0d97cb0dd68fd9a2c6e99d205679d9ec30aab6b1db009431538c4">+78/-0</a></td></tr>
<tr><td><strong>services/constellation/controller/resolver/database_resolver.go</strong><dd><code>Merges user where filters, injects remote phantom aliases, and uses alias-aware join keys.</code></dd></td><td><a href="https://github.com/nhost/nhost/pull/XXX/files#diff-b9153df4443a32f28d81a1c39c4c8616594e1ce2a54ed2069cb18cd149072bb8">+141/-21</a></td></tr>
<tr><td><strong>services/constellation/controller/resolver/database_resolver_internal_test.go</strong><dd><code>Extends resolver tests for merged filters, dedupe, and alias-aware lookups.</code></dd></td><td><a href="https://github.com/nhost/nhost/pull/XXX/files#diff-0d038a790651d79b813b649b11d93978eb7a41c7bd26b2c6ed6c8330fd05924b">+125/-6</a></td></tr>
<tr><td><strong>services/constellation/controller/resolver/remote_query.go</strong><dd><code>Stores local and remote phantom alias mappings and deletes effective response keys.</code></dd></td><td><a href="https://github.com/nhost/nhost/pull/XXX/files#diff-1b13d0fa661c74043f893f0dafef439c54be74e8cbd91e5af4aff0895cfc558e">+21/-4</a></td></tr>
<tr><td><strong>services/constellation/controller/resolver/remote_query_builder.go</strong><dd><code>Propagates source phantom aliases into remote query construction and join argument extraction.</code></dd></td><td><a href="https://github.com/nhost/nhost/pull/XXX/files#diff-584c866f76dc71897187c130d799f55e74a5518e9ad9ea2e9098a80a373343db">+26/-3</a></td></tr>
<tr><td><strong>services/constellation/controller/resolver/remote_relationship_resolver.go</strong><dd><code>Removes the union of phantom fields per parent path instead of skipping duplicate paths.</code></dd></td><td><a href="https://github.com/nhost/nhost/pull/XXX/files#diff-403360b4bd45bb784fc0f1a6ef95c95131c4e48ba267f3b53efa8f66c89fd82d">+18/-8</a></td></tr>
<tr><td><strong>services/constellation/controller/resolver/schema_resolver.go</strong><dd><code>Reads aliased local join fields for remote schema stitching.</code></dd></td><td><a href="https://github.com/nhost/nhost/pull/XXX/files#diff-42782e87a7e6ec8d687179af8bfdc376013e8dcbe1e438cdd4347119d67b1215">+7/-2</a></td></tr>
<tr><td><strong>services/constellation/controller/resolver/variable_resolution.go</strong><dd><code>Recursively resolves variables inside nested argument objects and lists.</code></dd></td><td><a href="https://github.com/nhost/nhost/pull/XXX/files#diff-156fee1288f6faed50b2ffe3c5afd8d857addabc4f394644d0e3ba115922d252">+20/-5</a></td></tr>
<tr><td><strong>services/constellation/controller/resolver/variable_resolution_internal_test.go</strong><dd><code>Adds variable resolution coverage for nested objects, lists, missing variables, and top-level variables.</code></dd></td><td><a href="https://github.com/nhost/nhost/pull/XXX/files#diff-27ecbcae4ca0250d1cc288deffb1bcaf70eb3490c299600d5d9e3510bccb5c2a">+88/-0</a></td></tr>
</table></details></td></tr>
<tr><td><strong>Controller and integration</strong></td><td><details><summary>3 files</summary><table>
<tr><td><strong>services/constellation/controller/results.go</strong><dd><code>Removes aliased phantom response keys from primary query results by path.</code></dd></td><td><a href="https://github.com/nhost/nhost/pull/XXX/files#diff-557f38a31bd2079b28b09db79a0c5d208324661dfeef33d27862fe3320bb8fde">+24/-5</a></td></tr>
<tr><td><strong>services/constellation/controller/results_internal_test.go</strong><dd><code>Covers cleanup of aliased phantom fields without deleting user aliases.</code></dd></td><td><a href="https://github.com/nhost/nhost/pull/XXX/files#diff-0f32b81a23d94b6996aaef894e7a1d53b285bfbc89168abd66f4a10f4601dd19">+49/-0</a></td></tr>
<tr><td><strong>services/constellation/integration/query_remote_relationships_test.go</strong><dd><code>Adds end-to-end cases for user filters and alias collisions in remote relationships.</code></dd></td><td><a href="https://github.com/nhost/nhost/pull/XXX/files#diff-9b1a9eb84d77beaf2980bfad28392c97fb44d38583d3a16404e2be9692770f1a">+55/-0</a></td></tr>
</table></details></td></tr>
<tr><td><strong>Documentation</strong></td><td><details><summary>1 file</summary><table>
<tr><td><strong>services/constellation/docs/developers/remote-relationships.md</strong><dd><code>Documents alias-aware phantom field selection and propagation.</code></dd></td><td><a href="https://github.com/nhost/nhost/pull/XXX/files#diff-67aacd920ad7bbf3e89e9334311b9b46b98bc1216c89a603000096060b7036ae">+3/-2</a></td></tr>
</table></details></td></tr>
</tbody></table>

</details>

___

<!-- nhost-reviewer:end -->
