### PR TITLE
feat(ghactivity): change link rendering to not show previews 

### DIFF
--- a/tools/ghactivity/internal/render/render.go
+++ b/tools/ghactivity/internal/render/render.go
@@ -10,7 +10,9 @@ import (
 	"github.com/nhost/nhost/tools/ghactivity/internal/activity"
 )
 
-// Markdown writes the report to w in the team's stand-up format.
+// Markdown writes the report to w in the team's stand-up format. Link URLs
+// are wrapped in angle brackets so that renderers like Slack and GitHub do
+// not expand them into rich previews.
 func Markdown(w io.Writer, r *activity.Report) error {
 	if err := writeHeader(w, r); err != nil {
 		return err
@@ -118,7 +120,7 @@ func writeItems(w io.Writer, items []activity.Item) error {
 
 	for _, it := range sorted {
 		if _, err := fmt.Fprintf(
-			w, "- [%s #%d](%s) %s\n", it.Kind, it.Number, it.URL, it.Title,
+			w, "- [%s #%d](<%s>) %s\n", it.Kind, it.Number, it.URL, it.Title,
 		); err != nil {
 			return wrap(err)
 		}

--- a/tools/ghactivity/internal/render/render_test.go
+++ b/tools/ghactivity/internal/render/render_test.go
@@ -117,11 +117,11 @@ func TestMarkdownItemsSortedAndFormatted(t *testing.T) {
 		t.Errorf("expected PR #4319 before #4321; got:\n%s", got)
 	}
 
-	if !strings.Contains(got, "[PR #12](https://example.com/pr/12) a reviewed pr") {
+	if !strings.Contains(got, "[PR #12](<https://example.com/pr/12>) a reviewed pr") {
 		t.Errorf("expected formatted reviewed PR line, got:\n%s", got)
 	}
 
-	if !strings.Contains(got, "[Issue #13](https://example.com/issue/13) an issue") {
+	if !strings.Contains(got, "[Issue #13](<https://example.com/issue/13>) an issue") {
 		t.Errorf("expected formatted issue line, got:\n%s", got)
 	}
 }


### PR DESCRIPTION
### Checklist

- [x] No breaking changes
- [x] Tests pass
- [x] New features have new tests
- [x] Documentation is updated (if applicable)
- [x] Title of the PR is in the correct format (see below)

<!-- nhost-reviewer:start -->
### **What this PR solves**
Markdown reports rendered by `gh activity` expand their PR/issue links into rich previews on Slack and GitHub, which clutters stand-up reports. This makes the renderer always wrap link URLs in angle brackets so renderers leave them as plain links.

___

### **PR Type**
Enhancement

___

### **Description**
- Change `render.Markdown` so PR/issue list items always emit URLs as `[title](<URL>)`, suppressing rich previews on Slack and GitHub.
- Update the affected assertions in the existing render test to expect the angle-bracketed format.

___

<details> <summary><h3> File Walkthrough</h3></summary>

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody>
<tr><td><strong>Enhancement</strong></td><td><details><summary>1 files</summary><table>
<tr>
  <td><strong>render.go</strong><dd><code>Wrap link URLs in angle brackets to suppress link previews</code></dd></td>
  <td><a href="https://github.com/nhost/nhost/pull/4469/files#diff-563d8a25977e05b1061f768f046b74caaa0469f215362551bca5e6e30b06e262">+4/-2</a></td>
</tr>
</table></details></td></tr>
<tr><td><strong>Tests</strong></td><td><details><summary>1 files</summary><table>
<tr>
  <td><strong>render_test.go</strong><dd><code>Expect angle-bracketed URLs in the formatted list output</code></dd></td>
  <td><a href="https://github.com/nhost/nhost/pull/4469/files#diff-28b89dd685afba5d8e5ef6ac0dd6709f582001466ce6f0039a16509ce187a353">+2/-2</a></td>
</tr>
</table></details></td></tr>
</tbody></table>

</details>

___

<!-- nhost-reviewer:end -->
