### PR TITLE
feat(constellation): accept permission columns wildcard shorthand

### DIFF
--- a/services/constellation/connector/sql/reconcile.go
+++ b/services/constellation/connector/sql/reconcile.go
@@ -11,6 +11,8 @@ import (
 	"github.com/nhost/nhost/services/constellation/metadata"
 )
 
+const selectPermissionAllColumns = "*"
+
 // reconcileMetadata walks dbMeta against the introspected objects and returns
 // a filtered copy in which every entity that does not exist in the source has
 // been removed. Each removal is recorded on inc (pass nil to discard).
@@ -120,10 +122,11 @@ func reconcileTables(
 		t := &surviving[i]
 
 		introspected, _ := objects.GetTable(t.Table.Schema, t.Table.Name)
-		cols := columnNameSet(introspected)
+		columnNames := tableColumnNames(introspected)
+		cols := columnNameSet(columnNames)
 
 		reconcileColumnConfig(ctx, logger, inc, dbName, t, cols)
-		reconcilePermissionColumns(ctx, logger, inc, dbName, t, cols)
+		reconcilePermissionColumns(ctx, logger, inc, dbName, t, columnNames, cols)
 		reconcileRelationships(ctx, logger, inc, dbName, t, survivingNames)
 		reconcileRelationshipFKIntrospection(ctx, logger, inc, dbName, t, introspected, objects)
 	}
@@ -131,16 +134,26 @@ func reconcileTables(
 	return surviving
 }
 
-// columnNameSet returns the set of column names exposed by t. The empty case
-// (nil t) is handled defensively so callers do not have to.
-func columnNameSet(t *introspection.Table) map[string]struct{} {
+// tableColumnNames returns the column names exposed by t in introspection
+// order. The empty case (nil t) is handled defensively so callers do not have
+// to.
+func tableColumnNames(t *introspection.Table) []string {
 	if t == nil {
 		return nil
 	}
 
-	out := make(map[string]struct{}, len(t.Columns))
+	out := make([]string, 0, len(t.Columns))
 	for _, col := range t.Columns {
-		out[col.Name] = struct{}{}
+		out = append(out, col.Name)
+	}
+
+	return out
+}
+
+func columnNameSet(columns []string) map[string]struct{} {
+	out := make(map[string]struct{}, len(columns))
+	for _, col := range columns {
+		out[col] = struct{}{}
 	}
 
 	return out
@@ -222,6 +235,7 @@ func reconcilePermissionColumns(
 	inc *metadata.Inconsistencies,
 	dbName string,
 	t *metadata.TableMetadata,
+	allColumns []string,
 	cols map[string]struct{},
 ) {
 	// The slice headers we received were value-copied from the caller's
@@ -233,7 +247,7 @@ func reconcilePermissionColumns(
 		p := &t.SelectPermissions[i]
 		p.Permission.Columns = filterColumnList(
 			ctx, logger, inc, dbName, t, p.Role, "select_permission.columns",
-			p.Permission.Columns, cols,
+			expandSelectPermissionColumns(p.Permission.Columns, allColumns), cols,
 		)
 	}
 
@@ -262,6 +276,14 @@ func reconcilePermissionColumns(
 			p.Permission.Set, cols,
 		)
 	}
+}
+
+func expandSelectPermissionColumns(list, allColumns []string) []string {
+	if len(list) == 1 && list[0] == selectPermissionAllColumns {
+		return slices.Clone(allColumns)
+	}
+
+	return list
 }
 
 func filterColumnList(

--- a/services/constellation/connector/sql/reconcile.go
+++ b/services/constellation/connector/sql/reconcile.go
@@ -11,7 +11,7 @@ import (
 	"github.com/nhost/nhost/services/constellation/metadata"
 )
 
-const selectPermissionAllColumns = "*"
+const permissionAllColumns = "*"
 
 // reconcileMetadata walks dbMeta against the introspected objects and returns
 // a filtered copy in which every entity that does not exist in the source has
@@ -247,7 +247,7 @@ func reconcilePermissionColumns(
 		p := &t.SelectPermissions[i]
 		p.Permission.Columns = filterColumnList(
 			ctx, logger, inc, dbName, t, p.Role, "select_permission.columns",
-			expandSelectPermissionColumns(p.Permission.Columns, allColumns), cols,
+			expandPermissionColumns(p.Permission.Columns, allColumns), cols,
 		)
 	}
 
@@ -256,7 +256,7 @@ func reconcilePermissionColumns(
 		p := &t.InsertPermissions[i]
 		p.Permission.Columns = filterColumnList(
 			ctx, logger, inc, dbName, t, p.Role, "insert_permission.columns",
-			p.Permission.Columns, cols,
+			expandPermissionColumns(p.Permission.Columns, allColumns), cols,
 		)
 		p.Permission.Set = filterColumnKeyMap(
 			ctx, logger, inc, dbName, t, p.Role, "insert_permission.set",
@@ -269,7 +269,7 @@ func reconcilePermissionColumns(
 		p := &t.UpdatePermissions[i]
 		p.Permission.Columns = filterColumnList(
 			ctx, logger, inc, dbName, t, p.Role, "update_permission.columns",
-			p.Permission.Columns, cols,
+			expandPermissionColumns(p.Permission.Columns, allColumns), cols,
 		)
 		p.Permission.Set = filterColumnKeyMap(
 			ctx, logger, inc, dbName, t, p.Role, "update_permission.set",
@@ -278,8 +278,8 @@ func reconcilePermissionColumns(
 	}
 }
 
-func expandSelectPermissionColumns(list, allColumns []string) []string {
-	if len(list) == 1 && list[0] == selectPermissionAllColumns {
+func expandPermissionColumns(list, allColumns []string) []string {
+	if len(list) == 1 && list[0] == permissionAllColumns {
 		return slices.Clone(allColumns)
 	}
 

--- a/services/constellation/connector/sql/reconcile_internal_test.go
+++ b/services/constellation/connector/sql/reconcile_internal_test.go
@@ -227,7 +227,7 @@ func TestReconcileMetadata_DropsMissingColumns(t *testing.T) {
 	}
 }
 
-func TestReconcileMetadata_ExpandsSelectPermissionAllColumnsShorthand(t *testing.T) {
+func TestReconcileMetadata_ExpandsPermissionAllColumnsShorthand(t *testing.T) {
 	t.Parallel()
 
 	dbMeta := &metadata.DatabaseMetadata{ //nolint:exhaustruct
@@ -239,7 +239,23 @@ func TestReconcileMetadata_ExpandsSelectPermissionAllColumnsShorthand(t *testing
 					{
 						Role: "user",
 						Permission: metadata.SelectPermissionConfig{ //nolint:exhaustruct
-							Columns: []string{selectPermissionAllColumns},
+							Columns: []string{permissionAllColumns},
+						},
+					},
+				},
+				InsertPermissions: []metadata.InsertPermission{
+					{
+						Role: "user",
+						Permission: metadata.InsertPermissionConfig{ //nolint:exhaustruct
+							Columns: []string{permissionAllColumns},
+						},
+					},
+				},
+				UpdatePermissions: []metadata.UpdatePermission{
+					{
+						Role: "user",
+						Permission: metadata.UpdatePermissionConfig{ //nolint:exhaustruct
+							Columns: []string{permissionAllColumns},
 						},
 					},
 				},
@@ -250,18 +266,56 @@ func TestReconcileMetadata_ExpandsSelectPermissionAllColumnsShorthand(t *testing
 	inc := metadata.NewInconsistencies()
 	out := reconcileMetadata(t.Context(), nil, inc, dbMeta, makeObjects())
 
-	got := out.Tables[0].SelectPermissions[0].Permission.Columns
-	if !slices.Equal(got, []string{"id", "name"}) {
-		t.Fatalf("select_permission.columns = %v, want [id name]", got)
+	permissions := []struct {
+		name string
+		got  []string
+	}{
+		{
+			name: "select_permission.columns",
+			got:  out.Tables[0].SelectPermissions[0].Permission.Columns,
+		},
+		{
+			name: "insert_permission.columns",
+			got:  out.Tables[0].InsertPermissions[0].Permission.Columns,
+		},
+		{
+			name: "update_permission.columns",
+			got:  out.Tables[0].UpdatePermissions[0].Permission.Columns,
+		},
+	}
+
+	for _, p := range permissions {
+		if !slices.Equal(p.got, []string{"id", "name"}) {
+			t.Fatalf("%s = %v, want [id name]", p.name, p.got)
+		}
 	}
 
 	if inc.Len() != 0 {
 		t.Fatalf("expected no inconsistencies, got %+v", inc.Snapshot())
 	}
 
-	inputColumns := dbMeta.Tables[0].SelectPermissions[0].Permission.Columns
-	if !slices.Equal(inputColumns, []string{selectPermissionAllColumns}) {
-		t.Fatalf("input columns mutated to %v", inputColumns)
+	inputColumns := []struct {
+		name string
+		got  []string
+	}{
+		{
+			name: "select_permission.columns",
+			got:  dbMeta.Tables[0].SelectPermissions[0].Permission.Columns,
+		},
+		{
+			name: "insert_permission.columns",
+			got:  dbMeta.Tables[0].InsertPermissions[0].Permission.Columns,
+		},
+		{
+			name: "update_permission.columns",
+			got:  dbMeta.Tables[0].UpdatePermissions[0].Permission.Columns,
+		},
+	}
+
+	for _, p := range inputColumns {
+		if !slices.Equal(p.got, []string{permissionAllColumns}) {
+			t.Fatalf("%s input columns mutated to %v", p.name, p.got)
+		}
 	}
 }
 

--- a/services/constellation/connector/sql/reconcile_internal_test.go
+++ b/services/constellation/connector/sql/reconcile_internal_test.go
@@ -227,6 +227,44 @@ func TestReconcileMetadata_DropsMissingColumns(t *testing.T) {
 	}
 }
 
+func TestReconcileMetadata_ExpandsSelectPermissionAllColumnsShorthand(t *testing.T) {
+	t.Parallel()
+
+	dbMeta := &metadata.DatabaseMetadata{ //nolint:exhaustruct
+		Name: "default",
+		Tables: []metadata.TableMetadata{ //nolint:exhaustruct
+			{
+				Table: metadata.TableSource{Schema: "public", Name: "users"},
+				SelectPermissions: []metadata.SelectPermission{
+					{
+						Role: "user",
+						Permission: metadata.SelectPermissionConfig{ //nolint:exhaustruct
+							Columns: []string{selectPermissionAllColumns},
+						},
+					},
+				},
+			},
+		},
+	}
+
+	inc := metadata.NewInconsistencies()
+	out := reconcileMetadata(t.Context(), nil, inc, dbMeta, makeObjects())
+
+	got := out.Tables[0].SelectPermissions[0].Permission.Columns
+	if !slices.Equal(got, []string{"id", "name"}) {
+		t.Fatalf("select_permission.columns = %v, want [id name]", got)
+	}
+
+	if inc.Len() != 0 {
+		t.Fatalf("expected no inconsistencies, got %+v", inc.Snapshot())
+	}
+
+	inputColumns := dbMeta.Tables[0].SelectPermissions[0].Permission.Columns
+	if !slices.Equal(inputColumns, []string{selectPermissionAllColumns}) {
+		t.Fatalf("input columns mutated to %v", inputColumns)
+	}
+}
+
 // TestReconcileMetadata_DoesNotMutateInput verifies that reconcileMetadata
 // keeps its godoc contract — "returns a filtered copy" — even when filtering
 // rewrites permission column lists / set maps. The slice headers we receive

--- a/services/constellation/docs/user/hasura-metadata-support.md
+++ b/services/constellation/docs/user/hasura-metadata-support.md
@@ -148,7 +148,7 @@ parameterized SQL values.
 
 | Field | Status | Notes |
 |---|---|---|
-| `columns` | ✅ | Gates column visibility. |
+| `columns` | ✅ | Gates column visibility. Accepts Hasura's `columns: '*'` all-columns shorthand and explicit column lists. |
 | `filter` | ✅ | Row filter; AND-ed into every `WHERE`. Full Hasura boolean-expression syntax. |
 | `allow_aggregations` | ✅ | Gates the `_aggregate` root field for the role. |
 | `limit` | ⚪ | **Not enforced.** A per-role row `limit` is parsed away and has no effect — enforce row caps another way. |

--- a/services/constellation/docs/user/hasura-metadata-support.md
+++ b/services/constellation/docs/user/hasura-metadata-support.md
@@ -160,7 +160,7 @@ parameterized SQL values.
 
 | Field | Status | Notes |
 |---|---|---|
-| `columns` | ✅ | Gates which columns the role may set. |
+| `columns` | ✅ | Gates which columns the role may set. Accepts Hasura's `columns: '*'` all-columns shorthand and explicit column lists. |
 | `check` | ✅ | Per-row boolean check; rows failing it are rejected (all-or-nothing). Evaluated against the input payload by default and switched to a post-INSERT check (against `RETURNING *`) when the predicate references a column whose final value is only known after the row exists — generated columns, identity columns (Postgres `GENERATED AS IDENTITY`, SQLite `INTEGER PRIMARY KEY` rowid alias), or a DB-defaulted column the payload omits. Enforced on Postgres via `RETURNING` + `constellation_throw_error`. |
 | `set` | ✅ | Column presets (incl. session variables) forcibly written on every insert. |
 | `backend_only` | ⚪ | Not honored — the mutation is exposed regardless. |
@@ -170,7 +170,7 @@ parameterized SQL values.
 
 | Field | Status | Notes |
 |---|---|---|
-| `columns` | ✅ | Gates which columns the role may modify. If a role has **no** updatable columns, the update mutations are omitted (see [`KNOWN_DIFFERENCES.md`](../../KNOWN_DIFFERENCES.md)). |
+| `columns` | ✅ | Gates which columns the role may modify. Accepts Hasura's `columns: '*'` all-columns shorthand and explicit column lists. If a role has **no** updatable columns, the update mutations are omitted (see [`KNOWN_DIFFERENCES.md`](../../KNOWN_DIFFERENCES.md)). |
 | `filter` | ✅ | Pre-condition: which rows are visible to update. |
 | `check` | ✅ | Post-condition on the updated row; violations rejected. |
 | `set` | ✅ | Column presets forcibly written on every update. |

--- a/services/constellation/metadata/convert_test.go
+++ b/services/constellation/metadata/convert_test.go
@@ -3,6 +3,7 @@ package metadata_test
 import (
 	"os"
 	"path/filepath"
+	"strings"
 	"testing"
 
 	"github.com/google/go-cmp/cmp"
@@ -68,6 +69,17 @@ func TestFromHasuraJSON(t *testing.T) {
 			check:   assertHappyPathJSON,
 		},
 		{
+			name: "select permission all-columns shorthand",
+			data: []byte(strings.Replace(
+				validHasuraJSON,
+				`"columns": ["id"]`,
+				`"columns": "*"`,
+				1,
+			)),
+			wantErr: false,
+			check:   assertAllColumnsShorthandJSON,
+		},
+		{
 			name:    "malformed JSON",
 			data:    []byte(`{not valid json`),
 			wantErr: true,
@@ -94,6 +106,24 @@ func TestFromHasuraJSON(t *testing.T) {
 			m, err := metadata.FromHasuraJSON(tt.data)
 			checkLoaderResult(t, m, err, tt.wantErr, tt.check)
 		})
+	}
+}
+
+func assertAllColumnsShorthandJSON(t *testing.T, m *metadata.Metadata) {
+	t.Helper()
+
+	if len(m.Databases) != 1 || len(m.Databases[0].Tables) != 1 {
+		t.Fatalf("unexpected metadata shape: %+v", m)
+	}
+
+	perms := m.Databases[0].Tables[0].SelectPermissions
+	if len(perms) != 1 {
+		t.Fatalf("expected one select permission, got %+v", perms)
+	}
+
+	got := perms[0].Permission.Columns
+	if !cmp.Equal(got, []string{"*"}) {
+		t.Fatalf("select permission columns mismatch:\n%s", cmp.Diff([]string{"*"}, got))
 	}
 }
 

--- a/services/constellation/metadata/internal/hasura/table.go
+++ b/services/constellation/metadata/internal/hasura/table.go
@@ -23,17 +23,17 @@ var errForeignKeyListEntryNotString = errors.New(
 	"foreign_key_constraint_on: list entry is not a string",
 )
 
-const selectPermissionAllColumns = "*"
+const permissionAllColumns = "*"
 
 var (
-	errSelectColumnsStringNotWildcard = errors.New(
-		"select permission columns string must be '*'",
+	errPermissionColumnsStringNotWildcard = errors.New(
+		"permission columns string must be '*'",
 	)
-	errSelectColumnsListEntryNotString = errors.New(
-		"select permission columns list entry is not a string",
+	errPermissionColumnsListEntryNotString = errors.New(
+		"permission columns list entry is not a string",
 	)
-	errUnexpectedSelectColumnsToken = errors.New(
-		"select permission columns: expected '*', array, or null",
+	errUnexpectedPermissionColumnsToken = errors.New(
+		"permission columns: expected '*', array, or null",
 	)
 )
 
@@ -160,7 +160,7 @@ func (p *SelectPermissionConfig) UnmarshalYAML(unmarshal func(any) error) error 
 		return fmt.Errorf("unmarshaling select permission: %w", err)
 	}
 
-	columns, err := parseSelectPermissionColumnsYAML(raw.Columns)
+	columns, err := parsePermissionColumnsYAML(raw.Columns)
 	if err != nil {
 		return fmt.Errorf("unmarshaling select permission columns: %w", err)
 	}
@@ -172,16 +172,16 @@ func (p *SelectPermissionConfig) UnmarshalYAML(unmarshal func(any) error) error 
 	return nil
 }
 
-func parseSelectPermissionColumnsYAML(value any) ([]string, error) {
+func parsePermissionColumnsYAML(value any) ([]string, error) {
 	switch v := value.(type) {
 	case nil:
 		return nil, nil
 	case string:
-		if v != selectPermissionAllColumns {
-			return nil, errSelectColumnsStringNotWildcard
+		if v != permissionAllColumns {
+			return nil, errPermissionColumnsStringNotWildcard
 		}
 
-		return []string{selectPermissionAllColumns}, nil
+		return []string{permissionAllColumns}, nil
 	case []string:
 		return append([]string(nil), v...), nil
 	case []any:
@@ -191,7 +191,7 @@ func parseSelectPermissionColumnsYAML(value any) ([]string, error) {
 			if !ok {
 				return nil, fmt.Errorf(
 					"%w (index %d, type %T)",
-					errSelectColumnsListEntryNotString, i, item,
+					errPermissionColumnsListEntryNotString, i, item,
 				)
 			}
 
@@ -200,7 +200,7 @@ func parseSelectPermissionColumnsYAML(value any) ([]string, error) {
 
 		return columns, nil
 	default:
-		return nil, fmt.Errorf("%w (type %T)", errUnexpectedSelectColumnsToken, value)
+		return nil, fmt.Errorf("%w (type %T)", errUnexpectedPermissionColumnsToken, value)
 	}
 }
 
@@ -219,7 +219,7 @@ func (p *SelectPermissionConfig) UnmarshalJSON(data []byte) error {
 		return fmt.Errorf("unmarshaling select permission: %w", err)
 	}
 
-	columns, err := parseSelectPermissionColumnsJSON(raw.Columns)
+	columns, err := parsePermissionColumnsJSON(raw.Columns)
 	if err != nil {
 		return fmt.Errorf("unmarshaling select permission columns: %w", err)
 	}
@@ -231,7 +231,7 @@ func (p *SelectPermissionConfig) UnmarshalJSON(data []byte) error {
 	return nil
 }
 
-func parseSelectPermissionColumnsJSON(value jsontext.Value) ([]string, error) {
+func parsePermissionColumnsJSON(value jsontext.Value) ([]string, error) {
 	if value == nil {
 		return nil, nil
 	}
@@ -250,11 +250,11 @@ func parseSelectPermissionColumnsJSON(value jsontext.Value) ([]string, error) {
 			return nil, fmt.Errorf("decoding columns shorthand: %w", err)
 		}
 
-		if shorthand != selectPermissionAllColumns {
-			return nil, errSelectColumnsStringNotWildcard
+		if shorthand != permissionAllColumns {
+			return nil, errPermissionColumnsStringNotWildcard
 		}
 
-		return []string{selectPermissionAllColumns}, nil
+		return []string{permissionAllColumns}, nil
 	case '[':
 		var columns []string
 		if err := json.Unmarshal(value, &columns); err != nil {
@@ -264,7 +264,7 @@ func parseSelectPermissionColumnsJSON(value jsontext.Value) ([]string, error) {
 		return columns, nil
 	default:
 		return nil, fmt.Errorf(
-			"%w (token %q)", errUnexpectedSelectColumnsToken,
+			"%w (token %q)", errUnexpectedPermissionColumnsToken,
 			firstNonWhitespaceByte(value),
 		)
 	}
@@ -278,6 +278,61 @@ type InsertPermissionConfig struct {
 	Set     map[string]any `json:"set,omitempty"     yaml:"set,omitempty"`
 }
 
+// UnmarshalYAML accepts Hasura's insert-permission `columns: '*'` shorthand
+// in addition to the explicit list of column names. The shorthand is kept as
+// a one-element slice and expanded after database introspection, when the full
+// column list is known.
+func (p *InsertPermissionConfig) UnmarshalYAML(unmarshal func(any) error) error {
+	type rawConfig struct {
+		Columns any            `yaml:"columns,omitempty"`
+		Check   map[string]any `yaml:"check,omitempty"`
+		Set     map[string]any `yaml:"set,omitempty"`
+	}
+
+	var raw rawConfig
+	if err := unmarshal(&raw); err != nil {
+		return fmt.Errorf("unmarshaling insert permission: %w", err)
+	}
+
+	columns, err := parsePermissionColumnsYAML(raw.Columns)
+	if err != nil {
+		return fmt.Errorf("unmarshaling insert permission columns: %w", err)
+	}
+
+	p.Columns = columns
+	p.Check = raw.Check
+	p.Set = raw.Set
+
+	return nil
+}
+
+// UnmarshalJSON accepts Hasura's insert-permission `columns: "*"` shorthand
+// in addition to the explicit list of column names. The shorthand is kept as
+// a one-element slice and expanded after database introspection, when the full
+// column list is known.
+func (p *InsertPermissionConfig) UnmarshalJSON(data []byte) error {
+	var raw struct {
+		Columns jsontext.Value `json:"columns,omitempty"`
+		Check   map[string]any `json:"check,omitempty"`
+		Set     map[string]any `json:"set,omitempty"`
+	}
+
+	if err := json.Unmarshal(data, &raw); err != nil {
+		return fmt.Errorf("unmarshaling insert permission: %w", err)
+	}
+
+	columns, err := parsePermissionColumnsJSON(raw.Columns)
+	if err != nil {
+		return fmt.Errorf("unmarshaling insert permission columns: %w", err)
+	}
+
+	p.Columns = columns
+	p.Check = raw.Check
+	p.Set = raw.Set
+
+	return nil
+}
+
 // UpdatePermissionConfig captures the columns, row filter, post-update check,
 // and presets an update permission grants.
 type UpdatePermissionConfig struct {
@@ -285,6 +340,65 @@ type UpdatePermissionConfig struct {
 	Filter  map[string]any `json:"filter,omitempty"  yaml:"filter,omitempty"`
 	Check   map[string]any `json:"check,omitempty"   yaml:"check,omitempty"`
 	Set     map[string]any `json:"set,omitempty"     yaml:"set,omitempty"`
+}
+
+// UnmarshalYAML accepts Hasura's update-permission `columns: '*'` shorthand
+// in addition to the explicit list of column names. The shorthand is kept as
+// a one-element slice and expanded after database introspection, when the full
+// column list is known.
+func (p *UpdatePermissionConfig) UnmarshalYAML(unmarshal func(any) error) error {
+	type rawConfig struct {
+		Columns any            `yaml:"columns,omitempty"`
+		Filter  map[string]any `yaml:"filter,omitempty"`
+		Check   map[string]any `yaml:"check,omitempty"`
+		Set     map[string]any `yaml:"set,omitempty"`
+	}
+
+	var raw rawConfig
+	if err := unmarshal(&raw); err != nil {
+		return fmt.Errorf("unmarshaling update permission: %w", err)
+	}
+
+	columns, err := parsePermissionColumnsYAML(raw.Columns)
+	if err != nil {
+		return fmt.Errorf("unmarshaling update permission columns: %w", err)
+	}
+
+	p.Columns = columns
+	p.Filter = raw.Filter
+	p.Check = raw.Check
+	p.Set = raw.Set
+
+	return nil
+}
+
+// UnmarshalJSON accepts Hasura's update-permission `columns: "*"` shorthand
+// in addition to the explicit list of column names. The shorthand is kept as
+// a one-element slice and expanded after database introspection, when the full
+// column list is known.
+func (p *UpdatePermissionConfig) UnmarshalJSON(data []byte) error {
+	var raw struct {
+		Columns jsontext.Value `json:"columns,omitempty"`
+		Filter  map[string]any `json:"filter,omitempty"`
+		Check   map[string]any `json:"check,omitempty"`
+		Set     map[string]any `json:"set,omitempty"`
+	}
+
+	if err := json.Unmarshal(data, &raw); err != nil {
+		return fmt.Errorf("unmarshaling update permission: %w", err)
+	}
+
+	columns, err := parsePermissionColumnsJSON(raw.Columns)
+	if err != nil {
+		return fmt.Errorf("unmarshaling update permission columns: %w", err)
+	}
+
+	p.Columns = columns
+	p.Filter = raw.Filter
+	p.Check = raw.Check
+	p.Set = raw.Set
+
+	return nil
 }
 
 // DeletePermissionConfig captures the row filter a delete permission applies.

--- a/services/constellation/metadata/internal/hasura/table.go
+++ b/services/constellation/metadata/internal/hasura/table.go
@@ -23,6 +23,20 @@ var errForeignKeyListEntryNotString = errors.New(
 	"foreign_key_constraint_on: list entry is not a string",
 )
 
+const selectPermissionAllColumns = "*"
+
+var (
+	errSelectColumnsStringNotWildcard = errors.New(
+		"select permission columns string must be '*'",
+	)
+	errSelectColumnsListEntryNotString = errors.New(
+		"select permission columns list entry is not a string",
+	)
+	errUnexpectedSelectColumnsToken = errors.New(
+		"select permission columns: expected '*', array, or null",
+	)
+)
+
 // TableMetadata is the Hasura representation of a tracked table.
 type TableMetadata struct {
 	Table               TableSource          `json:"table"                          yaml:"table"`
@@ -128,6 +142,132 @@ type SelectPermissionConfig struct {
 	Columns           []string       `json:"columns,omitempty"           yaml:"columns,omitempty"`
 	Filter            map[string]any `json:"filter,omitempty"            yaml:"filter,omitempty"`
 	AllowAggregations bool           `json:"allow_aggregations,omitzero" yaml:"allow_aggregations,omitempty"`
+}
+
+// UnmarshalYAML accepts Hasura's select-permission `columns: '*'` shorthand
+// in addition to the explicit list of column names. The shorthand is kept as
+// a one-element slice and expanded after database introspection, when the full
+// column list is known.
+func (p *SelectPermissionConfig) UnmarshalYAML(unmarshal func(any) error) error {
+	type rawConfig struct {
+		Columns           any            `yaml:"columns,omitempty"`
+		Filter            map[string]any `yaml:"filter,omitempty"`
+		AllowAggregations bool           `yaml:"allow_aggregations,omitempty"`
+	}
+
+	var raw rawConfig
+	if err := unmarshal(&raw); err != nil {
+		return fmt.Errorf("unmarshaling select permission: %w", err)
+	}
+
+	columns, err := parseSelectPermissionColumnsYAML(raw.Columns)
+	if err != nil {
+		return fmt.Errorf("unmarshaling select permission columns: %w", err)
+	}
+
+	p.Columns = columns
+	p.Filter = raw.Filter
+	p.AllowAggregations = raw.AllowAggregations
+
+	return nil
+}
+
+func parseSelectPermissionColumnsYAML(value any) ([]string, error) {
+	switch v := value.(type) {
+	case nil:
+		return nil, nil
+	case string:
+		if v != selectPermissionAllColumns {
+			return nil, errSelectColumnsStringNotWildcard
+		}
+
+		return []string{selectPermissionAllColumns}, nil
+	case []string:
+		return append([]string(nil), v...), nil
+	case []any:
+		columns := make([]string, 0, len(v))
+		for i, item := range v {
+			column, ok := item.(string)
+			if !ok {
+				return nil, fmt.Errorf(
+					"%w (index %d, type %T)",
+					errSelectColumnsListEntryNotString, i, item,
+				)
+			}
+
+			columns = append(columns, column)
+		}
+
+		return columns, nil
+	default:
+		return nil, fmt.Errorf("%w (type %T)", errUnexpectedSelectColumnsToken, value)
+	}
+}
+
+// UnmarshalJSON accepts Hasura's select-permission `columns: "*"` shorthand
+// in addition to the explicit list of column names. The shorthand is kept as
+// a one-element slice and expanded after database introspection, when the full
+// column list is known.
+func (p *SelectPermissionConfig) UnmarshalJSON(data []byte) error {
+	var raw struct {
+		Columns           jsontext.Value `json:"columns,omitempty"`
+		Filter            map[string]any `json:"filter,omitempty"`
+		AllowAggregations bool           `json:"allow_aggregations,omitzero"`
+	}
+
+	if err := json.Unmarshal(data, &raw); err != nil {
+		return fmt.Errorf("unmarshaling select permission: %w", err)
+	}
+
+	columns, err := parseSelectPermissionColumnsJSON(raw.Columns)
+	if err != nil {
+		return fmt.Errorf("unmarshaling select permission columns: %w", err)
+	}
+
+	p.Columns = columns
+	p.Filter = raw.Filter
+	p.AllowAggregations = raw.AllowAggregations
+
+	return nil
+}
+
+func parseSelectPermissionColumnsJSON(value jsontext.Value) ([]string, error) {
+	if value == nil {
+		return nil, nil
+	}
+
+	switch firstNonWhitespaceByte(value) {
+	case 'n':
+		var columns []string
+		if err := json.Unmarshal(value, &columns); err != nil {
+			return nil, fmt.Errorf("decoding columns null: %w", err)
+		}
+
+		return columns, nil
+	case '"':
+		var shorthand string
+		if err := json.Unmarshal(value, &shorthand); err != nil {
+			return nil, fmt.Errorf("decoding columns shorthand: %w", err)
+		}
+
+		if shorthand != selectPermissionAllColumns {
+			return nil, errSelectColumnsStringNotWildcard
+		}
+
+		return []string{selectPermissionAllColumns}, nil
+	case '[':
+		var columns []string
+		if err := json.Unmarshal(value, &columns); err != nil {
+			return nil, fmt.Errorf("decoding columns list: %w", err)
+		}
+
+		return columns, nil
+	default:
+		return nil, fmt.Errorf(
+			"%w (token %q)", errUnexpectedSelectColumnsToken,
+			firstNonWhitespaceByte(value),
+		)
+	}
 }
 
 // InsertPermissionConfig captures the columns, row-level check, and presets an

--- a/services/constellation/metadata/internal/hasura/table_internal_test.go
+++ b/services/constellation/metadata/internal/hasura/table_internal_test.go
@@ -2,6 +2,7 @@ package hasura
 
 import (
 	json "encoding/json/v2"
+	"fmt"
 	"strings"
 	"testing"
 
@@ -28,7 +29,7 @@ func TestSelectPermissionConfig_UnmarshalYAML(t *testing.T) {
 		{
 			name:            "all columns shorthand",
 			input:           "columns: '*'\nfilter: {}",
-			wantColumns:     []string{selectPermissionAllColumns},
+			wantColumns:     []string{permissionAllColumns},
 			wantErr:         false,
 			wantWrapContext: "",
 		},
@@ -94,7 +95,7 @@ func TestSelectPermissionConfig_UnmarshalJSON(t *testing.T) {
 		{
 			name:            "all columns shorthand",
 			input:           `{"columns":"*","filter":{}}`,
-			wantColumns:     []string{selectPermissionAllColumns},
+			wantColumns:     []string{permissionAllColumns},
 			wantErr:         false,
 			wantWrapContext: "",
 		},
@@ -142,6 +143,84 @@ func TestSelectPermissionConfig_UnmarshalJSON(t *testing.T) {
 
 			if !equalStringSlices(got.Columns, tt.wantColumns) {
 				t.Errorf("Columns = %v, want %v", got.Columns, tt.wantColumns)
+			}
+		})
+	}
+}
+
+func TestInsertAndUpdatePermissionConfig_UnmarshalColumnsShorthand(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name      string
+		input     []byte
+		unmarshal func([]byte) ([]string, error)
+	}{
+		{
+			name:  "insert yaml",
+			input: []byte("columns: '*'\ncheck: {}\nset: {id: X-Hasura-User-Id}"),
+			unmarshal: func(data []byte) ([]string, error) {
+				var got InsertPermissionConfig
+				if err := yaml.Unmarshal(data, &got); err != nil {
+					return nil, fmt.Errorf("unmarshaling insert permission yaml: %w", err)
+				}
+
+				return got.Columns, nil
+			},
+		},
+		{
+			name:  "insert json",
+			input: []byte(`{"columns":"*","check":{},"set":{"id":"X-Hasura-User-Id"}}`),
+			unmarshal: func(data []byte) ([]string, error) {
+				var got InsertPermissionConfig
+				if err := json.Unmarshal(data, &got); err != nil {
+					return nil, fmt.Errorf("unmarshaling insert permission json: %w", err)
+				}
+
+				return got.Columns, nil
+			},
+		},
+		{
+			name: "update yaml",
+			input: []byte(
+				"columns: '*'\nfilter: {}\ncheck: {}\nset: {updated_by: X-Hasura-User-Id}",
+			),
+			unmarshal: func(data []byte) ([]string, error) {
+				var got UpdatePermissionConfig
+				if err := yaml.Unmarshal(data, &got); err != nil {
+					return nil, fmt.Errorf("unmarshaling update permission yaml: %w", err)
+				}
+
+				return got.Columns, nil
+			},
+		},
+		{
+			name: "update json",
+			input: []byte(
+				`{"columns":"*","filter":{},"check":{},"set":{"updated_by":"X-Hasura-User-Id"}}`,
+			),
+			unmarshal: func(data []byte) ([]string, error) {
+				var got UpdatePermissionConfig
+				if err := json.Unmarshal(data, &got); err != nil {
+					return nil, fmt.Errorf("unmarshaling update permission json: %w", err)
+				}
+
+				return got.Columns, nil
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+
+			got, err := tt.unmarshal(tt.input)
+			if err != nil {
+				t.Fatalf("unmarshal failed: %v", err)
+			}
+
+			if !equalStringSlices(got, []string{permissionAllColumns}) {
+				t.Errorf("Columns = %v, want [%q]", got, permissionAllColumns)
 			}
 		})
 	}

--- a/services/constellation/metadata/internal/hasura/table_internal_test.go
+++ b/services/constellation/metadata/internal/hasura/table_internal_test.go
@@ -8,6 +8,145 @@ import (
 	"github.com/goccy/go-yaml"
 )
 
+func TestSelectPermissionConfig_UnmarshalYAML(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name            string
+		input           string
+		wantColumns     []string
+		wantErr         bool
+		wantWrapContext string
+	}{
+		{
+			name:            "explicit columns",
+			input:           "columns: [id, name]\nfilter: {}\nallow_aggregations: true",
+			wantColumns:     []string{"id", "name"},
+			wantErr:         false,
+			wantWrapContext: "",
+		},
+		{
+			name:            "all columns shorthand",
+			input:           "columns: '*'\nfilter: {}",
+			wantColumns:     []string{selectPermissionAllColumns},
+			wantErr:         false,
+			wantWrapContext: "",
+		},
+		{
+			name:            "non wildcard string rejected",
+			input:           "columns: id",
+			wantColumns:     nil,
+			wantErr:         true,
+			wantWrapContext: "must be '*'",
+		},
+		{
+			name:            "list with non-string entry rejected",
+			input:           "columns: [id, 42]",
+			wantColumns:     nil,
+			wantErr:         true,
+			wantWrapContext: "list entry is not a string",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+
+			var got SelectPermissionConfig
+
+			err := yaml.Unmarshal([]byte(tt.input), &got)
+			if (err != nil) != tt.wantErr {
+				t.Fatalf("unmarshal err = %v, wantErr=%v", err, tt.wantErr)
+			}
+
+			if tt.wantErr {
+				if err != nil && !strings.Contains(err.Error(), tt.wantWrapContext) {
+					t.Errorf("expected wrap context %q, got %v", tt.wantWrapContext, err)
+				}
+
+				return
+			}
+
+			if !equalStringSlices(got.Columns, tt.wantColumns) {
+				t.Errorf("Columns = %v, want %v", got.Columns, tt.wantColumns)
+			}
+		})
+	}
+}
+
+func TestSelectPermissionConfig_UnmarshalJSON(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name            string
+		input           string
+		wantColumns     []string
+		wantErr         bool
+		wantWrapContext string
+	}{
+		{
+			name:            "explicit columns",
+			input:           `{"columns":["id","name"],"filter":{},"allow_aggregations":true}`,
+			wantColumns:     []string{"id", "name"},
+			wantErr:         false,
+			wantWrapContext: "",
+		},
+		{
+			name:            "all columns shorthand",
+			input:           `{"columns":"*","filter":{}}`,
+			wantColumns:     []string{selectPermissionAllColumns},
+			wantErr:         false,
+			wantWrapContext: "",
+		},
+		{
+			name:            "null columns",
+			input:           `{"columns":null,"filter":{}}`,
+			wantColumns:     nil,
+			wantErr:         false,
+			wantWrapContext: "",
+		},
+		{
+			name:            "non wildcard string rejected",
+			input:           `{"columns":"id"}`,
+			wantColumns:     nil,
+			wantErr:         true,
+			wantWrapContext: "must be '*'",
+		},
+		{
+			name:            "list with non-string entry rejected",
+			input:           `{"columns":["id",42]}`,
+			wantColumns:     nil,
+			wantErr:         true,
+			wantWrapContext: "decoding columns list",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+
+			var got SelectPermissionConfig
+
+			err := json.Unmarshal([]byte(tt.input), &got)
+			if (err != nil) != tt.wantErr {
+				t.Fatalf("unmarshal err = %v, wantErr=%v", err, tt.wantErr)
+			}
+
+			if tt.wantErr {
+				if err != nil && !strings.Contains(err.Error(), tt.wantWrapContext) {
+					t.Errorf("expected wrap context %q, got %v", tt.wantWrapContext, err)
+				}
+
+				return
+			}
+
+			if !equalStringSlices(got.Columns, tt.wantColumns) {
+				t.Errorf("Columns = %v, want %v", got.Columns, tt.wantColumns)
+			}
+		})
+	}
+}
+
 // relationshipUsingCase is one input/output expectation pair used by both the
 // YAML and JSON test tables for RelationshipUsing.
 type relationshipUsingCase struct {


### PR DESCRIPTION
Fixes #4454

<!-- nhost-reviewer:start -->
### **What this PR solves**
This PR adds support for Hasura's `columns: "*"` permission shorthand in imported metadata. It preserves the shorthand during metadata parsing and expands it to concrete introspected columns during SQL metadata reconciliation.

___

### **PR Type**
Enhancement

___

### **Description**
- Accept `columns: '*'` / `columns: "*"` in select, insert, and update permission metadata unmarshalling.
- Expand all-columns permission shorthand to the table's introspected column list during SQL reconciliation without mutating input metadata.
- Document shorthand support and add parser/conversion/reconciliation tests.

___

### Diagram Walkthrough

```mermaid
flowchart LR
  A["Hasura metadata import"] --> B["metadata/internal/hasura permission parsers"]
  B --> C["metadata conversion keeps '*' sentinel"]
  C --> D["connector/sql reconcile expands using introspection"]
  D --> E["Runtime permission column lists"]
```

<details> <summary><h3> File Walkthrough</h3></summary>

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody>
<tr><td><strong>SQL reconciliation</strong></td><td><details><summary>2 files</summary><table>
<tr>
  <td><strong>services/constellation/connector/sql/reconcile.go</strong><dd><code>Expands permission all-columns shorthand before filtering permission column lists.</code></dd></td>
  <td><a href="https://github.com/nhost/nhost/pull/XXX/files#diff-ab787f06973e212424bf0e1ef4d1941754542d7cda91536b5931c51d864e94cd">+32/-10</a></td>
</tr>
<tr>
  <td><strong>services/constellation/connector/sql/reconcile_internal_test.go</strong><dd><code>Adds coverage that shorthand expands and input metadata is not mutated.</code></dd></td>
  <td><a href="https://github.com/nhost/nhost/pull/XXX/files#diff-42722fd49aed04bfeec1c66c7391ca9e6518dfe59e5d41a1ffc963d0713c1b6e">+92/-0</a></td>
</tr>
</table></details></td></tr>
<tr><td><strong>Metadata conversion</strong></td><td><details><summary>3 files</summary><table>
<tr>
  <td><strong>services/constellation/metadata/convert_test.go</strong><dd><code>Adds a Hasura JSON conversion case for the all-columns shorthand.</code></dd></td>
  <td><a href="https://github.com/nhost/nhost/pull/XXX/files#diff-0e0decd5a0eb11f4e3169eefc66fd007ee9478370b393566ea431fbbd28383e7">+30/-0</a></td>
</tr>
<tr>
  <td><strong>services/constellation/metadata/internal/hasura/table.go</strong><dd><code>Adds YAML/JSON custom unmarshalling for permission column shorthand.</code></dd></td>
  <td><a href="https://github.com/nhost/nhost/pull/XXX/files#diff-84f023345e75b5d3d1f1e6f7448e5c8b9103bdf783a26447c64c8a5ad8d3df9a">+254/-0</a></td>
</tr>
<tr>
  <td><strong>services/constellation/metadata/internal/hasura/table_internal_test.go</strong><dd><code>Covers shorthand, explicit lists, nulls, and invalid permission columns for JSON/YAML.</code></dd></td>
  <td><a href="https://github.com/nhost/nhost/pull/XXX/files#diff-29a6e778d841e6489392be519f97aa29c79c9d22b78231fb76623500b1607bb5">+218/-0</a></td>
</tr>
</table></details></td></tr>
<tr><td><strong>Documentation</strong></td><td><details><summary>1 file</summary><table>
<tr>
  <td><strong>services/constellation/docs/user/hasura-metadata-support.md</strong><dd><code>Documents all-columns shorthand support for select, insert, and update permissions.</code></dd></td>
  <td><a href="https://github.com/nhost/nhost/pull/XXX/files#diff-e15234ce667cdbf7b83f49be66f3128935518c0c94f66ec6914ea1291d3ae759">+3/-3</a></td>
</tr>
</table></details></td></tr>
</tbody></table>

</details>

___

<!-- nhost-reviewer:end -->