### PR TITLE
fix(constellation): preserve remote schema env headers and ints

### DIFF
--- a/.pi/extensions/subagent/index.ts
+++ b/.pi/extensions/subagent/index.ts
@@ -144,8 +144,8 @@ const subagentParamsSchema = Type.Object({
   ),
   confirmProjectAgents: Type.Optional(
     Type.Boolean({
-      description: 'Prompt before running project-local agents. Default: true.',
-      default: true,
+      description: 'Prompt before running project-local agents. Default: false.',
+      default: false,
     }),
   ),
   cwd: Type.Optional(
@@ -1053,7 +1053,7 @@ export default function nhostSubagentExtension(pi: ExtensionAPI): void {
       );
 
       if (
-        (params.confirmProjectAgents ?? true) &&
+        (params.confirmProjectAgents ?? false) &&
         projectAgentsRequested.length > 0 &&
         ctx.hasUI
       ) {

--- a/services/constellation/connector/composer/composer.go
+++ b/services/constellation/connector/composer/composer.go
@@ -369,6 +369,10 @@ func rsRelationshipSpec(
 	}
 
 	toSource := rel.Definition.ToSource
+	if toSource.RelationshipType != metadata.RelationshipTypeObject &&
+		toSource.RelationshipType != metadata.RelationshipTypeArray {
+		return relationships.RelationshipSpec{}, false //nolint:exhaustruct
+	}
 
 	return relationships.RelationshipSpec{
 		SourceConnector:   rsName,

--- a/services/constellation/connector/composer/composer.go
+++ b/services/constellation/connector/composer/composer.go
@@ -294,6 +294,11 @@ func dbRelationshipSpec(
 ) (relationships.RelationshipSpec, bool) {
 	if rel.Definition.ToSource != nil {
 		toSource := rel.Definition.ToSource
+		if toSource.RelationshipType != metadata.RelationshipTypeObject &&
+			toSource.RelationshipType != metadata.RelationshipTypeArray {
+			return relationships.RelationshipSpec{}, false //nolint:exhaustruct
+		}
+
 		isArray := toSource.RelationshipType == metadata.RelationshipTypeArray
 
 		return relationships.RelationshipSpec{

--- a/services/constellation/connector/composer/composer_internal_test.go
+++ b/services/constellation/connector/composer/composer_internal_test.go
@@ -260,8 +260,9 @@ func TestDBRelationshipSpec(t *testing.T) {
 	}
 }
 
-// TestRSRelationshipSpec covers the rs→db happy path and the nil-ToSource
-// skip (rs→rs is not supported and is currently the only other shape).
+// TestRSRelationshipSpec covers the rs→db happy path, the invalid-type skip,
+// and the nil-ToSource skip (rs→rs is not supported and is currently the only
+// other shape).
 func TestRSRelationshipSpec(t *testing.T) {
 	t.Parallel()
 
@@ -306,6 +307,23 @@ func TestRSRelationshipSpec(t *testing.T) {
 			},
 			wantOK:  true,
 			wantArr: false,
+		},
+		{
+			name: "rs_to_db_invalid_relationship_type",
+			rel: metadata.RemoteSchemaRelationshipDef{
+				Name: "broken",
+				Definition: metadata.RemoteSchemaRelationshipDefinition{
+					ToSource: &metadata.RemoteSchemaToSourceRelationship{
+						RelationshipType: "typo",
+						Source:           "default",
+						Table: metadata.RemoteSchemaTableRef{
+							Schema: "public", Name: "users",
+						},
+						FieldMapping: nil,
+					},
+				},
+			},
+			wantOK: false,
 		},
 		{
 			name: "nil_to_source_skipped",

--- a/services/constellation/connector/composer/composer_internal_test.go
+++ b/services/constellation/connector/composer/composer_internal_test.go
@@ -154,6 +154,24 @@ func TestDBRelationshipSpec(t *testing.T) {
 			wantDsc: "An object relationship",
 		},
 		{
+			name: "db_to_db_invalid_relationship_type",
+			rel: metadata.RemoteRelationship{
+				Name: "broken",
+				Definition: metadata.RemoteRelationshipDef{
+					ToSource: &metadata.ToSourceRelationship{
+						RelationshipType: "typo",
+						Source:           "default",
+						Table: metadata.TableSource{
+							Schema: "public", Name: "users",
+						},
+						FieldMapping: nil,
+					},
+					ToRemoteSchema: nil,
+				},
+			},
+			wantOK: false,
+		},
+		{
 			name: "db_to_rs",
 			rel: metadata.RemoteRelationship{
 				Name: "country",

--- a/services/constellation/connector/remoteschema/connector.go
+++ b/services/constellation/connector/remoteschema/connector.go
@@ -16,6 +16,7 @@ import (
 	"log/slog"
 	"net/http"
 	"net/url"
+	"os"
 	"time"
 
 	"github.com/nhost/nhost/services/constellation/graph"
@@ -148,11 +149,20 @@ func buildHeaders(meta *metadata.RemoteSchemaMetadata) (map[string]string, error
 	headers := make(map[string]string, len(meta.Definition.Headers))
 
 	for _, h := range meta.Definition.Headers {
-		value, err := h.Value.Resolve()
-		if err != nil {
-			return nil, fmt.Errorf(
-				"resolving header %q for remote schema %s: %w", h.Name, meta.Name, err,
-			)
+		value := h.Value
+		if h.ValueFromEnv != "" {
+			var ok bool
+
+			value, ok = os.LookupEnv(h.ValueFromEnv)
+			if !ok {
+				return nil, fmt.Errorf(
+					"resolving header %q for remote schema %s: %w: %s",
+					h.Name,
+					meta.Name,
+					metadata.ErrUnresolvedEnvVars,
+					h.ValueFromEnv,
+				)
+			}
 		}
 
 		headers[h.Name] = value

--- a/services/constellation/connector/remoteschema/connector_internal_test.go
+++ b/services/constellation/connector/remoteschema/connector_internal_test.go
@@ -1,0 +1,59 @@
+package remoteschema
+
+import (
+	"errors"
+	"os"
+	"testing"
+
+	"github.com/nhost/nhost/services/constellation/metadata"
+)
+
+func TestBuildHeadersLiteralAndEnv(t *testing.T) {
+	t.Setenv("REMOTE_HEADER", "resolved")
+
+	meta := &metadata.RemoteSchemaMetadata{
+		Name: "payments",
+		Definition: metadata.RemoteSchemaDefinition{
+			Headers: []metadata.RemoteSchemaHeader{
+				{Name: "x-literal", Value: "{{REMOTE_HEADER}}"},
+				{Name: "x-env", ValueFromEnv: "REMOTE_HEADER"},
+			},
+		},
+	}
+
+	headers, err := buildHeaders(meta)
+	if err != nil {
+		t.Fatalf("buildHeaders failed: %v", err)
+	}
+
+	if got, want := headers["x-literal"], "{{REMOTE_HEADER}}"; got != want {
+		t.Errorf("literal header = %q, want %q", got, want)
+	}
+
+	if got, want := headers["x-env"], "resolved"; got != want {
+		t.Errorf("env header = %q, want %q", got, want)
+	}
+}
+
+func TestBuildHeadersMissingEnv(t *testing.T) {
+	t.Parallel()
+
+	const missingEnv = "NHOST_TEST_MISSING_REMOTE_SCHEMA_HEADER_2B1B9F50F6F14D40"
+	if value, ok := os.LookupEnv(missingEnv); ok {
+		t.Skipf("%s is unexpectedly set to %q", missingEnv, value)
+	}
+
+	meta := &metadata.RemoteSchemaMetadata{
+		Name: "payments",
+		Definition: metadata.RemoteSchemaDefinition{
+			Headers: []metadata.RemoteSchemaHeader{
+				{Name: "x-env", ValueFromEnv: missingEnv},
+			},
+		},
+	}
+
+	_, err := buildHeaders(meta)
+	if !errors.Is(err, metadata.ErrUnresolvedEnvVars) {
+		t.Fatalf("buildHeaders error = %v, want ErrUnresolvedEnvVars", err)
+	}
+}

--- a/services/constellation/connector/sql/reconcile.go
+++ b/services/constellation/connector/sql/reconcile.go
@@ -31,6 +31,8 @@ const permissionAllColumns = "*"
 //   - Functions: dropped when absent from objects.Functions (kind=function).
 //   - Object/Array relationships: dropped when the target table (only when
 //     it lives in the same source) does not exist (kind=relationship).
+//   - Raw to_source remote relationships: dropped when relationship_type is
+//     missing or not one of object/array (kind=relationship).
 //
 // Reconciliation is intentionally scoped: Hasura-expression Filter/Check
 // trees inside permissions are not walked because they reference columns
@@ -127,6 +129,7 @@ func reconcileTables(
 
 		reconcileColumnConfig(ctx, logger, inc, dbName, t, cols)
 		reconcilePermissionColumns(ctx, logger, inc, dbName, t, columnNames, cols)
+		reconcileRemoteRelationshipTypes(ctx, logger, inc, dbName, t)
 		reconcileRelationships(ctx, logger, inc, dbName, t, survivingNames)
 		reconcileRelationshipFKIntrospection(ctx, logger, inc, dbName, t, introspected, objects)
 	}
@@ -394,6 +397,44 @@ func filterColumnKeyMap(
 	}
 
 	return out
+}
+
+// reconcileRemoteRelationshipTypes drops raw to_source remote relationships
+// whose relationship_type discriminator is missing or invalid. Valid raw
+// relationships are retained for cross-connector composition.
+func reconcileRemoteRelationshipTypes(
+	ctx context.Context,
+	logger *slog.Logger,
+	inc *metadata.Inconsistencies,
+	dbName string,
+	t *metadata.TableMetadata,
+) {
+	t.RemoteRelationships = slices.DeleteFunc(
+		slices.Clone(t.RemoteRelationships),
+		func(rel metadata.RemoteRelationship) bool {
+			toSource := rel.Definition.ToSource
+			if toSource == nil {
+				return false
+			}
+
+			if toSource.RelationshipType == metadata.RelationshipTypeObject ||
+				toSource.RelationshipType == metadata.RelationshipTypeArray {
+				return false
+			}
+
+			inc.RecordRelationship(
+				ctx, logger,
+				dbName,
+				t.Table.Schema, t.Table.Name, rel.Name,
+				fmt.Sprintf(
+					"invalid to_source relationship_type %q; expected object or array",
+					toSource.RelationshipType,
+				),
+			)
+
+			return true
+		},
+	)
 }
 
 // reconcileRelationships drops local object/array relationships whose target

--- a/services/constellation/connector/sql/reconcile_internal_test.go
+++ b/services/constellation/connector/sql/reconcile_internal_test.go
@@ -512,6 +512,63 @@ func TestReconcileMetadata_DropsRelationshipsWithMissingTarget(t *testing.T) {
 		"public.users.ghost_orders", "not tracked")
 }
 
+func TestReconcileMetadata_DropsInvalidRemoteRelationshipType(t *testing.T) {
+	t.Parallel()
+
+	dbMeta := &metadata.DatabaseMetadata{ //nolint:exhaustruct
+		Name: "default",
+		Tables: []metadata.TableMetadata{ //nolint:exhaustruct
+			{
+				Table: metadata.TableSource{Schema: "public", Name: "users"},
+				RemoteRelationships: []metadata.RemoteRelationship{
+					{
+						Name: "bad_remote",
+						Definition: metadata.RemoteRelationshipDef{ //nolint:exhaustruct
+							ToSource: &metadata.ToSourceRelationship{
+								FieldMapping:     map[string]string{"id": "id"},
+								RelationshipType: "typo",
+								Source:           "other",
+								Table: metadata.TableSource{
+									Schema: "public",
+									Name:   "users",
+								},
+							},
+						},
+					},
+					{
+						Name: "good_remote",
+						Definition: metadata.RemoteRelationshipDef{ //nolint:exhaustruct
+							ToSource: &metadata.ToSourceRelationship{
+								FieldMapping:     map[string]string{"id": "id"},
+								RelationshipType: metadata.RelationshipTypeArray,
+								Source:           "other",
+								Table: metadata.TableSource{
+									Schema: "public",
+									Name:   "users",
+								},
+							},
+						},
+					},
+				},
+			},
+		},
+	}
+
+	inc := metadata.NewInconsistencies()
+	out := reconcileMetadata(t.Context(), nil, inc, dbMeta, makeObjects())
+
+	if got := len(out.Tables[0].RemoteRelationships); got != 1 {
+		t.Fatalf("surviving remote relationships = %d, want 1", got)
+	}
+
+	if got := out.Tables[0].RemoteRelationships[0].Name; got != "good_remote" {
+		t.Fatalf("surviving remote relationship = %q, want good_remote", got)
+	}
+
+	mustHaveInconsistency(t, inc, metadata.InconsistencyKindRelationship,
+		"public.users.bad_remote", "invalid to_source relationship_type")
+}
+
 // TestReconcileMetadata_KeepsCrossSourceRelationships verifies cross-source
 // relationships (ManualConfiguration.Source pointing elsewhere) are not
 // dropped: the composer handles those independently.

--- a/services/constellation/docs/user/inconsistencies.md
+++ b/services/constellation/docs/user/inconsistencies.md
@@ -106,9 +106,12 @@ applies only to PostgreSQL sources.
 ### `relationship` (PostgreSQL / SQLite source)
 
 Recorded when an `object_relationships` or `array_relationships` entry targets
-a table that does not exist in the same source. Detected by checking
+a table that does not exist in the same source, or when a Hasura
+`remote_relationships[].definition.to_source.relationship_type` value is
+missing or not one of `object` / `array`. Detected by checking
 `using.foreign_key_constraint.table` and
-`using.manual_configuration.remote_table` against the surviving table set.
+`using.manual_configuration.remote_table` against the surviving table set, and
+by validating raw `to_source` remote relationship type discriminators.
 
 **Cross-source relationships** (`manual_configuration.source` pointing at a
 different source name) are *not* validated here — the composer's

--- a/services/constellation/docs/user/remote-schema.md
+++ b/services/constellation/docs/user/remote-schema.md
@@ -47,7 +47,7 @@ You can configure static headers to be sent with every request to the remote sch
 
 ```yaml
 headers:
-  # Literal value
+  # Literal value (sent byte-for-byte; {{VAR}} is not interpolated here)
   - name: x-custom-header
     value: "my-value"
 

--- a/services/constellation/metadata/convert.go
+++ b/services/constellation/metadata/convert.go
@@ -2,7 +2,9 @@ package metadata
 
 import (
 	"context"
+	stdjson "encoding/json"
 	"fmt"
+	"math"
 	"os"
 	"path/filepath"
 	"strings"
@@ -95,12 +97,12 @@ func convertDatabaseURL(h hasura.DatabaseURL) EnvString {
 	return EnvString(h.URL)
 }
 
-func convertEnvValue(h hasura.EnvValue) EnvString {
+func convertHeaderValue(h hasura.EnvValue) (string, string) {
 	if h.FromEnv != "" {
-		return EnvString("{{" + h.FromEnv + "}}")
+		return "", h.FromEnv
 	}
 
-	return EnvString(h.Value)
+	return h.Value, ""
 }
 
 func convertDatabase(h hasura.DatabaseMetadata) DatabaseMetadata {
@@ -248,7 +250,7 @@ func convertSelectPermissions(perms []hasura.SelectPermission) []SelectPermissio
 			Role: p.Role,
 			Permission: SelectPermissionConfig{
 				Columns:           p.Permission.Columns,
-				Filter:            p.Permission.Filter,
+				Filter:            normalizePermissionMap(p.Permission.Filter),
 				AllowAggregations: p.Permission.AllowAggregations,
 			},
 		}
@@ -264,8 +266,8 @@ func convertInsertPermissions(perms []hasura.InsertPermission) []InsertPermissio
 			Role: p.Role,
 			Permission: InsertPermissionConfig{
 				Columns: p.Permission.Columns,
-				Check:   p.Permission.Check,
-				Set:     p.Permission.Set,
+				Check:   normalizePermissionMap(p.Permission.Check),
+				Set:     normalizePermissionMap(p.Permission.Set),
 			},
 		}
 	}
@@ -280,9 +282,9 @@ func convertUpdatePermissions(perms []hasura.UpdatePermission) []UpdatePermissio
 			Role: p.Role,
 			Permission: UpdatePermissionConfig{
 				Columns: p.Permission.Columns,
-				Filter:  p.Permission.Filter,
-				Check:   p.Permission.Check,
-				Set:     p.Permission.Set,
+				Filter:  normalizePermissionMap(p.Permission.Filter),
+				Check:   normalizePermissionMap(p.Permission.Check),
+				Set:     normalizePermissionMap(p.Permission.Set),
 			},
 		}
 	}
@@ -296,12 +298,120 @@ func convertDeletePermissions(perms []hasura.DeletePermission) []DeletePermissio
 		result[i] = DeletePermission{
 			Role: p.Role,
 			Permission: DeletePermissionConfig{
-				Filter: p.Permission.Filter,
+				Filter: normalizePermissionMap(p.Permission.Filter),
 			},
 		}
 	}
 
 	return result
+}
+
+func normalizePermissionMap[M ~map[string]any](m M) map[string]any {
+	if m == nil {
+		return nil
+	}
+
+	normalized, _ := normalizePermissionValue(map[string]any(m)).(map[string]any)
+
+	return normalized
+}
+
+func normalizePermissionValue(v any) any {
+	switch value := v.(type) {
+	case map[string]any:
+		out := make(map[string]any, len(value))
+		for k, child := range value {
+			out[k] = normalizePermissionValue(child)
+		}
+
+		return out
+	case []any:
+		out := make([]any, len(value))
+		for i, child := range value {
+			out[i] = normalizePermissionValue(child)
+		}
+
+		return out
+	case stdjson.Number:
+		return normalizeJSONNumber(value)
+	case float64:
+		return normalizeFloat(value)
+	case float32:
+		return normalizeFloat(float64(value))
+	case int, int8, int16, int32, int64:
+		return normalizeSigned(value)
+	case uint, uint8, uint16, uint32, uint64:
+		return normalizeUnsigned(value)
+	default:
+		return value
+	}
+}
+
+func normalizeSigned(v any) int64 {
+	switch value := v.(type) {
+	case int:
+		return int64(value)
+	case int8:
+		return int64(value)
+	case int16:
+		return int64(value)
+	case int32:
+		return int64(value)
+	case int64:
+		return value
+	default:
+		return 0
+	}
+}
+
+func normalizeUnsigned(v any) any {
+	switch value := v.(type) {
+	case uint:
+		return normalizeUint(uint64(value))
+	case uint8:
+		return int64(value)
+	case uint16:
+		return int64(value)
+	case uint32:
+		return int64(value)
+	case uint64:
+		return normalizeUint(value)
+	default:
+		return v
+	}
+}
+
+func normalizeJSONNumber(n stdjson.Number) any {
+	if i, err := n.Int64(); err == nil {
+		return i
+	}
+
+	f, err := n.Float64()
+	if err != nil {
+		return n
+	}
+
+	return normalizeFloat(f)
+}
+
+func normalizeFloat(f float64) any {
+	if math.IsNaN(f) || math.IsInf(f, 0) || math.Trunc(f) != f {
+		return f
+	}
+
+	if f < float64(math.MinInt64) || f >= float64(math.MaxInt64) {
+		return f
+	}
+
+	return int64(f)
+}
+
+func normalizeUint(u uint64) any {
+	if u > math.MaxInt64 {
+		return u
+	}
+
+	return int64(u)
 }
 
 func convertTableSource(h hasura.TableSource) TableSource {
@@ -454,9 +564,11 @@ func convertRemoteSchemaURL(h hasura.RemoteSchemaDefinition) EnvString {
 func convertRemoteSchemaHeaders(headers []hasura.RemoteSchemaHeader) []RemoteSchemaHeader {
 	result := make([]RemoteSchemaHeader, len(headers))
 	for i, h := range headers {
+		value, valueFromEnv := convertHeaderValue(h.Value)
 		result[i] = RemoteSchemaHeader{
-			Name:  h.Name,
-			Value: convertEnvValue(h.Value),
+			Name:         h.Name,
+			Value:        value,
+			ValueFromEnv: valueFromEnv,
 		}
 	}
 

--- a/services/constellation/metadata/convert_internal_test.go
+++ b/services/constellation/metadata/convert_internal_test.go
@@ -1,6 +1,7 @@
 package metadata
 
 import (
+	stdjson "encoding/json"
 	"testing"
 
 	"github.com/google/go-cmp/cmp"
@@ -40,28 +41,38 @@ func TestConvertDatabaseURL(t *testing.T) {
 	}
 }
 
-func TestConvertEnvValue(t *testing.T) {
+func TestConvertHeaderValue(t *testing.T) {
 	t.Parallel()
 
 	tests := []struct {
-		name string
-		in   hasura.EnvValue
-		want EnvString
+		name             string
+		in               hasura.EnvValue
+		wantValue        string
+		wantValueFromEnv string
 	}{
 		{
-			name: "from env",
-			in:   hasura.EnvValue{FromEnv: "API_KEY"},
-			want: "{{API_KEY}}",
+			name:             "from env",
+			in:               hasura.EnvValue{FromEnv: "API_KEY"},
+			wantValue:        "",
+			wantValueFromEnv: "API_KEY",
 		},
 		{
-			name: "direct value",
-			in:   hasura.EnvValue{Value: "secret123"},
-			want: "secret123",
+			name:             "direct value",
+			in:               hasura.EnvValue{Value: "secret123"},
+			wantValue:        "secret123",
+			wantValueFromEnv: "",
 		},
 		{
-			name: "empty",
-			in:   hasura.EnvValue{},
-			want: "",
+			name:             "literal braces stay literal",
+			in:               hasura.EnvValue{Value: "{{API_KEY}}"},
+			wantValue:        "{{API_KEY}}",
+			wantValueFromEnv: "",
+		},
+		{
+			name:             "empty",
+			in:               hasura.EnvValue{},
+			wantValue:        "",
+			wantValueFromEnv: "",
 		},
 	}
 
@@ -69,9 +80,73 @@ func TestConvertEnvValue(t *testing.T) {
 		t.Run(tt.name, func(t *testing.T) {
 			t.Parallel()
 
-			got := convertEnvValue(tt.in)
-			if got != tt.want {
-				t.Errorf("convertEnvValue = %q, want %q", got, tt.want)
+			gotValue, gotValueFromEnv := convertHeaderValue(tt.in)
+			if gotValue != tt.wantValue || gotValueFromEnv != tt.wantValueFromEnv {
+				t.Errorf(
+					"convertHeaderValue = (%q, %q), want (%q, %q)",
+					gotValue,
+					gotValueFromEnv,
+					tt.wantValue,
+					tt.wantValueFromEnv,
+				)
+			}
+		})
+	}
+}
+
+func TestNormalizePermissionMap(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name string
+		in   map[string]any
+		want map[string]any
+	}{
+		{
+			name: "json number large integer",
+			in: map[string]any{
+				"id": map[string]any{"_eq": stdjson.Number("9007199254740993")},
+			},
+			want: map[string]any{
+				"id": map[string]any{"_eq": int64(9007199254740993)},
+			},
+		},
+		{
+			name: "yaml uint64 integer",
+			in: map[string]any{
+				"id": map[string]any{"_eq": uint64(9007199254740993)},
+			},
+			want: map[string]any{
+				"id": map[string]any{"_eq": int64(9007199254740993)},
+			},
+		},
+		{
+			name: "genuine float remains float",
+			in: map[string]any{
+				"score": map[string]any{"_eq": 1.5},
+			},
+			want: map[string]any{
+				"score": map[string]any{"_eq": 1.5},
+			},
+		},
+		{
+			name: "arrays are deep cloned",
+			in: map[string]any{
+				"_and": []any{map[string]any{"id": map[string]any{"_eq": uint(7)}}},
+			},
+			want: map[string]any{
+				"_and": []any{map[string]any{"id": map[string]any{"_eq": int64(7)}}},
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+
+			got := normalizePermissionMap(tt.in)
+			if diff := cmp.Diff(tt.want, got); diff != "" {
+				t.Errorf("normalizePermissionMap mismatch (-want +got):\n%s", diff)
 			}
 		})
 	}
@@ -829,7 +904,7 @@ func TestConvertRemoteSchema(t *testing.T) {
 				},
 			},
 			Headers: []RemoteSchemaHeader{
-				{Name: "x-api-key", Value: "{{PAYMENTS_KEY}}"},
+				{Name: "x-api-key", ValueFromEnv: "PAYMENTS_KEY"},
 			},
 		},
 		Permissions: []RemoteSchemaPermission{

--- a/services/constellation/metadata/convert_test.go
+++ b/services/constellation/metadata/convert_test.go
@@ -167,6 +167,57 @@ func assertHappyPathJSON(t *testing.T, m *metadata.Metadata) {
 	}
 }
 
+func TestFromHasuraJSONPermissionNumbers(t *testing.T) {
+	t.Parallel()
+
+	input := []byte(`{
+		"version": 3,
+		"sources": [{
+			"name": "default",
+			"kind": "postgres",
+			"configuration": {"connection_info": {"database_url": "postgres://localhost/db"}},
+			"tables": [{
+				"table": {"name": "users", "schema": "public"},
+				"select_permissions": [{
+					"role": "user",
+					"permission": {
+						"columns": ["id"],
+						"filter": {
+							"id": {"_eq": 9007199254740993},
+							"score": {"_eq": 1.5}
+						}
+					}
+				}]
+			}]
+		}]
+	}`)
+
+	m, err := metadata.FromHasuraJSON(input)
+	if err != nil {
+		t.Fatalf("FromHasuraJSON failed: %v", err)
+	}
+
+	filter := m.Databases[0].Tables[0].SelectPermissions[0].Permission.Filter
+
+	idFilter, ok := filter["id"].(map[string]any)
+	if !ok {
+		t.Fatalf("id filter = %#v, want map[string]any", filter["id"])
+	}
+
+	if got, want := idFilter["_eq"], int64(9007199254740993); got != want {
+		t.Errorf("large integer filter value = %#v (%T), want %#v", got, got, want)
+	}
+
+	scoreFilter, ok := filter["score"].(map[string]any)
+	if !ok {
+		t.Fatalf("score filter = %#v, want map[string]any", filter["score"])
+	}
+
+	if got, want := scoreFilter["_eq"], 1.5; got != want {
+		t.Errorf("float filter value = %#v (%T), want %#v", got, got, want)
+	}
+}
+
 func TestFromDetect_HasuraYAMLBranch(t *testing.T) {
 	t.Parallel()
 

--- a/services/constellation/metadata/internal/hasura/json_test.go
+++ b/services/constellation/metadata/internal/hasura/json_test.go
@@ -1,6 +1,7 @@
 package hasura_test
 
 import (
+	stdjson "encoding/json"
 	"encoding/json/jsontext"
 	json "encoding/json/v2"
 	"os"
@@ -218,6 +219,58 @@ func assertRemoteSchemas(t *testing.T, meta *hasura.Metadata) {
 			"expected header from_env 'REMOTE_API_KEY', got %q",
 			rs.Definition.Headers[1].Value.FromEnv,
 		)
+	}
+}
+
+func TestSelectPermissionConfig_UnmarshalJSONPreservesLargeInteger(t *testing.T) {
+	t.Parallel()
+
+	input := []byte(`{
+		"columns": ["id"],
+		"filter": {"id": {"_eq": 9007199254740993}}
+	}`)
+
+	var plain map[string]any
+	if err := json.Unmarshal(input, &plain); err != nil {
+		t.Fatalf("plain unmarshal failed: %v", err)
+	}
+
+	plainFilter, ok := plain["filter"].(map[string]any)
+	if !ok {
+		t.Fatalf("plain filter type = %T, want map[string]any", plain["filter"])
+	}
+
+	plainIDFilter, ok := plainFilter["id"].(map[string]any)
+	if !ok {
+		t.Fatalf("plain id filter type = %T, want map[string]any", plainFilter["id"])
+	}
+
+	if _, ok := plainIDFilter["_eq"].(float64); !ok {
+		t.Fatalf("plain _eq type = %T, want float64", plainIDFilter["_eq"])
+	}
+
+	var config hasura.SelectPermissionConfig
+	if err := json.Unmarshal(input, &config); err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	idFilter, ok := config.Filter["id"].(map[string]any)
+	if !ok {
+		t.Fatalf("permission id filter type = %T, want map[string]any", config.Filter["id"])
+	}
+
+	value := idFilter["_eq"]
+	if _, ok := value.(float64); ok {
+		t.Fatal("permission _eq type = float64, want json.Number")
+	}
+
+	number, ok := value.(stdjson.Number)
+	if !ok {
+		t.Fatalf("permission _eq type = %T, want json.Number", value)
+	}
+
+	if number.String() != "9007199254740993" {
+		t.Fatalf("permission _eq = %q, want 9007199254740993", number.String())
 	}
 }
 

--- a/services/constellation/metadata/internal/hasura/json_test.go
+++ b/services/constellation/metadata/internal/hasura/json_test.go
@@ -352,6 +352,61 @@ func TestFromJSON_ConvertRemoteRelationships(t *testing.T) {
 	}
 }
 
+func TestFromJSON_InvalidToSourceRelationshipTypeIsNotLowered(t *testing.T) {
+	t.Parallel()
+
+	input := []byte(`{
+		"version": 3,
+		"sources": [{
+			"name": "default",
+			"kind": "postgres",
+			"configuration": {"connection_info": {"database_url": "postgres://localhost/db"}},
+			"tables": [{
+				"table": {"name": "orders", "schema": "public"},
+				"remote_relationships": [{
+					"name": "customer",
+					"definition": {
+						"to_source": {
+							"field_mapping": {"customer_id": "id"},
+							"relationship_type": "typo",
+							"source": "customers_db",
+							"table": {"name": "customers", "schema": "public"}
+						}
+					}
+				}]
+			}]
+		}]
+	}`)
+
+	meta, err := hasura.FromJSON(input)
+	if err != nil {
+		t.Fatalf("FromJSON failed: %v", err)
+	}
+
+	table := meta.Databases[0].Tables[0]
+	if len(table.ObjectRelationships) != 0 {
+		t.Fatalf(
+			"invalid relationship_type produced object relationships: %+v",
+			table.ObjectRelationships,
+		)
+	}
+
+	if len(table.ArrayRelationships) != 0 {
+		t.Fatalf(
+			"invalid relationship_type produced array relationships: %+v",
+			table.ArrayRelationships,
+		)
+	}
+
+	if got := len(table.RemoteRelationships); got != 1 {
+		t.Fatalf("raw remote relationships = %d, want 1", got)
+	}
+
+	if got := table.RemoteRelationships[0].Definition.ToSource.RelationshipType; got != "typo" {
+		t.Fatalf("raw relationship_type = %q, want typo", got)
+	}
+}
+
 func TestConvertRemoteRelationships_RemoteSchemaCustomColumnNames(t *testing.T) {
 	t.Parallel()
 

--- a/services/constellation/metadata/internal/hasura/table.go
+++ b/services/constellation/metadata/internal/hasura/table.go
@@ -1,7 +1,9 @@
 package hasura
 
 import (
+	"bytes"
 	"context"
+	stdjson "encoding/json"
 	"encoding/json/jsontext"
 	json "encoding/json/v2"
 	"errors"
@@ -136,12 +138,38 @@ type DeletePermission struct {
 	Permission DeletePermissionConfig `json:"permission" yaml:"permission"`
 }
 
+// PermissionExpression is a Hasura boolean expression or preset map. Its JSON
+// unmarshaler preserves number tokens as json.Number instead of float64 so
+// large integer metadata literals are not rounded before native conversion.
+type PermissionExpression map[string]any
+
+// UnmarshalJSON decodes permission expressions with exact JSON number tokens.
+func (p *PermissionExpression) UnmarshalJSON(data []byte) error {
+	if bytes.Equal(data, []byte("null")) {
+		*p = nil
+
+		return nil
+	}
+
+	dec := stdjson.NewDecoder(bytes.NewReader(data))
+	dec.UseNumber()
+
+	var out map[string]any
+	if err := dec.Decode(&out); err != nil {
+		return fmt.Errorf("unmarshaling permission expression: %w", err)
+	}
+
+	*p = out
+
+	return nil
+}
+
 // SelectPermissionConfig captures the columns, row filter, and aggregation
 // access a select permission grants.
 type SelectPermissionConfig struct {
-	Columns           []string       `json:"columns,omitempty"           yaml:"columns,omitempty"`
-	Filter            map[string]any `json:"filter,omitempty"            yaml:"filter,omitempty"`
-	AllowAggregations bool           `json:"allow_aggregations,omitzero" yaml:"allow_aggregations,omitempty"`
+	Columns           []string             `json:"columns,omitempty"           yaml:"columns,omitempty"`
+	Filter            PermissionExpression `json:"filter,omitempty"            yaml:"filter,omitempty"`
+	AllowAggregations bool                 `json:"allow_aggregations,omitzero" yaml:"allow_aggregations,omitempty"`
 }
 
 // UnmarshalYAML accepts Hasura's select-permission `columns: '*'` shorthand
@@ -210,9 +238,9 @@ func parsePermissionColumnsYAML(value any) ([]string, error) {
 // column list is known.
 func (p *SelectPermissionConfig) UnmarshalJSON(data []byte) error {
 	var raw struct {
-		Columns           jsontext.Value `json:"columns,omitempty"`
-		Filter            map[string]any `json:"filter,omitempty"`
-		AllowAggregations bool           `json:"allow_aggregations,omitzero"`
+		Columns           jsontext.Value       `json:"columns,omitempty"`
+		Filter            PermissionExpression `json:"filter,omitempty"`
+		AllowAggregations bool                 `json:"allow_aggregations,omitzero"`
 	}
 
 	if err := json.Unmarshal(data, &raw); err != nil {
@@ -273,9 +301,9 @@ func parsePermissionColumnsJSON(value jsontext.Value) ([]string, error) {
 // InsertPermissionConfig captures the columns, row-level check, and presets an
 // insert permission grants.
 type InsertPermissionConfig struct {
-	Columns []string       `json:"columns,omitempty" yaml:"columns,omitempty"`
-	Check   map[string]any `json:"check,omitempty"   yaml:"check,omitempty"`
-	Set     map[string]any `json:"set,omitempty"     yaml:"set,omitempty"`
+	Columns []string             `json:"columns,omitempty" yaml:"columns,omitempty"`
+	Check   PermissionExpression `json:"check,omitempty"   yaml:"check,omitempty"`
+	Set     PermissionExpression `json:"set,omitempty"     yaml:"set,omitempty"`
 }
 
 // UnmarshalYAML accepts Hasura's insert-permission `columns: '*'` shorthand
@@ -312,9 +340,9 @@ func (p *InsertPermissionConfig) UnmarshalYAML(unmarshal func(any) error) error 
 // column list is known.
 func (p *InsertPermissionConfig) UnmarshalJSON(data []byte) error {
 	var raw struct {
-		Columns jsontext.Value `json:"columns,omitempty"`
-		Check   map[string]any `json:"check,omitempty"`
-		Set     map[string]any `json:"set,omitempty"`
+		Columns jsontext.Value       `json:"columns,omitempty"`
+		Check   PermissionExpression `json:"check,omitempty"`
+		Set     PermissionExpression `json:"set,omitempty"`
 	}
 
 	if err := json.Unmarshal(data, &raw); err != nil {
@@ -336,10 +364,10 @@ func (p *InsertPermissionConfig) UnmarshalJSON(data []byte) error {
 // UpdatePermissionConfig captures the columns, row filter, post-update check,
 // and presets an update permission grants.
 type UpdatePermissionConfig struct {
-	Columns []string       `json:"columns,omitempty" yaml:"columns,omitempty"`
-	Filter  map[string]any `json:"filter,omitempty"  yaml:"filter,omitempty"`
-	Check   map[string]any `json:"check,omitempty"   yaml:"check,omitempty"`
-	Set     map[string]any `json:"set,omitempty"     yaml:"set,omitempty"`
+	Columns []string             `json:"columns,omitempty" yaml:"columns,omitempty"`
+	Filter  PermissionExpression `json:"filter,omitempty"  yaml:"filter,omitempty"`
+	Check   PermissionExpression `json:"check,omitempty"   yaml:"check,omitempty"`
+	Set     PermissionExpression `json:"set,omitempty"     yaml:"set,omitempty"`
 }
 
 // UnmarshalYAML accepts Hasura's update-permission `columns: '*'` shorthand
@@ -378,10 +406,10 @@ func (p *UpdatePermissionConfig) UnmarshalYAML(unmarshal func(any) error) error 
 // column list is known.
 func (p *UpdatePermissionConfig) UnmarshalJSON(data []byte) error {
 	var raw struct {
-		Columns jsontext.Value `json:"columns,omitempty"`
-		Filter  map[string]any `json:"filter,omitempty"`
-		Check   map[string]any `json:"check,omitempty"`
-		Set     map[string]any `json:"set,omitempty"`
+		Columns jsontext.Value       `json:"columns,omitempty"`
+		Filter  PermissionExpression `json:"filter,omitempty"`
+		Check   PermissionExpression `json:"check,omitempty"`
+		Set     PermissionExpression `json:"set,omitempty"`
 	}
 
 	if err := json.Unmarshal(data, &raw); err != nil {
@@ -403,7 +431,7 @@ func (p *UpdatePermissionConfig) UnmarshalJSON(data []byte) error {
 
 // DeletePermissionConfig captures the row filter a delete permission applies.
 type DeletePermissionConfig struct {
-	Filter map[string]any `json:"filter,omitempty" yaml:"filter,omitempty"`
+	Filter PermissionExpression `json:"filter,omitempty" yaml:"filter,omitempty"`
 }
 
 // ObjectRelationship is a many-to-one relationship from this table to another.

--- a/services/constellation/metadata/internal/hasura/testdata/TestFromJSON_RealMetadata/golden.json
+++ b/services/constellation/metadata/internal/hasura/testdata/TestFromJSON_RealMetadata/golden.json
@@ -2891,7 +2891,7 @@
         "headers": [
           {
             "name": "x-nhost-webhook-secret",
-            "value": "{{NHOST_WEBHOOK_SECRET}}"
+            "value_from_env": "NHOST_WEBHOOK_SECRET"
           }
         ],
         "forward_client_headers": true

--- a/services/constellation/metadata/remote_schema.go
+++ b/services/constellation/metadata/remote_schema.go
@@ -55,8 +55,8 @@ type RemoteSchemaDefinition struct {
 	// remote schema.
 	Customization Customization `json:"customization,omitzero" toml:"customization,omitempty"`
 	// Headers are static request headers attached to every call to the
-	// remote endpoint, with environment-variable interpolation on each
-	// header value.
+	// remote endpoint. Literal values are forwarded verbatim; ValueFromEnv
+	// entries are resolved from the process environment.
 	Headers []RemoteSchemaHeader `json:"headers,omitempty" toml:"headers,omitempty"`
 	// ForwardClientHeaders, when true, forwards the incoming client
 	// request's headers to the remote endpoint in addition to Headers.
@@ -65,8 +65,9 @@ type RemoteSchemaDefinition struct {
 
 // RemoteSchemaHeader defines a header to be sent with requests to the remote schema.
 type RemoteSchemaHeader struct {
-	Name  string    `json:"name"  toml:"name"`
-	Value EnvString `json:"value" toml:"value"`
+	Name         string `json:"name"                     toml:"name"`
+	Value        string `json:"value,omitempty"          toml:"value,omitempty"`
+	ValueFromEnv string `json:"value_from_env,omitempty" toml:"value_from_env,omitempty"`
 }
 
 // RemoteSchemaPermission defines permissions for a specific role on a remote schema.

--- a/services/constellation/metadata/toml.go
+++ b/services/constellation/metadata/toml.go
@@ -30,7 +30,56 @@ func unmarshalTOML(data []byte) (*Metadata, error) {
 		return nil, fmt.Errorf("parsing TOML metadata: %w", err)
 	}
 
+	normalizeMetadataPermissionNumbers(&tm)
+
 	return &tm, nil
+}
+
+func normalizeMetadataPermissionNumbers(m *Metadata) {
+	if m == nil {
+		return
+	}
+
+	for i := range m.Databases {
+		for j := range m.Databases[i].Tables {
+			normalizeTablePermissionNumbers(&m.Databases[i].Tables[j])
+		}
+	}
+}
+
+func normalizeTablePermissionNumbers(t *TableMetadata) {
+	for i := range t.SelectPermissions {
+		t.SelectPermissions[i].Permission.Filter = normalizePermissionMap(
+			t.SelectPermissions[i].Permission.Filter,
+		)
+	}
+
+	for i := range t.InsertPermissions {
+		t.InsertPermissions[i].Permission.Check = normalizePermissionMap(
+			t.InsertPermissions[i].Permission.Check,
+		)
+		t.InsertPermissions[i].Permission.Set = normalizePermissionMap(
+			t.InsertPermissions[i].Permission.Set,
+		)
+	}
+
+	for i := range t.UpdatePermissions {
+		t.UpdatePermissions[i].Permission.Filter = normalizePermissionMap(
+			t.UpdatePermissions[i].Permission.Filter,
+		)
+		t.UpdatePermissions[i].Permission.Check = normalizePermissionMap(
+			t.UpdatePermissions[i].Permission.Check,
+		)
+		t.UpdatePermissions[i].Permission.Set = normalizePermissionMap(
+			t.UpdatePermissions[i].Permission.Set,
+		)
+	}
+
+	for i := range t.DeletePermissions {
+		t.DeletePermissions[i].Permission.Filter = normalizePermissionMap(
+			t.DeletePermissions[i].Permission.Filter,
+		)
+	}
 }
 
 // stripEmptyTableHeaders removes TOML table headers (e.g. [a.b]) that contain


### PR DESCRIPTION
<!-- nhost-reviewer:start -->
### **What this PR solves**
This PR improves Constellation metadata fidelity by preserving exact permission numeric literals, supporting Hasura remote schema header `value_from_env`, and dropping invalid raw remote relationship discriminators before composition.

___

### **PR Type**
Bug fix

___

### **Description**
- Preserve large integer permission values through Hasura JSON/TOML metadata conversion.
- Convert and resolve remote schema headers with explicit `value_from_env` semantics while keeping literal values byte-for-byte.
- Treat invalid `to_source.relationship_type` values as inconsistencies and skip them during connector composition.
- Update documentation, golden metadata, and Pi subagent project-agent confirmation defaults.

___

### Diagram Walkthrough

```mermaid
flowchart LR
  Hasura["Hasura metadata input"] --> Parser["hasura metadata parser"]
  Parser --> Native["Constellation native metadata"]
  Native --> Reconcile["SQL metadata reconciliation"]
  Native --> RemoteSchema["Remote schema connector headers"]
  Reconcile --> Composer["Connector composer relationships"]
```

<details> <summary><h3> File Walkthrough</h3></summary>

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody>
<tr><td><strong>Pi extension</strong></td><td><details><summary>1 file</summary><table>
<tr><td><strong>.pi/extensions/subagent/index.ts</strong><dd><code>Default project-agent confirmation prompting to disabled.</code></dd></td><td><a href="https://github.com/nhost/nhost/pull/XXX/files#diff-78770f497b6d646bca33d3970d4ff35dda2fa1f6c9b64372af33b5d23871530e">+3/-3</a></td></tr>
</table></details></td></tr>
<tr><td><strong>Constellation connectors</strong></td><td><details><summary>6 files</summary><table>
<tr><td><strong>services/constellation/connector/composer/composer.go</strong><dd><code>Skip invalid raw to_source relationship types during composition.</code></dd></td><td><a href="https://github.com/nhost/nhost/pull/XXX/files#diff-778dc2a007f10f386e8fbb3f7cc4796ec3f4547d9f9d6ea12b0f87621d195cb9">+9/-0</a></td></tr>
<tr><td><strong>services/constellation/connector/composer/composer_internal_test.go</strong><dd><code>Cover invalid database and remote-schema relationship discriminator handling.</code></dd></td><td><a href="https://github.com/nhost/nhost/pull/XXX/files#diff-ecba8e9c7685bbb1d51c537728e838c1e4ebed909d7715475cdef5cb418a417b">+38/-2</a></td></tr>
<tr><td><strong>services/constellation/connector/remoteschema/connector.go</strong><dd><code>Resolve remote schema headers from explicit environment references.</code></dd></td><td><a href="https://github.com/nhost/nhost/pull/XXX/files#diff-72077cda245f97e0692f1255d2d4a8dae399c6b86ec23bad501b6acd0285d308">+15/-5</a></td></tr>
<tr><td><strong>services/constellation/connector/remoteschema/connector_internal_test.go</strong><dd><code>Add literal and environment header resolution tests.</code></dd></td><td><a href="https://github.com/nhost/nhost/pull/XXX/files#diff-5c772c235cc78f29cfcd8caea37151a6d22a5a7efdab33f02ecf1f0f4a24091f">+59/-0</a></td></tr>
<tr><td><strong>services/constellation/connector/sql/reconcile.go</strong><dd><code>Record and drop raw remote relationships with missing or invalid types.</code></dd></td><td><a href="https://github.com/nhost/nhost/pull/XXX/files#diff-ab787f06973e212424bf0e1ef4d1941754542d7cda91536b5931c51d864e94cd">+41/-0</a></td></tr>
<tr><td><strong>services/constellation/connector/sql/reconcile_internal_test.go</strong><dd><code>Assert invalid raw relationship types are removed and reported.</code></dd></td><td><a href="https://github.com/nhost/nhost/pull/XXX/files#diff-42722fd49aed04bfeec1c66c7391ca9e6518dfe59e5d41a1ffc963d0713c1b6e">+57/-0</a></td></tr>
</table></details></td></tr>
<tr><td><strong>Constellation metadata</strong></td><td><details><summary>8 files</summary><table>
<tr><td><strong>services/constellation/metadata/convert.go</strong><dd><code>Normalize permission numbers and map Hasura env headers to native metadata.</code></dd></td><td><a href="https://github.com/nhost/nhost/pull/XXX/files#diff-1a7f6ead9aab4ab64dda6480b6610aed1bf9e98f2ab2efa67bdaef2a7b189ec5">+124/-12</a></td></tr>
<tr><td><strong>services/constellation/metadata/convert_internal_test.go</strong><dd><code>Test header conversion and permission number normalization helpers.</code></dd></td><td><a href="https://github.com/nhost/nhost/pull/XXX/files#diff-6db7d32fd5ec9d013016c28ac3bf8777c1d0b9a7b626f26e4817c0043650b2d5">+91/-16</a></td></tr>
<tr><td><strong>services/constellation/metadata/convert_test.go</strong><dd><code>Verify JSON permission large integers survive native conversion.</code></dd></td><td><a href="https://github.com/nhost/nhost/pull/XXX/files#diff-0e0decd5a0eb11f4e3169eefc66fd007ee9478370b393566ea431fbbd28383e7">+51/-0</a></td></tr>
<tr><td><strong>services/constellation/metadata/internal/hasura/json_test.go</strong><dd><code>Add parser tests for exact permission numbers and invalid remote relationships.</code></dd></td><td><a href="https://github.com/nhost/nhost/pull/XXX/files#diff-bfbc313af601f17a4f05fb9f43203174b46e2970c0bd617af6089e2c48ed0e6d">+108/-0</a></td></tr>
<tr><td><strong>services/constellation/metadata/internal/hasura/table.go</strong><dd><code>Decode permission expressions with json.Number-preserving unmarshaling.</code></dd></td><td><a href="https://github.com/nhost/nhost/pull/XXX/files#diff-84f023345e75b5d3d1f1e6f7448e5c8b9103bdf783a26447c64c8a5ad8d3df9a">+39/-11</a></td></tr>
<tr><td><strong>services/constellation/metadata/internal/hasura/testdata/TestFromJSON_RealMetadata/golden.json</strong><dd><code>Update remote schema header golden output to value_from_env.</code></dd></td><td><a href="https://github.com/nhost/nhost/pull/XXX/files#diff-9f02101f0d4160930dccd9df2d659be37a048877274a5247cb64ac6c1c200309">+1/-1</a></td></tr>
<tr><td><strong>services/constellation/metadata/remote_schema.go</strong><dd><code>Represent remote schema headers as literal value or value_from_env.</code></dd></td><td><a href="https://github.com/nhost/nhost/pull/XXX/files#diff-11f8bd3c48f4350bf8df874ef0658240004e7049c096beb93db9409a3cc1ca56">+5/-4</a></td></tr>
<tr><td><strong>services/constellation/metadata/toml.go</strong><dd><code>Normalize TOML permission numeric literals after metadata parsing.</code></dd></td><td><a href="https://github.com/nhost/nhost/pull/XXX/files#diff-ca6e8dcad281d5357725ec2bf662b3843fa1ed44379c9fc8bd52e90edac4a1c3">+49/-0</a></td></tr>
</table></details></td></tr>
<tr><td><strong>Documentation</strong></td><td><details><summary>2 files</summary><table>
<tr><td><strong>services/constellation/docs/user/inconsistencies.md</strong><dd><code>Document relationship inconsistencies for invalid raw remote relationship types.</code></dd></td><td><a href="https://github.com/nhost/nhost/pull/XXX/files#diff-7280ac45fa37f66f2f6a5ff6b3865fe5547f17cb653f60102444ddcb7f8e41a5">+5/-2</a></td></tr>
<tr><td><strong>services/constellation/docs/user/remote-schema.md</strong><dd><code>Clarify literal remote schema headers are not interpolated.</code></dd></td><td><a href="https://github.com/nhost/nhost/pull/XXX/files#diff-abd75d4c384c2824ede08131116f88986afe5c60bad41b8e6bc06ad87ece2a21">+1/-1</a></td></tr>
</table></details></td></tr>
</tbody></table>

</details>

___

<!-- nhost-reviewer:end -->