### PR TITLE
fix(constellation): preserve remote schema header env refs

### DIFF
--- a/services/constellation/connector/sql/sql_test.go
+++ b/services/constellation/connector/sql/sql_test.go
@@ -451,6 +451,81 @@ func TestNewConnector_KitchenSinkInconsistencies(t *testing.T) {
 	}
 }
 
+func TestNewConnector_RecordsInvalidHasuraRemoteRelationshipType(t *testing.T) {
+	t.Parallel()
+
+	meta, err := metadata.FromHasuraJSON([]byte(`{
+		"version": 3,
+		"sources": [{
+			"name": "default",
+			"kind": "postgres",
+			"configuration": {
+				"connection_info": {"database_url": "postgres://localhost/db"}
+			},
+			"tables": [{
+				"table": {"name": "orders", "schema": "public"},
+				"remote_relationships": [{
+					"name": "customer",
+					"definition": {
+						"to_source": {
+							"field_mapping": {"customer_id": "id"},
+							"relationship_type": "typo",
+							"source": "customers_db",
+							"table": {"name": "customers", "schema": "public"}
+						}
+					}
+				}]
+			}]
+		}]
+	}`))
+	if err != nil {
+		t.Fatalf("FromHasuraJSON: %v", err)
+	}
+
+	objs := introspection.NewObjects()
+	objs.Schemas["public"] = &introspection.Schema{
+		Tables: map[string]*introspection.Table{
+			"orders": {
+				Schema:       "public",
+				Name:         "orders",
+				IsInsertable: true,
+				IsUpdatable:  true,
+				Columns: []introspection.Column{
+					{Name: "id", Type: "uuid"},
+					{Name: "customer_id", Type: "uuid"},
+				},
+				PrimaryKeys: []string{"id"},
+			},
+		},
+	}
+
+	ctrl := gomock.NewController(t)
+	driver := mock.NewMockDriver(ctrl)
+	driver.EXPECT().Dialect().Return(&dialect.PostgresDialect{}).AnyTimes()
+	driver.EXPECT().Introspect(gomock.Any(), gomock.Any()).Return(objs, nil)
+	driver.EXPECT().Close().AnyTimes()
+
+	inc := metadata.NewInconsistencies()
+
+	conn, err := csql.NewConnector(t.Context(), driver, &meta.Databases[0], inc, nil)
+	if err != nil {
+		t.Fatalf("NewConnector: %v", err)
+	}
+
+	t.Cleanup(func() { conn.Close() })
+
+	for _, item := range inc.Snapshot() {
+		if item.Kind == metadata.InconsistencyKindRelationship &&
+			item.Source == "default" &&
+			item.Name == "public.orders.customer" &&
+			strings.Contains(item.Reason, "invalid to_source relationship_type") {
+			return
+		}
+	}
+
+	t.Fatalf("expected invalid relationship_type inconsistency, got %+v", inc.Snapshot())
+}
+
 func TestConnector_Close(t *testing.T) {
 	t.Parallel()
 

--- a/services/constellation/metadata/internal/hasura/table.go
+++ b/services/constellation/metadata/internal/hasura/table.go
@@ -767,6 +767,11 @@ func (t *TableMetadata) appendToSourceRelationship(remote RemoteRelationship) {
 			Name:  remote.Name,
 			Using: using,
 		})
+	default:
+		// Keep invalid entries in RemoteRelationships only. The native conversion
+		// preserves that raw entry so SQL-source reconciliation can record a
+		// relationship inconsistency once a collector is available.
+		return
 	}
 }
 


### PR DESCRIPTION
<!-- nhost-reviewer:start -->
### **What this PR solves**
Fixes several Hasura metadata compatibility gaps in Constellation: remote schema header env references are preserved and resolved explicitly, large integer permission literals avoid JSON float rounding, and invalid raw `to_source` relationship types are reported as inconsistencies instead of being composed.

___

### **PR Type**
Bug fix

___

### **Description**
- Split remote schema headers into literal `value` and `value_from_env` fields, with connector-time env resolution.
- Preserve and normalize exact numeric permission literals across Hasura JSON and TOML metadata conversion.
- Keep invalid raw `to_source` remote relationships out of composed relationships and record SQL-source inconsistencies for bad discriminators.
- Update tests, golden metadata output, and user docs to reflect the corrected behavior.

___

### Diagram Walkthrough

```mermaid
flowchart LR
  A["Hasura JSON/YAML metadata"] --> B["metadata/internal/hasura parsing"]
  B --> C["metadata conversion"]
  C --> D["SQL reconciliation"]
  C --> E["Remote schema connector"]
  D --> F["Relationship inconsistencies"]
  E --> G["Request headers"]
```

<details> <summary><h3> File Walkthrough</h3></summary>

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody>
<tr><td><strong>Pi tooling</strong></td><td><details><summary>1 file</summary><table>
<tr>
  <td><strong>.pi/extensions/subagent/index.ts</strong><dd><code>Default project-agent confirmation prompts to disabled in the subagent extension schema and runtime fallback.</code></dd></td>
  <td><a href="https://github.com/nhost/nhost/pull/4475/files#diff-78770f497b6d646bca33d3970d4ff35dda2fa1f6c9b64372af33b5d23871530e">+3/-3</a></td>
</tr>
</table></details></td></tr>
<tr><td><strong>Constellation connector behavior</strong></td><td><details><summary>8 files</summary><table>
<tr>
  <td><strong>services/constellation/connector/composer/composer.go</strong><dd><code>Skip remote relationship specs when raw to_source relationship_type is not object or array.</code></dd></td>
  <td><a href="https://github.com/nhost/nhost/pull/4475/files#diff-778dc2a007f10f386e8fbb3f7cc4796ec3f4547d9f9d6ea12b0f87621d195cb9">+9/-0</a></td>
</tr>
<tr>
  <td><strong>services/constellation/connector/composer/composer_internal_test.go</strong><dd><code>Add composer coverage for invalid db-to-db and remote-schema-to-db relationship type skips.</code></dd></td>
  <td><a href="https://github.com/nhost/nhost/pull/4475/files#diff-ecba8e9c7685bbb1d51c537728e838c1e4ebed909d7715475cdef5cb418a417b">+38/-2</a></td>
</tr>
<tr>
  <td><strong>services/constellation/connector/remoteschema/connector.go</strong><dd><code>Resolve remote schema header values from value_from_env only, leaving literal values untouched.</code></dd></td>
  <td><a href="https://github.com/nhost/nhost/pull/4475/files#diff-72077cda245f97e0692f1255d2d4a8dae399c6b86ec23bad501b6acd0285d308">+15/-5</a></td>
</tr>
<tr>
  <td><strong>services/constellation/connector/remoteschema/connector_internal_test.go</strong><dd><code>Cover literal header forwarding, env header resolution, and missing env failures.</code></dd></td>
  <td><a href="https://github.com/nhost/nhost/pull/4475/files#diff-5c772c235cc78f29cfcd8caea37151a6d22a5a7efdab33f02ecf1f0f4a24091f">+59/-0</a></td>
</tr>
<tr>
  <td><strong>services/constellation/connector/sql/reconcile.go</strong><dd><code>Drop invalid raw to_source remote relationships during SQL metadata reconciliation and record inconsistencies.</code></dd></td>
  <td><a href="https://github.com/nhost/nhost/pull/4475/files#diff-ab787f06973e212424bf0e1ef4d1941754542d7cda91536b5931c51d864e94cd">+41/-0</a></td>
</tr>
<tr>
  <td><strong>services/constellation/connector/sql/reconcile_internal_test.go</strong><dd><code>Assert invalid remote relationship types are removed while valid siblings survive.</code></dd></td>
  <td><a href="https://github.com/nhost/nhost/pull/4475/files#diff-42722fd49aed04bfeec1c66c7391ca9e6518dfe59e5d41a1ffc963d0713c1b6e">+57/-0</a></td>
</tr>
<tr>
  <td><strong>services/constellation/connector/sql/sql_test.go</strong><dd><code>Add connector-level coverage for invalid Hasura remote relationship type inconsistencies.</code></dd></td>
  <td><a href="https://github.com/nhost/nhost/pull/4475/files#diff-b9ec7984832d988547f5b76e1b61f90141687880ce43a5786b2c5139bf0608c0">+75/-0</a></td>
</tr>
<tr>
  <td><strong>services/constellation/metadata/internal/hasura/testdata/TestFromJSON_RealMetadata/golden.json</strong><dd><code>Update the remote schema header golden to emit value_from_env instead of synthesized template syntax.</code></dd></td>
  <td><a href="https://github.com/nhost/nhost/pull/4475/files#diff-9f02101f0d4160930dccd9df2d659be37a048877274a5247cb64ac6c1c200309">+1/-1</a></td>
</tr>
</table></details></td></tr>
<tr><td><strong>Constellation metadata parsing</strong></td><td><details><summary>7 files</summary><table>
<tr>
  <td><strong>services/constellation/metadata/convert.go</strong><dd><code>Convert header env references into value_from_env and normalize permission number values during conversion.</code></dd></td>
  <td><a href="https://github.com/nhost/nhost/pull/4475/files#diff-1a7f6ead9aab4ab64dda6480b6610aed1bf9e98f2ab2efa67bdaef2a7b189ec5">+124/-12</a></td>
</tr>
<tr>
  <td><strong>services/constellation/metadata/convert_internal_test.go</strong><dd><code>Replace EnvString header tests and add permission number normalization coverage.</code></dd></td>
  <td><a href="https://github.com/nhost/nhost/pull/4475/files#diff-6db7d32fd5ec9d013016c28ac3bf8777c1d0b9a7b626f26e4817c0043650b2d5">+91/-16</a></td>
</tr>
<tr>
  <td><strong>services/constellation/metadata/convert_test.go</strong><dd><code>Verify large JSON integer permission filters survive Hasura conversion exactly.</code></dd></td>
  <td><a href="https://github.com/nhost/nhost/pull/4475/files#diff-0e0decd5a0eb11f4e3169eefc66fd007ee9478370b393566ea431fbbd28383e7">+51/-0</a></td>
</tr>
<tr>
  <td><strong>services/constellation/metadata/internal/hasura/json_test.go</strong><dd><code>Add tests for JSON number preservation and invalid to_source relationship retention.</code></dd></td>
  <td><a href="https://github.com/nhost/nhost/pull/4475/files#diff-bfbc313af601f17a4f05fb9f43203174b46e2970c0bd617af6089e2c48ed0e6d">+108/-0</a></td>
</tr>
<tr>
  <td><strong>services/constellation/metadata/internal/hasura/table.go</strong><dd><code>Introduce PermissionExpression JSON decoding with UseNumber and avoid lowering invalid to_source relationship types.</code></dd></td>
  <td><a href="https://github.com/nhost/nhost/pull/4475/files#diff-84f023345e75b5d3d1f1e6f7448e5c8b9103bdf783a26447c64c8a5ad8d3df9a">+54/-21</a></td>
</tr>
<tr>
  <td><strong>services/constellation/metadata/remote_schema.go</strong><dd><code>Model remote schema headers with separate literal and env-reference fields.</code></dd></td>
  <td><a href="https://github.com/nhost/nhost/pull/4475/files#diff-11f8bd3c48f4350bf8df874ef0658240004e7049c096beb93db9409a3cc1ca56">+5/-4</a></td>
</tr>
<tr>
  <td><strong>services/constellation/metadata/toml.go</strong><dd><code>Normalize permission numbers after TOML metadata parsing.</code></dd></td>
  <td><a href="https://github.com/nhost/nhost/pull/4475/files#diff-ca6e8dcad281d5357725ec2bf662b3843fa1ed44379c9fc8bd52e90edac4a1c3">+49/-0</a></td>
</tr>
</table></details></td></tr>
<tr><td><strong>Documentation</strong></td><td><details><summary>2 files</summary><table>
<tr>
  <td><strong>services/constellation/docs/user/inconsistencies.md</strong><dd><code>Document relationship inconsistencies for missing or invalid raw to_source relationship_type values.</code></dd></td>
  <td><a href="https://github.com/nhost/nhost/pull/4475/files#diff-7280ac45fa37f66f2f6a5ff6b3865fe5547f17cb653f60102444ddcb7f8e41a5">+5/-2</a></td>
</tr>
<tr>
  <td><strong>services/constellation/docs/user/remote-schema.md</strong><dd><code>Clarify that literal remote schema header values are not interpolated.</code></dd></td>
  <td><a href="https://github.com/nhost/nhost/pull/4475/files#diff-abd75d4c384c2824ede08131116f88986afe5c60bad41b8e6bc06ad87ece2a21">+1/-1</a></td>
</tr>
</table></details></td></tr>
</tbody></table>

</details>

___

<!-- nhost-reviewer:end -->