### PR TITLE
fix(constellation): align subscription cohort variables

### DIFF
--- a/services/constellation/connector/sql/graphql/queries/multiplexed/multiplexed.go
+++ b/services/constellation/connector/sql/graphql/queries/multiplexed/multiplexed.go
@@ -378,6 +378,11 @@ func writeSessionVarsJSON(
 		}
 
 		val := arr[subscriberIndex]
+		if val == nil {
+			sb.WriteString("null")
+
+			continue
+		}
 
 		valStr := fmt.Sprintf("%v", val)
 

--- a/services/constellation/connector/sql/graphql/queries/multiplexed/multiplexed_test.go
+++ b/services/constellation/connector/sql/graphql/queries/multiplexed/multiplexed_test.go
@@ -369,6 +369,40 @@ func assertSessionVarString(t *testing.T, params []any, key, want string) {
 	}
 }
 
+func assertNilPaddedSessionVars(t *testing.T, params []any) {
+	t.Helper()
+
+	subA := parseResultVarsJSON(t, params, 0)
+
+	sessionA, ok := subA["session"].(map[string]any)
+	if !ok {
+		t.Fatal("sub-a missing session key in result vars")
+	}
+
+	if got := sessionA["x-hasura-user-id"]; got != "user-a" {
+		t.Errorf("sub-a user ID = %v, want user-a", got)
+	}
+
+	if got, exists := sessionA["x-hasura-org-id"]; !exists || got != nil {
+		t.Errorf("sub-a org ID = %v (exists %v), want explicit nil", got, exists)
+	}
+
+	subB := parseResultVarsJSON(t, params, 1)
+
+	sessionB, ok := subB["session"].(map[string]any)
+	if !ok {
+		t.Fatal("sub-b missing session key in result vars")
+	}
+
+	if got := sessionB["x-hasura-user-id"]; got != "user-b" {
+		t.Errorf("sub-b user ID = %v, want user-b", got)
+	}
+
+	if got := sessionB["x-hasura-org-id"]; got != "org-b" {
+		t.Errorf("sub-b org ID = %v, want org-b", got)
+	}
+}
+
 func TestPrepareParams(t *testing.T) {
 	t.Parallel()
 
@@ -430,6 +464,16 @@ func TestPrepareParams(t *testing.T) {
 				t.Helper()
 				assertSessionVarString(t, params, "x-hasura-user-id", `user "with" quotes`)
 			},
+		},
+		{
+			name:            "nil-padded session vars stay aligned",
+			subscriptionIDs: []string{"sub-a", "sub-b"},
+			sessionVarArrays: map[string][]any{
+				"x-hasura-user-id": {"user-a", "user-b"},
+				"x-hasura-org-id":  {nil, "org-b"},
+			},
+			cursorValues: nil,
+			assert:       assertNilPaddedSessionVars,
 		},
 	}
 

--- a/services/constellation/connector/sql/subscription/aligned_vars.go
+++ b/services/constellation/connector/sql/subscription/aligned_vars.go
@@ -1,0 +1,18 @@
+package subscription
+
+func assignAlignedVars(
+	varArrays map[string][]any,
+	vars map[string]any,
+	subscriberIndex int,
+	subscriberCount int,
+) {
+	for varName, varValue := range vars {
+		arr, exists := varArrays[varName]
+		if !exists {
+			arr = make([]any, subscriberCount)
+			varArrays[varName] = arr
+		}
+
+		arr[subscriberIndex] = varValue
+	}
+}

--- a/services/constellation/connector/sql/subscription/cohort_inputs_internal_test.go
+++ b/services/constellation/connector/sql/subscription/cohort_inputs_internal_test.go
@@ -1,0 +1,231 @@
+package subscription
+
+import "testing"
+
+func TestBuildSubscriberInputsAlignsSessionVars(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name          string
+		subscriptions map[string]*cohortSubscription
+		wantByID      map[string]map[string]any
+	}{
+		{
+			name: "heterogeneous key sets",
+			subscriptions: map[string]*cohortSubscription{
+				"a": newCohortSubscription(
+					"sub-a",
+					map[string]any{"x-hasura-user-id": "user-a"},
+					nil,
+				),
+				"b": newCohortSubscription(
+					"sub-b",
+					map[string]any{
+						"x-hasura-user-id": "user-b",
+						"x-hasura-org-id":  "org-b",
+					},
+					nil,
+				),
+			},
+			wantByID: map[string]map[string]any{
+				"sub-a": {
+					"x-hasura-user-id": "user-a",
+					"x-hasura-org-id":  nil,
+				},
+				"sub-b": {
+					"x-hasura-user-id": "user-b",
+					"x-hasura-org-id":  "org-b",
+				},
+			},
+		},
+		{
+			name: "identical key sets",
+			subscriptions: map[string]*cohortSubscription{
+				"a": newCohortSubscription(
+					"sub-a",
+					map[string]any{
+						"x-hasura-user-id": "user-a",
+						"x-hasura-org-id":  "org-a",
+					},
+					nil,
+				),
+				"b": newCohortSubscription(
+					"sub-b",
+					map[string]any{
+						"x-hasura-user-id": "user-b",
+						"x-hasura-org-id":  "org-b",
+					},
+					nil,
+				),
+			},
+			wantByID: map[string]map[string]any{
+				"sub-a": {
+					"x-hasura-user-id": "user-a",
+					"x-hasura-org-id":  "org-a",
+				},
+				"sub-b": {
+					"x-hasura-user-id": "user-b",
+					"x-hasura-org-id":  "org-b",
+				},
+			},
+		},
+		{
+			name: "empty session vars",
+			subscriptions: map[string]*cohortSubscription{
+				"a": newCohortSubscription("sub-a", nil, nil),
+				"b": newCohortSubscription("sub-b", nil, nil),
+			},
+			wantByID: map[string]map[string]any{
+				"sub-a": {},
+				"sub-b": {},
+			},
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+
+			subIDs, sessionVarArrays := buildSubscriberInputs(tc.subscriptions)
+
+			assertAlignedVars(t, subIDs, sessionVarArrays, tc.wantByID)
+		})
+	}
+}
+
+func TestBuildStreamSubscriberInputsAlignsVars(t *testing.T) {
+	t.Parallel()
+
+	subscriptions := map[string]*streamCohortSubscription{
+		"a": newStreamCohortSubscription(
+			"sub-a",
+			map[string]any{"x-hasura-user-id": "user-a"},
+			map[string]any{"limit": 10},
+			nil,
+		),
+		"b": newStreamCohortSubscription(
+			"sub-b",
+			map[string]any{
+				"x-hasura-user-id": "user-b",
+				"x-hasura-org-id":  "org-b",
+			},
+			map[string]any{
+				"limit":  10,
+				"offset": 20,
+			},
+			nil,
+		),
+	}
+
+	subIDs, sessionVarArrays, graphQLVarArrays := buildStreamSubscriberInputs(subscriptions)
+
+	assertAlignedVars(t, subIDs, sessionVarArrays, map[string]map[string]any{
+		"sub-a": {
+			"x-hasura-user-id": "user-a",
+			"x-hasura-org-id":  nil,
+		},
+		"sub-b": {
+			"x-hasura-user-id": "user-b",
+			"x-hasura-org-id":  "org-b",
+		},
+	})
+	assertAlignedVars(t, subIDs, graphQLVarArrays, map[string]map[string]any{
+		"sub-a": {
+			"limit":  10,
+			"offset": nil,
+		},
+		"sub-b": {
+			"limit":  10,
+			"offset": 20,
+		},
+	})
+}
+
+func TestBuildStreamTemplateVarsUsesFirstNonNilGraphQLValue(t *testing.T) {
+	t.Parallel()
+
+	_, graphQLVars := buildStreamTemplateVars(
+		map[string][]any{"x-hasura-user-id": {"user-a", "user-b"}},
+		map[string][]any{
+			"limit":  {nil, 10},
+			"offset": {nil, nil},
+		},
+	)
+
+	if graphQLVars["limit"] != 10 {
+		t.Errorf("limit = %v, want 10", graphQLVars["limit"])
+	}
+
+	if _, exists := graphQLVars["offset"]; !exists {
+		t.Fatal("offset missing from template GraphQL variables")
+	}
+
+	if graphQLVars["offset"] != nil {
+		t.Errorf("offset = %v, want nil", graphQLVars["offset"])
+	}
+}
+
+func assertAlignedVars(
+	t *testing.T,
+	subIDs []string,
+	varArrays map[string][]any,
+	wantByID map[string]map[string]any,
+) {
+	t.Helper()
+
+	if len(subIDs) != len(wantByID) {
+		t.Fatalf("subIDs length = %d, want %d", len(subIDs), len(wantByID))
+	}
+
+	indexByID := make(map[string]int, len(subIDs))
+	for index, subID := range subIDs {
+		indexByID[subID] = index
+	}
+
+	wantVars := make(map[string]struct{})
+	for subID, vars := range wantByID {
+		if _, exists := indexByID[subID]; !exists {
+			t.Fatalf("subIDs missing %s", subID)
+		}
+
+		for varName := range vars {
+			wantVars[varName] = struct{}{}
+		}
+	}
+
+	for varName, arr := range varArrays {
+		if _, expected := wantVars[varName]; !expected {
+			t.Errorf("unexpected variable array %s", varName)
+		}
+
+		if len(arr) != len(subIDs) {
+			t.Errorf("%s length = %d, want %d", varName, len(arr), len(subIDs))
+		}
+	}
+
+	for varName := range wantVars {
+		if _, exists := varArrays[varName]; !exists {
+			t.Errorf("missing variable array %s", varName)
+		}
+	}
+
+	for subID, vars := range wantByID {
+		index := indexByID[subID]
+		for varName, want := range vars {
+			arr := varArrays[varName]
+			if index >= len(arr) {
+				t.Fatalf(
+					"%s index %d out of range for %s length %d",
+					subID,
+					index,
+					varName,
+					len(arr),
+				)
+			}
+
+			if got := arr[index]; got != want {
+				t.Errorf("%s[%s] = %v, want %v", subID, varName, got, want)
+			}
+		}
+	}
+}

--- a/services/constellation/connector/sql/subscription/cohort_manager.go
+++ b/services/constellation/connector/sql/subscription/cohort_manager.go
@@ -290,19 +290,20 @@ func (m *cohortManager) executeAndNotifyCohort(
 func buildSubscriberInputs(
 	subscriptions map[string]*cohortSubscription,
 ) ([]string, map[string][]any) {
-	subIDs := make([]string, 0, len(subscriptions))
+	subscriberCount := len(subscriptions)
+	subIDs := make([]string, 0, subscriberCount)
 	sessionVarArrays := make(map[string][]any)
 
 	for _, s := range subscriptions {
+		subscriberIndex := len(subIDs)
 		subIDs = append(subIDs, s.id)
 
-		for varName, varValue := range s.sessionVariables {
-			if _, exists := sessionVarArrays[varName]; !exists {
-				sessionVarArrays[varName] = make([]any, 0, len(subscriptions))
-			}
-
-			sessionVarArrays[varName] = append(sessionVarArrays[varName], varValue)
-		}
+		assignAlignedVars(
+			sessionVarArrays,
+			s.sessionVariables,
+			subscriberIndex,
+			subscriberCount,
+		)
 	}
 
 	return subIDs, sessionVarArrays

--- a/services/constellation/connector/sql/subscription/stream_cohort_manager.go
+++ b/services/constellation/connector/sql/subscription/stream_cohort_manager.go
@@ -298,28 +298,27 @@ func (m *streamCohortManager) executeAndRebuild(
 func buildStreamSubscriberInputs(
 	subscriptions map[string]*streamCohortSubscription,
 ) ([]string, map[string][]any, map[string][]any) {
-	subIDs := make([]string, 0, len(subscriptions))
+	subscriberCount := len(subscriptions)
+	subIDs := make([]string, 0, subscriberCount)
 	sessionVarArrays := make(map[string][]any)
 	graphQLVarArrays := make(map[string][]any)
 
 	for _, s := range subscriptions {
+		subscriberIndex := len(subIDs)
 		subIDs = append(subIDs, s.id)
 
-		for varName, varValue := range s.sessionVariables {
-			if _, exists := sessionVarArrays[varName]; !exists {
-				sessionVarArrays[varName] = make([]any, 0, len(subscriptions))
-			}
-
-			sessionVarArrays[varName] = append(sessionVarArrays[varName], varValue)
-		}
-
-		for varName, varValue := range s.graphQLVariables {
-			if _, exists := graphQLVarArrays[varName]; !exists {
-				graphQLVarArrays[varName] = make([]any, 0, len(subscriptions))
-			}
-
-			graphQLVarArrays[varName] = append(graphQLVarArrays[varName], varValue)
-		}
+		assignAlignedVars(
+			sessionVarArrays,
+			s.sessionVariables,
+			subscriberIndex,
+			subscriberCount,
+		)
+		assignAlignedVars(
+			graphQLVarArrays,
+			s.graphQLVariables,
+			subscriberIndex,
+			subscriberCount,
+		)
 	}
 
 	return subIDs, sessionVarArrays, graphQLVarArrays
@@ -518,8 +517,17 @@ func buildStreamTemplateVars(
 
 	templateGraphQLVars := make(map[string]any, len(graphQLVarArrays))
 	for varName, values := range graphQLVarArrays {
-		if len(values) > 0 {
-			templateGraphQLVars[varName] = values[0]
+		if len(values) == 0 {
+			continue
+		}
+
+		templateGraphQLVars[varName] = nil
+		for _, value := range values {
+			if value != nil {
+				templateGraphQLVars[varName] = value
+
+				break
+			}
 		}
 	}
 


### PR DESCRIPTION
<!-- pi-reviewer:start -->
### **What this change solves**
This change fixes subscription multiplexing cases where subscribers in the same cohort provide different session or GraphQL variable keys, keeping per-subscriber variable arrays aligned with explicit null padding.

___

### **Change Type**
Bug fix

___

### **Description**
- Add a shared subscription helper that assigns per-subscriber variables into fixed-width arrays, leaving absent keys as nil for that subscriber index.
- Update normal and streaming cohort input builders to use aligned variable arrays, and choose a non-nil stream template variable value when available.
- Teach multiplexed result-variable JSON generation to serialize nil values as JSON null and cover the behavior with tests.

___

<details> <summary><h3> File Walkthrough</h3></summary>

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody>
<tr><td><strong>Constellation subscriptions</strong></td><td><details><summary>6 files</summary><table>
<tr><td><strong>services/constellation/connector/sql/graphql/queries/multiplexed/multiplexed.go</strong><dd><code>Serialize nil session variable values as JSON null in multiplexed result variables.</code></dd></td><td>+5/-0</td></tr>
<tr><td><strong>services/constellation/connector/sql/graphql/queries/multiplexed/multiplexed_test.go</strong><dd><code>Add coverage for nil-padded session variable arrays in prepared multiplexed params.</code></dd></td><td>+44/-0</td></tr>
<tr><td><strong>services/constellation/connector/sql/subscription/aligned_vars.go</strong><dd><code>Add helper to assign subscriber variable values into aligned fixed-size arrays.</code></dd></td><td>+18/-0</td></tr>
<tr><td><strong>services/constellation/connector/sql/subscription/cohort_inputs_internal_test.go</strong><dd><code>Add white-box tests for normal and streaming cohort variable alignment.</code></dd></td><td>+231/-0</td></tr>
<tr><td><strong>services/constellation/connector/sql/subscription/cohort_manager.go</strong><dd><code>Build normal subscription session variable arrays with aligned nil padding.</code></dd></td><td>+9/-8</td></tr>
<tr><td><strong>services/constellation/connector/sql/subscription/stream_cohort_manager.go</strong><dd><code>Align stream session and GraphQL variables and select non-nil template vars.</code></dd></td><td>+26/-18</td></tr>
</table></details></td></tr>
</tbody></table>

</details>

___

<!-- pi-reviewer:end -->