### PR TITLE
fix(constellation): use raw HMAC JWT secrets

### DIFF
--- a/services/constellation/internal/jwt/jwt_internal_test.go
+++ b/services/constellation/internal/jwt/jwt_internal_test.go
@@ -3,8 +3,8 @@ package jwt
 import (
 	"bytes"
 	"context"
-	"encoding/base64"
 	"log/slog"
+	"strconv"
 	"strings"
 	"sync/atomic"
 	"testing"
@@ -72,36 +72,27 @@ func TestAuthenticatorCloseCancelsJWKSContext(t *testing.T) {
 	}
 }
 
-// TestDecodeHMACKeyLogsInterpretation guards the M8 observability contract:
-// decodeHMACKey must record at DEBUG which interpretation it chose (base64 vs
-// raw bytes) with the documented attribute names, and must never log key
-// material. A future refactor that renames the messages/attributes or drops
-// the logging would break operators relying on it, so the shape is pinned here.
-func TestDecodeHMACKeyLogsInterpretation(t *testing.T) {
+// TestStaticHMACKeyUsesRawBytesAndLogsSafely guards the Hasura-compatible
+// HMAC key contract: the configured key string is used as raw UTF-8 bytes even
+// when it also happens to be valid base64. The startup DEBUG log records only
+// safe metadata and must never include key material.
+func TestStaticHMACKeyUsesRawBytesAndLogsSafely(t *testing.T) {
 	t.Parallel()
 
-	base64Key := base64.StdEncoding.EncodeToString([]byte("supersecret"))
-
 	tests := []struct {
-		name     string
-		key      string
-		want     []byte
-		wantMsg  string
-		wantAttr []string
+		name string
+		alg  jwtconfig.Algorithm
+		key  string
 	}{
 		{
-			name:     "valid base64 decodes and logs base64 interpretation",
-			key:      base64Key,
-			want:     []byte("supersecret"),
-			wantMsg:  "jwt hmac key interpreted as base64",
-			wantAttr: []string{"encoded_len=16", "decoded_len=11"},
+			name: "hs256 valid-base64-looking key stays raw",
+			alg:  jwtconfig.AlgorithmHS256,
+			key:  "dGVzdA==",
 		},
 		{
-			name:     "non-base64 falls back to raw bytes and logs raw interpretation",
-			key:      "my-hmac-signing-secret",
-			want:     []byte("my-hmac-signing-secret"),
-			wantMsg:  "jwt hmac key interpreted as raw bytes",
-			wantAttr: []string{"key_len=22"},
+			name: "hs512 hex key stays raw",
+			alg:  jwtconfig.AlgorithmHS512,
+			key:  "0f987876650b4a085e64594fae9219e7781b17506bec02489ad061fba8cb22db",
 		},
 	}
 
@@ -115,20 +106,36 @@ func TestDecodeHMACKeyLogsInterpretation(t *testing.T) {
 				Level: slog.LevelDebug,
 			}))
 
-			got := decodeHMACKey(tt.key, logger)
-			if !bytes.Equal(got, tt.want) {
-				t.Errorf("decodeHMACKey() = %q, want %q", got, tt.want)
+			sv := &secretValidator{}
+			if err := sv.initStatic(
+				jwtconfig.Secret{Type: tt.alg, Key: tt.key},
+				logger,
+			); err != nil {
+				t.Fatalf("initStatic() error = %v", err)
+			}
+
+			gotKey, err := sv.keyFunc(&gojwt.Token{})
+			if err != nil {
+				t.Fatalf("keyFunc() error = %v", err)
+			}
+
+			got, ok := gotKey.([]byte)
+			if !ok {
+				t.Fatalf("keyFunc() key type = %T, want []byte", gotKey)
+			}
+
+			if !bytes.Equal(got, []byte(tt.key)) {
+				t.Errorf("keyFunc() key = %q, want raw key bytes %q", got, []byte(tt.key))
 			}
 
 			out := buf.String()
-			if !strings.Contains(out, tt.wantMsg) {
-				t.Errorf("log output %q does not contain message %q", out, tt.wantMsg)
+			if !strings.Contains(out, "jwt hmac key used as raw bytes") {
+				t.Errorf("log output %q does not contain raw-bytes message", out)
 			}
 
-			for _, attr := range tt.wantAttr {
-				if !strings.Contains(out, attr) {
-					t.Errorf("log output %q does not contain attribute %q", out, attr)
-				}
+			wantAttr := "key_len=" + strconv.Itoa(len(tt.key))
+			if !strings.Contains(out, wantAttr) {
+				t.Errorf("log output %q does not contain attribute %q", out, wantAttr)
 			}
 
 			if strings.Contains(out, tt.key) {
@@ -138,12 +145,31 @@ func TestDecodeHMACKeyLogsInterpretation(t *testing.T) {
 	}
 }
 
-func TestDecodeHMACKeyNilLoggerDoesNotPanic(t *testing.T) {
+func TestStaticHMACKeyNilLoggerDoesNotPanic(t *testing.T) {
 	t.Parallel()
 
-	got := decodeHMACKey("my-hmac-signing-secret", nil)
-	if !bytes.Equal(got, []byte("my-hmac-signing-secret")) {
-		t.Errorf("decodeHMACKey() = %q, want raw key bytes", got)
+	const key = "my-hmac-signing-secret"
+
+	sv := &secretValidator{}
+	if err := sv.initStatic(
+		jwtconfig.Secret{Type: jwtconfig.AlgorithmHS256, Key: key},
+		nil,
+	); err != nil {
+		t.Fatalf("initStatic() error = %v", err)
+	}
+
+	gotKey, err := sv.keyFunc(&gojwt.Token{})
+	if err != nil {
+		t.Fatalf("keyFunc() error = %v", err)
+	}
+
+	got, ok := gotKey.([]byte)
+	if !ok {
+		t.Fatalf("keyFunc() key type = %T, want []byte", gotKey)
+	}
+
+	if !bytes.Equal(got, []byte(key)) {
+		t.Errorf("keyFunc() key = %q, want raw key bytes", got)
 	}
 }
 

--- a/services/constellation/internal/jwt/jwt_test.go
+++ b/services/constellation/internal/jwt/jwt_test.go
@@ -67,6 +67,8 @@ func TestAuthenticator(t *testing.T) { //nolint:maintidx
 
 	rsaPrivKey, rsaPubPEM := generateRSAKeyPair(t)
 
+	const validBase64LookingHMACKey = "0f987876650b4a085e64594fae9219e7781b17506bec02489ad061fba8cb22db"
+
 	cases := []struct {
 		name            string
 		config          jwtconfig.Config
@@ -1129,22 +1131,45 @@ func TestAuthenticator(t *testing.T) { //nolint:maintidx
 
 		// --- HMAC key encoding ---
 		{
-			name: "hs256 - base64 encoded key",
+			name: "hs256 - valid-base64-looking key verified as raw bytes",
 			config: jwtconfig.Config{
 				Secrets: []jwtconfig.Secret{
-					{Type: jwtconfig.AlgorithmHS256, Key: "dGVzdA=="}, // base64("test")
+					{Type: jwtconfig.AlgorithmHS256, Key: validBase64LookingHMACKey},
 				},
 			},
-			headersFn: bearerTokenFn("test", gojwt.SigningMethodHS256, gojwt.MapClaims{
-				"exp": gojwt.NewNumericDate(time.Now().Add(time.Hour)),
-				"https://hasura.io/jwt/claims": hasuraClaims(
-					[]string{"user"}, "user", nil,
-				),
-			}),
+			headersFn: bearerTokenFn(
+				validBase64LookingHMACKey,
+				gojwt.SigningMethodHS256,
+				gojwt.MapClaims{
+					"exp": gojwt.NewNumericDate(time.Now().Add(time.Hour)),
+					"https://hasura.io/jwt/claims": hasuraClaims(
+						[]string{"user"}, "user", nil,
+					),
+				},
+			),
 			expectedSession: &jwt.SessionResult{
 				Role:      "user",
 				Variables: expectedVars("user", []string{"user"}, "user", nil),
 			},
+		},
+		{
+			name: "hs256 - token signed with base64-decoded key is rejected",
+			config: jwtconfig.Config{
+				Secrets: []jwtconfig.Secret{
+					{Type: jwtconfig.AlgorithmHS256, Key: validBase64LookingHMACKey},
+				},
+			},
+			headersFn: base64DecodedBearerTokenFn(
+				validBase64LookingHMACKey,
+				gojwt.SigningMethodHS256,
+				gojwt.MapClaims{
+					"exp": gojwt.NewNumericDate(time.Now().Add(time.Hour)),
+					"https://hasura.io/jwt/claims": hasuraClaims(
+						[]string{"user"}, "user", nil,
+					),
+				},
+			),
+			wantErr: true,
 		},
 
 		// --- Hasura claims type edge cases ---
@@ -1839,6 +1864,42 @@ func bearerTokenFn(
 	claims gojwt.MapClaims,
 ) func(*testing.T) http.Header {
 	return bearerTokenFnWithPrefix("Bearer ", key, method, claims)
+}
+
+func base64DecodedBearerTokenFn(
+	encodedKey string,
+	method gojwt.SigningMethod,
+	claims gojwt.MapClaims,
+) func(*testing.T) http.Header {
+	return func(t *testing.T) http.Header {
+		t.Helper()
+
+		decodedKey, err := base64.StdEncoding.DecodeString(encodedKey)
+		if err != nil {
+			t.Fatalf("decode HMAC key fixture: %v", err)
+		}
+
+		return bearerTokenBytesFn(decodedKey, method, claims)(t)
+	}
+}
+
+func bearerTokenBytesFn(
+	key []byte,
+	method gojwt.SigningMethod,
+	claims gojwt.MapClaims,
+) func(*testing.T) http.Header {
+	return func(t *testing.T) http.Header {
+		t.Helper()
+
+		token := gojwt.NewWithClaims(method, claims)
+
+		tokenStr, err := token.SignedString(key)
+		if err != nil {
+			t.Fatalf("failed to sign token: %v", err)
+		}
+
+		return http.Header{"Authorization": {"Bearer " + tokenStr}}
+	}
 }
 
 // bearerTokenFnWithPrefix is like bearerTokenFn but allows a custom prefix (e.g. "bearer " for case-insensitive tests).

--- a/services/constellation/internal/jwt/jwtconfig/config.go
+++ b/services/constellation/internal/jwt/jwtconfig/config.go
@@ -171,9 +171,10 @@ type Secret struct {
 	// Type names the signing algorithm. Required when using a static key
 	// (Type+Key form); omit when using JWKURL.
 	Type Algorithm `json:"type,omitempty"`
-	// Key is the signing key material for the static form: a raw or
-	// base64-encoded shared secret for HS*, or a PEM-encoded RSA public key
-	// for RS*. Required when Type is set; omit when using JWKURL.
+	// Key is the signing key material for the static form: the raw shared
+	// secret, used as its UTF-8 bytes to match Hasura/Nhost Auth, for HS*, or a
+	// PEM-encoded RSA public key for RS*. Required when Type is set; omit when
+	// using JWKURL.
 	Key string `json:"key,omitempty"`
 	// Kid pins validation to a specific key ID. Optional; when set, JWTs
 	// without a matching `kid` header are rejected. Applies to both JWKURL

--- a/services/constellation/internal/jwt/validator.go
+++ b/services/constellation/internal/jwt/validator.go
@@ -4,7 +4,6 @@ import (
 	"context"
 	"crypto/rsa"
 	"crypto/x509"
-	"encoding/base64"
 	"encoding/pem"
 	"errors"
 	"fmt"
@@ -97,7 +96,14 @@ func (sv *secretValidator) initJWKS(
 func (sv *secretValidator) initStatic(secret jwtconfig.Secret, logger *slog.Logger) error {
 	switch secret.Type {
 	case jwtconfig.AlgorithmHS256, jwtconfig.AlgorithmHS384, jwtconfig.AlgorithmHS512:
-		key := decodeHMACKey(secret.Key, logger)
+		key := []byte(secret.Key)
+		if logger != nil {
+			logger.Debug(
+				"jwt hmac key used as raw bytes",
+				slog.Int("key_len", len(secret.Key)),
+			)
+		}
+
 		sv.keyFunc = func(_ *jwt.Token) (any, error) {
 			return key, nil
 		}
@@ -163,37 +169,6 @@ func (sv *secretValidator) close() {
 	if sv.jwksCancel != nil {
 		sv.jwksCancel()
 	}
-}
-
-// decodeHMACKey tries base64 decoding first, falls back to raw bytes.
-// The base64 error is intentionally swallowed: this implements the documented
-// "key is base64 OR raw bytes" contract. The opposite failure mode — a raw
-// secret that happens to look like base64 being silently decoded — is
-// observable at DEBUG: operators chasing an inscrutable "signature invalid"
-// error can confirm which interpretation was used at startup. Only key lengths
-// are logged, never key material.
-func decodeHMACKey(key string, logger *slog.Logger) []byte {
-	decoded, err := base64.StdEncoding.DecodeString(key)
-	if err == nil {
-		if logger != nil {
-			logger.Debug(
-				"jwt hmac key interpreted as base64",
-				slog.Int("encoded_len", len(key)),
-				slog.Int("decoded_len", len(decoded)),
-			)
-		}
-
-		return decoded
-	}
-
-	if logger != nil {
-		logger.Debug(
-			"jwt hmac key interpreted as raw bytes",
-			slog.Int("key_len", len(key)),
-		)
-	}
-
-	return []byte(key)
 }
 
 // parseRSAPublicKey parses a PEM-encoded RSA public key.


### PR DESCRIPTION
<!-- nhost-reviewer:start -->
### **What this PR solves**
This PR aligns Constellation JWT HMAC validation with Hasura/Nhost Auth by treating configured shared secrets as raw UTF-8 bytes, even when they look base64-encoded.
___

### **PR Type**
Bug fix

___

### **Description**
- Treat HS* JWT static secrets as raw bytes, update the config docs, and pin the behavior with positive and negative authentication tests.

___

### Diagram Walkthrough

```mermaid
flowchart LR
  A["JWT static secret config"] --> B["Constellation HMAC validator"]
  B --> C["Raw UTF-8 key bytes"]
```

<details> <summary><h3> File Walkthrough</h3></summary>

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody>
<tr><td><strong>Constellation JWT</strong></td><td><details><summary>4 files</summary><table>
<tr><td><strong>services/constellation/internal/jwt/jwt_internal_test.go</strong><dd><code>Replaces decode helper tests with raw-byte static HMAC key behavior and safe logging coverage.</code></dd></td><td><a href="https://github.com/nhost/nhost/pull/XXX/files#diff-152cf17a823df23b31c4812c1aef6f01bfefd93aa542e79f647fc26e331111ab">+63/-37</a></td></tr>
<tr><td><strong>services/constellation/internal/jwt/jwt_test.go</strong><dd><code>Adds auth tests for base64-looking HMAC secrets used raw and decoded-key rejection.</code></dd></td><td><a href="https://github.com/nhost/nhost/pull/XXX/files#diff-d6f448bcd3b3e968775ca18686553b09f9215b1804ce82a3cc329f8825f294a3">+69/-8</a></td></tr>
<tr><td><strong>services/constellation/internal/jwt/jwtconfig/config.go</strong><dd><code>Documents HS* static keys as raw shared secrets used as UTF-8 bytes.</code></dd></td><td><a href="https://github.com/nhost/nhost/pull/XXX/files#diff-6d9ea423b0bc7e219dae09b5cd41c5fa48d01679b88828f49c41e8fa62eade47">+4/-3</a></td></tr>
<tr><td><strong>services/constellation/internal/jwt/validator.go</strong><dd><code>Removes base64 decoding for HMAC keys and logs safe raw-key metadata.</code></dd></td><td><a href="https://github.com/nhost/nhost/pull/XXX/files#diff-1740efcc5a2d5204cb05732ee8be202334ec1393e06620e5b4b8eb46d81a7e29">+8/-33</a></td></tr>
</table></details></td></tr>
</tbody></table>

</details>

___

<!-- nhost-reviewer:end -->
