### PR TITLE
fix(cli): graceful Postgres shutdown on 'nhost down'

### DIFF
--- a/cli/dockercompose/compose.go
+++ b/cli/dockercompose/compose.go
@@ -74,19 +74,21 @@ func (e Environment) MarshalYAML() (any, error) {
 
 //nolint:tagliatelle
 type Service struct {
-	Image       string                    `yaml:"image"`
-	DependsOn   map[string]DependsOn      `yaml:"depends_on,omitempty"`
-	EntryPoint  []string                  `yaml:"entrypoint,omitempty"`
-	Command     []string                  `yaml:"command,omitempty"`
-	Environment Environment               `yaml:"environment,omitempty"`
-	ExtraHosts  []string                  `yaml:"extra_hosts"`
-	HealthCheck *HealthCheck              `yaml:"healthcheck,omitempty"`
-	Labels      map[string]string         `yaml:"labels,omitempty"`
-	Networks    map[string]*NetworkConfig `yaml:"networks,omitempty"`
-	Ports       []Port                    `yaml:"ports,omitempty"`
-	Restart     string                    `yaml:"restart"`
-	Volumes     []Volume                  `yaml:"volumes,omitempty"`
-	WorkingDir  *string                   `yaml:"working_dir,omitempty"`
+	Image           string                    `yaml:"image"`
+	DependsOn       map[string]DependsOn      `yaml:"depends_on,omitempty"`
+	EntryPoint      []string                  `yaml:"entrypoint,omitempty"`
+	Command         []string                  `yaml:"command,omitempty"`
+	Environment     Environment               `yaml:"environment,omitempty"`
+	ExtraHosts      []string                  `yaml:"extra_hosts"`
+	HealthCheck     *HealthCheck              `yaml:"healthcheck,omitempty"`
+	Labels          map[string]string         `yaml:"labels,omitempty"`
+	Networks        map[string]*NetworkConfig `yaml:"networks,omitempty"`
+	Ports           []Port                    `yaml:"ports,omitempty"`
+	Restart         string                    `yaml:"restart"`
+	StopGracePeriod string                    `yaml:"stop_grace_period,omitempty"`
+	StopSignal      string                    `yaml:"stop_signal,omitempty"`
+	Volumes         []Volume                  `yaml:"volumes,omitempty"`
+	WorkingDir      *string                   `yaml:"working_dir,omitempty"`
 }
 
 type DependsOn struct {

--- a/cli/dockercompose/postgres.go
+++ b/cli/dockercompose/postgres.go
@@ -78,7 +78,9 @@ func postgres( //nolint:funlen
 				Protocol:  "tcp",
 			},
 		},
-		Restart: "always",
+		Restart:         "always",
+		StopGracePeriod: "60s",
+		StopSignal:      "SIGTERM",
 		Volumes: []Volume{
 			{
 				Type:     "volume",

--- a/cli/dockercompose/postgres_test.go
+++ b/cli/dockercompose/postgres_test.go
@@ -51,8 +51,12 @@ func expectedPostgres(tmpdir string) *Service {
 		},
 		Labels:   nil,
 		Networks: networkAliases("postgres-service"),
-		Ports:    []Port{{Mode: "ingress", Target: 5432, Published: "5432", Protocol: "tcp"}},
-		Restart:  "always",
+		Ports: []Port{
+			{Mode: "ingress", Target: 5432, Published: "5432", Protocol: "tcp"},
+		},
+		Restart:         "always",
+		StopGracePeriod: "60s",
+		StopSignal:      "SIGTERM",
 		Volumes: []Volume{
 			{
 				Type:     "volume",


### PR DESCRIPTION
Fixes #3978

**Problem:** `nhost down` didn't give Postgres enough time to shut down cleanly (checkpoint + WAL flush). On next `nhost up`, logs showed: `database system was not properly shut down; automatic recovery in progress`

**Solution:** Add `StopGracePeriod: 60s` and `StopSignal: SIGTERM` to the Postgres service in docker-compose. This gives Postgres 60 seconds to checkpoint and flush WAL before Docker sends SIGKILL.

**Testing:** All existing dockercompose tests pass. Manual verification: `nhost up` → `nhost down` → `nhost up` shows clean Postgres startup without recovery messages.