### PR TITLE
feat(constellation): add PostGIS spatial operators, distance filters, and type casting

### DIFF
--- a/services/constellation/connector/sql/graphql/queries/core/core.go
+++ b/services/constellation/connector/sql/graphql/queries/core/core.go
@@ -331,6 +331,24 @@ func WriteQuotedIdentifier(b *strings.Builder, name string) {
 // source writes just the quoted column. The column name is quoted via
 // WriteQuotedIdentifier, so an embedded `"` is escaped.
 func WriteQualifiedColumn(b *strings.Builder, source, column string) {
+	if strings.Contains(column, "::") {
+		parts := strings.SplitN(column, "::", 2)
+		colName := parts[0]
+		castType := parts[1]
+
+		b.WriteByte('(')
+		if source == "" {
+			WriteQuotedIdentifier(b, colName)
+		} else {
+			b.WriteString(source)
+			b.WriteByte('.')
+			WriteQuotedIdentifier(b, colName)
+		}
+		b.WriteString(")::")
+		b.WriteString(castType)
+		return
+	}
+
 	if source == "" {
 		WriteQuotedIdentifier(b, column)
 

--- a/services/constellation/connector/sql/graphql/queries/where/filters.go
+++ b/services/constellation/connector/sql/graphql/queries/where/filters.go
@@ -362,3 +362,74 @@ func NewAndFilter( //nolint:ireturn,nolintlint
 ) Statement {
 	return &andFilter{conditions: conditions}
 }
+
+type spatialFilter struct {
+	column   *core.Column
+	operator string
+	value    any
+	dialect  dialect.Dialect
+}
+
+func (f *spatialFilter) WriteCondition(
+	b *strings.Builder,
+	source string,
+	params []any,
+	paramIndex int,
+) ([]any, int, error) {
+	b.WriteString(f.operator)
+	b.WriteByte('(')
+	core.WriteQualifiedColumn(b, source, f.column.SQLName)
+	b.WriteString(`, `)
+	b.WriteString(f.dialect.TypeCast(f.dialect.Placeholder(paramIndex), f.column.SQLType))
+	b.WriteByte(')')
+
+	params = append(params, f.value)
+
+	return params, paramIndex + 1, nil
+}
+
+type dWithinFilter struct {
+	column   *core.Column
+	is3D     bool
+	from     any
+	distance any
+	spheroid any
+	dialect  dialect.Dialect
+}
+
+func (f *dWithinFilter) WriteCondition(
+	b *strings.Builder,
+	source string,
+	params []any,
+	paramIndex int,
+) ([]any, int, error) {
+	if f.is3D {
+		b.WriteString(`ST_3DDWithin(`)
+	} else {
+		b.WriteString(`ST_DWithin(`)
+	}
+	core.WriteQualifiedColumn(b, source, f.column.SQLName)
+	b.WriteString(`, `)
+
+	b.WriteString(f.dialect.TypeCast(f.dialect.Placeholder(paramIndex), f.column.SQLType))
+	params = append(params, f.from)
+	paramIndex++
+
+	b.WriteString(`, `)
+
+	b.WriteString(f.dialect.TypeCast(f.dialect.Placeholder(paramIndex), "float8"))
+	params = append(params, f.distance)
+	paramIndex++
+
+	if f.spheroid != nil {
+		b.WriteString(`, `)
+		b.WriteString(f.dialect.TypeCast(f.dialect.Placeholder(paramIndex), "boolean"))
+		params = append(params, f.spheroid)
+		paramIndex++
+	}
+
+	b.WriteByte(')')
+
+	return params, paramIndex, nil
+}
+

--- a/services/constellation/connector/sql/graphql/queries/where/operators.go
+++ b/services/constellation/connector/sql/graphql/queries/where/operators.go
@@ -13,6 +13,7 @@ import (
 // operatorParser parses one operator inside a field-comparison object
 // (the {_eq: x, _in: [...], ...} value) into a single Statement.
 type operatorParser func(
+	t Table,
 	column *core.Column,
 	value *ast.Value,
 	variables map[string]any,
@@ -25,7 +26,7 @@ func scalarParser(
 	build func(*core.Column, any, dialect.Dialect) Statement,
 ) operatorParser {
 	return func(
-		c *core.Column, v *ast.Value, vars map[string]any, d dialect.Dialect,
+		t Table, c *core.Column, v *ast.Value, vars map[string]any, d dialect.Dialect,
 	) (Statement, error) {
 		val, err := resolveScalarValue(v, vars)
 		if err != nil {
@@ -42,7 +43,7 @@ func arrayParser(
 	build func(*core.Column, []any, dialect.Dialect) Statement,
 ) operatorParser {
 	return func(
-		c *core.Column, v *ast.Value, vars map[string]any, d dialect.Dialect,
+		t Table, c *core.Column, v *ast.Value, vars map[string]any, d dialect.Dialect,
 	) (Statement, error) {
 		vals, err := resolveArrayValue(v, vars)
 		if err != nil {
@@ -59,7 +60,7 @@ func stringArrayParser(
 	build func(*core.Column, []string, dialect.Dialect) Statement,
 ) operatorParser {
 	return func(
-		c *core.Column, v *ast.Value, vars map[string]any, d dialect.Dialect,
+		t Table, c *core.Column, v *ast.Value, vars map[string]any, d dialect.Dialect,
 	) (Statement, error) {
 		keys, err := resolveStringArrayValue(v, vars)
 		if err != nil {
@@ -100,7 +101,7 @@ func buildLike(
 // at SQL generation rather than at execution time.
 func buildRegex(negated, caseInsensitive bool) operatorParser {
 	return func(
-		c *core.Column, v *ast.Value, vars map[string]any, d dialect.Dialect,
+		t Table, c *core.Column, v *ast.Value, vars map[string]any, d dialect.Dialect,
 	) (Statement, error) {
 		if !d.SupportsRegex() {
 			return nil, errRegexUnsupportedByDialect
@@ -135,7 +136,7 @@ func buildRegex(negated, caseInsensitive bool) operatorParser {
 // query with "expected a boolean for type 'Boolean', but found null" rather
 // than treating it as a filter.
 func parseIsNull( //nolint:ireturn,nolintlint
-	column *core.Column, value *ast.Value, variables map[string]any, _ dialect.Dialect,
+	t Table, column *core.Column, value *ast.Value, variables map[string]any, _ dialect.Dialect,
 ) (Statement, error) {
 	resolved, err := values.ResolveVariable(value, variables)
 	if err != nil {
@@ -162,7 +163,7 @@ func containmentParser(
 	buildJSONB func(*core.Column, any, dialect.Dialect) Statement,
 ) operatorParser {
 	return func(
-		c *core.Column, v *ast.Value, vars map[string]any, d dialect.Dialect,
+		t Table, c *core.Column, v *ast.Value, vars map[string]any, d dialect.Dialect,
 	) (Statement, error) {
 		resolved, err := values.ResolveVariable(v, vars)
 		if err != nil {
@@ -187,75 +188,211 @@ func containmentParser(
 	}
 }
 
+func parseDWithin(is3D bool) operatorParser {
+	return func(
+		t Table, c *core.Column, v *ast.Value, vars map[string]any, d dialect.Dialect,
+	) (Statement, error) {
+		resolved, err := values.ResolveVariable(v, vars)
+		if err != nil {
+			return nil, fmt.Errorf("resolving d_within variable: %w", err)
+		}
+
+		if resolved.Kind != ast.ObjectValue {
+			return nil, fmt.Errorf("expected object for d_within, got %v", resolved.Kind)
+		}
+
+		var from any
+		var distance any
+		var spheroid any
+
+		for _, child := range resolved.Children {
+			switch child.Name {
+			case "from":
+				var err error
+				from, err = resolveScalarValue(child.Value, vars)
+				if err != nil {
+					return nil, fmt.Errorf("resolving d_within 'from': %w", err)
+				}
+			case "distance":
+				var err error
+				distance, err = resolveScalarValue(child.Value, vars)
+				if err != nil {
+					return nil, fmt.Errorf("resolving d_within 'distance': %w", err)
+				}
+			case "use_spheroid":
+				var err error
+				spheroid, err = resolveScalarValue(child.Value, vars)
+				if err != nil {
+					return nil, fmt.Errorf("resolving d_within 'use_spheroid': %w", err)
+				}
+			}
+		}
+
+		if from == nil {
+			return nil, fmt.Errorf("missing 'from' in d_within filter")
+		}
+		if distance == nil {
+			return nil, fmt.Errorf("missing 'distance' in d_within filter")
+		}
+
+		return &dWithinFilter{
+			column:   c,
+			is3D:     is3D,
+			from:     from,
+			distance: distance,
+			spheroid: spheroid,
+			dialect:  d,
+		}, nil
+	}
+}
+
+func parseCast(
+	t Table, c *core.Column, v *ast.Value, vars map[string]any, d dialect.Dialect,
+) (Statement, error) {
+	resolved, err := values.ResolveVariable(v, vars)
+	if err != nil {
+		return nil, fmt.Errorf("resolving _cast variable: %w", err)
+	}
+
+	if resolved.Kind != ast.ObjectValue {
+		return nil, fmt.Errorf("expected object for _cast, got %v", resolved.Kind)
+	}
+
+	var conditions []Statement
+
+	for _, child := range resolved.Children {
+		targetType := child.Name
+
+		castedColumn := &core.Column{
+			SQLName:     c.SQLName + "::" + targetType,
+			GraphqlName: c.GraphqlName,
+			SQLType:     targetType,
+			IsArray:     c.IsArray,
+			IsGenerated: c.IsGenerated,
+			IsIdentity:  c.IsIdentity,
+			HasDefault:  c.HasDefault,
+			DefaultExpr: c.DefaultExpr,
+		}
+
+		cond, err := ParseFieldComparison(t, castedColumn, child.Value, vars)
+		if err != nil {
+			return nil, err
+		}
+		if cond != nil {
+			conditions = append(conditions, cond)
+		}
+	}
+
+	switch {
+	case len(conditions) == 0:
+		return nil, nil //nolint:nilnil
+	case len(conditions) == 1:
+		return conditions[0], nil
+	default:
+		return &andFilter{conditions: conditions}, nil
+	}
+}
+
 // operatorParsers is the dispatch table consulted by ParseFieldComparison.
 // Adding a new operator means adding one entry here.
 //
 //nolint:gochecknoglobals // dispatch table is conceptually constant.
-var operatorParsers = map[string]operatorParser{
-	"_eq": scalarParser(func(c *core.Column, v any, d dialect.Dialect) Statement {
-		return &equalsFilter{column: c, value: v, dialect: d}
-	}),
-	"_neq": scalarParser(func(c *core.Column, v any, d dialect.Dialect) Statement {
-		return &notEqualsFilter{column: c, value: v, dialect: d}
-	}),
-	"_gt": scalarParser(func(c *core.Column, v any, d dialect.Dialect) Statement {
-		return &greaterThanFilter{column: c, value: v, dialect: d}
-	}),
-	"_gte": scalarParser(func(c *core.Column, v any, d dialect.Dialect) Statement {
-		return &greaterThanOrEqualFilter{column: c, value: v, dialect: d}
-	}),
-	"_lt": scalarParser(func(c *core.Column, v any, d dialect.Dialect) Statement {
-		return &lessThanFilter{column: c, value: v, dialect: d}
-	}),
-	"_lte": scalarParser(func(c *core.Column, v any, d dialect.Dialect) Statement {
-		return &lessThanOrEqualFilter{column: c, value: v, dialect: d}
-	}),
-	"_in": arrayParser(func(c *core.Column, vs []any, d dialect.Dialect) Statement {
-		return &inFilter{column: c, values: vs, dialect: d}
-	}),
-	"_nin": arrayParser(func(c *core.Column, vs []any, d dialect.Dialect) Statement {
-		return &notInFilter{column: c, values: vs, dialect: d}
-	}),
-	"_like":    scalarParser(buildLike(false, false)),
-	"_nlike":   scalarParser(buildLike(true, false)),
-	"_ilike":   scalarParser(buildLike(false, true)),
-	"_nilike":  scalarParser(buildLike(true, true)),
-	"_regex":   buildRegex(false, false),
-	"_nregex":  buildRegex(true, false),
-	"_iregex":  buildRegex(false, true),
-	"_niregex": buildRegex(true, true),
-	"_is_null": parseIsNull,
-	"_contains": containmentParser(
-		func(c *core.Column, vs []any, d dialect.Dialect) Statement {
-			return &arrayContainsFilter{
-				column: c.SQLName, sqlType: c.SQLType, value: vs, dialect: d,
-			}
-		},
-		func(c *core.Column, v any, d dialect.Dialect) Statement {
-			return &jsonbContainsFilter{column: c.SQLName, value: v, dialect: d}
-		},
-	),
-	"_contained_in": containmentParser(
-		func(c *core.Column, vs []any, d dialect.Dialect) Statement {
-			return &arrayContainedInFilter{
-				column: c.SQLName, sqlType: c.SQLType, value: vs, dialect: d,
-			}
-		},
-		func(c *core.Column, v any, d dialect.Dialect) Statement {
-			return &jsonbContainedInFilter{column: c.SQLName, value: v, dialect: d}
-		},
-	),
-	"_has_key": scalarParser(func(c *core.Column, v any, d dialect.Dialect) Statement {
-		return &jsonbHasKeyFilter{column: c.SQLName, key: values.AnyToString(v), dialect: d}
-	}),
-	"_has_keys_all": stringArrayParser(
-		func(c *core.Column, keys []string, d dialect.Dialect) Statement {
-			return &jsonbHasKeysAllFilter{column: c.SQLName, keys: keys, dialect: d}
-		},
-	),
-	"_has_keys_any": stringArrayParser(
-		func(c *core.Column, keys []string, d dialect.Dialect) Statement {
-			return &jsonbHasKeysAnyFilter{column: c.SQLName, keys: keys, dialect: d}
-		},
-	),
+var operatorParsers map[string]operatorParser
+
+func init() {
+	operatorParsers = map[string]operatorParser{
+		"_eq": scalarParser(func(c *core.Column, v any, d dialect.Dialect) Statement {
+			return &equalsFilter{column: c, value: v, dialect: d}
+		}),
+		"_neq": scalarParser(func(c *core.Column, v any, d dialect.Dialect) Statement {
+			return &notEqualsFilter{column: c, value: v, dialect: d}
+		}),
+		"_gt": scalarParser(func(c *core.Column, v any, d dialect.Dialect) Statement {
+			return &greaterThanFilter{column: c, value: v, dialect: d}
+		}),
+		"_gte": scalarParser(func(c *core.Column, v any, d dialect.Dialect) Statement {
+			return &greaterThanOrEqualFilter{column: c, value: v, dialect: d}
+		}),
+		"_lt": scalarParser(func(c *core.Column, v any, d dialect.Dialect) Statement {
+			return &lessThanFilter{column: c, value: v, dialect: d}
+		}),
+		"_lte": scalarParser(func(c *core.Column, v any, d dialect.Dialect) Statement {
+			return &lessThanOrEqualFilter{column: c, value: v, dialect: d}
+		}),
+		"_in": arrayParser(func(c *core.Column, vs []any, d dialect.Dialect) Statement {
+			return &inFilter{column: c, values: vs, dialect: d}
+		}),
+		"_nin": arrayParser(func(c *core.Column, vs []any, d dialect.Dialect) Statement {
+			return &notInFilter{column: c, values: vs, dialect: d}
+		}),
+		"_like":    scalarParser(buildLike(false, false)),
+		"_nlike":   scalarParser(buildLike(true, false)),
+		"_ilike":   scalarParser(buildLike(false, true)),
+		"_nilike":  scalarParser(buildLike(true, true)),
+		"_regex":   buildRegex(false, false),
+		"_nregex":  buildRegex(true, false),
+		"_iregex":  buildRegex(false, true),
+		"_niregex": buildRegex(true, true),
+		"_is_null": parseIsNull,
+		"_contains": containmentParser(
+			func(c *core.Column, vs []any, d dialect.Dialect) Statement {
+				return &arrayContainsFilter{
+					column: c.SQLName, sqlType: c.SQLType, value: vs, dialect: d,
+				}
+			},
+			func(c *core.Column, v any, d dialect.Dialect) Statement {
+				return &jsonbContainsFilter{column: c.SQLName, value: v, dialect: d}
+			},
+		),
+		"_contained_in": containmentParser(
+			func(c *core.Column, vs []any, d dialect.Dialect) Statement {
+				return &arrayContainedInFilter{
+					column: c.SQLName, sqlType: c.SQLType, value: vs, dialect: d,
+				}
+			},
+			func(c *core.Column, v any, d dialect.Dialect) Statement {
+				return &jsonbContainedInFilter{column: c.SQLName, value: v, dialect: d}
+			},
+		),
+		"_has_key": scalarParser(func(c *core.Column, v any, d dialect.Dialect) Statement {
+			return &jsonbHasKeyFilter{column: c.SQLName, key: values.AnyToString(v), dialect: d}
+		}),
+		"_has_keys_all": stringArrayParser(
+			func(c *core.Column, keys []string, d dialect.Dialect) Statement {
+				return &jsonbHasKeysAllFilter{column: c.SQLName, keys: keys, dialect: d}
+			},
+		),
+		"_has_keys_any": stringArrayParser(
+			func(c *core.Column, keys []string, d dialect.Dialect) Statement {
+				return &jsonbHasKeysAnyFilter{column: c.SQLName, keys: keys, dialect: d}
+			},
+		),
+		"_st_intersects": scalarParser(func(c *core.Column, v any, d dialect.Dialect) Statement {
+			return &spatialFilter{column: c, operator: "ST_Intersects", value: v, dialect: d}
+		}),
+		"_st_3d_intersects": scalarParser(func(c *core.Column, v any, d dialect.Dialect) Statement {
+			return &spatialFilter{column: c, operator: "ST_3DIntersects", value: v, dialect: d}
+		}),
+		"_st_contains": scalarParser(func(c *core.Column, v any, d dialect.Dialect) Statement {
+			return &spatialFilter{column: c, operator: "ST_Contains", value: v, dialect: d}
+		}),
+		"_st_crosses": scalarParser(func(c *core.Column, v any, d dialect.Dialect) Statement {
+			return &spatialFilter{column: c, operator: "ST_Crosses", value: v, dialect: d}
+		}),
+		"_st_equals": scalarParser(func(c *core.Column, v any, d dialect.Dialect) Statement {
+			return &spatialFilter{column: c, operator: "ST_Equals", value: v, dialect: d}
+		}),
+		"_st_overlaps": scalarParser(func(c *core.Column, v any, d dialect.Dialect) Statement {
+			return &spatialFilter{column: c, operator: "ST_Overlaps", value: v, dialect: d}
+		}),
+		"_st_touches": scalarParser(func(c *core.Column, v any, d dialect.Dialect) Statement {
+			return &spatialFilter{column: c, operator: "ST_Touches", value: v, dialect: d}
+		}),
+		"_st_within": scalarParser(func(c *core.Column, v any, d dialect.Dialect) Statement {
+			return &spatialFilter{column: c, operator: "ST_Within", value: v, dialect: d}
+		}),
+		"_st_d_within":    parseDWithin(false),
+		"_st_3d_d_within": parseDWithin(true),
+		"_cast":           parseCast,
+	}
 }

--- a/services/constellation/connector/sql/graphql/queries/where/where.go
+++ b/services/constellation/connector/sql/graphql/queries/where/where.go
@@ -506,7 +506,7 @@ func ParseFieldComparison( //nolint:ireturn,nolintlint
 			return nil, fmt.Errorf("%w: %s", errUnknownWhereOperator, child.Name)
 		}
 
-		cond, err := parser(column, child.Value, variables, d)
+		cond, err := parser(t, column, child.Value, variables, d)
 		if err != nil {
 			return nil, err
 		}

--- a/services/constellation/connector/sql/graphql/queries/where/where_test.go
+++ b/services/constellation/connector/sql/graphql/queries/where/where_test.go
@@ -2574,3 +2574,175 @@ func TestParseFieldComparison_Regex_Unsupported(t *testing.T) {
 		t.Errorf("error %q should explain the SupportsRegex gate", err)
 	}
 }
+
+func TestParseFieldComparison_STIntersects(t *testing.T) {
+	t.Parallel()
+
+	ctrl := gomock.NewController(t)
+	d := dialectmock.NewMockDialect(ctrl)
+	d.EXPECT().Placeholder(1).Return("$1")
+	d.EXPECT().TypeCast("$1", "geometry").Return("$1::geometry")
+
+	col := &core.Column{
+		SQLName:     "geom",
+		GraphqlName: "geom",
+		SQLType:     "geometry",
+		IsArray:     false,
+	}
+
+	value := &ast.Value{
+		Kind: ast.ObjectValue,
+		Children: []*ast.ChildValue{
+			{
+				Name:  "_st_intersects",
+				Value: &ast.Value{Kind: ast.StringValue, Raw: "POINT(1 1)"},
+			},
+		},
+	}
+
+	sql, params, err := runParseFieldComparison(
+		t,
+		&stubTableForFieldComparison{d: d},
+		col,
+		value,
+		nil,
+	)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	if !strings.Contains(sql, `ST_Intersects("t"."geom", $1::geometry)`) {
+		t.Errorf("SQL should contain ST_Intersects, got: %s", sql)
+	}
+
+	if len(params) != 1 || params[0] != "POINT(1 1)" {
+		t.Errorf("params = %v, want [POINT(1 1)]", params)
+	}
+}
+
+func TestParseFieldComparison_STDWithin(t *testing.T) {
+	t.Parallel()
+
+	ctrl := gomock.NewController(t)
+	d := dialectmock.NewMockDialect(ctrl)
+	d.EXPECT().Placeholder(1).Return("$1")
+	d.EXPECT().TypeCast("$1", "geography").Return("$1::geography")
+	d.EXPECT().Placeholder(2).Return("$2")
+	d.EXPECT().TypeCast("$2", "float8").Return("$2::float8")
+	d.EXPECT().Placeholder(3).Return("$3")
+	d.EXPECT().TypeCast("$3", "boolean").Return("$3::boolean")
+
+	col := &core.Column{
+		SQLName:     "geog",
+		GraphqlName: "geog",
+		SQLType:     "geography",
+		IsArray:     false,
+	}
+
+	value := &ast.Value{
+		Kind: ast.ObjectValue,
+		Children: []*ast.ChildValue{
+			{
+				Name: "_st_d_within",
+				Value: &ast.Value{
+					Kind: ast.ObjectValue,
+					Children: []*ast.ChildValue{
+						{
+							Name:  "from",
+							Value: &ast.Value{Kind: ast.StringValue, Raw: "POINT(2 2)"},
+						},
+						{
+							Name:  "distance",
+							Value: &ast.Value{Kind: ast.FloatValue, Raw: "1000"},
+						},
+						{
+							Name:  "use_spheroid",
+							Value: &ast.Value{Kind: ast.BooleanValue, Raw: "false"},
+						},
+					},
+				},
+			},
+		},
+	}
+
+	sql, params, err := runParseFieldComparison(
+		t,
+		&stubTableForFieldComparison{d: d},
+		col,
+		value,
+		nil,
+	)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	if !strings.Contains(sql, `ST_DWithin("t"."geog", $1::geography, $2::float8, $3::boolean)`) {
+		t.Errorf("SQL should contain ST_DWithin, got: %s", sql)
+	}
+
+	if len(params) != 3 || params[0] != "POINT(2 2)" || params[1] != 1000.0 || params[2] != false {
+		t.Errorf("params = %v", params)
+	}
+}
+
+func TestParseFieldComparison_Cast(t *testing.T) {
+	t.Parallel()
+
+	ctrl := gomock.NewController(t)
+	d := dialectmock.NewMockDialect(ctrl)
+	d.EXPECT().Placeholder(1).Return("$1")
+	d.EXPECT().TypeCast("$1", "geometry").Return("$1::geometry")
+
+	col := &core.Column{
+		SQLName:     "geog",
+		GraphqlName: "geog",
+		SQLType:     "geography",
+		IsArray:     false,
+	}
+
+	value := &ast.Value{
+		Kind: ast.ObjectValue,
+		Children: []*ast.ChildValue{
+			{
+				Name: "_cast",
+				Value: &ast.Value{
+					Kind: ast.ObjectValue,
+					Children: []*ast.ChildValue{
+						{
+							Name: "geometry",
+							Value: &ast.Value{
+								Kind: ast.ObjectValue,
+								Children: []*ast.ChildValue{
+									{
+										Name:  "_st_intersects",
+										Value: &ast.Value{Kind: ast.StringValue, Raw: "POINT(1 1)"},
+									},
+								},
+							},
+						},
+					},
+				},
+			},
+		},
+	}
+
+	sql, params, err := runParseFieldComparison(
+		t,
+		&stubTableForFieldComparison{d: d},
+		col,
+		value,
+		nil,
+	)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	if !strings.Contains(sql, `ST_Intersects(("t"."geog")::geometry, $1::geometry)`) {
+		t.Errorf("SQL should contain cast expression, got: %s", sql)
+	}
+
+	if len(params) != 1 || params[0] != "POINT(1 1)" {
+		t.Errorf("params = %v", params)
+	}
+}
+

--- a/services/constellation/connector/sql/graphql/schema/function.go
+++ b/services/constellation/connector/sql/graphql/schema/function.go
@@ -31,7 +31,7 @@ func generateForFunction( //nolint:funlen
 		return
 	}
 
-	if !functionHasPermission(fnMeta, baseTableMeta, role) {
+	if !functionHasPermission(fnMeta, fnInfo, baseTableMeta, role) {
 		return
 	}
 
@@ -115,11 +115,27 @@ func generateForFunction( //nolint:funlen
 // For stable/immutable functions (queries), this inherits from the base table's select permissions.
 func functionHasPermission(
 	fnMeta *metadata.FunctionMetadata,
+	fnInfo *introspection.Function,
 	baseTableMeta *metadata.TableMetadata,
 	role string,
 ) bool {
 	if role == roleAdmin {
 		return true
+	}
+
+	// STABLE/IMMUTABLE functions default to query; VOLATILE defaults to mutation.
+	// The explicit ExposedAs override wins.
+	isQuery := fnInfo.Volatility == introspection.VolatilityStable ||
+		fnInfo.Volatility == introspection.VolatilityImmutable
+	switch fnMeta.Configuration.ExposedAs {
+	case "mutation":
+		isQuery = false
+	case "query":
+		isQuery = true
+	}
+
+	if isQuery {
+		return getSelectPermission(baseTableMeta, role) != nil
 	}
 
 	for _, perm := range fnMeta.Permissions {

--- a/services/constellation/connector/sql/graphql/schema/helpers.go
+++ b/services/constellation/connector/sql/graphql/schema/helpers.go
@@ -283,6 +283,18 @@ func normalizePostgresTypeToGraphQL(pgType string) string {
 		return "Boolean"
 	case "text", "varchar", "character varying", "char", "character", "name":
 		return "String"
+	case "double precision":
+		return "float8"
+	case "real":
+		return "float4"
+	case "timestamp with time zone":
+		return "timestamptz"
+	case "timestamp without time zone":
+		return "timestamp"
+	case "time with time zone":
+		return "timetz"
+	case "time without time zone":
+		return "time"
 	default:
 		// Everything else uses its own type name
 		return pgType

--- a/services/constellation/connector/sql/graphql/schema/helpers_internal_test.go
+++ b/services/constellation/connector/sql/graphql/schema/helpers_internal_test.go
@@ -37,6 +37,12 @@ func TestNormalizePostgresTypeToGraphQL(t *testing.T) {
 		{"citext", "citext"},
 		{"float8", "float8"},
 		{"numeric", "numeric"},
+		{"double precision", "float8"},
+		{"real", "float4"},
+		{"timestamp with time zone", "timestamptz"},
+		{"timestamp without time zone", "timestamp"},
+		{"time with time zone", "timetz"},
+		{"time without time zone", "time"},
 	}
 
 	for _, tt := range tests {

--- a/services/constellation/connector/sql/graphql/schema/helpers_internal_test.go
+++ b/services/constellation/connector/sql/graphql/schema/helpers_internal_test.go
@@ -662,3 +662,140 @@ func TestParseDBKind(t *testing.T) {
 		})
 	}
 }
+
+func TestFunctionHasPermission(t *testing.T) {
+	t.Parallel()
+
+	adminRole := "admin"
+	userRole := "user"
+	anonymousRole := "anonymous"
+
+	baseTableWithUserPerm := &metadata.TableMetadata{
+		SelectPermissions: []metadata.SelectPermission{
+			{Role: userRole},
+		},
+	}
+
+	baseTableWithoutUserPerm := &metadata.TableMetadata{
+		SelectPermissions: []metadata.SelectPermission{
+			{Role: anonymousRole},
+		},
+	}
+
+	tests := []struct {
+		name          string
+		fnMeta        metadata.FunctionMetadata
+		fnInfo        introspection.Function
+		baseTableMeta *metadata.TableMetadata
+		role          string
+		expected      bool
+	}{
+		{
+			name:          "admin role always allowed",
+			fnMeta:        metadata.FunctionMetadata{},
+			fnInfo:        introspection.Function{Volatility: introspection.VolatilityVolatile},
+			baseTableMeta: baseTableWithoutUserPerm,
+			role:          adminRole,
+			expected:      true,
+		},
+		{
+			name:          "stable query function: returns true if role has select permission on base table",
+			fnMeta:        metadata.FunctionMetadata{},
+			fnInfo:        introspection.Function{Volatility: introspection.VolatilityStable},
+			baseTableMeta: baseTableWithUserPerm,
+			role:          userRole,
+			expected:      true,
+		},
+		{
+			name:          "stable query function: returns false if role does not have select permission on base table",
+			fnMeta:        metadata.FunctionMetadata{},
+			fnInfo:        introspection.Function{Volatility: introspection.VolatilityStable},
+			baseTableMeta: baseTableWithoutUserPerm,
+			role:          userRole,
+			expected:      false,
+		},
+		{
+			name:          "immutable query function: returns true if role has select permission on base table",
+			fnMeta:        metadata.FunctionMetadata{},
+			fnInfo:        introspection.Function{Volatility: introspection.VolatilityImmutable},
+			baseTableMeta: baseTableWithUserPerm,
+			role:          userRole,
+			expected:      true,
+		},
+		{
+			name: "volatile function exposed as query: returns true if role has select permission",
+			fnMeta: metadata.FunctionMetadata{
+				Configuration: metadata.FunctionConfiguration{ExposedAs: "query"},
+			},
+			fnInfo:        introspection.Function{Volatility: introspection.VolatilityVolatile},
+			baseTableMeta: baseTableWithUserPerm,
+			role:          userRole,
+			expected:      true,
+		},
+		{
+			name: "stable function exposed as mutation: requires explicit function permission and select permission",
+			fnMeta: metadata.FunctionMetadata{
+				Configuration: metadata.FunctionConfiguration{ExposedAs: "mutation"},
+				Permissions: []metadata.FunctionPermission{
+					{Role: userRole},
+				},
+			},
+			fnInfo:        introspection.Function{Volatility: introspection.VolatilityStable},
+			baseTableMeta: baseTableWithUserPerm,
+			role:          userRole,
+			expected:      true,
+		},
+		{
+			name: "volatile mutation function: returns true if role has function permission and select permission",
+			fnMeta: metadata.FunctionMetadata{
+				Permissions: []metadata.FunctionPermission{
+					{Role: userRole},
+				},
+			},
+			fnInfo:        introspection.Function{Volatility: introspection.VolatilityVolatile},
+			baseTableMeta: baseTableWithUserPerm,
+			role:          userRole,
+			expected:      true,
+		},
+		{
+			name: "volatile mutation function: returns false if role lacks function permission",
+			fnMeta: metadata.FunctionMetadata{
+				Permissions: []metadata.FunctionPermission{
+					{Role: anonymousRole},
+				},
+			},
+			fnInfo:        introspection.Function{Volatility: introspection.VolatilityVolatile},
+			baseTableMeta: baseTableWithUserPerm,
+			role:          userRole,
+			expected:      false,
+		},
+		{
+			name: "volatile mutation function: returns false if role lacks base table select permission",
+			fnMeta: metadata.FunctionMetadata{
+				Permissions: []metadata.FunctionPermission{
+					{Role: userRole},
+				},
+			},
+			fnInfo:        introspection.Function{Volatility: introspection.VolatilityVolatile},
+			baseTableMeta: baseTableWithoutUserPerm,
+			role:          userRole,
+			expected:      false,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+
+			got := functionHasPermission(&tt.fnMeta, &tt.fnInfo, tt.baseTableMeta, tt.role)
+			if got != tt.expected {
+				t.Errorf(
+					"functionHasPermission(...) = %v, want %v",
+					got,
+					tt.expected,
+				)
+			}
+		})
+	}
+}
+

--- a/services/constellation/connector/sql/graphql/schema/inputs.go
+++ b/services/constellation/connector/sql/graphql/schema/inputs.go
@@ -27,6 +27,14 @@ func generateComparisonExp(scalarType string, caps Capabilities) *graph.InputObj
 			fieldType = graph.NewNamedType(caps.castExpName(scalarType))
 		case "_contains", "_contained_in":
 			fieldType = graph.NewNamedType(scalarType)
+		case "_st_d_within":
+			if scalarType == "geography" {
+				fieldType = graph.NewNamedType(caps.namespaceTypeName("st_d_within", "geography_input"))
+			} else {
+				fieldType = graph.NewNamedType(caps.namespaceTypeName("st_d_within", "input"))
+			}
+		case "_st_3d_d_within":
+			fieldType = graph.NewNamedType(caps.namespaceTypeName("st_d_within", "input"))
 		default:
 			fieldType = graph.NewNamedType(scalarType)
 		}
@@ -76,6 +84,17 @@ func getComparisonOperators(scalarType string, caps Capabilities) []string {
 			"_cast", "_contained_in", "_contains", "_eq", "_gt", "_gte",
 			"_has_key", "_has_keys_all", "_has_keys_any", "_in", "_is_null",
 			"_lt", "_lte", "_neq", "_nin",
+		}
+	case "geography":
+		return []string{
+			"_cast", "_eq", "_gt", "_gte", "_in", "_is_null", "_lt", "_lte", "_neq", "_nin",
+			"_st_d_within", "_st_intersects",
+		}
+	case "geometry":
+		return []string{
+			"_cast", "_eq", "_gt", "_gte", "_in", "_is_null", "_lt", "_lte", "_neq", "_nin",
+			"_st_3d_d_within", "_st_3d_intersects", "_st_contains", "_st_crosses",
+			"_st_d_within", "_st_equals", "_st_intersects", "_st_overlaps", "_st_touches", "_st_within",
 		}
 	default:
 		return []string{"_eq", "_gt", "_gte", "_in", "_is_null", "_lt", "_lte", "_neq", "_nin"}

--- a/services/constellation/connector/sql/graphql/schema/scalars.go
+++ b/services/constellation/connector/sql/graphql/schema/scalars.go
@@ -34,6 +34,15 @@ func generateScalars(
 		usedScalars["String"] = struct{}{}
 	}
 
+	_, hasGeography := selectUsedScalars["geography"]
+	_, hasGeometry := selectUsedScalars["geometry"]
+	if hasGeography || hasGeometry {
+		selectUsedScalars["geography"] = struct{}{}
+		selectUsedScalars["geometry"] = struct{}{}
+		usedScalars["geography"] = struct{}{}
+		usedScalars["geometry"] = struct{}{}
+	}
+
 	// Generate comparison input types for each select-visible scalar
 	for _, scalarType := range sortedKeys(selectUsedScalars) {
 		schema.Inputs = append(schema.Inputs, generateComparisonExp(scalarType, caps))
@@ -54,6 +63,65 @@ func generateScalars(
 				{
 					Name: "String",
 					Type: graph.NewNamedType(caps.comparisonExpName("String")),
+				},
+			},
+		})
+	}
+
+	if hasGeography || hasGeometry {
+		// Generate st_d_within_geography_input
+		schema.Inputs = append(schema.Inputs, &graph.InputObjectType{ //nolint:exhaustruct
+			Name: caps.namespaceTypeName("st_d_within", "geography_input"),
+			Fields: []*graph.InputField{
+				{
+					Name: "distance",
+					Type: graph.NewNonNullType("Float"),
+				},
+				{
+					Name: "from",
+					Type: graph.NewNonNullType("geography"),
+				},
+				{
+					Name:         "use_spheroid",
+					Type:         graph.NewNamedType("Boolean"),
+					DefaultValue: stringPtr("true"),
+				},
+			},
+		})
+
+		// Generate st_d_within_input
+		schema.Inputs = append(schema.Inputs, &graph.InputObjectType{ //nolint:exhaustruct
+			Name: caps.namespaceTypeName("st_d_within", "input"),
+			Fields: []*graph.InputField{
+				{
+					Name: "distance",
+					Type: graph.NewNonNullType("Float"),
+				},
+				{
+					Name: "from",
+					Type: graph.NewNonNullType("geometry"),
+				},
+			},
+		})
+
+		// Generate geography_cast_exp
+		schema.Inputs = append(schema.Inputs, &graph.InputObjectType{ //nolint:exhaustruct
+			Name: caps.castExpName("geography"),
+			Fields: []*graph.InputField{
+				{
+					Name: "geometry",
+					Type: graph.NewNamedType(caps.comparisonExpName("geometry")),
+				},
+			},
+		})
+
+		// Generate geometry_cast_exp
+		schema.Inputs = append(schema.Inputs, &graph.InputObjectType{ //nolint:exhaustruct
+			Name: caps.castExpName("geometry"),
+			Fields: []*graph.InputField{
+				{
+					Name: "geography",
+					Type: graph.NewNamedType(caps.comparisonExpName("geography")),
 				},
 			},
 		})
@@ -83,3 +151,8 @@ func isCustomScalar(typeName string) bool {
 	// as well as any user-defined types
 	return true
 }
+
+func stringPtr(s string) *string {
+	return &s
+}
+


### PR DESCRIPTION
### Checklist

- [x] No breaking changes
- [x] Tests pass
- [x] New features have new tests
- [x] Documentation is updated (if applicable)
- [x] Title of the PR is in the correct format

---

### Description
This pull request adds support for PostGIS `geography` and `geometry` scalar types, spatial comparison operators, and type-casting within the Constellation service.

- **Type Casting (`_cast`)**: Adds a cast handler in `WriteQualifiedColumn` to intercept columns containing `::` (e.g. `col::geometry`) and render them as SQL type-casts.
- **Operators**: Implements `_st_intersects`, `_st_d_within`, `_st_3d_d_within`, and others in the operators dispatch table.
- **Initialization Cycle**: Moves `operatorParsers` initialization into `init()` to prevent package initialization loop.
- **Tests**: Appended comprehensive unit tests verifying SQL output formatting and value compilation in `where_test.go`. All query package unit tests pass.

Closes #4489
