### PR TITLE
fix(dashboard): don't elevate permissions when security-keys data is missing

### DIFF
--- a/dashboard/src/features/account/settings/hooks/useActionWithElevatedPermissions.test.tsx
+++ b/dashboard/src/features/account/settings/hooks/useActionWithElevatedPermissions.test.tsx
@@ -1,0 +1,141 @@
+import { HttpResponse, http } from 'msw';
+import { setupServer } from 'msw/node';
+import { useState } from 'react';
+import { vi } from 'vitest';
+import { mockMatchMediaValue, mockSession } from '@/tests/mocks';
+import nhostGraphQLLink from '@/tests/msw/mocks/graphql/nhostGraphQLLink';
+import { render, screen, waitFor } from '@/tests/testUtils';
+import useActionWithElevatedPermissions from './useActionWithElevatedPermissions';
+
+Object.defineProperty(window, 'matchMedia', {
+  writable: true,
+  value: vi.fn().mockImplementation(mockMatchMediaValue),
+});
+
+// startAuthentication wraps the browser WebAuthn API, which jsdom can't drive;
+// mock it so the elevation flow can resolve. The network calls around it are
+// mocked via MSW below.
+vi.mock('@simplewebauthn/browser', () => ({
+  startAuthentication: vi.fn().mockResolvedValue({ id: 'test-credential' }),
+}));
+
+const AUTH_URL = 'https://local.auth.local.nhost.run/v1';
+
+const server = setupServer();
+
+const securityKeysHandler = (
+  keys: Array<{ id: string; nickname: string | null }> | null,
+) =>
+  nhostGraphQLLink.query('securityKeys', () =>
+    HttpResponse.json(
+      keys
+        ? { data: { authUserSecurityKeys: keys } }
+        : { errors: [{ message: 'boom' }] },
+    ),
+  );
+
+function TestComponent({
+  actionFn,
+}: {
+  actionFn: (...args: unknown[]) => Promise<unknown>;
+}) {
+  const [result, setResult] = useState<string>('idle');
+  const run = useActionWithElevatedPermissions({
+    actionFn,
+    successMessage: 'done',
+  });
+
+  return (
+    <button
+      type="button"
+      onClick={async () => setResult(String(await run()))}
+      data-testid="run"
+    >
+      {result}
+    </button>
+  );
+}
+
+describe('useActionWithElevatedPermissions', () => {
+  beforeAll(() => {
+    server.listen();
+  });
+
+  beforeEach(() => {
+    server.resetHandlers();
+    vi.clearAllMocks();
+  });
+
+  afterAll(() => {
+    server.close();
+  });
+
+  it('runs the action without elevation when the user has no security keys', async () => {
+    server.use(securityKeysHandler([]));
+    const actionFn = vi.fn().mockResolvedValue(undefined);
+
+    render(<TestComponent actionFn={actionFn} />);
+    screen.getByTestId('run').click();
+
+    await waitFor(() => expect(actionFn).toHaveBeenCalledTimes(1));
+    expect(screen.getByTestId('run')).toHaveTextContent('true');
+  });
+
+  it('does not elevate and surfaces an error when the security-keys count is indeterminate', async () => {
+    // Query errors -> data undefined, and the in-hook refetch hits the same
+    // failing handler. The action must abort instead of firing a WebAuthn
+    // challenge or silently skipping elevation.
+    server.use(securityKeysHandler(null));
+    const actionFn = vi.fn().mockResolvedValue(undefined);
+
+    render(<TestComponent actionFn={actionFn} />);
+    screen.getByTestId('run').click();
+
+    await waitFor(() =>
+      expect(
+        screen.getByText(
+          'Could not verify your security settings. Please try again.',
+        ),
+      ).toBeInTheDocument(),
+    );
+    expect(actionFn).not.toHaveBeenCalled();
+    expect(screen.getByTestId('run')).toHaveTextContent('false');
+  });
+
+  it('recovers via refetch when the initial security-keys query failed', async () => {
+    // Initial load errors (data undefined), then the in-hook refetch succeeds
+    // with no keys -> the action proceeds without elevation.
+    server.use(
+      nhostGraphQLLink.query(
+        'securityKeys',
+        () => HttpResponse.json({ errors: [{ message: 'boom' }] }),
+        { once: true },
+      ),
+      securityKeysHandler([]),
+    );
+    const actionFn = vi.fn().mockResolvedValue(undefined);
+
+    render(<TestComponent actionFn={actionFn} />);
+    screen.getByTestId('run').click();
+
+    await waitFor(() => expect(actionFn).toHaveBeenCalledTimes(1));
+    expect(screen.getByTestId('run')).toHaveTextContent('true');
+  });
+
+  it('elevates and runs the action when the user has security keys', async () => {
+    server.use(
+      securityKeysHandler([{ id: 'key-1', nickname: 'My key' }]),
+      http.post(`${AUTH_URL}/elevate/webauthn`, () => HttpResponse.json({})),
+      http.post(`${AUTH_URL}/elevate/webauthn/verify`, () =>
+        HttpResponse.json({ session: mockSession }),
+      ),
+    );
+    const actionFn = vi.fn().mockResolvedValue(undefined);
+
+    render(<TestComponent actionFn={actionFn} />);
+    screen.getByTestId('run').click();
+
+    await waitFor(() => expect(actionFn).toHaveBeenCalledTimes(1));
+    expect(screen.getByTestId('run')).toHaveTextContent('true');
+  });
+});

--- a/dashboard/src/features/account/settings/hooks/useActionWithElevatedPermissions.ts
+++ b/dashboard/src/features/account/settings/hooks/useActionWithElevatedPermissions.ts
@@ -21,10 +21,30 @@ function useActionWithElevatedPermissions<F extends Action>({
   successMessage,
 }: Props<F>) {
   const elevatePermissions = useElevatedPermissions();
-  const { data } = useGetSecurityKeys();
+  const { data, refetch } = useGetSecurityKeys();
 
   async function requestPermissions() {
-    if (data?.authUserSecurityKeys.length === 0) {
+    // The decision below must run on a known security-keys count. While the
+    // query is loading (or after an error) `data` is undefined, so fetch a
+    // fresh count before branching rather than treating "unknown" as "has keys".
+    let keys = data?.authUserSecurityKeys;
+    if (!keys) {
+      try {
+        keys = (await refetch()).data?.authUserSecurityKeys;
+      } catch {
+        // leave keys undefined; handled below
+      }
+    }
+
+    if (!keys) {
+      // Don't guess a branch when the count is indeterminate: neither silently
+      // skip elevation nor fire a WebAuthn challenge the user may not be able to
+      // complete. Surface the failure so they can retry.
+      toast.error('Could not verify your security settings. Please try again.');
+      return false;
+    }
+
+    if (keys.length === 0) {
       return true;
     }
     const isPermissionsElevated = await elevatePermissions();


### PR DESCRIPTION
### Checklist

- [x] No breaking changes
- [x] Tests pass
- [x] New features have new tests
- [ ] Documentation is updated (if applicable)
- [x] Title of the PR is in the correct format (see below)

<!-- nhost-reviewer:start -->
### **What this PR solves**
When the security-keys query was still loading or had errored, `data` was `undefined` and the elevation logic treated that "unknown" state as "the user has security keys", firing a WebAuthn challenge (or otherwise mis-branching) on incomplete data. This change refetches a fresh count before deciding and aborts with a clear error when the count remains indeterminate, so permissions are never elevated or skipped on missing data.

___

### **PR Type**
Bug fix

___

### **Description**
- Refetch the security-keys count before branching when `data` is undefined (loading or post-error), instead of assuming the user has keys.
- Abort the action and surface a toast (`Could not verify your security settings. Please try again.`) when the count is still indeterminate after refetch.
- Add unit tests covering no-keys, indeterminate-count, refetch-recovery, and has-keys elevation paths using MSW.

___

<details> <summary><h3> File Walkthrough</h3></summary>

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody>
<tr><td><strong>Bug fix</strong></td><td><details><summary>1 files</summary><table>
<tr>
  <td><strong>useActionWithElevatedPermissions.ts</strong><dd><code>Refetch security-keys count and abort on indeterminate data before deciding on elevation</code></dd></td>
  <td><a href="https://github.com/nhost/nhost/pull/4498/files#diff-3390879c4a0cd70aa1db6672a1607c5c2444c0bf653b711d73eda8ee466aa61a">+22/-2</a></td>
</tr>
</table></details></td></tr>
<tr><td><strong>Tests</strong></td><td><details><summary>1 files</summary><table>
<tr>
  <td><strong>useActionWithElevatedPermissions.test.tsx</strong><dd><code>New MSW-backed tests for no-keys, indeterminate, refetch-recovery, and has-keys paths</code></dd></td>
  <td><a href="https://github.com/nhost/nhost/pull/4498/files#diff-615af0691b24c1ecbf8c0c1c5e2f18620f212757beb197d683289c2b4d0d10c2">+141/-0</a></td>
</tr>
</table></details></td></tr>
</tbody></table>

</details>

___

<!-- nhost-reviewer:end -->
