### PR TITLE
fix(auth): require elevated permissions to link a provider

### DIFF
--- a/docs/src/content/docs/products/auth/elevated-permissions.mdx
+++ b/docs/src/content/docs/products/auth/elevated-permissions.mdx
@@ -41,6 +41,7 @@ Some user information needs to be changed via Auth's API rather than via graphql
 - [/user/mfa](/reference/auth/post-user-mfa) for enabling or disabling MFA
 - [/user/webauthn/add](/reference/auth/post-user-webauthn-add) for adding security keys
 - [/pat](/reference/auth/post-pat) for PAT creation
+- the provider `connect` flow for linking an additional OAuth provider to an existing account
 
 To protect these endpoints and require the elevated claim you can use the following configuration option:
 

--- a/services/auth/go/cmd/serve.go
+++ b/services/auth/go/cmd/serve.go
@@ -523,7 +523,7 @@ func CommandServe() *cli.Command { //nolint:funlen,maintidx
 					},
 					Default: "disabled",
 				},
-				Usage:    "Require x-hasura-auth-elevated claim to perform certain actions: create PATs, change email and/or password, enable/disable MFA and add security keys. If set to `recommended` the claim check is only performed if the user has a security key attached. If set to `required` the only action that won't require the claim is setting a security key for the first time.",
+				Usage:    "Require x-hasura-auth-elevated claim to perform certain actions: create PATs, change email and/or password, enable/disable MFA, add security keys, and link a provider to an existing account. If set to `recommended` the claim check is only performed if the user has a security key attached. If set to `required` the only action that won't require the claim is setting a security key for the first time.",
 				Category: "security",
 				Sources:  cli.EnvVars("AUTH_REQUIRE_ELEVATED_CLAIM"),
 			},

--- a/services/auth/go/controller/errors.go
+++ b/services/auth/go/controller/errors.go
@@ -53,6 +53,7 @@ var (
 	ErrInvalidRequest                  = &APIError{api.InvalidRequest}
 	ErrSignupDisabled                  = &APIError{api.SignupDisabled}
 	ErrUnauthenticatedUser             = &APIError{api.InvalidRequest}
+	ErrElevatedClaimRequired           = &APIError{api.InvalidRequest}
 	ErrDisabledEndpoint                = &APIError{api.DisabledEndpoint}
 	ErrEmailAlreadyVerified            = &APIError{api.EmailAlreadyVerified}
 	ErrInvalidRefreshToken             = &APIError{api.InvalidRefreshToken}

--- a/services/auth/go/controller/main_test.go
+++ b/services/auth/go/controller/main_test.go
@@ -183,9 +183,16 @@ type getControllerOpts struct {
 	idTokenValidatorProviders func(t *testing.T) *oidc.IDTokenValidatorProviders
 	totp                      *controller.Totp
 	encrypter                 controller.Encrypter
+	elevatedClaimMode         string
 }
 
 type getControllerOptsFunc func(*getControllerOpts)
+
+func withElevatedClaimMode(mode string) getControllerOptsFunc {
+	return func(o *getControllerOpts) {
+		o.elevatedClaimMode = mode
+	}
+}
 
 func withCusomClaimer(cc func(*gomock.Controller) controller.CustomClaimer) getControllerOptsFunc {
 	return func(o *getControllerOpts) {
@@ -252,11 +259,16 @@ func getController(
 		cc = controllerOpts.customClaimer(ctrl)
 	}
 
+	elevatedClaimMode := controllerOpts.elevatedClaimMode
+	if elevatedClaimMode == "" {
+		elevatedClaimMode = "disabled"
+	}
+
 	jwtGetter, err := controller.NewJWTGetter(
 		[]byte(config.JWTSecret),
 		time.Second*time.Duration(config.AccessTokenExpiresIn),
 		cc,
-		"",
+		elevatedClaimMode,
 		nil,
 		config.ServerURL.String(),
 	)

--- a/services/auth/go/controller/sign_in_provider_callback_get.go
+++ b/services/auth/go/controller/sign_in_provider_callback_get.go
@@ -10,6 +10,7 @@ import (
 	"github.com/google/uuid"
 	"golang.org/x/oauth2"
 
+	"github.com/nhost/nhost/internal/lib/oapi"
 	oapimw "github.com/nhost/nhost/internal/lib/oapi/middleware"
 	"github.com/nhost/nhost/services/auth/go/api"
 	"github.com/nhost/nhost/services/auth/go/oidc"
@@ -377,6 +378,27 @@ func (ctrl *Controller) signinProviderProviderCallbackConnect(
 	if err != nil {
 		logger.ErrorContext(ctx, "invalid jwt token", logError(err))
 		return ErrInvalidRequest
+	}
+
+	// Linking a provider is a permanent, sensitive write, so it must honor
+	// AUTH_REQUIRE_ELEVATED_CLAIM like every other sensitive endpoint. The
+	// spec-driven security middleware can't enforce it on this route because the
+	// token arrives in the connect parameter rather than the Authorization
+	// header, so we run the same elevated-claim check the middleware runs.
+	var requestPath string
+	if c := oapi.GetGinContext(ctx); c != nil && c.Request != nil && c.Request.URL != nil {
+		requestPath = c.Request.URL.Path
+	}
+
+	elevated, err := ctrl.wf.jwtGetter.verifyElevatedClaim(ctx, jwtToken, requestPath)
+	if err != nil {
+		logger.ErrorContext(ctx, "error verifying elevated claim", logError(err))
+		return ErrInternalServerError
+	}
+
+	if !elevated {
+		logger.WarnContext(ctx, "elevated claim required to link provider")
+		return ErrElevatedClaimRequired
 	}
 
 	// Extract user ID from JWT token

--- a/services/auth/go/controller/sign_in_provider_callback_get_test.go
+++ b/services/auth/go/controller/sign_in_provider_callback_get_test.go
@@ -94,6 +94,79 @@ func getStateWithFlowAndPKCE(
 	return state
 }
 
+// connectLinkSuccessDB builds the DB mock for a successful provider link: the
+// connect user is fetched, the provider row is inserted, and the provider
+// session is persisted.
+func connectLinkSuccessDB(
+	userID, userIDConnect uuid.UUID,
+) func(ctrl *gomock.Controller) controller.DBClient {
+	return func(ctrl *gomock.Controller) controller.DBClient {
+		mock := mock.NewMockDBClient(ctrl)
+
+		mock.EXPECT().GetUser( //nolint:dupl
+			gomock.Any(),
+			userIDConnect,
+		).Return(sql.AuthUser{
+			ID: userID,
+			CreatedAt: pgtype.Timestamptz{
+				Time: time.Now(),
+			},
+			UpdatedAt:   pgtype.Timestamptz{},
+			LastSeen:    pgtype.Timestamptz{},
+			Disabled:    false,
+			DisplayName: "John",
+			AvatarUrl:   "",
+			Locale:      "en",
+			Email:       sql.Text("fake@gmail.com"),
+			PhoneNumber: pgtype.Text{},
+			PasswordHash: sql.Text(
+				"$2a$10$pyv7eu9ioQcFnLSz7u/enex22P3ORdh6z6116Vj5a3vSjo0oxFa1u",
+			),
+			EmailVerified:            true,
+			PhoneNumberVerified:      false,
+			NewEmail:                 pgtype.Text{},
+			OtpMethodLastUsed:        pgtype.Text{},
+			OtpHash:                  pgtype.Text{},
+			OtpHashExpiresAt:         pgtype.Timestamptz{},
+			DefaultRole:              "user",
+			IsAnonymous:              false,
+			TotpSecret:               pgtype.Text{},
+			ActiveMfaType:            pgtype.Text{},
+			Ticket:                   pgtype.Text{},
+			TicketExpiresAt:          sql.TimestampTz(time.Now()),
+			Metadata:                 []byte{},
+			WebauthnCurrentChallenge: pgtype.Text{},
+		}, nil)
+
+		mock.EXPECT().InsertUserProvider(
+			gomock.Any(),
+			sql.InsertUserProviderParams{
+				UserID:         userIDConnect,
+				ProviderID:     "fake",
+				ProviderUserID: "1234567890",
+			},
+		).Return(
+			sql.AuthUserProvider{
+				ID:             userIDConnect,
+				CreatedAt:      pgtype.Timestamptz{},
+				UpdatedAt:      pgtype.Timestamptz{},
+				UserID:         userID,
+				AccessToken:    "unset",
+				RefreshToken:   pgtype.Text{},
+				ProviderID:     "fake",
+				ProviderUserID: "1234567890",
+			}, nil,
+		)
+
+		mock.EXPECT().UpdateProviderSession(
+			gomock.Any(),
+			gomock.Any(),
+		).Return(nil)
+
+		return mock
+	}
+}
+
 func TestSignInProviderCallback(t *testing.T) { //nolint:maintidx
 	t.Parallel()
 
@@ -120,6 +193,18 @@ func TestSignInProviderCallback(t *testing.T) { //nolint:maintidx
 
 	// Create JWT token for connect tests
 	jwtToken := "eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJleHAiOjEwNzExMTE4MDI0LCJodHRwczovL2hhc3VyYS5pby9qd3QvY2xhaW1zIjp7IngtaGFzdXJhLWFsbG93ZWQtcm9sZXMiOlsibWUiLCJ1c2VyIiwiZWRpdG9yIl0sIngtaGFzdXJhLWRlZmF1bHQtcm9sZSI6InVzZXIiLCJ4LWhhc3VyYS11c2VyLWlkIjoiZjkwNzgyZGUtZjBhMy00MWZlLWI3NzgtMDFlNGY4MGMyNDEzIiwieC1oYXN1cmEtdXNlci1pcy1hbm9ueW1vdXMiOiJmYWxzZSJ9LCJpYXQiOjE3MTExMTgwMjQsImlzcyI6Imhhc3VyYS1hdXRoIiwic3ViIjoiZjkwNzgyZGUtZjBhMy00MWZlLWI3NzgtMDFlNGY4MGMyNDEzIn0.wms_3kNeVVeqxQvSMcM2l7By1BTz4uteKSAGmVgafYY" //nolint:gosec
+
+	// Same connect identity as jwtToken but carrying the elevated claim, used to
+	// exercise the AUTH_REQUIRE_ELEVATED_CLAIM gate on the link flow.
+	elevatedConnect := signTestToken(t, jwtGetter, userIDConnect, map[string]any{
+		"https://hasura.io/jwt/claims": map[string]any{
+			"x-hasura-allowed-roles":     []string{"me", "user", "editor"},
+			"x-hasura-auth-elevated":     userIDConnect.String(),
+			"x-hasura-default-role":      "user",
+			"x-hasura-user-id":           userIDConnect.String(),
+			"x-hasura-user-is-anonymous": "false",
+		},
+	})
 
 	cases := []testRequest[api.SignInProviderCallbackGetRequestObject, api.SignInProviderCallbackGetResponseObject]{
 		{ //nolint:dupl
@@ -901,72 +986,7 @@ func TestSignInProviderCallback(t *testing.T) { //nolint:maintidx
 		{
 			name:   "connect - success",
 			config: getConfig,
-			db: func(ctrl *gomock.Controller) controller.DBClient {
-				mock := mock.NewMockDBClient(ctrl)
-
-				mock.EXPECT().GetUser( //nolint:dupl
-					gomock.Any(),
-					userIDConnect,
-				).Return(sql.AuthUser{
-					ID: userID,
-					CreatedAt: pgtype.Timestamptz{
-						Time: time.Now(),
-					},
-					UpdatedAt:   pgtype.Timestamptz{},
-					LastSeen:    pgtype.Timestamptz{},
-					Disabled:    false,
-					DisplayName: "John",
-					AvatarUrl:   "",
-					Locale:      "en",
-					Email:       sql.Text("fake@gmail.com"),
-					PhoneNumber: pgtype.Text{},
-					PasswordHash: sql.Text(
-						"$2a$10$pyv7eu9ioQcFnLSz7u/enex22P3ORdh6z6116Vj5a3vSjo0oxFa1u",
-					),
-					EmailVerified:            true,
-					PhoneNumberVerified:      false,
-					NewEmail:                 pgtype.Text{},
-					OtpMethodLastUsed:        pgtype.Text{},
-					OtpHash:                  pgtype.Text{},
-					OtpHashExpiresAt:         pgtype.Timestamptz{},
-					DefaultRole:              "user",
-					IsAnonymous:              false,
-					TotpSecret:               pgtype.Text{},
-					ActiveMfaType:            pgtype.Text{},
-					Ticket:                   pgtype.Text{},
-					TicketExpiresAt:          sql.TimestampTz(time.Now()),
-					Metadata:                 []byte{},
-					WebauthnCurrentChallenge: pgtype.Text{},
-				}, nil)
-
-				mock.EXPECT().InsertUserProvider(
-					gomock.Any(),
-					sql.InsertUserProviderParams{
-						UserID:         userIDConnect,
-						ProviderID:     "fake",
-						ProviderUserID: "1234567890",
-					},
-				).Return(
-
-					sql.AuthUserProvider{
-						ID:             userIDConnect,
-						CreatedAt:      pgtype.Timestamptz{},
-						UpdatedAt:      pgtype.Timestamptz{},
-						UserID:         userID,
-						AccessToken:    "unset",
-						RefreshToken:   pgtype.Text{},
-						ProviderID:     "fake",
-						ProviderUserID: "1234567890",
-					}, nil,
-				)
-
-				mock.EXPECT().UpdateProviderSession(
-					gomock.Any(),
-					gomock.Any(),
-				).Return(nil)
-
-				return mock
-			},
+			db:     connectLinkSuccessDB(userID, userIDConnect),
 			request: api.SignInProviderCallbackGetRequestObject{
 				Params: api.SignInProviderCallbackGetParams{
 					Code: new("valid-code-1"),
@@ -994,72 +1014,7 @@ func TestSignInProviderCallback(t *testing.T) { //nolint:maintidx
 			// provider must not block linking.
 			name:   "connect - success - unverified provider email still links",
 			config: getConfig,
-			db: func(ctrl *gomock.Controller) controller.DBClient {
-				mock := mock.NewMockDBClient(ctrl)
-
-				mock.EXPECT().GetUser( //nolint:dupl
-					gomock.Any(),
-					userIDConnect,
-				).Return(sql.AuthUser{
-					ID: userID,
-					CreatedAt: pgtype.Timestamptz{
-						Time: time.Now(),
-					},
-					UpdatedAt:   pgtype.Timestamptz{},
-					LastSeen:    pgtype.Timestamptz{},
-					Disabled:    false,
-					DisplayName: "John",
-					AvatarUrl:   "",
-					Locale:      "en",
-					Email:       sql.Text("fake@gmail.com"),
-					PhoneNumber: pgtype.Text{},
-					PasswordHash: sql.Text(
-						"$2a$10$pyv7eu9ioQcFnLSz7u/enex22P3ORdh6z6116Vj5a3vSjo0oxFa1u",
-					),
-					EmailVerified:            true,
-					PhoneNumberVerified:      false,
-					NewEmail:                 pgtype.Text{},
-					OtpMethodLastUsed:        pgtype.Text{},
-					OtpHash:                  pgtype.Text{},
-					OtpHashExpiresAt:         pgtype.Timestamptz{},
-					DefaultRole:              "user",
-					IsAnonymous:              false,
-					TotpSecret:               pgtype.Text{},
-					ActiveMfaType:            pgtype.Text{},
-					Ticket:                   pgtype.Text{},
-					TicketExpiresAt:          sql.TimestampTz(time.Now()),
-					Metadata:                 []byte{},
-					WebauthnCurrentChallenge: pgtype.Text{},
-				}, nil)
-
-				mock.EXPECT().InsertUserProvider(
-					gomock.Any(),
-					sql.InsertUserProviderParams{
-						UserID:         userIDConnect,
-						ProviderID:     "fake",
-						ProviderUserID: "1234567890",
-					},
-				).Return(
-
-					sql.AuthUserProvider{
-						ID:             userIDConnect,
-						CreatedAt:      pgtype.Timestamptz{},
-						UpdatedAt:      pgtype.Timestamptz{},
-						UserID:         userID,
-						AccessToken:    "unset",
-						RefreshToken:   pgtype.Text{},
-						ProviderID:     "fake",
-						ProviderUserID: "1234567890",
-					}, nil,
-				)
-
-				mock.EXPECT().UpdateProviderSession(
-					gomock.Any(),
-					gomock.Any(),
-				).Return(nil)
-
-				return mock
-			},
+			db:     connectLinkSuccessDB(userID, userIDConnect),
 			request: api.SignInProviderCallbackGetRequestObject{
 				Params: api.SignInProviderCallbackGetParams{
 					Code: new("valid-code-unverified-email"),
@@ -1077,6 +1032,61 @@ func TestSignInProviderCallback(t *testing.T) { //nolint:maintidx
 			expectedJWT:       nil,
 			jwtTokenFn:        nil,
 			getControllerOpts: nil,
+		},
+
+		{
+			// With AUTH_REQUIRE_ELEVATED_CLAIM=required, linking a provider must
+			// fail when the connect JWT lacks the elevated claim, mirroring every
+			// other sensitive endpoint. The write must be rejected before any DB
+			// access.
+			name:   "connect - elevated claim required, claim missing",
+			config: getConfig,
+			db: func(ctrl *gomock.Controller) controller.DBClient {
+				return mock.NewMockDBClient(ctrl)
+			},
+			request: api.SignInProviderCallbackGetRequestObject{
+				Params: api.SignInProviderCallbackGetParams{
+					Code: new("valid-code-1"),
+					State: getState(t, jwtGetter, &jwtToken, api.SignUpOptions{
+						RedirectTo: new("http://localhost:3000/connect-rejected"),
+					}),
+				},
+				Provider: "fake",
+			},
+			expectedResponse: controller.ErrorRedirectResponse{
+				Headers: struct{ Location string }{
+					Location: `^http://localhost:3000/connect-rejected\?error=invalid-request&errorDescription=The\+request\+payload\+is\+incorrect&state=some-random-state$`,
+				},
+			},
+			expectedJWT:       nil,
+			jwtTokenFn:        nil,
+			getControllerOpts: []getControllerOptsFunc{withElevatedClaimMode("required")},
+		},
+
+		{
+			// With AUTH_REQUIRE_ELEVATED_CLAIM=required, a connect JWT that does
+			// carry the elevated claim links successfully, just like every other
+			// sensitive endpoint accepts a freshly elevated token.
+			name:   "connect - elevated claim required, claim present",
+			config: getConfig,
+			db:     connectLinkSuccessDB(userID, userIDConnect),
+			request: api.SignInProviderCallbackGetRequestObject{
+				Params: api.SignInProviderCallbackGetParams{
+					Code: new("valid-code-1"),
+					State: getState(t, jwtGetter, &elevatedConnect, api.SignUpOptions{
+						RedirectTo: new("http://localhost:3000/connect-success"),
+					}),
+				},
+				Provider: "fake",
+			},
+			expectedResponse: api.SignInProviderCallbackGet302Response{
+				Headers: api.SignInProviderCallbackGet302ResponseHeaders{
+					Location: `^http://localhost:3000/connect-success\?state=some-random-state$`,
+				},
+			},
+			expectedJWT:       nil,
+			jwtTokenFn:        nil,
+			getControllerOpts: []getControllerOptsFunc{withElevatedClaimMode("required")},
 		},
 
 		{


### PR DESCRIPTION
### Checklist

- [x] No breaking changes
- [x] Tests pass
- [x] New features have new tests
- [x] Documentation is updated (if applicable)
- [x] Title of the PR is in the correct format (see below)

<!-- nhost-reviewer:start -->
### **What this PR solves**
Provider linking via the OAuth `connect` flow was the only sensitive write that ignored `AUTH_REQUIRE_ELEVATED_CLAIM` — unlike create-PAT, change-email/password, add-security-key, and id-token linking, the connect callback never checked the elevated claim. This makes the handler run the same `verifyElevatedClaim` check before the permanent provider write, so once an operator enables step-up a non-elevated (e.g. stolen) access token can no longer silently link a provider identity. It is a no-op on the default `disabled` config.

___

### **PR Type**
Bug fix

___

### **Description**
- Run `verifyElevatedClaim` in the OAuth `connect` callback handler, right after the connect-token is validated and before the permanent `InsertUserProvider` write, so provider linking honors `AUTH_REQUIRE_ELEVATED_CLAIM` exactly like every other sensitive endpoint. The token rides in the OAuth `state`, not the `Authorization` header, so the spec-driven middleware can't enforce it — hence the in-handler check.
- Add `ErrElevatedClaimRequired`, returned (as a redirect error) when a non-elevated token attempts to link while step-up is `required`/`recommended`.
- Make the controller test harness configurable for elevated mode (`withElevatedClaimMode`) and default it to `disabled` to match production; extract a shared `connectLinkSuccessDB` mock helper and add cases covering the refuse (non-elevated) and allow (elevated) paths.

___

### Diagram Walkthrough

```mermaid
flowchart LR
  A["OAuth callback<br/>(state carries connect JWT)"] --> B["Validate connect token"]
  B --> C["verifyElevatedClaim (new)"]
  C -- "elevated, or mode disabled" --> D["InsertUserProvider (link)"]
  C -- "missing in required mode" --> E["Redirect with error, no DB write"]
```

<details> <summary><h3> File Walkthrough</h3></summary>

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody>
<tr><td><strong>Provider-linking fix</strong></td><td><details><summary>2 files</summary><table>
<tr>
  <td><strong>sign_in_provider_callback_get.go</strong><dd><code>Enforce the elevated claim in the connect handler before linking</code></dd></td>
  <td><a href="https://github.com/nhost/nhost/pull/4502/files#diff-9e238e788812ed538d76f2a9e40e6bd1ae998d1b63a2d5190bed5bf685dbc426">+22/-0</a></td>
</tr>
<tr>
  <td><strong>errors.go</strong><dd><code>Add ErrElevatedClaimRequired</code></dd></td>
  <td><a href="https://github.com/nhost/nhost/pull/4502/files#diff-9d0f3741d467d6dfbb9be19a35ae6dc580d0a79a6136fd39b9b32e67e0abdd77">+1/-0</a></td>
</tr>
</table></details></td></tr>
<tr><td><strong>Tests</strong></td><td><details><summary>2 files</summary><table>
<tr>
  <td><strong>sign_in_provider_callback_get_test.go</strong><dd><code>Add refuse/allow link cases; extract shared success-mock helper</code></dd></td>
  <td><a href="https://github.com/nhost/nhost/pull/4502/files#diff-b17006540ebd75d24d292ec72f27612363c1d629e4e844e06c0a70b116bee81a">+142/-132</a></td>
</tr>
<tr>
  <td><strong>main_test.go</strong><dd><code>Add withElevatedClaimMode option; default harness mode to disabled</code></dd></td>
  <td><a href="https://github.com/nhost/nhost/pull/4502/files#diff-73ecf0497c8215feabfd33fd12853c6ca1e7f86741dcfeef687b37558299baf1">+13/-1</a></td>
</tr>
</table></details></td></tr>
</tbody></table>

</details>

___

<!-- nhost-reviewer:end -->
