### PR TITLE
chore(nixops): scope pinned toolchain overlays

### DIFF
--- a/.github/workflows/nixops_checks.yaml
+++ b/.github/workflows/nixops_checks.yaml
@@ -11,6 +11,10 @@ on:
       - "flake.lock"
       - "nixops/**"
       - "build/**"
+
+      # the pinned-toolchains check in checks.nixops scans every .nix file
+      # in the repo, so run it whenever any of them changes
+      - "**.nix"
   merge_group:
 
 concurrency:
@@ -28,6 +32,7 @@ jobs:
         flake.lock
         nixops/**
         build/**
+        **.nix
 
   check-permissions:
     needs: [detect-changes]

--- a/.github/workflows/wf_detect_changes.yaml
+++ b/.github/workflows/wf_detect_changes.yaml
@@ -9,7 +9,8 @@ on:
         required: true
         description: >
           Newline-separated list of path patterns to check.
-          Supports exact file paths and directory globs (e.g., "services/auth/**").
+          Supports exact file paths, directory globs (e.g., "services/auth/**")
+          and extension globs (e.g., "**.nix").
           Lines starting with # are ignored.
     outputs:
       should_run:
@@ -52,6 +53,13 @@ jobs:
               prefix="${pattern%/**}"
               if echo "$CHANGED" | grep -q "^${prefix}/"; then
                 echo "Matched directory pattern: $pattern"
+                echo "should_run=true" >> "$GITHUB_OUTPUT"
+                exit 0
+              fi
+            elif [[ "$pattern" == "**"* ]]; then
+              suffix=$(printf '%s' "${pattern#\*\*}" | sed 's/\./\\./g')
+              if echo "$CHANGED" | grep -q "${suffix}$"; then
+                echo "Matched suffix pattern: $pattern"
                 echo "should_run=true" >> "$GITHUB_OUTPUT"
                 exit 0
               fi

--- a/cli/project.nix
+++ b/cli/project.nix
@@ -65,9 +65,9 @@ let
     jq
     curl
     cacert
-    gqlgen
-    gqlgenc
-    oapi-codegen
+    nhost.gqlgen
+    nhost.gqlgenc
+    nhost.oapi-codegen
   ];
 
   buildInputs = [ ];
@@ -107,15 +107,15 @@ rec {
     buildInputs =
       with pkgs;
       [
-        certbot-full
+        nhost.certbot-full
         python312Packages.certbot-dns-route53
 
-        gqlgen
+        nhost.gqlgen
 
         # javascript
-        nodejs-pinned
-        pnpm
-        biome
+        nhost.nodejs
+        nhost.pnpm
+        nhost.biome
       ]
       ++ checkDeps
       ++ buildInputs

--- a/cli/project.nix
+++ b/cli/project.nix
@@ -113,7 +113,7 @@ rec {
         gqlgen
 
         # javascript
-        nodejs
+        nodejs-pinned
         pnpm
         biome
       ]

--- a/dashboard/project.nix
+++ b/dashboard/project.nix
@@ -79,7 +79,7 @@ let
     playwright-driver
   ];
 
-  buildInputs = with pkgs; [ nodejs ];
+  buildInputs = with pkgs; [ nodejs-pinned ];
 
   nativeBuildInputs = with pkgs; [
     pnpm
@@ -260,9 +260,9 @@ rec {
     nativeBuildInputs = with pkgs; [
       pnpm
       cacert
-      nodejs
+      nodejs-pinned
     ];
-    buildInputs = with pkgs; [ nodejs ];
+    buildInputs = with pkgs; [ nodejs-pinned ];
 
     configurePhase = ''
       export NEXT_PUBLIC_DASHBOARD_VERSION=${version}
@@ -355,7 +355,7 @@ rec {
           ];
           Entrypoint = [
             "${entrypoint}/bin/docker-entrypoint.sh"
-            "${pkgs.nodejs}/bin/node"
+            "${pkgs.nodejs-pinned}/bin/node"
             "/dashboard/server.js"
           ];
         };

--- a/dashboard/project.nix
+++ b/dashboard/project.nix
@@ -74,15 +74,15 @@ let
   };
 
   checkDeps = with pkgs; [
-    nhost-cli
+    nhost.nhost-cli
     lychee
     playwright-driver
   ];
 
-  buildInputs = with pkgs; [ nodejs-pinned ];
+  buildInputs = with pkgs; [ nhost.nodejs ];
 
   nativeBuildInputs = with pkgs; [
-    pnpm
+    nhost.pnpm
     cacert
   ];
 
@@ -178,7 +178,7 @@ rec {
     buildInputs =
       with pkgs;
       [
-        vercel
+        nhost.vercel
       ]
       ++ checkDeps
       ++ buildInputs
@@ -258,11 +258,11 @@ rec {
     inherit name version src;
 
     nativeBuildInputs = with pkgs; [
-      pnpm
+      nhost.pnpm
       cacert
-      nodejs-pinned
+      nhost.nodejs
     ];
-    buildInputs = with pkgs; [ nodejs-pinned ];
+    buildInputs = with pkgs; [ nhost.nodejs ];
 
     configurePhase = ''
       export NEXT_PUBLIC_DASHBOARD_VERSION=${version}
@@ -355,7 +355,7 @@ rec {
           ];
           Entrypoint = [
             "${entrypoint}/bin/docker-entrypoint.sh"
-            "${pkgs.nodejs-pinned}/bin/node"
+            "${pkgs.nhost.nodejs}/bin/node"
             "/dashboard/server.js"
           ];
         };

--- a/docs/project.nix
+++ b/docs/project.nix
@@ -57,10 +57,10 @@ let
     vale
   ];
 
-  buildInputs = with pkgs; [ nodejs-pinned ];
+  buildInputs = with pkgs; [ nhost.nodejs ];
 
   nativeBuildInputs = with pkgs; [
-    pnpm
+    nhost.pnpm
     cacert
   ];
 

--- a/docs/project.nix
+++ b/docs/project.nix
@@ -57,7 +57,7 @@ let
     vale
   ];
 
-  buildInputs = with pkgs; [ nodejs ];
+  buildInputs = with pkgs; [ nodejs-pinned ];
 
   nativeBuildInputs = with pkgs; [
     pnpm

--- a/examples/demos/project.nix
+++ b/examples/demos/project.nix
@@ -56,14 +56,14 @@ let
   };
 
   checkDeps = with pkgs; [
-    nhost-cli
-    biome
+    nhost.nhost-cli
+    nhost.biome
   ];
 
-  buildInputs = with pkgs; [ nodejs-pinned ];
+  buildInputs = with pkgs; [ nhost.nodejs ];
 
   nativeBuildInputs = with pkgs; [
-    pnpm
+    nhost.pnpm
     cacert
   ];
 in
@@ -99,11 +99,11 @@ in
     inherit name version src;
 
     nativeBuildInputs = with pkgs; [
-      pnpm
+      nhost.pnpm
       cacert
-      nodejs-pinned
+      nhost.nodejs
     ];
-    buildInputs = with pkgs; [ nodejs-pinned ];
+    buildInputs = with pkgs; [ nhost.nodejs ];
 
     buildPhase = ''
       mkdir -p $TMPDIR/home

--- a/examples/demos/project.nix
+++ b/examples/demos/project.nix
@@ -60,7 +60,7 @@ let
     biome
   ];
 
-  buildInputs = with pkgs; [ nodejs ];
+  buildInputs = with pkgs; [ nodejs-pinned ];
 
   nativeBuildInputs = with pkgs; [
     pnpm
@@ -101,9 +101,9 @@ in
     nativeBuildInputs = with pkgs; [
       pnpm
       cacert
-      nodejs
+      nodejs-pinned
     ];
-    buildInputs = with pkgs; [ nodejs ];
+    buildInputs = with pkgs; [ nodejs-pinned ];
 
     buildPhase = ''
       mkdir -p $TMPDIR/home

--- a/examples/guides/project.nix
+++ b/examples/guides/project.nix
@@ -60,14 +60,14 @@ let
   };
 
   checkDeps = with pkgs; [
-    nhost-cli
-    biome
+    nhost.nhost-cli
+    nhost.biome
   ];
 
-  buildInputs = with pkgs; [ nodejs-pinned ];
+  buildInputs = with pkgs; [ nhost.nodejs ];
 
   nativeBuildInputs = with pkgs; [
-    pnpm
+    nhost.pnpm
     cacert
   ];
 in
@@ -103,11 +103,11 @@ in
     inherit name version src;
 
     nativeBuildInputs = with pkgs; [
-      pnpm
+      nhost.pnpm
       cacert
-      nodejs-pinned
+      nhost.nodejs
     ];
-    buildInputs = with pkgs; [ nodejs-pinned ];
+    buildInputs = with pkgs; [ nhost.nodejs ];
 
     buildPhase = ''
       mkdir -p $TMPDIR/home

--- a/examples/guides/project.nix
+++ b/examples/guides/project.nix
@@ -64,7 +64,7 @@ let
     biome
   ];
 
-  buildInputs = with pkgs; [ nodejs ];
+  buildInputs = with pkgs; [ nodejs-pinned ];
 
   nativeBuildInputs = with pkgs; [
     pnpm
@@ -105,9 +105,9 @@ in
     nativeBuildInputs = with pkgs; [
       pnpm
       cacert
-      nodejs
+      nodejs-pinned
     ];
-    buildInputs = with pkgs; [ nodejs ];
+    buildInputs = with pkgs; [ nodejs-pinned ];
 
     buildPhase = ''
       mkdir -p $TMPDIR/home

--- a/examples/tutorials/project.nix
+++ b/examples/tutorials/project.nix
@@ -62,14 +62,14 @@ let
   };
 
   checkDeps = with pkgs; [
-    nhost-cli
-    biome
+    nhost.nhost-cli
+    nhost.biome
   ];
 
-  buildInputs = with pkgs; [ nodejs-pinned ];
+  buildInputs = with pkgs; [ nhost.nodejs ];
 
   nativeBuildInputs = with pkgs; [
-    pnpm
+    nhost.pnpm
     cacert
   ];
 in
@@ -105,11 +105,11 @@ in
     inherit name version src;
 
     nativeBuildInputs = with pkgs; [
-      pnpm
+      nhost.pnpm
       cacert
-      nodejs-pinned
+      nhost.nodejs
     ];
-    buildInputs = with pkgs; [ nodejs-pinned ];
+    buildInputs = with pkgs; [ nhost.nodejs ];
 
     buildPhase = ''
       mkdir -p $TMPDIR/home

--- a/examples/tutorials/project.nix
+++ b/examples/tutorials/project.nix
@@ -66,7 +66,7 @@ let
     biome
   ];
 
-  buildInputs = with pkgs; [ nodejs ];
+  buildInputs = with pkgs; [ nodejs-pinned ];
 
   nativeBuildInputs = with pkgs; [
     pnpm
@@ -107,9 +107,9 @@ in
     nativeBuildInputs = with pkgs; [
       pnpm
       cacert
-      nodejs
+      nodejs-pinned
     ];
-    buildInputs = with pkgs; [ nodejs ];
+    buildInputs = with pkgs; [ nodejs-pinned ];
 
     buildPhase = ''
       mkdir -p $TMPDIR/home

--- a/flake.nix
+++ b/flake.nix
@@ -248,12 +248,12 @@
               lychee
 
               # javascript
-              nodejs
+              nodejs-pinned
               pnpm
               biome
 
               # go
-              go
+              go-pinned
               golines
               gofumpt
               golangci-lint
@@ -303,7 +303,7 @@
 
           pnpm = pkgs.mkShell {
             buildInputs = with pkgs; [
-              nodejs
+              nodejs-pinned
               pnpm
             ];
           };
@@ -311,11 +311,11 @@
           security-updates = pkgs.mkShell {
             buildInputs = with pkgs; [
               # pnpm audit --fix=update
-              nodejs
+              nodejs-pinned
               pnpm
 
               # govulncheck-wrapper -fix → go get / go mod tidy / go mod vendor
-              go
+              go-pinned
               govulncheck
               self.packages.${system}.govulncheck-wrapper
             ];
@@ -334,7 +334,7 @@
           vercel = pkgs.mkShell {
             buildInputs = with pkgs; [
               pnpm
-              nodejs
+              nodejs-pinned
               vercel
             ];
           };

--- a/flake.nix
+++ b/flake.nix
@@ -237,38 +237,38 @@
               skopeo
 
               # cli
-              certbot-full
+              nhost.certbot-full
               python312Packages.certbot-dns-route53
 
-              nhost-cli
+              nhost.nhost-cli
 
               # dashboard
-              vercel
+              nhost.vercel
               playwright-driver
               lychee
 
               # javascript
-              nodejs-pinned
-              pnpm
-              biome
+              nhost.nodejs
+              nhost.pnpm
+              nhost.biome
 
               # go
-              go-pinned
-              golines
+              nhost.go
+              nhost.golines
               gofumpt
-              golangci-lint
-              gqlgen
-              gqlgenc
-              oapi-codegen
+              nhost.golangci-lint
+              nhost.gqlgen
+              nhost.gqlgenc
+              nhost.oapi-codegen
               mockgen
-              sqlc
+              nhost.sqlc
               vacuum-go
-              govulncheck
+              nhost.govulncheck
 
               # others
-              postgresql_18-client
+              nhost.postgresql_18-client
               bun
-              pi-agent
+              nhost.pi-agent
 
               # docs
               vale
@@ -303,20 +303,20 @@
 
           pnpm = pkgs.mkShell {
             buildInputs = with pkgs; [
-              nodejs-pinned
-              pnpm
+              nhost.nodejs
+              nhost.pnpm
             ];
           };
 
           security-updates = pkgs.mkShell {
             buildInputs = with pkgs; [
               # pnpm audit --fix=update
-              nodejs-pinned
-              pnpm
+              nhost.nodejs
+              nhost.pnpm
 
               # govulncheck-wrapper -fix → go get / go mod tidy / go mod vendor
-              go-pinned
-              govulncheck
+              nhost.go
+              nhost.govulncheck
               self.packages.${system}.govulncheck-wrapper
             ];
 
@@ -333,9 +333,9 @@
 
           vercel = pkgs.mkShell {
             buildInputs = with pkgs; [
-              pnpm
-              nodejs-pinned
-              vercel
+              nhost.pnpm
+              nhost.nodejs
+              nhost.vercel
             ];
           };
 
@@ -395,7 +395,7 @@
           mcp-docker-image = mcpf.dockerImage;
           nixops = nixopsf.package;
           nixops-docker-image = nixopsf.dockerImage;
-          pi-agent = pkgs.pi-agent;
+          pi-agent = pkgs.nhost.pi-agent;
           postgres-pg16 = postgresf.packages.pg16-package;
           postgres-pg16-docker-image = postgresf.packages.pg16-docker-image;
           postgres-pg16-as-dir = postgresf.packages.pg16-as-dir;

--- a/internal/lib/nhostclient/project.nix
+++ b/internal/lib/nhostclient/project.nix
@@ -29,7 +29,7 @@ let
   ldflags = [ ];
 
   checkDeps = with pkgs; [
-    oapi-codegen
+    nhost.oapi-codegen
   ];
 
   buildInputs = [ ];

--- a/nixops/lib/go/example/flake.nix
+++ b/nixops/lib/go/example/flake.nix
@@ -64,9 +64,9 @@
           default = nixops-lib.go.devShell {
             buildInputs = with pkgs; [
               mockgen
-              gqlgen
-              gqlgenc
-              oapi-codegen
+              nhost.gqlgen
+              nhost.gqlgenc
+              nhost.oapi-codegen
               skopeo
             ];
           };

--- a/nixops/lib/go/go.nix
+++ b/nixops/lib/go/go.nix
@@ -1,7 +1,7 @@
 { pkgs, nix2containerPkgs }:
 let
   goCheckDeps = with pkgs; [
-    go
+    go-pinned
     clang
     golangci-lint
     richgo
@@ -168,7 +168,7 @@ in
       nativeBuildInputs,
       postInstall ? "",
     }:
-    (pkgs.buildGoModule.override { go = pkgs.go; } {
+    (pkgs.buildGoModule-pinned {
       inherit
         src
         version
@@ -213,7 +213,7 @@ in
           '';
 
           postFixup = (old.postFixup or "") + ''
-            find $out/bin -type f -exec remove-references-to -t ${pkgs.go} {} +
+            find $out/bin -type f -exec remove-references-to -t ${pkgs.go-pinned} {} +
 
             # Re-sign darwin (Mach-O) binaries after modification to fix invalid signatures
             for f in $out/bin/*; do

--- a/nixops/lib/go/go.nix
+++ b/nixops/lib/go/go.nix
@@ -1,14 +1,14 @@
 { pkgs, nix2containerPkgs }:
 let
   goCheckDeps = with pkgs; [
-    go-pinned
+    nhost.go
     clang
-    golangci-lint
+    nhost.golangci-lint
     richgo
-    golines
+    nhost.golines
     gofumpt
-    govulncheck
-    govulncheck-wrapper
+    nhost.govulncheck
+    nhost.govulncheck-wrapper
   ];
 
   dockerImageFn =
@@ -19,7 +19,7 @@ let
       package,
       buildInputs,
       maxLayers,
-      arch ? pkgs.go.GOARCH,
+      arch ? pkgs.nhost.go.GOARCH,
       contents ? [ ],
       config ? { },
     }:
@@ -168,7 +168,7 @@ in
       nativeBuildInputs,
       postInstall ? "",
     }:
-    (pkgs.buildGoModule-pinned {
+    (pkgs.nhost.buildGoModule {
       inherit
         src
         version
@@ -213,7 +213,7 @@ in
           '';
 
           postFixup = (old.postFixup or "") + ''
-            find $out/bin -type f -exec remove-references-to -t ${pkgs.go-pinned} {} +
+            find $out/bin -type f -exec remove-references-to -t ${pkgs.nhost.go} {} +
 
             # Re-sign darwin (Mach-O) binaries after modification to fix invalid signatures
             for f in $out/bin/*; do
@@ -233,7 +233,7 @@ in
       package,
       buildInputs,
       maxLayers ? 100,
-      arch ? pkgs.go.GOARCH,
+      arch ? pkgs.nhost.go.GOARCH,
       contents ? [ ],
       config ? { },
     }:

--- a/nixops/lib/js/js.nix
+++ b/nixops/lib/js/js.nix
@@ -1,10 +1,10 @@
 { pkgs, nix2containerPkgs }:
 let
   jsCheckDeps = with pkgs; [
-    pnpm
+    nhost.pnpm
     cacert
-    nodejs-pinned
-    biome
+    nhost.nodejs
+    nhost.biome
   ];
 
   mkNodeModules =
@@ -22,9 +22,9 @@ let
       dontFixup = true;
 
       nativeBuildInputs = with pkgs; [
-        pnpm
+        nhost.pnpm
         cacert
-        nodejs-pinned
+        nhost.nodejs
       ];
 
       buildPhase = ''
@@ -167,7 +167,7 @@ let
         jsCheckDeps
         ++ (with pkgs; [
           corepack
-          vercel
+          nhost.vercel
         ])
         ++ buildInputs
         ++ nativeBuildInputs;

--- a/nixops/lib/js/js.nix
+++ b/nixops/lib/js/js.nix
@@ -3,7 +3,7 @@ let
   jsCheckDeps = with pkgs; [
     pnpm
     cacert
-    nodejs
+    nodejs-pinned
     biome
   ];
 
@@ -24,7 +24,7 @@ let
       nativeBuildInputs = with pkgs; [
         pnpm
         cacert
-        nodejs
+        nodejs-pinned
       ];
 
       buildPhase = ''

--- a/nixops/lib/nix/nix.nix
+++ b/nixops/lib/nix/nix.nix
@@ -1,7 +1,7 @@
 { pkgs }:
 let
   goCheckDeps = with pkgs; [
-    go
+    go-pinned
     clang
     golangci-lint
     richgo
@@ -27,4 +27,31 @@ in
 
         mkdir $out
       '';
+
+  # Guard against reintroducing the unpinned toolchains: bare `go`/`nodejs`
+  # resolve to nixpkgs' versions and silently swap out the pinned ones (use
+  # `go-pinned`/`nodejs-pinned` instead). Worse, re-overriding the global
+  # attrs in an overlay taints every nixpkgs package that builds with them,
+  # defeating cache.nixos.org. See nixops/overlays/{go,js}.nix.
+  checkPinnedToolchains =
+    {
+      src,
+    }:
+    pkgs.runCommand "check-pinned-toolchains" { } ''
+      pattern='^[[:space:]]*(go|nodejs)[[:space:]]*$|pkgs\.(go|nodejs)([^-_a-zA-Z0-9.]|$)|\[[[:space:]]*(go|nodejs)[[:space:]]*\]'
+
+      # vercel/node-env.nix and functions/project.nix take `nodejs` as a
+      # function argument (fed nodejs-pinned / the stock node runtime images).
+      matches=$(grep -rnE --include='*.nix' -e "$pattern" ${src} \
+        | grep -vE '/nixops/overlays/vercel/|/services/functions/project\.nix:' \
+        || true)
+
+      if [ -n "$matches" ]; then
+        echo "unpinned go/nodejs references found; use go-pinned / nodejs-pinned:" >&2
+        echo "$matches" >&2
+        exit 1
+      fi
+
+      mkdir $out
+    '';
 }

--- a/nixops/lib/nix/nix.nix
+++ b/nixops/lib/nix/nix.nix
@@ -28,26 +28,56 @@ in
         mkdir $out
       '';
 
-  # Guard against reintroducing the unpinned toolchains: bare `go`/`nodejs`
-  # resolve to nixpkgs' versions and silently swap out the pinned ones (use
-  # `go-pinned`/`nodejs-pinned` instead). Worse, re-overriding the global
-  # attrs in an overlay taints every nixpkgs package that builds with them,
-  # defeating cache.nixos.org. See nixops/overlays/{go,js}.nix.
+  # Guard against reintroducing the unpinned toolchains/builders: bare
+  # `go`/`nodejs`/`buildGoModule` resolve to nixpkgs' versions and silently
+  # swap out the pinned ones (use `go-pinned`/`nodejs-pinned`/
+  # `buildGoModule-pinned` instead). Worse, re-exporting the global attrs from
+  # the overlay taints every nixpkgs package that builds with them, defeating
+  # cache.nixos.org. See nixops/overlays/{go,js}.nix.
   checkPinnedToolchains =
     {
       src,
     }:
-    pkgs.runCommand "check-pinned-toolchains" { } ''
-      pattern='^[[:space:]]*(go|nodejs)[[:space:]]*$|pkgs\.(go|nodejs)([^-_a-zA-Z0-9.]|$)|\[[[:space:]]*(go|nodejs)[[:space:]]*\]'
+    let
+      l = pkgs.lib // builtins;
 
-      # vercel/node-env.nix and functions/project.nix take `nodejs` as a
-      # function argument (fed nodejs-pinned / the stock node runtime images).
+      # Global toolchain/builder attrs the overlay must never export.
+      forbiddenOverlayAttrs = [
+        "buildGoModule"
+        "buildNpmPackage"
+        "go"
+        "nodejs"
+        "nodejs-slim_24"
+      ];
+
+      # flake.nix wires (only) this composed overlay into nixpkgs, so an
+      # overlay file not reachable from it cannot taint anything. Overlays are
+      # plain functions: applying one and inspecting its attr names is exact,
+      # and laziness keeps it cheap (no attr values are forced).
+      overlayFile = "${src}/nixops/overlays/default.nix";
+
+      overlayViolations = l.optionals (l.pathExists overlayFile) (
+        l.intersectLists forbiddenOverlayAttrs (l.attrNames (import overlayFile pkgs pkgs))
+      );
+    in
+    pkgs.runCommand "check-pinned-toolchains" { } ''
+      ${l.optionalString (overlayViolations != [ ]) ''
+        echo "the nixpkgs overlay exports global toolchain attrs; export *-pinned names instead:" >&2
+        printf '  %s\n' ${l.escapeShellArgs overlayViolations} >&2
+        exit 1
+      ''}
+
+      pattern='^[[:space:]]*(go|nodejs|buildGoModule)[[:space:]]*$|(pkgs|final)\.(go|nodejs|buildGoModule)([^-_a-zA-Z0-9.]|$)|\[[[:space:]]*(go|nodejs|buildGoModule)[[:space:]]*\]'
+
+      # vercel/node-env.nix is generated node2nix code wired by the overlay
+      # with nodejs-pinned; its internals intentionally still name the
+      # parameter `nodejs`.
       matches=$(grep -rnE --include='*.nix' -e "$pattern" ${src} \
-        | grep -vE '/nixops/overlays/vercel/|/services/functions/project\.nix:' \
+        | grep -vE '/nixops/overlays/vercel/' \
         || true)
 
       if [ -n "$matches" ]; then
-        echo "unpinned go/nodejs references found; use go-pinned / nodejs-pinned:" >&2
+        echo "unpinned go/nodejs/buildGoModule references found; use go-pinned / nodejs-pinned / buildGoModule-pinned:" >&2
         echo "$matches" >&2
         exit 1
       fi

--- a/nixops/lib/nix/nix.nix
+++ b/nixops/lib/nix/nix.nix
@@ -1,15 +1,4 @@
 { pkgs }:
-let
-  goCheckDeps = with pkgs; [
-    go-pinned
-    clang
-    golangci-lint
-    richgo
-    golines
-    gofumpt
-    govulncheck
-  ];
-in
 {
   check =
     {
@@ -28,12 +17,13 @@ in
         mkdir $out
       '';
 
-  # Guard against reintroducing the unpinned toolchains/builders: bare
-  # `go`/`nodejs`/`buildGoModule` resolve to nixpkgs' versions and silently
-  # swap out the pinned ones (use `go-pinned`/`nodejs-pinned`/
-  # `buildGoModule-pinned` instead). Worse, re-exporting the global attrs from
-  # the overlay taints every nixpkgs package that builds with them, defeating
-  # cache.nixos.org. See nixops/overlays/{go,js}.nix.
+  # Guard against reintroducing unpinned toolchains: everything Nhost pins
+  # lives under `pkgs.nhost.*` (see nixops/overlays/). The overlay must not
+  # export anything else — shadowing global nixpkgs attrs (go, nodejs, ...)
+  # taints every nixpkgs package that builds with them, defeating
+  # cache.nixos.org. And references to nixpkgs attrs that `pkgs.nhost.*`
+  # shadows must go through the namespace, or they silently resolve to
+  # nixpkgs' unpinned versions.
   checkPinnedToolchains =
     {
       src,
@@ -41,46 +31,56 @@ in
     let
       l = pkgs.lib // builtins;
 
-      # Global toolchain/builder attrs the overlay must never export.
-      forbiddenOverlayAttrs = [
-        "buildGoModule"
-        "buildNpmPackage"
-        "go"
-        "nodejs"
-        "nodejs-slim_24"
-      ];
-
       # flake.nix wires (only) this composed overlay into nixpkgs, so an
       # overlay file not reachable from it cannot taint anything. Overlays are
       # plain functions: applying one and inspecting its attr names is exact,
       # and laziness keeps it cheap (no attr values are forced).
       overlayFile = "${src}/nixops/overlays/default.nix";
 
-      overlayViolations = l.optionals (l.pathExists overlayFile) (
-        l.intersectLists forbiddenOverlayAttrs (l.attrNames (import overlayFile pkgs pkgs))
+      overlayAttrs = l.optionals (l.pathExists overlayFile) (l.attrNames (import overlayFile pkgs pkgs));
+
+      overlayViolations = l.remove "nhost" overlayAttrs;
+
+      # Names provided under `pkgs.nhost.*` that also exist as top-level
+      # nixpkgs attrs: a bare `pkgs.<name>` reference silently picks the
+      # unpinned nixpkgs version, so grep for those. Names with no nixpkgs
+      # counterpart (nhost-cli, npm_11, ...) fail evaluation loudly on their
+      # own.
+      shadowedNames = l.optionals (l.elem "nhost" overlayAttrs) (
+        l.intersectLists (l.attrNames (import overlayFile pkgs pkgs).nhost) (l.attrNames pkgs)
       );
+
+      namesAlt = l.concatStringsSep "|" shadowedNames;
+
+      pattern = l.concatStringsSep "|" [
+        "^[[:space:]]*(${namesAlt})[[:space:]]*$"
+        "(pkgs|final)\\.(${namesAlt})([^-_a-zA-Z0-9.]|$)"
+        "\\[[[:space:]]*(${namesAlt})[[:space:]]*\\]"
+      ];
     in
     pkgs.runCommand "check-pinned-toolchains" { } ''
       ${l.optionalString (overlayViolations != [ ]) ''
-        echo "the nixpkgs overlay exports global toolchain attrs; export *-pinned names instead:" >&2
+        echo "the nixpkgs overlay must only export the nhost namespace; found extra attrs:" >&2
         printf '  %s\n' ${l.escapeShellArgs overlayViolations} >&2
         exit 1
       ''}
 
-      pattern='^[[:space:]]*(go|nodejs|buildGoModule)[[:space:]]*$|(pkgs|final)\.(go|nodejs|buildGoModule)([^-_a-zA-Z0-9.]|$)|\[[[:space:]]*(go|nodejs|buildGoModule)[[:space:]]*\]'
+      ${l.optionalString (shadowedNames != [ ]) ''
+        pattern='${pattern}'
 
-      # vercel/node-env.nix is generated node2nix code wired by the overlay
-      # with nodejs-pinned; its internals intentionally still name the
-      # parameter `nodejs`.
-      matches=$(grep -rnE --include='*.nix' -e "$pattern" ${src} \
-        | grep -vE '/nixops/overlays/vercel/' \
-        || true)
+        # vercel/node-env.nix is generated node2nix code wired by the overlay
+        # with the pinned node; its internals intentionally still name the
+        # parameter `nodejs`. vendor/ is third-party code.
+        matches=$(grep -rnE --include='*.nix' -e "$pattern" ${src} \
+          | grep -vE '/nixops/overlays/vercel/|/vendor/' \
+          || true)
 
-      if [ -n "$matches" ]; then
-        echo "unpinned go/nodejs/buildGoModule references found; use go-pinned / nodejs-pinned / buildGoModule-pinned:" >&2
-        echo "$matches" >&2
-        exit 1
-      fi
+        if [ -n "$matches" ]; then
+          echo "references to nixpkgs attrs shadowed by pkgs.nhost.* found; use pkgs.nhost.<name>:" >&2
+          echo "$matches" >&2
+          exit 1
+        fi
+      ''}
 
       mkdir $out
     '';

--- a/nixops/overlays/default.nix
+++ b/nixops/overlays/default.nix
@@ -4,13 +4,6 @@ final: prev:
     doCheck = false;
   });
 
-  linux-pam = prev.linux-pam.overrideAttrs (oldAttrs: {
-    outputs = [
-      "out"
-      "scripts"
-    ];
-  });
-
   nhost-cli = final.callPackage ./nhost-cli.nix { inherit final; };
 
   pi-agent = final.callPackage ./pi-agent.nix { inherit final; };

--- a/nixops/overlays/default.nix
+++ b/nixops/overlays/default.nix
@@ -1,13 +1,19 @@
-final: prev:
-{
-  certbot-full = prev.certbot.overrideAttrs (old: {
-    doCheck = false;
-  });
+final: prev: {
+  # Everything Nhost pins or builds from source lives under `pkgs.nhost.*`.
+  # The overlay deliberately exports nothing else: shadowing global nixpkgs
+  # attrs (go, nodejs, buildGoModule, ...) taints every nixpkgs package that
+  # builds with them, defeating cache.nixos.org.
+  # `nixops-lib.nix.checkPinnedToolchains` enforces this.
+  nhost = {
+    certbot-full = prev.certbot.overrideAttrs (old: {
+      doCheck = false;
+    });
 
-  nhost-cli = final.callPackage ./nhost-cli.nix { inherit final; };
+    nhost-cli = final.callPackage ./nhost-cli.nix { inherit final; };
 
-  pi-agent = final.callPackage ./pi-agent.nix { inherit final; };
+    pi-agent = final.callPackage ./pi-agent.nix { inherit final; };
+  }
+  // import ./go.nix final prev
+  // import ./js.nix final prev
+  // import ./postgres.nix final prev;
 }
-// import ./go.nix final prev
-// import ./js.nix final prev
-// import ./postgres.nix final prev

--- a/nixops/overlays/go.nix
+++ b/nixops/overlays/go.nix
@@ -3,7 +3,12 @@ let
   fs = final.lib.fileset;
 in
 rec {
-  go = prev.go_1_26.overrideAttrs (
+  # Go toolchain pinned ahead of nixpkgs, scoped to our own packages (and the
+  # dev shell via project.nix). Deliberately NOT exported as `go` /
+  # `buildGoModule`: overriding those globally taints every nixpkgs package
+  # with go in its build closure (even libcap), forcing source rebuilds of
+  # huge dependency cones instead of substituting them from cache.nixos.org.
+  go-pinned = prev.go_1_26.overrideAttrs (
     finalAttrs: previousAttrs: rec {
       version = "1.26.4";
 
@@ -15,9 +20,9 @@ rec {
     }
   );
 
-  buildGoModule = prev.buildGoModule.override { go = go; };
+  buildGoModule-pinned = prev.buildGoModule.override { go = go-pinned; };
 
-  golangci-lint = final.buildGoModule rec {
+  golangci-lint = final.buildGoModule-pinned rec {
     pname = "golangci-lint";
     version = "2.9.0";
     src = final.fetchFromGitHub {
@@ -38,7 +43,7 @@ rec {
     doCheck = false;
   };
 
-  golines = final.buildGoModule rec {
+  golines = final.buildGoModule-pinned rec {
     pname = "golines";
     version = "0.14.0";
     src = final.fetchFromGitHub {
@@ -56,7 +61,7 @@ rec {
     };
   };
 
-  govulncheck = final.buildGoModule rec {
+  govulncheck = final.buildGoModule-pinned rec {
     pname = "govulncheck";
     version = "1.1.4";
     src = final.fetchFromGitHub {
@@ -82,7 +87,7 @@ rec {
     doCheck = false;
   });
 
-  gqlgenc = final.buildGoModule rec {
+  gqlgenc = final.buildGoModule-pinned rec {
     pname = "gqlgenc";
     version = "0.33.0";
     src = final.fetchFromGitHub {
@@ -102,7 +107,7 @@ rec {
     };
   };
 
-  govulncheck-wrapper = final.buildGoModule {
+  govulncheck-wrapper = final.buildGoModule-pinned {
     pname = "govulncheck-wrapper";
     version = "0.0.0-dev";
     src = fs.toSource {

--- a/nixops/overlays/go.nix
+++ b/nixops/overlays/go.nix
@@ -3,12 +3,12 @@ let
   fs = final.lib.fileset;
 in
 rec {
-  # Go toolchain pinned ahead of nixpkgs, scoped to our own packages (and the
-  # dev shell via project.nix). Deliberately NOT exported as `go` /
+  # Go toolchain pinned ahead of nixpkgs, exposed only under `pkgs.nhost.*`
+  # (see default.nix). Deliberately NOT exported as global `go` /
   # `buildGoModule`: overriding those globally taints every nixpkgs package
   # with go in its build closure (even libcap), forcing source rebuilds of
   # huge dependency cones instead of substituting them from cache.nixos.org.
-  go-pinned = prev.go_1_26.overrideAttrs (
+  go = prev.go_1_26.overrideAttrs (
     finalAttrs: previousAttrs: rec {
       version = "1.26.4";
 
@@ -20,9 +20,9 @@ rec {
     }
   );
 
-  buildGoModule-pinned = prev.buildGoModule.override { go = go-pinned; };
+  buildGoModule = prev.buildGoModule.override { inherit go; };
 
-  golangci-lint = final.buildGoModule-pinned rec {
+  golangci-lint = final.nhost.buildGoModule rec {
     pname = "golangci-lint";
     version = "2.9.0";
     src = final.fetchFromGitHub {
@@ -43,7 +43,7 @@ rec {
     doCheck = false;
   };
 
-  golines = final.buildGoModule-pinned rec {
+  golines = final.nhost.buildGoModule rec {
     pname = "golines";
     version = "0.14.0";
     src = final.fetchFromGitHub {
@@ -61,7 +61,7 @@ rec {
     };
   };
 
-  govulncheck = final.buildGoModule-pinned rec {
+  govulncheck = final.nhost.buildGoModule rec {
     pname = "govulncheck";
     version = "1.1.4";
     src = final.fetchFromGitHub {
@@ -87,7 +87,7 @@ rec {
     doCheck = false;
   });
 
-  gqlgenc = final.buildGoModule-pinned rec {
+  gqlgenc = final.nhost.buildGoModule rec {
     pname = "gqlgenc";
     version = "0.33.0";
     src = final.fetchFromGitHub {
@@ -107,7 +107,7 @@ rec {
     };
   };
 
-  govulncheck-wrapper = final.buildGoModule-pinned {
+  govulncheck-wrapper = final.nhost.buildGoModule {
     pname = "govulncheck-wrapper";
     version = "0.0.0-dev";
     src = fs.toSource {

--- a/nixops/overlays/js.nix
+++ b/nixops/overlays/js.nix
@@ -90,6 +90,7 @@
 
     pnpm =
       (final.callPackage "${final.path}/pkgs/development/tools/pnpm/generic.nix" {
+        nodejs = final.nodejs-pinned;
         version = "11.1.0";
         hash = "sha256-VzyCrTVuiwl+bKxIG3OB+d7tM6MYr38xGYSFjr4fl+8=";
       }).overrideAttrs

--- a/nixops/overlays/js.nix
+++ b/nixops/overlays/js.nix
@@ -22,13 +22,13 @@
     };
   in
   rec {
-    # Node toolchain pinned ahead of nixpkgs, scoped to our own packages (and
-    # the dev shell via project.nix). Deliberately NOT exported as
+    # Node toolchain pinned ahead of nixpkgs, exposed only under `pkgs.nhost.*`
+    # (see default.nix). Deliberately NOT exported as global
     # `nodejs`/`nodejs-slim_24`: overriding those globally taints every nixpkgs
     # package with node in its build closure (npm hooks, docs themes, scons,
     # ...), forcing source rebuilds of huge dependency cones instead of
     # substituting them from cache.nixos.org.
-    nodejs-slim-pinned = prev.nodejs-slim_24.overrideAttrs (oldAttrs: rec {
+    nodejs-slim = prev.nodejs-slim_24.overrideAttrs (oldAttrs: rec {
       version = "24.16.0";
       src = prev.fetchurl {
         url = "https://nodejs.org/dist/v${version}/node-v${version}.tar.xz";
@@ -41,16 +41,16 @@
       ) (oldAttrs.patches or [ ]);
     });
 
-    nodejs-pinned = final.symlinkJoin {
+    nodejs = final.symlinkJoin {
       name = "nodejs";
-      version = final.nodejs-slim-pinned.version;
+      version = final.nhost.nodejs-slim.version;
       paths = [
-        final.nodejs-slim-pinned
+        final.nhost.nodejs-slim
         npm_11
       ];
 
       passthru = {
-        inherit (final.nodejs-slim-pinned)
+        inherit (final.nhost.nodejs-slim)
           version
           python
           meta
@@ -58,7 +58,7 @@
           ;
 
         pkgs = final.callPackage "${final.path}/pkgs/development/node-packages/default.nix" {
-          nodejs = final.nodejs-pinned;
+          nodejs = final.nhost.nodejs;
         };
       };
     };
@@ -66,7 +66,7 @@
     vercel =
       (import ./vercel {
         pkgs = final;
-        nodejs = final.nodejs-pinned;
+        nodejs = final.nhost.nodejs;
       })."vercel-53.3.2";
 
     npm_11 = final.stdenv.mkDerivation rec {
@@ -76,7 +76,7 @@
         url = "https://registry.npmjs.org/npm/-/npm-${version}.tgz";
         sha256 = "sha256-KS8ULcGowBGZujSgflfPAWwmDqLFm2Tz7uiqrnoudQQ=";
       };
-      nativeBuildInputs = [ final.nodejs-slim-pinned.out ];
+      nativeBuildInputs = [ final.nhost.nodejs-slim.out ];
       dontBuild = true;
       installPhase = ''
         mkdir -p $out/lib/node_modules/npm
@@ -90,7 +90,7 @@
 
     pnpm =
       (final.callPackage "${final.path}/pkgs/development/tools/pnpm/generic.nix" {
-        nodejs = final.nodejs-pinned;
+        nodejs = final.nhost.nodejs;
         version = "11.1.0";
         hash = "sha256-VzyCrTVuiwl+bKxIG3OB+d7tM6MYr38xGYSFjr4fl+8=";
       }).overrideAttrs

--- a/nixops/overlays/js.nix
+++ b/nixops/overlays/js.nix
@@ -22,7 +22,13 @@
     };
   in
   rec {
-    nodejs-slim_24 = prev.nodejs-slim_24.overrideAttrs (oldAttrs: rec {
+    # Node toolchain pinned ahead of nixpkgs, scoped to our own packages (and
+    # the dev shell via project.nix). Deliberately NOT exported as
+    # `nodejs`/`nodejs-slim_24`: overriding those globally taints every nixpkgs
+    # package with node in its build closure (npm hooks, docs themes, scons,
+    # ...), forcing source rebuilds of huge dependency cones instead of
+    # substituting them from cache.nixos.org.
+    nodejs-slim-pinned = prev.nodejs-slim_24.overrideAttrs (oldAttrs: rec {
       version = "24.16.0";
       src = prev.fetchurl {
         url = "https://nodejs.org/dist/v${version}/node-v${version}.tar.xz";
@@ -35,16 +41,16 @@
       ) (oldAttrs.patches or [ ]);
     });
 
-    nodejs = final.symlinkJoin {
+    nodejs-pinned = final.symlinkJoin {
       name = "nodejs";
-      version = final.nodejs-slim_24.version;
+      version = final.nodejs-slim-pinned.version;
       paths = [
-        final.nodejs-slim_24
+        final.nodejs-slim-pinned
         npm_11
       ];
 
       passthru = {
-        inherit (final.nodejs-slim_24)
+        inherit (final.nodejs-slim-pinned)
           version
           python
           meta
@@ -52,7 +58,7 @@
           ;
 
         pkgs = final.callPackage "${final.path}/pkgs/development/node-packages/default.nix" {
-          nodejs = final.nodejs;
+          nodejs = final.nodejs-pinned;
         };
       };
     };
@@ -60,12 +66,8 @@
     vercel =
       (import ./vercel {
         pkgs = final;
-        nodejs = final.nodejs;
+        nodejs = final.nodejs-pinned;
       })."vercel-53.3.2";
-
-    buildNpmPackage = prev.buildNpmPackage.override {
-      nodejs = prev.nodejs;
-    };
 
     npm_11 = final.stdenv.mkDerivation rec {
       pname = "npm";
@@ -74,7 +76,7 @@
         url = "https://registry.npmjs.org/npm/-/npm-${version}.tgz";
         sha256 = "sha256-KS8ULcGowBGZujSgflfPAWwmDqLFm2Tz7uiqrnoudQQ=";
       };
-      nativeBuildInputs = [ final.nodejs-slim_24.out ];
+      nativeBuildInputs = [ final.nodejs-slim-pinned.out ];
       dontBuild = true;
       installPhase = ''
         mkdir -p $out/lib/node_modules/npm
@@ -124,10 +126,6 @@
                   'resourceLimits: this._workerResourceLimits, trackUnmanagedFds: false'
             '';
         });
-
-    ell = prev.ell.overrideAttrs (oldAttrs: {
-      doCheck = false;
-    });
 
     biome = final.stdenv.mkDerivation {
       pname = "biome";

--- a/nixops/project.nix
+++ b/nixops/project.nix
@@ -41,7 +41,7 @@ let
       gh
       git-cliff
       gnused
-      go
+      go-pinned
       go-migrate
       gofumpt
       golangci-lint
@@ -54,7 +54,7 @@ let
       mockgen
       nhost-cli
       nixfmt
-      nodejs
+      nodejs-pinned
       vercel
       oapi-codegen
       pkg-config
@@ -133,7 +133,20 @@ let
   };
 in
 {
-  check = nixops-lib.nix.check { inherit src; };
+  check = pkgs.symlinkJoin {
+    name = "check-nixops";
+    paths = [
+      (nixops-lib.nix.check { inherit src; })
+      (nixops-lib.nix.checkPinnedToolchains {
+        # Repo-wide: toolchain regressions tend to land in the individual
+        # projects' project.nix, not under nixops/.
+        src = fs.toSource {
+          root = ../.;
+          fileset = fs.fileFilter (f: f.hasExt "nix") ../.;
+        };
+      })
+    ];
+  };
 
   devShell = pkgs.mkShell {
     buildInputs = checkDeps ++ buildInputs ++ nativeBuildInputs;

--- a/nixops/project.nix
+++ b/nixops/project.nix
@@ -30,10 +30,10 @@ let
   # for every project's dev-shell and `make check`.
   buildInputs =
     (with pkgs; [
-      biome
+      nhost.biome
       bun
       cacert
-      certbot-full
+      nhost.certbot-full
       clang
       curl
       diffutils
@@ -41,40 +41,40 @@ let
       gh
       git-cliff
       gnused
-      go-pinned
+      nhost.go
       go-migrate
       gofumpt
-      golangci-lint
-      golines
-      govulncheck
-      gqlgen
-      gqlgenc
+      nhost.golangci-lint
+      nhost.golines
+      nhost.govulncheck
+      nhost.gqlgen
+      nhost.gqlgenc
       jq
       lychee
       mockgen
-      nhost-cli
+      nhost.nhost-cli
       nixfmt
-      nodejs-pinned
-      vercel
-      oapi-codegen
+      nhost.nodejs
+      nhost.vercel
+      nhost.oapi-codegen
       pkg-config
       playwright-driver
-      pnpm
-      postgresql_14-client
-      postgresql_15
-      postgresql_15-client
-      postgresql_16
-      postgresql_16-client
-      postgresql_17
-      postgresql_17-client
-      postgresql_18
-      postgresql_18-client
+      nhost.pnpm
+      nhost.postgresql_14-client
+      nhost.postgresql_15
+      nhost.postgresql_15-client
+      nhost.postgresql_16
+      nhost.postgresql_16-client
+      nhost.postgresql_17
+      nhost.postgresql_17-client
+      nhost.postgresql_18
+      nhost.postgresql_18-client
       python312Packages.certbot-dns-route53
       skopeo
-      sqlc
+      nhost.sqlc
       vacuum-go
       vale
-      wal-g
+      nhost.wal-g
     ])
     ++ pkgs.lib.optionals pkgs.stdenv.isLinux [
     ]

--- a/packages/nhost-js/project.nix
+++ b/packages/nhost-js/project.nix
@@ -54,14 +54,14 @@ let
   };
 
   checkDeps = with pkgs; [
-    nhost-cli
+    nhost.nhost-cli
     self.packages.${pkgs.system}.codegen
   ];
 
-  buildInputs = with pkgs; [ nodejs-pinned ];
+  buildInputs = with pkgs; [ nhost.nodejs ];
 
   nativeBuildInputs = with pkgs; [
-    pnpm
+    nhost.pnpm
     cacert
   ];
 in
@@ -72,7 +72,7 @@ in
     buildInputs =
       with pkgs;
       [
-        vercel
+        nhost.vercel
       ]
       ++ checkDeps
       ++ buildInputs
@@ -94,11 +94,11 @@ in
     inherit name version src;
 
     nativeBuildInputs = with pkgs; [
-      pnpm
+      nhost.pnpm
       cacert
-      nodejs-pinned
+      nhost.nodejs
     ];
-    buildInputs = with pkgs; [ nodejs-pinned ];
+    buildInputs = with pkgs; [ nhost.nodejs ];
 
     buildPhase = ''
       cp -r ${src} src

--- a/packages/nhost-js/project.nix
+++ b/packages/nhost-js/project.nix
@@ -58,7 +58,7 @@ let
     self.packages.${pkgs.system}.codegen
   ];
 
-  buildInputs = with pkgs; [ nodejs ];
+  buildInputs = with pkgs; [ nodejs-pinned ];
 
   nativeBuildInputs = with pkgs; [
     pnpm
@@ -96,9 +96,9 @@ in
     nativeBuildInputs = with pkgs; [
       pnpm
       cacert
-      nodejs
+      nodejs-pinned
     ];
-    buildInputs = with pkgs; [ nodejs ];
+    buildInputs = with pkgs; [ nodejs-pinned ];
 
     buildPhase = ''
       cp -r ${src} src

--- a/packages/stripe-graphql-js/project.nix
+++ b/packages/stripe-graphql-js/project.nix
@@ -47,10 +47,10 @@ let
     ];
   };
 
-  buildInputs = with pkgs; [ nodejs-pinned ];
+  buildInputs = with pkgs; [ nhost.nodejs ];
 
   nativeBuildInputs = with pkgs; [
-    pnpm
+    nhost.pnpm
     cacert
   ];
 in
@@ -80,11 +80,11 @@ in
     inherit name version src;
 
     nativeBuildInputs = with pkgs; [
-      pnpm
+      nhost.pnpm
       cacert
-      nodejs-pinned
+      nhost.nodejs
     ];
-    buildInputs = with pkgs; [ nodejs-pinned ];
+    buildInputs = with pkgs; [ nhost.nodejs ];
 
     buildPhase = ''
       cp -r ${src} src

--- a/packages/stripe-graphql-js/project.nix
+++ b/packages/stripe-graphql-js/project.nix
@@ -47,7 +47,7 @@ let
     ];
   };
 
-  buildInputs = with pkgs; [ nodejs ];
+  buildInputs = with pkgs; [ nodejs-pinned ];
 
   nativeBuildInputs = with pkgs; [
     pnpm
@@ -82,9 +82,9 @@ in
     nativeBuildInputs = with pkgs; [
       pnpm
       cacert
-      nodejs
+      nodejs-pinned
     ];
-    buildInputs = with pkgs; [ nodejs ];
+    buildInputs = with pkgs; [ nodejs-pinned ];
 
     buildPhase = ''
       cp -r ${src} src

--- a/services/auth/project.nix
+++ b/services/auth/project.nix
@@ -58,11 +58,11 @@ let
   ];
 
   checkDeps = with pkgs; [
-    nhost-cli
+    nhost.nhost-cli
     mockgen
-    oapi-codegen
-    sqlc
-    postgresql_18-client
+    nhost.oapi-codegen
+    nhost.sqlc
+    nhost.postgresql_18-client
     vacuum-go
     bun
   ];

--- a/services/constellation/project.nix
+++ b/services/constellation/project.nix
@@ -37,11 +37,11 @@ let
   ];
 
   checkDeps = with pkgs; [
-    nhost-cli
+    nhost.nhost-cli
     mockgen
-    oapi-codegen
-    sqlc
-    postgresql_18-client
+    nhost.oapi-codegen
+    nhost.sqlc
+    nhost.postgresql_18-client
   ];
 
   buildInputs = [ ];

--- a/services/functions/project.nix
+++ b/services/functions/project.nix
@@ -84,7 +84,7 @@ let
   };
 
   mkDockerImage =
-    { nodejs }:
+    { nodeRuntime }:
     pkgs.runCommand "image-as-dir" { } ''
       ${
         (nix2containerPkgs.nix2container.buildImage {
@@ -97,7 +97,7 @@ let
             paths = [
               serverFiles
               pkgs.busybox
-              nodejs
+              nodeRuntime
               pkgs.gitMinimal
               pkgs.openssh
               pkgs.cacert
@@ -119,7 +119,7 @@ let
               "TMPDIR=/tmp"
               "SSL_CERT_FILE=${pkgs.cacert}/etc/ssl/certs/ca-bundle.crt"
               "NODE_PATH=${node_modules_runtime}/${submodule}/node_modules"
-              "PATH=/tmp/corepack-shims:${node_modules_runtime}/${submodule}/node_modules/.bin:${nodejs}/bin:${pkgs.gitMinimal}/bin:${pkgs.openssh}/bin:/bin:/usr/bin"
+              "PATH=/tmp/corepack-shims:${node_modules_runtime}/${submodule}/node_modules/.bin:${nodeRuntime}/bin:${pkgs.gitMinimal}/bin:${pkgs.openssh}/bin:/bin:/usr/bin"
               "SERVER_PATH=/opt/server"
               "NHOST_PROJECT_PATH=/opt/project"
               "PACKAGE_MANAGER=pnpm"
@@ -171,6 +171,6 @@ in
 
   package = serverFiles;
 
-  node22DockerImage = mkDockerImage { nodejs = pkgs.nodejs_22; };
-  node24DockerImage = mkDockerImage { nodejs = pkgs.nodejs_24; };
+  node22DockerImage = mkDockerImage { nodeRuntime = pkgs.nodejs_22; };
+  node24DockerImage = mkDockerImage { nodeRuntime = pkgs.nodejs_24; };
 }

--- a/services/functions/project.nix
+++ b/services/functions/project.nix
@@ -138,10 +138,10 @@ let
 
   checkDeps = with pkgs; [ ];
 
-  buildInputs = with pkgs; [ nodejs-pinned ];
+  buildInputs = with pkgs; [ nhost.nodejs ];
 
   nativeBuildInputs = with pkgs; [
-    pnpm
+    nhost.pnpm
     cacert
   ];
 in

--- a/services/functions/project.nix
+++ b/services/functions/project.nix
@@ -138,7 +138,7 @@ let
 
   checkDeps = with pkgs; [ ];
 
-  buildInputs = with pkgs; [ nodejs ];
+  buildInputs = with pkgs; [ nodejs-pinned ];
 
   nativeBuildInputs = with pkgs; [
     pnpm

--- a/services/postgres/extensions/pg_search.nix
+++ b/services/postgres/extensions/pg_search.nix
@@ -23,7 +23,7 @@ buildPGRXExtension rec {
   pname = "pg_search";
   version = "0.24.0";
 
-  cargo-pgrx = pkgs.cargo-pgrx_0_18_1;
+  cargo-pgrx = pkgs.nhost.cargo-pgrx_0_18_1;
 
   doCheck = false;
 

--- a/services/postgres/postgres.nix
+++ b/services/postgres/postgres.nix
@@ -89,7 +89,7 @@ in
         base-pg
         folders
         postgres_with_plugins
-        pkgs.wal-g
+        pkgs.nhost.wal-g
         pkgs.cacert
       ]
       ++ pkgs.lib.optionals pkgs.stdenv.isLinux [

--- a/services/postgres/project.nix
+++ b/services/postgres/project.nix
@@ -35,9 +35,9 @@ let
 
   mkAsDir = image: pkgs.runCommand "image-as-dir" { } "${image.copyTo}/bin/copy-to dir:$out";
 
-  pg16 = mkPostgres pkgs.postgresql_16;
-  pg17 = mkPostgres pkgs.postgresql_17;
-  pg18 = mkPostgres pkgs.postgresql_18;
+  pg16 = mkPostgres pkgs.nhost.postgresql_16;
+  pg17 = mkPostgres pkgs.nhost.postgresql_17;
+  pg18 = mkPostgres pkgs.nhost.postgresql_18;
 in
 {
   check =
@@ -45,7 +45,7 @@ in
       {
         __noChroot = true;
         nativeBuildInputs = with pkgs; [
-          postgresql_18
+          nhost.postgresql_18
           diffutils
         ];
       }
@@ -77,7 +77,7 @@ in
 
   devShell = pkgs.mkShell {
     buildInputs = with pkgs; [
-      wal-g
+      nhost.wal-g
       docker-client
       skopeo
     ];

--- a/services/storage/project.nix
+++ b/services/storage/project.nix
@@ -56,8 +56,8 @@ let
 
   checkDeps = with pkgs; [
     mockgen
-    oapi-codegen
-    gqlgenc
+    nhost.oapi-codegen
+    nhost.gqlgenc
     vacuum-go
   ];
 


### PR DESCRIPTION
<!-- nhost-reviewer:start -->
### **What this PR solves**
This PR keeps Go and Node toolchains pinned without overriding nixpkgs' global `go`, `buildGoModule`, `nodejs`, or Node package-builder attributes. It also adds a Nix check and workflow trigger coverage so future `.nix` changes cannot reintroduce unpinned toolchain references silently.

___

### **PR Type**
Enhancement

___

### **Description**
- Rename pinned Go and Node overlay exports to `go-pinned`, `buildGoModule-pinned`, `nodejs-pinned`, and `nodejs-slim-pinned` so only Nhost-owned packages consume them.
- Update project shells and package builds across the repo to use the pinned toolchain aliases explicitly.
- Add a `checkPinnedToolchains` Nix check and extend GitHub change detection so nixops checks run for any `.nix` file change.
- Drop broad overlay overrides for unrelated nixpkgs packages to preserve upstream binary cache reuse.

___

### Diagram Walkthrough

```mermaid
flowchart LR
  A["Any .nix change"] --> B["wf_detect_changes suffix glob"]
  B --> C["nixops_checks workflow"]
  C --> D["nixops check"]
  D --> E["checkPinnedToolchains"]
  E --> F["Require go-pinned/nodejs-pinned"]
```

<details> <summary><h3> File Walkthrough</h3></summary>

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody>
<tr><td><strong>GitHub workflows</strong></td><td><details><summary>2 files</summary><table>
<tr>
  <td><strong>.github/workflows/nixops_checks.yaml</strong><dd><code>Runs nixops checks for all repository .nix changes because the pinned-toolchains check scans every Nix file.</code></dd></td>
  <td><a href="https://github.com/nhost/nhost/pull/4506/files#diff-5201e3151155366e6bb8b672a9fb68b52ae38b8c20c5f09c44953c040892226f">+5/-0</a></td>
</tr>
<tr>
  <td><strong>.github/workflows/wf_detect_changes.yaml</strong><dd><code>Adds suffix-style extension glob matching such as **.nix to the reusable change detector.</code></dd></td>
  <td><a href="https://github.com/nhost/nhost/pull/4506/files#diff-7e46bab7aa067785666929c49ad8fcc6a836e88209bafa3b8029d1ea40d98e2a">+9/-1</a></td>
</tr>
</table></details></td></tr>
<tr><td><strong>Project Nix files</strong></td><td><details><summary>10 files</summary><table>
<tr>
  <td><strong>cli/project.nix</strong><dd><code>Switches CLI development JavaScript tooling from bare nodejs to nodejs-pinned.</code></dd></td>
  <td><a href="https://github.com/nhost/nhost/pull/4506/files#diff-02e27e8c362889995fcb502cc7802ce44664dedbaffc546095431a050374c927">+1/-1</a></td>
</tr>
<tr>
  <td><strong>dashboard/project.nix</strong><dd><code>Uses nodejs-pinned for dashboard builds, shells, and Docker entrypoint execution.</code></dd></td>
  <td><a href="https://github.com/nhost/nhost/pull/4506/files#diff-e456dcfd6231480081b3c9a2a95204bd061853442d5e3a38330625d01cb1a6a1">+4/-4</a></td>
</tr>
<tr>
  <td><strong>docs/project.nix</strong><dd><code>Uses nodejs-pinned for documentation builds.</code></dd></td>
  <td><a href="https://github.com/nhost/nhost/pull/4506/files#diff-8c4658c93f89aa3cbc7671465147938c58e14e66e3b95309b9fc4a11969a7fe4">+1/-1</a></td>
</tr>
<tr>
  <td><strong>examples/demos/project.nix</strong><dd><code>Uses nodejs-pinned for demo example checks and builds.</code></dd></td>
  <td><a href="https://github.com/nhost/nhost/pull/4506/files#diff-f6086e59795d16f4c73cb0e5f90b986e288deb5f176c80c5c035f1703ff86760">+3/-3</a></td>
</tr>
<tr>
  <td><strong>examples/guides/project.nix</strong><dd><code>Uses nodejs-pinned for guide example checks and builds.</code></dd></td>
  <td><a href="https://github.com/nhost/nhost/pull/4506/files#diff-65c8830b4c3074e59267275284f270f4dfa95ce2722d7634e3e3c77f66f8235e">+3/-3</a></td>
</tr>
<tr>
  <td><strong>examples/tutorials/project.nix</strong><dd><code>Uses nodejs-pinned for tutorial example checks and builds.</code></dd></td>
  <td><a href="https://github.com/nhost/nhost/pull/4506/files#diff-31667632ab7b36d1bdaeb05e4a0a289561e1c713964c91086db848f30ad4f7e4">+3/-3</a></td>
</tr>
<tr>
  <td><strong>nixops/project.nix</strong><dd><code>Uses pinned toolchains in nixops shells and composes the repo-wide pinned-toolchains check into nixops check.</code></dd></td>
  <td><a href="https://github.com/nhost/nhost/pull/4506/files#diff-36b666e7f8b2a0262065708ad307cfcc07b3f959515ca2bfad889c3d09266eeb">+16/-3</a></td>
</tr>
<tr>
  <td><strong>packages/nhost-js/project.nix</strong><dd><code>Uses nodejs-pinned for SDK package checks and builds.</code></dd></td>
  <td><a href="https://github.com/nhost/nhost/pull/4506/files#diff-8aa0f2b40e1054e08a33a0b071a6c672edbfeeb281f6c51e94dd73035014a6e9">+3/-3</a></td>
</tr>
<tr>
  <td><strong>packages/stripe-graphql-js/project.nix</strong><dd><code>Uses nodejs-pinned for Stripe GraphQL package checks and builds.</code></dd></td>
  <td><a href="https://github.com/nhost/nhost/pull/4506/files#diff-1d1685c97398e96e77a0e6cbe7ce87e375a36e249c9980ec51e6036eecf1be39">+3/-3</a></td>
</tr>
<tr>
  <td><strong>services/functions/project.nix</strong><dd><code>Uses nodejs-pinned for the functions service development runtime.</code></dd></td>
  <td><a href="https://github.com/nhost/nhost/pull/4506/files#diff-478ae77cf85885988b637453974d32f4bf4840bd557c0d71da2e2620ababdf0a">+1/-1</a></td>
</tr>
</table></details></td></tr>
<tr><td><strong>Flake and Nix libraries</strong></td><td><details><summary>4 files</summary><table>
<tr>
  <td><strong>flake.nix</strong><dd><code>Uses pinned Go and Node aliases in shared development shells.</code></dd></td>
  <td><a href="https://github.com/nhost/nhost/pull/4506/files#diff-206b9ce276ab5971a2489d75eb1b12999d4bf3843b7988cbe8d687cfde61dea0">+6/-6</a></td>
</tr>
<tr>
  <td><strong>nixops/lib/go/go.nix</strong><dd><code>Uses go-pinned and buildGoModule-pinned for Go checks, builds, and reference cleanup.</code></dd></td>
  <td><a href="https://github.com/nhost/nhost/pull/4506/files#diff-711b0f2dfff3f38b941381bf6af354bcb322ef967cc0280aaf5a76677f2d375e">+3/-3</a></td>
</tr>
<tr>
  <td><strong>nixops/lib/js/js.nix</strong><dd><code>Uses nodejs-pinned for shared JavaScript check and build helpers.</code></dd></td>
  <td><a href="https://github.com/nhost/nhost/pull/4506/files#diff-bdae1ae0f0031ce2c2e0356df4460e40363922c9658b25c773ebfe29fe052cf9">+2/-2</a></td>
</tr>
<tr>
  <td><strong>nixops/lib/nix/nix.nix</strong><dd><code>Adds a repo-wide Nix check that fails on bare go/nodejs toolchain references outside allowlisted paths.</code></dd></td>
  <td><a href="https://github.com/nhost/nhost/pull/4506/files#diff-2c2d20644d903cc6dac5e72077c8a2ccad31b7fee87e0e8f96847a263a89e624">+28/-1</a></td>
</tr>
</table></details></td></tr>
<tr><td><strong>Nix overlays</strong></td><td><details><summary>3 files</summary><table>
<tr>
  <td><strong>nixops/overlays/default.nix</strong><dd><code>Removes the linux-pam output override from the default overlay set.</code></dd></td>
  <td><a href="https://github.com/nhost/nhost/pull/4506/files#diff-e4be264a030552b8cd3f899006babce6af945a9bfa065ddd42886930b1797c9f">+0/-7</a></td>
</tr>
<tr>
  <td><strong>nixops/overlays/go.nix</strong><dd><code>Renames pinned Go exports and updates Nhost Go tooling builds to consume buildGoModule-pinned.</code></dd></td>
  <td><a href="https://github.com/nhost/nhost/pull/4506/files#diff-5a8ebb114931d48d708d09186b893784786c56d999f9f91cb698c9482c74f4ba">+12/-7</a></td>
</tr>
<tr>
  <td><strong>nixops/overlays/js.nix</strong><dd><code>Renames pinned Node exports, wires npm/vercel to nodejs-pinned, and stops overriding buildNpmPackage globally.</code></dd></td>
  <td><a href="https://github.com/nhost/nhost/pull/4506/files#diff-97e4512702da292a4600b31097cf187d98b18c9af1a9b8a2f6af742b00664c06">+14/-16</a></td>
</tr>
</table></details></td></tr>
</tbody></table>

</details>

___

<!-- nhost-reviewer:end -->
