### PR TITLE
fix(dashboard): increase the width of the service column

### DIFF
--- a/dashboard/src/features/orgs/projects/logs/components/LogsBody/columns.tsx
+++ b/dashboard/src/features/orgs/projects/logs/components/LogsBody/columns.tsx
@@ -17,7 +17,7 @@ import { useMemo } from 'react';
 export const ACTIONS_WIDTH = 44;
 export const TIMESTAMP_WIDTH = 145;
 export const LOG_LEVEL_WIDTH = 80;
-export const SERVICE_WIDTH = 110;
+export const SERVICE_WIDTH = 120;
 export const LOG_MIN_WIDTH = 300;
 export const LOG_CHAR_WIDTH = 7.5;
 export const LOG_CELL_PADDING = 16;
@@ -69,11 +69,11 @@ function ServiceCell({ getValue }: { getValue: () => string }) {
     <span
       title={service}
       className={cn(
-        'inline-flex max-w-full items-center truncate rounded px-1.5 py-0.5 font-mono text-xs-',
+        'inline-flex max-w-full items-center rounded px-1.5 py-0.5 font-mono text-xs-',
         className,
       )}
     >
-      {label}
+      <span className="truncate">{label}</span>
     </span>
   );
 }


### PR DESCRIPTION
### Checklist

- [x] No breaking changes
- [x] Tests pass
- [ ] New features have new tests
- [ ] Documentation is updated (if applicable)
- [x] Title of the PR is in the correct format (see below)

<!-- nhost-reviewer:start -->
### **What this PR solves**
The service column in the logs table was too narrow and its truncation/ellipsis did not render correctly because `truncate` was applied to a flex container. This widens the column slightly and moves truncation onto the inner text element so the service label ellipsizes properly.

___

### **PR Type**
Bug fix

___

### **Description**
- Increase `SERVICE_WIDTH` from `110` to `120` px to give the service column a bit more room.
- Move the `truncate` utility off the outer `inline-flex` badge span and onto a new inner `<span>` wrapping the label so `text-overflow: ellipsis` works as intended.

___

<details> <summary><h3> File Walkthrough</h3></summary>

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody>
<tr><td><strong>Dashboard</strong></td><td><details><summary>1 files</summary><table>
<tr>
  <td><strong>columns.tsx</strong><dd><code>Widen service column and fix label truncation</code></dd></td>
  <td><a href="https://github.com/nhost/nhost/pull/4508/files#diff-106133a1e0bc37d5d40435eb1ae99ccc032455fc3a0ce5fdf988ea556f361180">+3/-3</a></td>
</tr>
</table></details></td></tr>
</tbody></table>

</details>

___

<!-- nhost-reviewer:end -->
