### PR TITLE
fix(dashboard): optimize DataBrowserSidebar tests

### DIFF
--- a/dashboard/src/features/orgs/projects/database/dataGrid/components/DataBrowserSidebar/DataBrowserSidebar.test.tsx
+++ b/dashboard/src/features/orgs/projects/database/dataGrid/components/DataBrowserSidebar/DataBrowserSidebar.test.tsx
@@ -34,6 +34,8 @@ const mocks = vi.hoisted(() => ({
   useTableSchemaQuery: vi.fn(),
   useTableIsEnumQuery: vi.fn(),
   useSetTableIsEnumMutation: vi.fn(),
+  useTableComputedFieldsQuery: vi.fn(),
+  usePostgresFunctionsQuery: vi.fn(),
 }));
 
 vi.mock('next/router', () => ({
@@ -166,6 +168,20 @@ vi.mock(
   '@/features/orgs/projects/database/dataGrid/hooks/useSetTableIsEnumMutation',
   () => ({
     useSetTableIsEnumMutation: mocks.useSetTableIsEnumMutation,
+  }),
+);
+
+vi.mock(
+  '@/features/orgs/projects/database/dataGrid/hooks/useTableComputedFieldsQuery',
+  () => ({
+    useTableComputedFieldsQuery: mocks.useTableComputedFieldsQuery,
+  }),
+);
+
+vi.mock(
+  '@/features/orgs/projects/database/dataGrid/hooks/usePostgresFunctionsQuery',
+  () => ({
+    usePostgresFunctionsQuery: mocks.usePostgresFunctionsQuery,
   }),
 );
 
@@ -325,6 +341,18 @@ function setupMocks() {
   mocks.useSetTableIsEnumMutation.mockReturnValue({
     mutateAsync: vi.fn(),
   });
+  mocks.useTableComputedFieldsQuery.mockReturnValue({
+    data: [],
+    isLoading: false,
+    error: null,
+    isError: false,
+  });
+  mocks.usePostgresFunctionsQuery.mockReturnValue({
+    data: { functions: [] },
+    isLoading: false,
+    error: null,
+    isError: false,
+  });
 }
 
 function getVisibleObjectNames(): string[] {
@@ -469,6 +497,9 @@ async function openGraphQLSettingsDrawer(
   await user.click(
     await screen.findByRole('menuitem', { name: /Edit GraphQL/ }),
   );
+
+  // wait for the loaded form (its "Back" button) before querying its fields.
+  await screen.findByRole('button', { name: 'Back' }, { timeout: 15000 });
 }
 
 describe('DataBrowserSidebar — discard guard for GraphQL settings drawer', () => {


### PR DESCRIPTION
### Checklist

- [x] No breaking changes
- [x] Tests pass
- [ ] New features have new tests
- [ ] Documentation is updated (if applicable)
- [x] Title of the PR is in the correct format (see below)


<!-- nhost-reviewer:start -->
### **What this PR solves**
The `DataBrowserSidebar` GraphQL-settings drawer started rendering a computed-fields section backed by two new hooks (`useTableComputedFieldsQuery`, `usePostgresFunctionsQuery`), which broke the existing test suite. This PR stabilizes the tests by mocking those hooks and waiting for the async-loaded form to mount before asserting on its fields.

___

### **PR Type**
Tests

___

### **Description**
- Adds `vi.hoisted` mocks and `setupMocks()` return values for `useTableComputedFieldsQuery` and `usePostgresFunctionsQuery` so the GraphQL-settings drawer renders without errors under test.
- Waits for the drawer form's "Back" button (`findByRole` with a 15s ceiling) inside `openGraphQLSettingsDrawer` so field queries no longer race the async-loaded form.

___

<details> <summary><h3> File Walkthrough</h3></summary>

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody>
<tr><td><strong>Tests</strong></td><td><details><summary>1 files</summary><table>
<tr>
  <td><strong>DataBrowserSidebar.test.tsx</strong><dd><code>Mock two new query hooks and await the loaded drawer form</code></dd></td>
  <td><a href="https://github.com/nhost/nhost/pull/4509/files#diff-4c95eedb4be397ac4d6952477e32a3f78c23ba91fd98e73ba6c5cf4bc4ee1575">+31/-0</a></td>
</tr>
</table></details></td></tr>
</tbody></table>

</details>

___

<!-- nhost-reviewer:end -->
