### PR TITLE
fix(dashboard): move the check mark to the left in combobox

### DIFF
--- a/dashboard/src/components/ui/v3/combobox.tsx
+++ b/dashboard/src/components/ui/v3/combobox.tsx
@@ -193,13 +193,13 @@ const Combobox = forwardRef<HTMLButtonElement, ComboboxProps>(
                         setOpen(false);
                       }}
                     >
-                      {option.render ?? option.label}
                       <Check
                         className={cn(
-                          'ml-auto size-4',
+                          'mr-2 size-4 shrink-0',
                           option.value === value ? 'opacity-100' : 'opacity-0',
                         )}
                       />
+                      {option.render ?? option.label}
                     </CommandItem>
                   ))}
                 </CommandGroup>


### PR DESCRIPTION
### Checklist

- [x] No breaking changes
- [x] Tests pass
- [ ] New features have new tests
- [ ] Documentation is updated (if applicable)
- [x] Title of the PR is in the correct format (see below)

<!-- nhost-reviewer:start -->
### **What this PR solves**
In the v3 `Combobox` dropdown, the selected-item checkmark was right-aligned (`ml-auto`), so it floated far from the option text and sat at a different position per row depending on label width. This moves the checkmark to a fixed position on the left of each row, giving a consistent, scannable selection indicator.

___

### **PR Type**
Enhancement

___

### **Description**
- Reorder the `CommandItem` children so the `Check` icon renders before the option label/`render` content instead of after it.
- Replace the checkmark's `ml-auto` (push-to-right) styling with `mr-2 size-4 shrink-0` so it sits at a fixed left position with consistent spacing and no shrinking.

___

<details> <summary><h3> File Walkthrough</h3></summary>

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody>
<tr><td><strong>Enhancement</strong></td><td><details><summary>1 files</summary><table>
<tr>
  <td><strong>combobox.tsx</strong><dd><code>Move selected-item checkmark to the left of the option label</code></dd></td>
  <td><a href="https://github.com/nhost/nhost/pull/4515/files#diff-cf6e48c7c01b35c82d7b12ea4fb427c7631fbff1b99ae223037716a1beb4865c">+2/-2</a></td>
</tr>
</table></details></td></tr>
</tbody></table>

</details>

___

<!-- nhost-reviewer:end -->

