### PR TITLE
fix(dashboard): show confirmation modal when closing Table form if it's dirty

### DIFF
--- a/dashboard/src/features/orgs/projects/database/dataGrid/components/BaseForeignKeyForm/BaseForeignKeyForm.tsx
+++ b/dashboard/src/features/orgs/projects/database/dataGrid/components/BaseForeignKeyForm/BaseForeignKeyForm.tsx
@@ -1,6 +1,6 @@
 import { useRouter } from 'next/router';
 import { useEffect } from 'react';
-import { useFormContext, useFormState } from 'react-hook-form';
+import { useFormContext } from 'react-hook-form';
 import * as Yup from 'yup';
 import { useDialog } from '@/components/common/DialogProvider';
 import { Form } from '@/components/form/Form';
@@ -65,15 +65,17 @@ export type BaseForeignKeySchemaValues = Yup.InferType<
   typeof baseForeignKeyValidationSchema
 >;
 
+const DIRTY_SOURCE_ID = 'base-foreign-keyform';
+
 export default function BaseForeignKeyForm({
   availableColumns,
   onSubmit: handleExternalSubmit,
   onCancel,
   submitButtonText = 'Save',
-  location,
   disableOriginColumn,
+  location,
 }: BaseForeignKeyFormProps) {
-  const { onDirtyStateChange } = useDialog();
+  const { setDirtySource } = useDialog();
 
   const router = useRouter();
   const {
@@ -81,32 +83,24 @@ export default function BaseForeignKeyForm({
   } = router;
 
   const form = useFormContext<BaseForeignKeySchemaValues>();
-  const { control } = form;
-  const { dirtyFields, isSubmitting } =
-    useFormState<BaseForeignKeySchemaValues>();
+  const { control, subscribe, formState } = form;
+  const { isSubmitting } = formState;
 
   const { data } = useDatabaseQuery([dataSourceSlug]);
 
   const schemas = data?.schemas ?? [];
   const tables = data?.tableLikeObjects ?? [];
 
-  // react-hook-form's isDirty gets true even if an input field is focused, then
-  // immediately unfocused - we can't rely on that information
-  const isDirty = Object.keys(dirtyFields).length > 0;
-
   useEffect(() => {
-    const unsubscribe = form.subscribe({
-      formState: { dirtyFields: true },
-      callback: ({ dirtyFields: subscribedDirtyFields }) => {
-        onDirtyStateChange(
-          Object.keys(subscribedDirtyFields ?? {}).length > 0,
-          location,
-        );
+    const unsubscribe = subscribe({
+      formState: { isDirty: true },
+      callback: ({ isDirty: isDirtyNext }) => {
+        setDirtySource(DIRTY_SOURCE_ID, Boolean(isDirtyNext), location);
       },
     });
 
     return () => unsubscribe();
-  }, [form, onDirtyStateChange, location]);
+  }, [subscribe, setDirtySource, location]);
 
   return (
     <Form
@@ -203,12 +197,7 @@ export default function BaseForeignKeyForm({
           {submitButtonText}
         </ButtonWithLoading>
 
-        <Button
-          type="button"
-          variant="outline"
-          onClick={onCancel}
-          tabIndex={isDirty ? -1 : 0}
-        >
+        <Button type="button" variant="outline" onClick={onCancel}>
           Cancel
         </Button>
       </div>

--- a/dashboard/src/features/orgs/projects/database/dataGrid/components/BaseTableForm/BaseTableForm.tsx
+++ b/dashboard/src/features/orgs/projects/database/dataGrid/components/BaseTableForm/BaseTableForm.tsx
@@ -54,7 +54,7 @@ export interface BaseTableFormProps extends DialogFormProps {
   /**
    * Function to be called when the operation is cancelled.
    */
-  onCancel?: VoidFunction;
+  onCancel?: (event?: MouseEvent<HTMLButtonElement>) => void;
   /**
    * Submit button text.
    *
@@ -164,17 +164,11 @@ function FormFooter({
 }: Pick<BaseTableFormProps, 'onCancel' | 'submitButtonText'> & {
   onSubmitClick?: VoidFunction;
 }) {
-  const { closeDrawerWithDirtyGuard } = useDialog();
   const { isSubmitting } = useFormState();
-
-  const handleCancel = (event: MouseEvent<HTMLButtonElement>) => {
-    onCancel?.();
-    closeDrawerWithDirtyGuard(event);
-  };
 
   return (
     <div className="box grid flex-shrink-0 grid-flow-col justify-between gap-3 border-t-1 p-2">
-      <Button type="button" variant="ghost" onClick={handleCancel}>
+      <Button type="button" variant="ghost" onClick={onCancel}>
         Cancel
       </Button>
 
@@ -206,24 +200,19 @@ export default function BaseTableForm({
     'foreignKeys',
   ]);
   const { setDirtySource } = useDialog();
-  const form = useFormContext();
+  const { subscribe } = useFormContext();
 
   useEffect(() => {
-    const unsubscribe = form.subscribe({
-      formState: { dirtyFields: true },
-      callback: ({ dirtyFields }) => {
-        setDirtySource(
-          DIRTY_SOURCE_ID,
-          Object.keys(dirtyFields ?? {}).length > 0,
-          location,
-        );
+    const unsubscribe = subscribe({
+      formState: { isDirty: true },
+      callback: ({ isDirty }) => {
+        setDirtySource(DIRTY_SOURCE_ID, Boolean(isDirty), location);
       },
     });
     return () => {
       unsubscribe();
-      setDirtySource(DIRTY_SOURCE_ID, false, location);
     };
-  }, [form, setDirtySource, location]);
+  }, [subscribe, setDirtySource, location]);
 
   const showSchemaPicker =
     !!onSchemaChange && !!availableSchemas && availableSchemas.length > 0;


### PR DESCRIPTION
### Checklist

- [x] No breaking changes
- [x] Tests pass
- [ ] New features have new tests
- [ ] Documentation is updated (if applicable)
- [x] Title of the PR is in the correct format (see below)

<!-- nhost-reviewer:start -->
### **What this PR solves**
Clicking **Cancel** in the Create/Edit Table drawer did not reliably show the unsaved-changes confirmation: the footer invoked the provider-injected `onCancel` with no event (closing the drawer immediately) and then called the dirty guard a second time, so the guard was effectively skipped. This PR makes both database forms delegate cancel handling entirely to the `DialogProvider` (forwarding the click event) and switches dirty tracking to react-hook-form's revert-aware `isDirty`, so the confirmation fires correctly when — and only when — the form is actually dirty.

___

### **PR Type**
Bug fix

___

### **Description**
- **BaseTableForm:** removed the local `closeDrawerWithDirtyGuard` call from `FormFooter`; the Cancel button now calls the provider-injected `onCancel` directly and forwards the click event, fixing the double-invocation that skipped the dirty guard.
- **BaseTableForm:** widened the `onCancel` prop from `VoidFunction` to `(event?: MouseEvent<HTMLButtonElement>) => void` so the click event reaches the provider's guard.
- **BaseTableForm & BaseForeignKeyForm:** switched the dirty subscription from counting `dirtyFields` keys to react-hook-form's `isDirty` (which compares against `defaultValues` and won't stay dirty after a revert), destructuring `subscribe` directly from the form.
- **BaseForeignKeyForm:** migrated from the legacy `onDirtyStateChange` callback to `setDirtySource` with a dedicated `DIRTY_SOURCE_ID`, forwarding the injected `location`, and removed the `tabIndex`-on-dirty toggle on the Cancel button.
- **BaseTableForm:** dropped the unmount `setDirtySource(..., false, location)` reset, relying on the provider's `clearDirtySources(location)` on close.

___

### Diagram Walkthrough

```mermaid
flowchart LR
  A["Cancel click<br/>(MouseEvent)"] --> B["Form onClick={onCancel}"]
  B --> C["DialogProvider<br/>injected onCancel wrapper"]
  C --> D["closeDrawerWithDirtyGuard(event)"]
  D --> E{"isDirty source<br/>registered?"}
  E -->|yes| F["Unsaved-changes<br/>confirmation"]
  E -->|no| G["closeDrawer()"]
```

<details> <summary><h3> File Walkthrough</h3></summary>

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody>
<tr><td><strong>Dashboard — Database forms</strong></td><td><details><summary>2 files</summary><table>
<tr>
  <td><strong>BaseTableForm.tsx</strong><dd><code>Delegate Cancel to the provider's onCancel (forwarding the event), widen onCancel signature, track dirty via isDirty.</code></dd></td>
  <td><a href="https://github.com/nhost/nhost/pull/4517/files#diff-33e0bcf77738162f71af2ab673966d2e61d1e270ad09179c23e2d29d18582f80">+8/-19</a></td>
</tr>
<tr>
  <td><strong>BaseForeignKeyForm.tsx</strong><dd><code>Migrate from onDirtyStateChange to setDirtySource, track dirty via isDirty, drop the Cancel tabIndex toggle.</code></dd></td>
  <td><a href="https://github.com/nhost/nhost/pull/4517/files#diff-cbe94cfc99f8a498d6dad78f69b72f41b3841a67f244aa10b8916424e4d8c9bc">+13/-24</a></td>
</tr>
</table></details></td></tr>
</tbody></table>

</details>

___

<!-- nhost-reviewer:end -->
