### PR TITLE
fix(docs): remove unneeded body css for svelte tutorial

### DIFF
--- a/docs/src/content/docs/getting-started/tutorials/svelte/2-protected-routes.mdx
+++ b/docs/src/content/docs/getting-started/tutorials/svelte/2-protected-routes.mdx
@@ -399,8 +399,6 @@ Note: We've integrated the navigation directly into our `+layout.svelte` file, a
 
 body {
   margin: 0;
-  display: flex;
-  place-items: center;
   min-width: 320px;
   min-height: 100vh;
 }


### PR DESCRIPTION
### Checklist

- [x] No breaking changes
- [x] Tests pass
- [ ] New features have new tests
- [x] Documentation is updated (if applicable)
- [x] Title of the PR is in the correct format (see below)

See [issue](https://github.com/nhost/nhost/issues/4518).

CSS changes preview:
<img width="1040" height="805" alt="bettershot_1781189453839" src="https://github.com/user-attachments/assets/361c997b-1e4b-4d87-8600-d1c712e4ce57" />

