### PR TITLE
chore(dashboard): disable Segment analytics on dev and staging

### DIFF
--- a/dashboard/src/lib/segment.ts
+++ b/dashboard/src/lib/segment.ts
@@ -1,13 +1,13 @@
 import { AnalyticsBrowser, type ID } from '@segment/analytics-next';
 import { isPlatform } from '@/utils/env';
-//import { isDevOrStaging } from '@/utils/helpers';
+import { isDevOrStaging } from '@/utils/helpers';
 
 export const analytics = AnalyticsBrowser.load(
   {
     writeKey: process.env.NEXT_PUBLIC_ANALYTICS_WRITE_KEY!,
   },
   {
-    disable: !isPlatform(), //|| isDevOrStaging(),
+    disable: !isPlatform() || isDevOrStaging(),
   },
 );
 


### PR DESCRIPTION
<!-- nhost-reviewer:start -->
### **What this PR solves**
Segment analytics was only disabled when the dashboard wasn't running on the Nhost platform, so dev and staging deployments still emitted real analytics events. This change restores the previously commented-out `isDevOrStaging()` guard so analytics is also disabled on dev/staging, keeping production analytics data clean.

___

### **PR Type**
Configuration

___

### **Description**
- Re-enable the `isDevOrStaging()` import and the `|| isDevOrStaging()` clause in the Segment `analytics` loader so analytics is disabled on dev/staging environments.
- Remove the leftover commented-out import and trailing inline comment (dead code).

___

<details> <summary><h3> File Walkthrough</h3></summary>

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody>
<tr><td><strong>Configuration</strong></td><td><details><summary>1 files</summary><table>
<tr>
  <td><strong>segment.ts</strong><dd><code>Disable Segment analytics on dev/staging via isDevOrStaging()</code></dd></td>
  <td><a href="https://github.com/nhost/nhost/pull/XXX/files#diff-a23427ba42161ffe844159b21f2901e32e6518c61895d5b0e90c653df6876d0c">+2/-2</a></td>
</tr>
</table></details></td></tr>
</tbody></table>

</details>

___

<!-- nhost-reviewer:end -->
