### PR TITLE
fix(dashboard): unify session argument wording across GraphQL settings

### DIFF
--- a/dashboard/src/features/orgs/projects/database/dataGrid/components/EditFunctionGraphQLSettingsForm/EditFunctionGraphQLSettingsForm.tsx
+++ b/dashboard/src/features/orgs/projects/database/dataGrid/components/EditFunctionGraphQLSettingsForm/EditFunctionGraphQLSettingsForm.tsx
@@ -433,8 +433,7 @@ export default function EditFunctionGraphQLSettingsForm({
                         Session Argument
                       </h3>
                       <p className="text-muted-foreground text-sm+">
-                        Name of the function argument that accepts session info
-                        JSON (e.g., hasura_session).
+                        The argument that receives the User Session as JSON.
                       </p>
                     </div>
                     <FormInput
@@ -442,7 +441,7 @@ export default function EditFunctionGraphQLSettingsForm({
                       control={form.control}
                       name="sessionArgument"
                       label=""
-                      placeholder="Enter session argument name..."
+                      placeholder="user_session"
                       className="max-w-sm"
                     />
                   </div>


### PR DESCRIPTION
### Checklist

- [X] No breaking changes
- [X] Tests pass
- [X] New features have new tests
- [X] Documentation is updated (if applicable)
- [X] Title of the PR is in the correct format (see below)

<!-- nhost-reviewer:start -->
### **What this PR solves**
The "Session Argument" field in the Edit Function GraphQL Settings form described itself with Hasura ("Name of the function argument that accepts session info JSON (e.g., hasura_session)") and a generic placeholder, while the identical field in the computed-fields section of the table GraphQL settings form already uses the standardized User Session wording. This PR aligns the function form's helper text and placeholder with that wording so both settings surfaces describe the Session Argument identically.

___

### **PR Type**
Bug fix

___

### **Description**
- Replace the Session Argument helper text in `EditFunctionGraphQLSettingsForm` with the standardized sentence already used by `ComputedFieldFormFields`: "The argument that receives the User Session as JSON."
- Change the input placeholder from "Enter session argument name..." to the example value `user_session`, matching the computed-fields field.

___

<details> <summary><h3> File Walkthrough</h3></summary>

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody>
<tr><td><strong>UI copy</strong></td><td><details><summary>1 files</summary><table>
<tr>
  <td><strong>EditFunctionGraphQLSettingsForm.tsx</strong><dd><code>Align Session Argument helper text and placeholder with the computed-fields wording</code></dd></td>
  <td><a href="https://github.com/nhost/nhost/pull/4521/files#diff-3aaaf5297d6de02bdc08caef20f4b1268d5026f3dc4ca7f6c39471562ef95f96">+2/-3</a></td>
</tr>
</table></details></td></tr>
</tbody></table>

</details>

___

<!-- nhost-reviewer:end -->
