### PR TITLE
fix(dashboard): mixed light/dark theme after signing in and switching tabs

### DIFF
--- a/dashboard/src/components/ui/v2/ColorPreferenceProvider/ColorPreferenceContext.ts
+++ b/dashboard/src/components/ui/v2/ColorPreferenceProvider/ColorPreferenceContext.ts
@@ -1,4 +1,5 @@
 import { createContext } from 'react';
+import { COLOR_PREFERENCE_STORAGE_KEY } from '@/utils/constants/common';
 
 export interface ColorPreferenceContextProps {
   /**
@@ -20,7 +21,7 @@ export interface ColorPreferenceContextProps {
   /**
    * The key used to store the color preference in the local storage.
    *
-   * @default 'color-preference'
+   * @default COLOR_PREFERENCE_STORAGE_KEY
    */
   colorPreferenceStorageKey: string;
 }
@@ -29,7 +30,7 @@ const ColorPreferenceContext = createContext<ColorPreferenceContextProps>({
   color: 'light',
   colorPreference: 'system',
   setColorPreference: () => {},
-  colorPreferenceStorageKey: 'color-preference',
+  colorPreferenceStorageKey: COLOR_PREFERENCE_STORAGE_KEY,
 });
 
 export default ColorPreferenceContext;

--- a/dashboard/src/components/ui/v2/ColorPreferenceProvider/ColorPreferenceProvider.tsx
+++ b/dashboard/src/components/ui/v2/ColorPreferenceProvider/ColorPreferenceProvider.tsx
@@ -1,6 +1,7 @@
 import useMediaQuery from '@mui/material/useMediaQuery';
 import type { PropsWithChildren } from 'react';
 import { useCallback, useEffect, useMemo, useState } from 'react';
+import { COLOR_PREFERENCE_STORAGE_KEY } from '@/utils/constants/common';
 import ColorPreferenceContext from './ColorPreferenceContext';
 
 export interface ColorPreferenceProviderProps
@@ -8,14 +9,14 @@ export interface ColorPreferenceProviderProps
   /**
    * The key used to store the color preference in the local storage.
    *
-   * @default 'color-preference'
+   * @default COLOR_PREFERENCE_STORAGE_KEY
    */
   colorPreferenceStorageKey?: string;
 }
 
 function ColorPreferenceProvider({
   children,
-  colorPreferenceStorageKey = 'color-mode',
+  colorPreferenceStorageKey = COLOR_PREFERENCE_STORAGE_KEY,
 }: ColorPreferenceProviderProps) {
   const [colorPreference, setColorPreference] = useState<
     'light' | 'dark' | 'system'

--- a/dashboard/src/components/ui/v2/ThemeProvider/ThemeProvider.test.tsx
+++ b/dashboard/src/components/ui/v2/ThemeProvider/ThemeProvider.test.tsx
@@ -1,0 +1,68 @@
+import { afterEach, describe, expect, it } from 'vitest';
+import { ThemeProvider } from '@/components/ui/v2/ThemeProvider';
+import { cleanup, render, screen, waitFor } from '@/tests/testUtils';
+import { COLOR_PREFERENCE_STORAGE_KEY } from '@/utils/constants/common';
+
+describe('ThemeProvider', () => {
+  afterEach(() => {
+    cleanup();
+    localStorage.clear();
+    document.documentElement.className = '';
+  });
+
+  it('applies the stored color preference to the <html> element', async () => {
+    localStorage.setItem(COLOR_PREFERENCE_STORAGE_KEY, 'dark');
+
+    render(
+      <ThemeProvider>
+        <span>app</span>
+      </ThemeProvider>,
+    );
+
+    await waitFor(() =>
+      expect(document.documentElement.classList.contains('dark')).toBe(true),
+    );
+    expect(document.documentElement.classList.contains('light')).toBe(false);
+  });
+
+  it('scopes a manual color to a wrapper element instead of <html>', async () => {
+    document.documentElement.classList.add('dark');
+
+    render(
+      <ThemeProvider color="dark">
+        <span>signin</span>
+      </ThemeProvider>,
+    );
+
+    const child = await screen.findByText('signin');
+    expect(child.parentElement).toHaveClass('dark', 'contents');
+    expect(document.documentElement.classList.contains('dark')).toBe(true);
+    expect(document.documentElement.classList.contains('light')).toBe(false);
+  });
+
+  it('keeps the root preference on <html> when a scoped provider mounts later', async () => {
+    localStorage.setItem(COLOR_PREFERENCE_STORAGE_KEY, 'dark');
+
+    const { rerender } = render(
+      <ThemeProvider>
+        <span>app</span>
+      </ThemeProvider>,
+    );
+
+    await waitFor(() =>
+      expect(document.documentElement.classList.contains('dark')).toBe(true),
+    );
+
+    rerender(
+      <ThemeProvider>
+        <ThemeProvider color="dark">
+          <span>signin</span>
+        </ThemeProvider>
+      </ThemeProvider>,
+    );
+
+    await screen.findByText('signin');
+    expect(document.documentElement.classList.contains('dark')).toBe(true);
+    expect(document.documentElement.classList.contains('light')).toBe(false);
+  });
+});

--- a/dashboard/src/components/ui/v2/ThemeProvider/ThemeProvider.tsx
+++ b/dashboard/src/components/ui/v2/ThemeProvider/ThemeProvider.tsx
@@ -6,6 +6,7 @@ import { type PropsWithChildren, useEffect } from 'react';
 import { ColorPreferenceProvider } from '@/components/ui/v2/ColorPreferenceProvider';
 import { createTheme } from '@/components/ui/v2/createTheme';
 import { useColorPreference } from '@/components/ui/v2/useColorPreference';
+import { COLOR_PREFERENCE_STORAGE_KEY } from '@/utils/constants/common';
 
 function ThemeProviderContent({
   children,
@@ -14,12 +15,15 @@ function ThemeProviderContent({
   const { color: preferredColor } = useColorPreference();
   const theme = createTheme(manualColor || preferredColor);
 
-  // Use effect to set the class on the root html tag
   useEffect(() => {
+    if (manualColor) {
+      return;
+    }
+
     const rootElement = document.documentElement;
-    rootElement.classList.remove('light', 'dark'); // Remove previous classes
-    rootElement.classList.add(preferredColor); // Add the current class
-  }, [preferredColor]);
+    rootElement.classList.remove('light', 'dark');
+    rootElement.classList.add(preferredColor);
+  }, [preferredColor, manualColor]);
 
   return (
     <MaterialThemeProvider theme={theme}>
@@ -34,7 +38,11 @@ function ThemeProviderContent({
       <Head>
         <meta name="theme-color" content={theme.palette.background.paper} />
       </Head>
-      {children}
+      {manualColor ? (
+        <div className={`${manualColor} contents`}>{children}</div>
+      ) : (
+        children
+      )}
     </MaterialThemeProvider>
   );
 }
@@ -43,11 +51,14 @@ export interface ThemeProviderProps extends PropsWithChildren<unknown> {
   /**
    * The key used to store the color preference in local storage.
    *
-   * @default 'color-preference'
+   * @default COLOR_PREFERENCE_STORAGE_KEY
    */
   colorPreferenceStorageKey?: string;
   /**
-   * Manually set the color preference.
+   * Manually set the color preference. When set, the provider is scoped: it
+   * themes only its own subtree (MUI theme plus a `light`/`dark` class on a
+   * wrapper element for Tailwind tokens) and leaves the `<html>` class —
+   * owned by the root provider in `_app.tsx` — untouched.
    */
   color?: 'light' | 'dark';
 }
@@ -55,7 +66,7 @@ export interface ThemeProviderProps extends PropsWithChildren<unknown> {
 function ThemeProvider({
   children,
   color,
-  colorPreferenceStorageKey = 'color-preference',
+  colorPreferenceStorageKey = COLOR_PREFERENCE_STORAGE_KEY,
 }: ThemeProviderProps) {
   return (
     <ColorPreferenceProvider


### PR DESCRIPTION
| Before | After |
| --------- | ------ |
| <img width="365" height="323" alt="Screenshot 2026-06-11 at 20 23 18" src="https://github.com/user-attachments/assets/ee310e72-07c3-4df8-b91c-54db7cb3351f" /> |  <img width="365" height="323" alt="Screenshot 2026-06-11 at 20 23 36" src="https://github.com/user-attachments/assets/b5683296-bbf6-415a-b606-1346392a6055" />   |

### Checklist

- [X] No breaking changes
- [X] Tests pass
- [X] New features have new tests
- [X] Documentation is updated (if applicable)
- [X] Title of the PR is in the correct format (see below)


<!-- nhost-reviewer:start -->
### **What this PR solves**
Nested `ThemeProvider` instances with a manual `color` (sign-in pages via `UnauthenticatedLayout`, the OAuth2 authorize page) used to rewrite the global `light`/`dark` class on `<html>` — while reading the preference from mismatched localStorage keys (`'color-preference'` / `'color-mode'` instead of the app's `'nhost-color-preference'`). After signing in and switching browser tabs this could leave the dashboard rendering a mix of light and dark styles. Scoped providers now theme only their own subtree and leave the `<html>` class to the root provider, and all providers share one storage-key constant.

___

### **PR Type**
Bug fix

___

### **Description**
- `ThemeProvider` with a manual `color` no longer touches the `light`/`dark` class on `<html>`; it scopes theming to its subtree via the MUI theme plus a `display: contents` wrapper div carrying the Tailwind `light`/`dark` class.
- Unifies the color-preference localStorage key: `ThemeProvider`, `ColorPreferenceProvider`, and the `ColorPreferenceContext` default value now all use the shared `COLOR_PREFERENCE_STORAGE_KEY` (`'nhost-color-preference'`) instead of the divergent `'color-preference'` / `'color-mode'` literals.
- Adds tests covering the root provider applying the stored preference to `<html>`, the scoped wrapper for a manual color, and a late-mounting scoped provider leaving the root preference intact.

___

### Diagram Walkthrough

```mermaid
flowchart LR
  Root["Root ThemeProvider (_app.tsx, no color prop)"] -->|useEffect| Html["light/dark class on document.documentElement"]
  Scoped["Scoped ThemeProvider (color=dark): signin / oauth authorize"] --> Mui["MUI theme via createTheme(color)"]
  Scoped --> Wrap["wrapper div with color + contents classes (Tailwind)"]
  Scoped -.->|no longer writes| Html
```

<details> <summary><h3> File Walkthrough</h3></summary>

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody>
<tr><td><strong>Bug fix</strong></td><td><details><summary>3 files</summary><table>
<tr>
  <td><strong>ThemeProvider.tsx</strong><dd><code>Skip the html-class effect when a manual color is set; render a scoped `color + contents` wrapper div; default the storage key to the shared constant</code></dd></td>
  <td><a href="https://github.com/nhost/nhost/pull/4522/files#diff-8d1f2140a216b2d35497c20ae599113e84bc4b7b7053a17e014c292b1477614f">+19/-8</a></td>
</tr>
<tr>
  <td><strong>ColorPreferenceProvider.tsx</strong><dd><code>Replace the stray 'color-mode' default storage key with the shared COLOR_PREFERENCE_STORAGE_KEY constant</code></dd></td>
  <td><a href="https://github.com/nhost/nhost/pull/4522/files#diff-e23702afc317f273b5b3bf12dea1fd9da1bfdc7f3f1ec1915d4146962470e7fd">+3/-2</a></td>
</tr>
<tr>
  <td><strong>ColorPreferenceContext.ts</strong><dd><code>Use COLOR_PREFERENCE_STORAGE_KEY for the createContext default value and its JSDoc instead of the stale 'color-preference' literal</code></dd></td>
  <td><a href="https://github.com/nhost/nhost/pull/4522/files#diff-5ed1743a11ff8f71067a7d302a3fe32c4848b246af328d69f72c528060e4eba7">+3/-2</a></td>
</tr>
</table></details></td></tr>
<tr><td><strong>Tests</strong></td><td><details><summary>1 files</summary><table>
<tr>
  <td><strong>ThemeProvider.test.tsx</strong><dd><code>New tests: stored preference applied to html, manual color scoped to wrapper, late-mounting scoped provider keeps root preference</code></dd></td>
  <td><a href="https://github.com/nhost/nhost/pull/4522/files#diff-0631cad2c8657add990ee5a22912eccf75e6be274fe8f24c0c2f869b48aa289c">+68/-0</a></td>
</tr>
</table></details></td></tr>
</tbody></table>

</details>

___

<!-- nhost-reviewer:end -->
