### PR TITLE
fix(storage): map Hasura invalid-jwt error to 401 Unauthorized

### DIFF
--- a/services/storage/controller/errors.go
+++ b/services/storage/controller/errors.go
@@ -210,6 +210,15 @@ func BadDataError(err error, publicMessage string) *APIError {
 	}
 }
 
+func UnauthorizedError(err error, publicMessage string) *APIError {
+	return &APIError{
+		statusCode:    http.StatusUnauthorized,
+		publicMessage: publicMessage,
+		err:           err,
+		data:          nil,
+	}
+}
+
 func NewAPIError(
 	statusCode int,
 	publicMessage string,

--- a/services/storage/metadata/hasura.go
+++ b/services/storage/metadata/hasura.go
@@ -26,6 +26,8 @@ func parseGraphqlError(err error) *controller.APIError {
 			return controller.ForbiddenError(ghErr, "you are not authorized")
 		case "data-exception", "constraint-violation":
 			return controller.BadDataError(err, ghErr.Error())
+		case "invalid-jwt":
+			return controller.UnauthorizedError(ghErr, "invalid or expired jwt")
 		default:
 			return controller.InternalServerError(err)
 		}


### PR DESCRIPTION
Resolves #3389 

### Checklist

- [x] No breaking changes
- [x] Tests pass
- [ ] New features have new tests
- [ ] Documentation is updated (if applicable)
- [x] Title of the PR is in the correct format (see below)

---
### PR Type

Bug Fix

---
### Description
Handles mapping Hasura's invalid-jwt error to an HTTP 401 Unauthorized status in the storage service so client applications can properly handle expired tokens.
