### PR TITLE
fix(functions): replace ctx.watch() with mtime polling for Docker bind mounts

### DIFF
--- a/services/functions/server.js
+++ b/services/functions/server.js
@@ -67,6 +67,11 @@ const functionEntries = new Map();
 // Track discovered functions for metadata endpoint
 const functionMeta = new Map();
 
+// Track source file mtimes for polling-based change detection.
+// inotify/FSEvents do not fire reliably over Docker bind-mount volumes,
+// so ctx.watch() silently misses edits to existing function files.
+const functionMtimes = new Map();
+
 // Single esbuild context covering every function's wrapper as an entry point.
 // Per-function contexts retained the parsed dep graph (express, aws-sdk, ...)
 // once per function, multiplying memory by N. A single context shares one
@@ -83,6 +88,19 @@ function scheduleRebuild(functionsPath) {
   rebuildInFlight = rebuildInFlight
     .catch(() => {})
     .then(() => rebuildContext(functionsPath));
+  return rebuildInFlight;
+}
+
+// Incremental rebuild reuses the existing context (no dispose/recreate), used
+// when only file contents changed (not the entry-point set).
+function scheduleIncrementalRebuild() {
+  rebuildInFlight = rebuildInFlight
+    .catch(() => {})
+    .then(async () => {
+      if (buildContext) {
+        await buildContext.rebuild();
+      }
+    });
   return rebuildInFlight;
 }
 
@@ -133,6 +151,9 @@ function prepareFunctionEntry(functionsPath, file) {
   const route = fileToRoute(file);
 
   functionEntries.set(file, { wrapperPath, outfile, route, safeName });
+  try {
+    functionMtimes.set(file, fs.statSync(absoluteFuncPath).mtimeMs);
+  } catch {}
   functionMeta.set(file, {
     path: path.join('functions', file),
     route,
@@ -165,6 +186,7 @@ function disposeFunctionEntry(file) {
 
   functionEntries.delete(file);
   functionMeta.delete(file);
+  functionMtimes.delete(file);
   functionHandlers.delete(entry.route);
 }
 
@@ -262,8 +284,21 @@ async function rebuildContext(functionsPath) {
   });
 
   await ctx.rebuild();
-  await ctx.watch();
+  // Do NOT call ctx.watch() — inotify/FSEvents are unreliable on Docker
+  // bind-mount volumes; content changes are detected via mtime polling
+  // instead (see the setInterval below in main()).
   buildContext = ctx;
+
+  // Re-snapshot mtimes so the poll has a fresh baseline after a context
+  // recreate.
+  for (const [file] of functionEntries) {
+    try {
+      functionMtimes.set(
+        file,
+        fs.statSync(path.join(functionsPath, file)).mtimeMs,
+      );
+    } catch {}
+  }
 }
 
 function findRoute(reqPath) {
@@ -348,23 +383,22 @@ const main = async () => {
     await scheduleRebuild(functionsPath);
   }
 
-  // Poll for new/deleted function files. Filesystem events (chokidar/inotify)
-  // are unreliable over Docker volume mounts — add/unlink all arrive as
-  // "change", so we periodically re-discover and diff instead. When the entry
-  // set changes, the esbuild context is recreated with the new entry points;
-  // edits inside existing functions are picked up by ctx.watch() without a
-  // recreate.
+  // Poll for new/deleted files and content changes. Filesystem events
+  // (inotify/FSEvents) are unreliable over Docker bind-mount volumes, so we
+  // poll instead: entry-set changes recreate the esbuild context; content
+  // changes (mtime diff) trigger an incremental rebuild on the existing
+  // context.
   setInterval(async () => {
     const currentFiles = new Set(discoverFunctions(functionsPath));
     const knownFiles = new Set(functionEntries.keys());
 
-    let changed = false;
+    let entrySetChanged = false;
 
     for (const file of currentFiles) {
       if (!knownFiles.has(file)) {
         serverLog('INFO', fileToRoute(file), `New function detected: ${file}`);
         prepareFunctionEntry(functionsPath, file);
-        changed = true;
+        entrySetChanged = true;
       }
     }
 
@@ -373,15 +407,41 @@ const main = async () => {
         const route = fileToRoute(file);
         disposeFunctionEntry(file);
         serverLog('INFO', route, `Removed (${file} deleted)`);
-        changed = true;
+        entrySetChanged = true;
       }
     }
 
-    if (changed) {
+    if (entrySetChanged) {
       try {
         await scheduleRebuild(functionsPath);
       } catch (err) {
         serverLog('ERROR', '', 'Failed to rebuild context:', err);
+      }
+      // rebuildContext re-snapshots all mtimes, so skip content-change check.
+      return;
+    }
+
+    // Content-change detection: check mtime of every known function file.
+    // This replaces ctx.watch() which relied on inotify — broken on Docker
+    // bind-mount volumes.
+    let contentChanged = false;
+    for (const [file, entry] of functionEntries) {
+      try {
+        const mtimeMs = fs.statSync(path.join(functionsPath, file)).mtimeMs;
+        const prev = functionMtimes.get(file);
+        if (prev !== undefined && mtimeMs !== prev) {
+          functionMtimes.set(file, mtimeMs);
+          contentChanged = true;
+          serverLog('INFO', entry.route, `Changed: ${file}`);
+        }
+      } catch {}
+    }
+
+    if (contentChanged) {
+      try {
+        await scheduleIncrementalRebuild();
+      } catch (err) {
+        serverLog('ERROR', '', 'Incremental rebuild failed:', err);
       }
     }
   }, 1000);


### PR DESCRIPTION
## What

Resolves #4233 — Functions fail to hot-reload on content changes during local development.

## Why

Currently, `esbuild`'s `ctx.watch()` relies on `inotify` (Linux) or `FSEvents` (macOS) to detect filesystem events. These events do not propagate reliably through Docker bind-mount volumes, which is the exact mechanism `nhost up` uses to mount the local workspace into the functions container. 

The server already had a 1-second polling loop in place to handle structural changes (new or deleted files) for this exact reason, but content changes to existing files were still falling back to the broken `ctx.watch()` implementation.

## How

- **Removed `ctx.watch()` entirely:** It provides no value inside the Docker volume constraints.
- **Unified Change Detection:** Extended the existing 1-second `setInterval` loop to track and compare `mtimeMs` for all known source files.
- **Zero-Overhead Rebuilds:** When an mtime diff is detected, the poller triggers `scheduleIncrementalRebuild()`. This explicitly re-uses the existing esbuild `buildContext`, avoiding the heavy memory/CPU overhead of disposing and recreating the AST/context.
- **Safe Baselines:** Context recreates (which happen on entry-set changes) now safely re-snapshot all `mtimes` to ensure the next poll starts with a clean baseline.

## Testing

*(Testing via local Node.js environment replacing Docker volume injection)*

**Before:**
Saving an existing function file resulted in no build logs, and subsequent requests returned stale responses.

**After:**
Function changes are detected within ~1s and correctly trigger an incremental esbuild reload.

<img width="953" height="286" alt="Screenshot 2026-06-13 at 1 43 16 PM" src="https://github.com/user-attachments/assets/ea04ed45-8f30-4999-a1dc-2a7136113220" />
<img width="948" height="161" alt="Screenshot 2026-06-13 at 1 43 42 PM" src="https://github.com/user-attachments/assets/9f450b0c-56d8-458c-bde7-99f5f980ee07" />


### Checklist

- [x] No breaking changes
- [x] Tests pass
- [ ] New features have new tests
- [ ] Documentation is updated (if applicable)
- [x] Title of the PR is in the correct format (see below)