### PR TITLE
feat(examples): add OAuth account linking to react demo

### DIFF
--- a/examples/demos/backend/nhost/metadata/databases/default/tables/auth_user_providers.yaml
+++ b/examples/demos/backend/nhost/metadata/databases/default/tables/auth_user_providers.yaml
@@ -46,3 +46,14 @@ object_relationships:
   - name: user
     using:
       foreign_key_constraint_on: user_id
+select_permissions:
+  - role: user
+    permission:
+      columns:
+        - id
+        - provider_id
+        - user_id
+      filter:
+        user_id:
+          _eq: X-Hasura-User-Id
+    comment: ""

--- a/examples/demos/react-demo/README.md
+++ b/examples/demos/react-demo/README.md
@@ -6,6 +6,7 @@ This demo application showcases how to use the Nhost SDK with React.
 
 - **Authentication** — Sign up, sign in, and sign out with multiple methods (email/password, magic link, GitHub OAuth, WebAuthn)
 - **Multi-factor Authentication** — TOTP-based MFA and WebAuthn security keys
+- **OAuth account linking** — Link an additional OAuth provider (GitHub) to an existing account from the profile page
 - **Protected routes** — Centralized authentication checks using layout routes
 - **User profile management** — Display name, email, roles, session info, password change
 - **Todo management** — Full CRUD with GraphQL backend, stale todo detection (visual indicators and "mark as active" action)
@@ -37,13 +38,14 @@ This demo application showcases how to use the Nhost SDK with React.
 | `/signin/mfa` | MFA verification |
 | `/signup` | Sign up with multiple methods |
 | `/verify` | Email verification callback |
+| `/connect/callback` | OAuth account-linking (connect) callback — reports success/failure |
 | `/oauth2/consent` | OAuth2 authorization consent page |
 
 ### Protected Routes (require authentication)
 
 | Path | Description |
 |------|-------------|
-| `/profile` | User profile, session info, MFA settings, security keys, password change |
+| `/profile` | User profile, session info, MFA settings, security keys, connected accounts, password change |
 | `/todos` | Todo list management (CRUD), stale todo indicators |
 | `/upload` | File upload and management |
 | `/communities` | Community management with file sharing, inline description editing |
@@ -70,6 +72,10 @@ The application uses a `ProtectedRoute` component (in `/src/components/Protected
 - **Magic link** — Passwordless email-based authentication
 - **GitHub OAuth** — Social login via GitHub
 - **WebAuthn** — Passwordless authentication with security keys or biometrics
+
+### Account Linking
+
+The `LinkedAccounts` component on the profile page lets a signed-in user link an additional OAuth provider (GitHub) to their existing account instead of creating a separate one. It starts the provider "connect" flow by passing the current access token as the `connect` parameter, then Auth redirects back to `/connect/callback`, which reports success or failure. Already-linked providers are read from the user's `userProviders` relationship so the UI shows "Connected" once linked. When the server sets `AUTH_REQUIRE_ELEVATED_CLAIM`, linking requires an elevated session.
 
 ## OAuth2
 

--- a/examples/demos/react-demo/src/App.tsx
+++ b/examples/demos/react-demo/src/App.tsx
@@ -11,6 +11,7 @@ import Navigation from './components/Navigation';
 import ProtectedRoute from './components/ProtectedRoute';
 import { AuthProvider } from './lib/nhost/AuthProvider';
 import Communities from './pages/Communities';
+import ConnectCallback from './pages/ConnectCallback';
 import Consent from './pages/Consent';
 import Functions from './pages/Functions';
 import Home from './pages/Home';
@@ -63,6 +64,7 @@ const router = createBrowserRouter(
       />
       <Route path="signup" element={<SignUp />} />
       <Route path="verify" element={<Verify />} />
+      <Route path="connect/callback" element={<ConnectCallback />} />
       <Route path="oauth2/consent" element={<Consent />} />
       <Route element={<ProtectedRoute />}>
         <Route path="profile" element={<Profile />} />

--- a/examples/demos/react-demo/src/components/LinkedAccounts.tsx
+++ b/examples/demos/react-demo/src/components/LinkedAccounts.tsx
@@ -1,0 +1,67 @@
+import type { JSX } from 'react';
+import { useAuth } from '../lib/nhost/AuthProvider';
+
+/**
+ * LinkedAccounts lets an already–authenticated user link an additional OAuth
+ * provider to their existing account (the provider "connect" flow).
+ *
+ * Unlike social sign-in, this passes the current access token as the `connect`
+ * parameter so Auth links the provider identity onto the logged-in user instead
+ * of creating/looking up a separate account. No PKCE code is exchanged on
+ * return — Auth redirects straight back to `redirectTo` with `?state=` (success)
+ * or `?error=...&errorDescription=...` (failure), which `ConnectCallback`
+ * renders.
+ *
+ * When the server is configured with `AUTH_REQUIRE_ELEVATED_CLAIM`, linking
+ * requires an elevated session, mirroring the other sensitive endpoints.
+ */
+export default function LinkedAccounts(): JSX.Element {
+  const { nhost, session } = useAuth();
+
+  const handleLink = (provider: 'github'): void => {
+    const accessToken = session?.accessToken;
+    if (!accessToken) return;
+
+    const origin = window.location.origin;
+
+    const url = nhost.auth.signInProviderURL(provider, {
+      // Marks this as a link of the current account rather than a new sign-in.
+      connect: accessToken,
+      redirectTo: `${origin}/connect/callback`,
+      // Echoed back as `?state=` so the callback page can name the provider.
+      state: provider,
+    });
+
+    window.location.href = url;
+  };
+
+  return (
+    <div className="glass-card p-8 mb-6">
+      <h3 className="text-xl mb-4">Connected Accounts</h3>
+      <p className="mb-6 text-sm" style={{ color: 'var(--text-muted)' }}>
+        Link an additional OAuth provider to your existing account. If the
+        server requires elevated permissions, you'll need an elevated session to
+        link.
+      </p>
+
+      <button
+        type="button"
+        onClick={() => handleLink('github')}
+        className="btn btn-secondary w-full flex items-center justify-center gap-2"
+      >
+        <svg
+          xmlns="http://www.w3.org/2000/svg"
+          width="20"
+          height="20"
+          viewBox="0 0 24 24"
+          fill="currentColor"
+          role="img"
+          aria-label="GitHub logo"
+        >
+          <path d="M12 0c-6.626 0-12 5.373-12 12 0 5.302 3.438 9.8 8.207 11.387.599.111.793-.261.793-.577v-2.234c-3.338.726-4.033-1.416-4.033-1.416-.546-1.387-1.333-1.756-1.333-1.756-1.089-.745.083-.729.083-.729 1.205.084 1.839 1.237 1.839 1.237 1.07 1.834 2.807 1.304 3.492.997.107-.775.418-1.305.762-1.604-2.665-.305-5.467-1.334-5.467-5.931 0-1.311.469-2.381 1.236-3.221-.124-.303-.535-1.524.117-3.176 0 0 1.008-.322 3.301 1.23.957-.266 1.983-.399 3.003-.404 1.02.005 2.047.138 3.006.404 2.291-1.552 3.297-1.23 3.297-1.23.653 1.653.242 2.874.118 3.176.77.84 1.235 1.911 1.235 3.221 0 4.609-2.807 5.624-5.479 5.921.43.372.823 1.102.823 2.222v3.293c0 .319.192.694.801.576 4.765-1.589 8.199-6.086 8.199-11.386 0-6.627-5.373-12-12-12z" />
+        </svg>
+        Link GitHub
+      </button>
+    </div>
+  );
+}

--- a/examples/demos/react-demo/src/components/LinkedAccounts.tsx
+++ b/examples/demos/react-demo/src/components/LinkedAccounts.tsx
@@ -1,9 +1,12 @@
-import type { JSX } from 'react';
+import type { ErrorResponse } from '@nhost/nhost-js/auth';
+import type { FetchError, FetchResponse } from '@nhost/nhost-js/fetch';
+import { type JSX, useCallback, useEffect, useState } from 'react';
 import { useAuth } from '../lib/nhost/AuthProvider';
 
 /**
  * LinkedAccounts lets an already–authenticated user link an additional OAuth
- * provider to their existing account (the provider "connect" flow).
+ * provider to their existing account (the provider "connect" flow) and shows
+ * which providers are already connected.
  *
  * Unlike social sign-in, this passes the current access token as the `connect`
  * parameter so Auth links the provider identity onto the logged-in user instead
@@ -12,11 +15,69 @@ import { useAuth } from '../lib/nhost/AuthProvider';
  * or `?error=...&errorDescription=...` (failure), which `ConnectCallback`
  * renders.
  *
+ * The linked state is read from the user's `userProviders` relationship so the
+ * UI shows "Connected" once a provider is linked rather than always offering to
+ * link again.
+ *
  * When the server is configured with `AUTH_REQUIRE_ELEVATED_CLAIM`, linking
  * requires an elevated session, mirroring the other sensitive endpoints.
  */
+
+interface LinkedProvidersResponse {
+  data?: {
+    user?: {
+      userProviders: Array<{
+        id: string;
+        providerId: string;
+      }>;
+    };
+  };
+}
+
 export default function LinkedAccounts(): JSX.Element {
-  const { nhost, session } = useAuth();
+  const { nhost, user, session } = useAuth();
+  const [isGithubLinked, setIsGithubLinked] = useState<boolean>(false);
+  const [isLoading, setIsLoading] = useState<boolean>(true);
+  const [error, setError] = useState<string | null>(null);
+
+  // Load the providers already linked to the current account so the UI can
+  // reflect the real state instead of always offering to link.
+  const fetchLinkedProviders = useCallback(async (): Promise<void> => {
+    if (!user?.id) return;
+
+    setError(null);
+
+    try {
+      const response: FetchResponse<LinkedProvidersResponse> =
+        await nhost.graphql.request({
+          query: `
+            query GetLinkedProviders($userId: uuid!) {
+              user(id: $userId) {
+                userProviders {
+                  id
+                  providerId
+                }
+              }
+            }
+          `,
+          variables: {
+            userId: user.id,
+          },
+        });
+
+      const providers = response.body?.data?.user?.userProviders ?? [];
+      setIsGithubLinked(providers.some((p) => p.providerId === 'github'));
+    } catch (err) {
+      const error = err as FetchError<ErrorResponse>;
+      setError(`Failed to load connected accounts: ${error.message}`);
+    } finally {
+      setIsLoading(false);
+    }
+  }, [nhost, user?.id]);
+
+  useEffect(() => {
+    void fetchLinkedProviders();
+  }, [fetchLinkedProviders]);
 
   const handleLink = (provider: 'github'): void => {
     const accessToken = session?.accessToken;
@@ -39,29 +100,43 @@ export default function LinkedAccounts(): JSX.Element {
     <div className="glass-card p-8 mb-6">
       <h3 className="text-xl mb-4">Connected Accounts</h3>
       <p className="mb-6 text-sm" style={{ color: 'var(--text-muted)' }}>
-        Link an additional OAuth provider to your existing account. If the
-        server requires elevated permissions, you'll need an elevated session to
-        link.
+        Link an additional OAuth provider to your existing account. 
       </p>
 
-      <button
-        type="button"
-        onClick={() => handleLink('github')}
-        className="btn btn-secondary w-full flex items-center justify-center gap-2"
-      >
-        <svg
-          xmlns="http://www.w3.org/2000/svg"
-          width="20"
-          height="20"
-          viewBox="0 0 24 24"
-          fill="currentColor"
-          role="img"
-          aria-label="GitHub logo"
-        >
-          <path d="M12 0c-6.626 0-12 5.373-12 12 0 5.302 3.438 9.8 8.207 11.387.599.111.793-.261.793-.577v-2.234c-3.338.726-4.033-1.416-4.033-1.416-.546-1.387-1.333-1.756-1.333-1.756-1.089-.745.083-.729.083-.729 1.205.084 1.839 1.237 1.839 1.237 1.07 1.834 2.807 1.304 3.492.997.107-.775.418-1.305.762-1.604-2.665-.305-5.467-1.334-5.467-5.931 0-1.311.469-2.381 1.236-3.221-.124-.303-.535-1.524.117-3.176 0 0 1.008-.322 3.301 1.23.957-.266 1.983-.399 3.003-.404 1.02.005 2.047.138 3.006.404 2.291-1.552 3.297-1.23 3.297-1.23.653 1.653.242 2.874.118 3.176.77.84 1.235 1.911 1.235 3.221 0 4.609-2.807 5.624-5.479 5.921.43.372.823 1.102.823 2.222v3.293c0 .319.192.694.801.576 4.765-1.589 8.199-6.086 8.199-11.386 0-6.627-5.373-12-12-12z" />
-        </svg>
-        Link GitHub
-      </button>
+      {error && <div className="alert alert-error mb-4">{error}</div>}
+
+      <div className="flex items-center justify-between gap-3">
+        <div className="flex items-center gap-2">
+          <svg
+            xmlns="http://www.w3.org/2000/svg"
+            width="20"
+            height="20"
+            viewBox="0 0 24 24"
+            fill="currentColor"
+            role="img"
+            aria-label="GitHub logo"
+          >
+            <path d="M12 0c-6.626 0-12 5.373-12 12 0 5.302 3.438 9.8 8.207 11.387.599.111.793-.261.793-.577v-2.234c-3.338.726-4.033-1.416-4.033-1.416-.546-1.387-1.333-1.756-1.333-1.756-1.089-.745.083-.729.083-.729 1.205.084 1.839 1.237 1.839 1.237 1.07 1.834 2.807 1.304 3.492.997.107-.775.418-1.305.762-1.604-2.665-.305-5.467-1.334-5.467-5.931 0-1.311.469-2.381 1.236-3.221-.124-.303-.535-1.524.117-3.176 0 0 1.008-.322 3.301 1.23.957-.266 1.983-.399 3.003-.404 1.02.005 2.047.138 3.006.404 2.291-1.552 3.297-1.23 3.297-1.23.653 1.653.242 2.874.118 3.176.77.84 1.235 1.911 1.235 3.221 0 4.609-2.807 5.624-5.479 5.921.43.372.823 1.102.823 2.222v3.293c0 .319.192.694.801.576 4.765-1.589 8.199-6.086 8.199-11.386 0-6.627-5.373-12-12-12z" />
+          </svg>
+          <span>GitHub</span>
+        </div>
+
+        {isLoading ? (
+          <span className="text-sm" style={{ color: 'var(--text-muted)' }}>
+            Checking…
+          </span>
+        ) : isGithubLinked ? (
+          <span className="font-semibold text-green-500">Connected</span>
+        ) : (
+          <button
+            type="button"
+            onClick={() => handleLink('github')}
+            className="btn btn-secondary flex items-center justify-center gap-2"
+          >
+            Link GitHub
+          </button>
+        )}
+      </div>
     </div>
   );
 }

--- a/examples/demos/react-demo/src/components/LinkedAccounts.tsx
+++ b/examples/demos/react-demo/src/components/LinkedAccounts.tsx
@@ -100,7 +100,7 @@ export default function LinkedAccounts(): JSX.Element {
     <div className="glass-card p-8 mb-6">
       <h3 className="text-xl mb-4">Connected Accounts</h3>
       <p className="mb-6 text-sm" style={{ color: 'var(--text-muted)' }}>
-        Link an additional OAuth provider to your existing account. 
+        Link an additional OAuth provider to your existing account.
       </p>
 
       {error && <div className="alert alert-error mb-4">{error}</div>}

--- a/examples/demos/react-demo/src/pages/ConnectCallback.tsx
+++ b/examples/demos/react-demo/src/pages/ConnectCallback.tsx
@@ -1,0 +1,68 @@
+import { type JSX, useEffect, useState } from 'react';
+import { useLocation, useNavigate } from 'react-router-dom';
+
+/**
+ * ConnectCallback renders the result of the provider "connect" (account
+ * linking) flow.
+ *
+ * The connect flow does NOT return an authorization code — Auth redirects back
+ * here directly after linking. Success looks like `?state=<provider>`; failure
+ * adds `?error=<code>&errorDescription=<text>`. There is nothing to exchange,
+ * so (unlike `/verify`) we only read the query params and report the outcome.
+ */
+export default function ConnectCallback(): JSX.Element {
+  const location = useLocation();
+  const navigate = useNavigate();
+
+  const params = new URLSearchParams(location.search);
+  const error = params.get('error');
+  const errorDescription = params.get('errorDescription');
+  // We pass the provider id as `state` when starting the link.
+  const provider = params.get('state');
+
+  const [status] = useState<'success' | 'error'>(error ? 'error' : 'success');
+
+  useEffect(() => {
+    if (status === 'success') {
+      const timer = setTimeout(() => navigate('/profile'), 2000);
+      return () => clearTimeout(timer);
+    }
+    return undefined;
+  }, [status, navigate]);
+
+  const providerLabel = provider === 'github' ? 'GitHub' : provider || 'provider';
+
+  return (
+    <div>
+      <h1>Account Linking</h1>
+
+      <div className="page-center">
+        {status === 'success' ? (
+          <div>
+            <p className="verification-status">✓ {providerLabel} linked!</p>
+            <p>Your account is now connected. Redirecting to your profile...</p>
+          </div>
+        ) : (
+          <div>
+            <p className="verification-status error">Linking failed</p>
+            <p className="margin-bottom">
+              {errorDescription || error || 'Unknown error'}
+            </p>
+            <p className="margin-bottom text-sm" style={{ color: 'var(--text-muted)' }}>
+              If the server requires elevated permissions, you must elevate your
+              session (e.g. with a security key) before linking a provider.
+            </p>
+
+            <button
+              type="button"
+              onClick={() => navigate('/profile')}
+              className="btn btn-secondary"
+            >
+              Back to Profile
+            </button>
+          </div>
+        )}
+      </div>
+    </div>
+  );
+}

--- a/examples/demos/react-demo/src/pages/ConnectCallback.tsx
+++ b/examples/demos/react-demo/src/pages/ConnectCallback.tsx
@@ -30,7 +30,8 @@ export default function ConnectCallback(): JSX.Element {
     return undefined;
   }, [status, navigate]);
 
-  const providerLabel = provider === 'github' ? 'GitHub' : provider || 'provider';
+  const providerLabel =
+    provider === 'github' ? 'GitHub' : provider || 'provider';
 
   return (
     <div>
@@ -48,7 +49,10 @@ export default function ConnectCallback(): JSX.Element {
             <p className="margin-bottom">
               {errorDescription || error || 'Unknown error'}
             </p>
-            <p className="margin-bottom text-sm" style={{ color: 'var(--text-muted)' }}>
+            <p
+              className="margin-bottom text-sm"
+              style={{ color: 'var(--text-muted)' }}
+            >
               If the server requires elevated permissions, you must elevate your
               session (e.g. with a security key) before linking a provider.
             </p>

--- a/examples/demos/react-demo/src/pages/Profile.tsx
+++ b/examples/demos/react-demo/src/pages/Profile.tsx
@@ -3,6 +3,7 @@ import type { FetchError, FetchResponse } from '@nhost/nhost-js/fetch';
 import type { JSX } from 'react';
 import { useEffect, useState } from 'react';
 import ChangePassword from '../components/ChangePassword';
+import LinkedAccounts from '../components/LinkedAccounts';
 import MFASettings from '../components/MFASettings';
 import SecurityKeys from '../components/SecurityKeys';
 import { useAuth } from '../lib/nhost/AuthProvider';
@@ -112,6 +113,8 @@ export default function Profile(): JSX.Element {
       />
 
       <SecurityKeys />
+
+      <LinkedAccounts />
 
       <ChangePassword />
     </div>


### PR DESCRIPTION
Adds an OAuth account-linking demo to the react example.

- New "Connected Accounts" panel on the Profile page to link a provider (GitHub) to the current account and show its linked state
- New `connect/callback` page that renders the link success/error result
- Grant the `user` role self-scoped select on `auth_user_providers` so the demo can read which providers are linked
<img width="1184" height="374" alt="Screenshot_20260614_155047" src="https://github.com/user-attachments/assets/2495c5eb-a9fe-4a28-9315-d8b03eaeedde" />
