### PR TITLE
fix(dashboard): enable e2e tests

### DIFF
--- a/.github/actions/setup-nix/action.yml
+++ b/.github/actions/setup-nix/action.yml
@@ -29,10 +29,16 @@ runs:
           experimental-features = nix-command flakes
           sandbox = relaxed
           access-tokens = github.com=${{ inputs.GITHUB_TOKEN }}
-          substituters = https://cache.nixos.org/?priority=40 s3://nhost-nix-cache?endpoint=https://14bc02755b64adb7c8c62b5420d0a457.eu.r2.cloudflarestorage.com&region=auto&priority=50
+          substituters = https://cache.nixos.org/?priority=40 s3://nhost-nix-cache?endpoint=https://14bc02755b64adb7c8c62b5420d0a457.eu.r2.cloudflarestorage.com&region=auto&priority=10
           trusted-public-keys = cache.nixos.org-1:6NCHdD59X431o0gWypbMrAURkbJ16ZPMQFGspcDShjY= ${{ inputs.NIX_CACHE_PUB_KEY }}
           keep-env-derivations = true
           keep-outputs = true
+          # Build from source when a substitute fails (e.g. a corrupt narinfo
+          # upstream) instead of aborting the job. See nixops/project.nix where
+          # geos is cached: this lets the first build past a bad cache.nixos.org
+          # entry and into our R2 cache, after which the priority=10 nhost
+          # substituter serves it.
+          fallback = true
 
     - name: "Configure Nix daemon cache access and build collector"
       # The Nix daemon runs as root and doesn't inherit AWS_* env vars

--- a/dashboard/e2e/database/permissions-graphql-verification.test.ts
+++ b/dashboard/e2e/database/permissions-graphql-verification.test.ts
@@ -4,13 +4,13 @@ import { TEST_ORGANIZATION_SLUG, TEST_PROJECT_SUBDOMAIN } from '@/e2e/env';
 import { expect, test } from '@/e2e/fixtures/auth-hook';
 import {
   clickPermissionButton,
-  getGraphQLResult,
   navigateToGraphQLPlayground,
   navigateToSQLEditor,
   prepareTable,
   runGraphQLQuery,
   runSQL,
-  setGraphQLHeaders,
+  selectGraphQLRole,
+  waitForPlaygroundRolesLoaded,
 } from '@/e2e/utils';
 
 const tableName = snakeCase(faker.lorem.words(3));
@@ -58,29 +58,40 @@ test.describe
       await context.close();
     });
 
+    test.afterAll(async ({ browser }) => {
+      // Drop the table the suite created so a CI retry of beforeAll does not
+      // hit "table already exists" and staging is not left polluted.
+      const context = await browser.newContext({
+        storageState: 'e2e/.auth/user.json',
+      });
+      const page = await context.newPage();
+
+      await navigateToSQLEditor({ page });
+      await runSQL({
+        page,
+        sql: `DROP TABLE IF EXISTS public.${tableName} CASCADE;`,
+      });
+
+      await context.close();
+    });
+
     test('public role should not be able to query books without permissions', async ({
       authenticatedNhostPage: page,
     }) => {
+      const rolesLoaded = waitForPlaygroundRolesLoaded(page);
       await navigateToGraphQLPlayground({ page });
+      await rolesLoaded;
 
-      await setGraphQLHeaders({
-        page,
-        headers: { 'x-hasura-role': 'public' },
-      });
+      await selectGraphQLRole({ page, role: 'public' });
 
       await runGraphQLQuery({
         page,
         query: `query { ${tableName} { id title genre status } }`,
       });
 
-      const result = await getGraphQLResult({ page });
-
-      const hasError =
-        result.includes('error') ||
-        result.includes('not found in type') ||
-        result.includes('not exist') ||
-        result.includes('permission');
-      expect(hasError).toBe(true);
+      await expect(page.getByLabel('Result Window')).toContainText(
+        /field '.*' not found in type|not exist|permission/i,
+      );
     });
 
     test('public role should only see books matching custom check', async ({
@@ -114,19 +125,19 @@ test.describe
 
       await page.getByText('Add check').click();
       await columnSearch.fill('genre');
-      await columnSearch.press('Enter');
+      await page.locator('[cmdk-item][data-value="genre"]').click();
 
       await page.getByText('Select variable...').click();
       await variableSearch.fill('fiction');
-      await page.getByRole('option', { name: /fiction/i }).click();
+      await page.locator('[cmdk-item][data-value="create"]').click();
 
       await page.getByRole('button', { name: /^add$/i }).click();
       await columnSearch.fill('status');
-      await columnSearch.press('Enter');
+      await page.locator('[cmdk-item][data-value="status"]').click();
 
       await page.getByText('Select variable...').click();
       await variableSearch.fill('published');
-      await page.getByRole('option', { name: /published/i }).click();
+      await page.locator('[cmdk-item][data-value="create"]').click();
 
       await page.getByRole('button', { name: /select all/i }).click();
       await page.getByRole('button', { name: /save/i }).click();
@@ -135,22 +146,20 @@ test.describe
         page.getByText(/permission has been saved successfully/i),
       ).toBeVisible();
 
+      const rolesLoaded = waitForPlaygroundRolesLoaded(page);
       await navigateToGraphQLPlayground({ page });
+      await rolesLoaded;
 
-      await setGraphQLHeaders({
-        page,
-        headers: { 'x-hasura-role': 'public' },
-      });
+      await selectGraphQLRole({ page, role: 'public' });
 
       await runGraphQLQuery({
         page,
         query: `query { ${tableName} { id title genre status } }`,
       });
 
-      const result = await getGraphQLResult({ page });
-
-      expect(result).toContain('The Great Gatsby');
-      expect(result).not.toContain('A Brief History of Time');
-      expect(result).not.toContain('Draft Novel');
+      const resultWindow = page.getByLabel('Result Window');
+      await expect(resultWindow).toContainText('The Great Gatsby');
+      await expect(resultWindow).not.toContainText('A Brief History of Time');
+      await expect(resultWindow).not.toContainText('Draft Novel');
     });
   });

--- a/dashboard/e2e/onboarding/onboarding.test.ts
+++ b/dashboard/e2e/onboarding/onboarding.test.ts
@@ -3,13 +3,20 @@ import type { Page } from '@playwright/test';
 import { expect, test } from '@/e2e/fixtures/auth-hook';
 import {
   cleanupOnboardingTestIfNeeded,
-  getCardExpiration,
+  deleteOrganization,
+  fillStripeCheckout,
   getOrgSlugFromUrl,
+  gotoOrgPageViaSwitcher,
   gotoUrl,
   loginWithFreeUser,
+  selectOrgByName,
 } from '@/e2e/utils';
 
 let page: Page;
+
+function generateOrganizationName() {
+  return faker.lorem.words(3).slice(0, 32);
+}
 
 test.beforeAll(async ({ browser }) => {
   await cleanupOnboardingTestIfNeeded();
@@ -19,210 +26,102 @@ test.beforeAll(async ({ browser }) => {
 });
 
 test('user should be able to finish onboarding', async () => {
-  await gotoUrl(page, `/onboarding`);
-  await expect(page.getByText('Welcome to Nhost!')).toBeVisible();
-  const organizationName = faker.lorem.words(3).slice(0, 32);
+  await gotoUrl(page, '/onboarding');
+  await expect(
+    page.getByRole('heading', { name: 'Welcome to Nhost!' }),
+  ).toBeVisible();
+
+  const organizationName = generateOrganizationName();
 
   await page.getByLabel('Organization Name').fill(organizationName);
-  await page.getByText('Select organization type', { exact: true }).click();
-  await page.getByText('Personal Project').nth(1).click();
+
+  await page.getByLabel(/describe your organization/i).click();
+  await page.getByRole('option', { name: 'Personal Project' }).click();
 
   await page.getByText('Pro', { exact: true }).click();
 
-  await page.getByText('Create Organization').click();
+  await page.getByRole('button', { name: 'Create Organization' }).click();
 
-  const stripeFrame = page
-    .frameLocator('iframe[name="embedded-checkout"]')
-    .first();
-  stripeFrame.getByText('Subscribe to Nhost');
-  await stripeFrame.getByLabel('Email').fill(faker.internet.email());
+  await fillStripeCheckout(page);
 
-  await stripeFrame
-    .getByPlaceholder('1234 1234 1234 1234')
-    .fill('4242424242424242');
-
-  await stripeFrame.getByPlaceholder('MM / YY').fill(getCardExpiration());
-  await stripeFrame.getByPlaceholder('CVC').fill('123');
-  await stripeFrame
-    .getByPlaceholder('Full name on card')
-    .fill('EndyTo EndyTest');
-  await stripeFrame.locator('#billingCountry').scrollIntoViewIfNeeded();
-
-  const manualAddressLink = stripeFrame.getByText('Enter address manually');
-  if (await manualAddressLink.isVisible()) {
-    await stripeFrame.getByPlaceholder('Address', { exact: true }).click();
-    await manualAddressLink.click();
-    await stripeFrame
-      .getByPlaceholder('Address line 1', { exact: true })
-      .fill('123 Main Street');
-    await stripeFrame
-      .getByPlaceholder('City', { exact: true })
-      .fill('Springfield');
-    await stripeFrame.getByPlaceholder('ZIP', { exact: true }).fill('62701');
-  }
-
-  const stripePassToggle = stripeFrame.locator('#enableStripePass');
-  if (await stripePassToggle.isChecked()) {
-    await stripePassToggle.click({ force: true });
-  }
-
-  stripeFrame
-    .getByTestId('hosted-payment-submit-button')
-    .scrollIntoViewIfNeeded();
-  await stripeFrame
-    .getByTestId('hosted-payment-submit-button')
-    .click({ force: true });
-
+  await page.waitForURL('**/onboarding/project', { timeout: 60000 });
   await expect(
-    page.getByText('Processing new organization request').first(),
-  ).toBeVisible();
-  await page.waitForSelector(
-    'div:has-text("Organization created successfully. Redirecting...")',
-  );
+    page.getByRole('heading', { name: 'Create Your First Project' }),
+  ).toBeVisible({ timeout: 30000 });
 
-  await expect(page.getByText('Create Your First Project')).toBeVisible();
-
-  const projectName = faker.lorem.words(3).slice(0, 32);
+  const projectName = generateOrganizationName();
   await page.getByLabel('Project Name').fill(projectName);
 
-  await page.getByText('Create Project', { exact: true }).click();
+  await page.getByRole('button', { name: 'Create Project' }).click();
 
-  await expect(page.getByText('Creating your project...')).toBeVisible();
-  await expect(page.getByText('Project created successfully!')).toBeVisible();
+  await expect(page.getByText('Project created successfully!')).toBeVisible({
+    timeout: 30000,
+  });
 
   await expect(page.getByText('Internal info')).toBeVisible();
 
-  await page.waitForSelector('h3:has-text("Project Health")', {
-    timeout: 180000,
-  });
+  await expect(
+    page.getByRole('heading', { name: 'Project Health' }),
+  ).toBeVisible({ timeout: 180000 });
 });
 
 test('should delete the new organization', async () => {
   const newOrgSlug = getOrgSlugFromUrl(page.url());
-  await gotoUrl(page, `/orgs/${newOrgSlug}/projects`);
-  await page.getByRole('link', { name: 'Settings' }).click();
-
-  await page.waitForSelector('h3:has-text("Delete Organization")');
-  await page.getByRole('button', { name: 'Delete' }).click();
-
-  await page.waitForSelector('h2:has-text("Delete Organization")');
-  await expect(page.getByTestId('deleteOrgButton')).toBeDisabled();
-
-  await page.getByLabel("I'm sure I want to delete this Organization").click();
-  await expect(page.getByTestId('deleteOrgButton')).toBeDisabled();
-  await page.getByLabel('I understand this action cannot be undone').click();
-  await expect(page.getByTestId('deleteOrgButton')).not.toBeDisabled();
-
-  await page.getByTestId('deleteOrgButton').click();
-
-  await page.waitForSelector('div:has-text("Deleting the organization")');
-  await page.waitForSelector(
-    'div:has-text("Successfully deleted the organization")',
-  );
-
-  await page.waitForSelector('h2:has-text("Welcome to Nhost!")');
+  await deleteOrganization(page, newOrgSlug);
 });
 
 test('should be able to upgrade an organization', async () => {
-  await gotoUrl(page, `/onboarding`);
-  expect(page.getByText('Welcome to Nhost!')).toBeVisible();
-  const organizationName = faker.lorem.words(3).slice(0, 32);
+  await gotoUrl(page, '/onboarding');
+  await expect(
+    page.getByRole('heading', { name: 'Welcome to Nhost!' }),
+  ).toBeVisible();
+
+  const organizationName = generateOrganizationName();
 
   await page.getByLabel('Organization Name').fill(organizationName);
-  await page.getByText('Select organization type', { exact: true }).click();
-  await page.getByText('Personal Project').nth(1).click();
 
-  await page.getByText('Create Organization').click();
+  await page.getByLabel(/describe your organization/i).click();
+  await page.getByRole('option', { name: 'Personal Project' }).click();
 
-  await page.waitForSelector(
-    'div:has-text("Organization created successfully!")',
-  );
-  await page.getByText('Select organization', { exact: true }).click();
-  await page.getByRole('option', { name: organizationName }).click();
+  await page.getByRole('button', { name: 'Create Organization' }).click();
 
-  await page.waitForSelector('h2:has-text("Welcome to Nhost!")');
-  await page.getByRole('link', { name: 'Billing' }).click();
+  await expect(
+    page.getByText('Organization created successfully!'),
+  ).toBeVisible({ timeout: 30000 });
 
-  await page.waitForSelector('h4:has-text("Subscription plan")');
-  await expect(page.getByText('Upgrade')).toBeEnabled();
-  await page.getByText('Upgrade').click();
-  await page.waitForSelector('h2:has-text("Upgrade Organization")');
+  await gotoUrl(page, '/', { expectRedirect: true });
+  const newOrgSlug = await selectOrgByName(page, organizationName);
+
+  await gotoOrgPageViaSwitcher(page, 'Billing');
+  await page.waitForURL(`**/orgs/${newOrgSlug}/billing`);
+
+  await expect(
+    page.getByRole('heading', { name: 'Subscription plan' }),
+  ).toBeVisible();
+
+  const upgradeButton = page.getByRole('button', { name: 'Upgrade' });
+  await expect(upgradeButton).toBeEnabled();
+  await upgradeButton.click();
+
+  await expect(
+    page.getByRole('heading', { name: /upgrade organization/i }),
+  ).toBeVisible();
 
   await page.getByText('Pro', { exact: true }).click();
 
   await page.getByTestId('upgradeOrgSubmitButton').click();
-  await page.waitForSelector('button[data-testid="upgradeOrgSubmitButton"]', {
-    state: 'hidden',
+  await expect(page.getByTestId('upgradeOrgSubmitButton')).toBeHidden();
+
+  await fillStripeCheckout(page);
+
+  await expect(page.getByTestId('message')).toHaveText(
+    'Upgrading organization',
+  );
+
+  await expect(page.getByTestId('message')).toBeHidden({ timeout: 60000 });
+  await expect(page.getByText('Spending Notifications')).toBeVisible({
+    timeout: 30000,
   });
 
-  const stripeFrame = page
-    .frameLocator('iframe[name="embedded-checkout"]')
-    .first();
-  stripeFrame
-    .locator('div[data-testid="product-summary"]')
-    .waitFor({ state: 'visible' });
-  await stripeFrame.getByLabel('Email').fill(faker.internet.email());
-
-  await stripeFrame
-    .getByPlaceholder('1234 1234 1234 1234')
-    .fill('4242424242424242');
-
-  await stripeFrame.getByPlaceholder('MM / YY').fill(getCardExpiration());
-  await stripeFrame.getByPlaceholder('CVC').fill('123');
-  await stripeFrame
-    .getByPlaceholder('Full name on card')
-    .fill('EndyTo EndyTest');
-  await stripeFrame.locator('#billingCountry').scrollIntoViewIfNeeded();
-
-  const manualAddressLink = stripeFrame.getByText('Enter address manually');
-  if (await manualAddressLink.isVisible()) {
-    await stripeFrame.getByPlaceholder('Address', { exact: true }).click();
-    await manualAddressLink.click();
-    await stripeFrame
-      .getByPlaceholder('Address line 1', { exact: true })
-      .fill('123 Main Street');
-    await stripeFrame
-      .getByPlaceholder('City', { exact: true })
-      .fill('Springfield');
-    await stripeFrame.getByPlaceholder('ZIP', { exact: true }).fill('62701');
-  }
-
-  const stripePassToggle = stripeFrame.locator('#enableStripePass');
-  if (await stripePassToggle.isChecked()) {
-    await stripePassToggle.click({ force: true });
-  }
-
-  stripeFrame
-    .getByTestId('hosted-payment-submit-button')
-    .scrollIntoViewIfNeeded();
-  await stripeFrame
-    .getByTestId('hosted-payment-submit-button')
-    .click({ force: true });
-  await page.waitForSelector('div:has-text("Upgrading organization")');
-  await page.waitForSelector(
-    'div:has-text("Organization has been upgraded successfully.")',
-  );
-  await page.waitForSelector('span:has-text("Spending Notifications")');
-
-  await page.getByRole('link', { name: 'Settings' }).click();
-
-  await page.waitForSelector('h3:has-text("Delete Organization")');
-  await page.getByRole('button', { name: 'Delete' }).click();
-
-  await page.waitForSelector('h2:has-text("Delete Organization")');
-  await expect(page.getByTestId('deleteOrgButton')).toBeDisabled();
-
-  await page.getByLabel("I'm sure I want to delete this Organization").click();
-  await expect(page.getByTestId('deleteOrgButton')).toBeDisabled();
-  await page.getByLabel('I understand this action cannot be undone').click();
-  await expect(page.getByTestId('deleteOrgButton')).not.toBeDisabled();
-
-  await page.getByTestId('deleteOrgButton').click();
-
-  await page.waitForSelector('div:has-text("Deleting the organization")');
-  await page.waitForSelector(
-    'div:has-text("Successfully deleted the organization")',
-  );
-
-  await page.waitForSelector('h2:has-text("Welcome to Nhost!")');
+  await deleteOrganization(page, newOrgSlug);
 });

--- a/dashboard/e2e/utils.ts
+++ b/dashboard/e2e/utils.ts
@@ -1,5 +1,5 @@
 import { faker } from '@faker-js/faker';
-import type { Page } from '@playwright/test';
+import type { FrameLocator, Page } from '@playwright/test';
 import { add, format } from 'date-fns-v4';
 import {
   TEST_ONBOARDING_USER,
@@ -275,14 +275,109 @@ export async function gotoAuthURL(page: Page) {
   await page.waitForURL(authUrl, { waitUntil: 'load' });
 }
 
-export async function gotoUrl(page: Page, url: string) {
+/**
+ * Navigates to a URL and waits for the page to settle.
+ *
+ * By default it asserts the browser stays on `url` (the correct behavior for a
+ * route that renders in place). Some routes — notably `/` — always redirect the
+ * user away (to onboarding or an org route), so `waitForURL(url)` would wait
+ * forever. Pass `expectRedirect: true` for those: the caller knows a redirect is
+ * coming, so we wait until the browser actually leaves `url`.
+ *
+ * The redirect away from `/` is client-side (an effect in the index page that
+ * runs after `useOrgs` resolves), so the initial document `load` fires while the
+ * page is still on `/`. Waiting only for `load` returns on that intermediate
+ * state, and a caller that immediately drives the header (e.g. the org switcher)
+ * races the in-flight navigation, which tears down the just-opened popover. We
+ * therefore wait for the URL to settle on the redirect target before returning.
+ *
+ * @param page - The Playwright page object.
+ * @param url - The URL to navigate to.
+ * @param options - Optional settings.
+ * @param options.expectRedirect - Set when `url` is known to redirect elsewhere;
+ *   waits for the browser to leave `url` instead of asserting it stays.
+ */
+export async function gotoUrl(
+  page: Page,
+  url: string,
+  options: { expectRedirect?: boolean } = {},
+) {
   await page.goto(url);
+
+  if (options.expectRedirect) {
+    const target = new URL(url, page.url()).href;
+    await page.waitForURL((current) => current.href !== target, {
+      waitUntil: 'load',
+    });
+    return;
+  }
+
   await page.waitForURL(url, { waitUntil: 'load' });
 }
 
 export function getOrgSlugFromUrl(url: string) {
-  const orgSlug = url.split('/orgs/')[1].split('/projects/')[0];
+  const orgSlug = url.split('/orgs/')[1]?.split('/')[0];
   return orgSlug;
+}
+
+/**
+ * Selects an organization by its name via the header org switcher, the same way
+ * a user does, and waits until the URL carries the org's slug.
+ *
+ * The org name (what the user typed) is not the backend-assigned slug the routes
+ * are keyed by, so we drive the switcher to navigate and then read the slug off
+ * the resulting URL rather than looking it up out-of-band.
+ *
+ * @param page - The Playwright page object.
+ * @param orgName - The exact (unique) name of the organization to select.
+ * @returns A promise resolving to the organization's slug, parsed from the URL.
+ */
+export async function selectOrgByName(
+  page: Page,
+  orgName: string,
+): Promise<string> {
+  const switcher = page.getByTestId('org-switcher');
+  await expect(switcher).toBeVisible();
+
+  // The trigger is a Radix popover toggle: clicking it when the popover is
+  // already open closes it. Open it once, guarding on aria-expanded so a retry
+  // never accidentally toggles it shut.
+  if ((await switcher.getAttribute('aria-expanded')) !== 'true') {
+    await switcher.click();
+  }
+  const search = page.getByPlaceholder('Select organization...');
+  await expect(search).toBeVisible();
+
+  // The org list is fetched fresh on the page the redirect lands on, so a
+  // just-created org can appear a beat after the popover opens. Retry only the
+  // data-dependent part: refill the search and re-check for the option, without
+  // re-clicking (and thus toggling) the trigger.
+  await expect(async () => {
+    await search.fill('');
+    await search.fill(orgName);
+    await expect(page.getByRole('option', { name: orgName })).toBeVisible();
+  }).toPass();
+
+  await page.getByRole('option', { name: orgName }).click();
+  await page.waitForURL('**/orgs/*/projects');
+
+  return getOrgSlugFromUrl(page.url());
+}
+
+/**
+ * Navigates to a page within the currently selected organization via the header
+ * page switcher. Assumes the page is already on a route within the org.
+ *
+ * @param page - The Playwright page object.
+ * @param label - The visible label of the org page to navigate to.
+ * @returns A promise that resolves once the option has been selected.
+ */
+export async function gotoOrgPageViaSwitcher(
+  page: Page,
+  label: 'Billing' | 'Settings' | 'Members' | 'Projects',
+) {
+  await page.getByTestId('org-pages-switcher').click();
+  await page.getByRole('option', { name: label, exact: true }).click();
 }
 
 export function getCardExpiration() {
@@ -300,9 +395,104 @@ export async function loginWithFreeUser(page: Page) {
   await page.getByLabel('Password').fill(TEST_USER_PASSWORD);
   await page.getByRole('button', { name: /sign in/i }).click();
 
-  await page.waitForSelector('h2:has-text("Welcome to Nhost!")', {
-    timeout: 20000,
-  });
+  await expect(
+    page.getByRole('heading', { name: 'Welcome to Nhost!' }),
+  ).toBeVisible({ timeout: 20000 });
+}
+
+/**
+ * Fills and submits the Stripe embedded checkout form rendered inside the
+ * `embedded-checkout` iframe (used by both the onboarding paid-org flow and the
+ * billing upgrade flow). Stripe's hosted form mounts asynchronously and varies
+ * by region/experiment, so every interaction waits on the element it targets
+ * rather than assuming a fixed layout.
+ *
+ * @param page - The Playwright page object.
+ * @returns A promise that resolves once the payment has been submitted.
+ */
+export async function fillStripeCheckout(page: Page) {
+  const stripeFrame: FrameLocator = page
+    .locator('iframe[name="embedded-checkout"]')
+    .first()
+    .contentFrame();
+
+  const emailField = stripeFrame.getByLabel('Email');
+  await expect(emailField).toBeVisible({ timeout: 30000 });
+  await emailField.fill(faker.internet.email());
+
+  await stripeFrame
+    .getByPlaceholder('1234 1234 1234 1234')
+    .fill('4242424242424242');
+  await stripeFrame.getByPlaceholder('MM / YY').fill(getCardExpiration());
+  await stripeFrame.getByPlaceholder('CVC').fill('123');
+  await stripeFrame
+    .getByPlaceholder('Full name on card')
+    .fill('EndyTo EndyTest');
+  await stripeFrame.locator('#billingCountry').scrollIntoViewIfNeeded();
+
+  const manualAddressLink = stripeFrame.getByText('Enter address manually');
+  if (await manualAddressLink.isVisible()) {
+    await stripeFrame.getByPlaceholder('Address', { exact: true }).click();
+    await manualAddressLink.click();
+    await stripeFrame
+      .getByPlaceholder('Address line 1', { exact: true })
+      .fill('123 Main Street');
+    await stripeFrame
+      .getByPlaceholder('City', { exact: true })
+      .fill('Springfield');
+    await stripeFrame.getByPlaceholder('ZIP', { exact: true }).fill('62701');
+  }
+
+  const stripePassToggle = stripeFrame.locator('#enableStripePass');
+  if (await stripePassToggle.isChecked()) {
+    await stripePassToggle.click({ force: true });
+  }
+
+  const submitButton = stripeFrame.getByTestId('hosted-payment-submit-button');
+  await submitButton.scrollIntoViewIfNeeded();
+  await expect(submitButton).toBeEnabled();
+  await submitButton.click();
+}
+
+/**
+ * Deletes the organization the page is currently scoped to. Assumes the page is
+ * on a route within the organization (it navigates to its settings) and that
+ * the org is empty enough to be deletable. Drives the two-checkbox confirmation
+ * dialog and waits for the success toast and the redirect to the empty state.
+ *
+ * @param page - The Playwright page object.
+ * @param orgSlug - The slug of the organization to delete.
+ * @returns A promise that resolves once the organization has been deleted.
+ */
+export async function deleteOrganization(page: Page, orgSlug: string) {
+  await gotoOrgPageViaSwitcher(page, 'Settings');
+  await page.waitForURL(`**/orgs/${orgSlug}/settings`);
+
+  await expect(
+    page.getByRole('heading', { name: 'Delete Organization' }),
+  ).toBeVisible();
+  await page.getByRole('button', { name: 'Delete', exact: true }).click();
+
+  await expect(
+    page.getByRole('alertdialog').getByText('Delete Organization'),
+  ).toBeVisible();
+
+  const confirmButton = page.getByTestId('deleteOrgButton');
+  await expect(confirmButton).toBeDisabled();
+
+  await page.getByLabel("I'm sure I want to delete this Organization").check();
+  await expect(confirmButton).toBeDisabled();
+  await page.getByLabel('I understand this action cannot be undone').check();
+  await expect(confirmButton).toBeEnabled();
+
+  await confirmButton.click();
+
+  await expect(
+    page.getByText('Successfully deleted the organization'),
+  ).toBeVisible({ timeout: 30000 });
+  await expect(
+    page.getByRole('heading', { name: 'Welcome to Nhost!' }),
+  ).toBeVisible({ timeout: 30000 });
 }
 
 export function toPascalCase(str: string, divider = ' ') {
@@ -666,6 +856,17 @@ export async function runSQL({ page, sql }: { page: Page; sql: string }) {
   await expect(page.getByText(/success/i)).toBeVisible();
 }
 
+export function waitForPlaygroundRolesLoaded(page: Page) {
+  return page.waitForResponse(
+    (response) =>
+      response.request().method() === 'POST' &&
+      response.url().includes(`${TEST_PROJECT_SUBDOMAIN}.graphql.`) &&
+      (response.request().postData() ?? '')
+        .toLowerCase()
+        .includes('remoteappgetusersandauthroles'),
+  );
+}
+
 export async function navigateToGraphQLPlayground({
   page,
   orgSlug = TEST_ORGANIZATION_SLUG,
@@ -683,22 +884,41 @@ export async function navigateToGraphQLPlayground({
     .waitFor({ timeout: 30000 });
 }
 
-export async function setGraphQLHeaders({
+/**
+ * Selects a role in the GraphiQL playground's Role dropdown
+ * (`UserAndRoleSelect`). Unlike editing the Headers JSON, this Radix Select
+ * updates `userHeaders` synchronously (no debounce), so the rebuilt fetcher
+ * carries `x-hasura-role: <role>` on the next request the caller triggers.
+ *
+ * @param page - The Playwright page object.
+ * @param role - The role to select (e.g. `public`).
+ * @returns A promise that resolves once the role is selected.
+ */
+export async function selectGraphQLRole({
   page,
-  headers,
+  role,
 }: {
   page: Page;
-  headers: Record<string, string>;
+  role: string;
 }) {
-  await page.getByRole('button', { name: 'Headers' }).click();
+  const roleTrigger = page.getByTestId('graphql-role-select');
 
-  const headersEditor = page.getByLabel('Headers');
-  await headersEditor.click();
-  await page.keyboard.press('Control+a');
-  await page.keyboard.press('Backspace');
-  await page.keyboard.type(JSON.stringify(headers), { delay: 10 });
+  await expect(async () => {
+    await roleTrigger.click();
+    await page.getByRole('option', { name: role, exact: true }).click();
+    await expect(roleTrigger).toContainText(role);
+  }).toPass();
 }
 
+/**
+ * Types a query into the GraphiQL editor and executes it. This drives the
+ * playground exactly as a user does; callers assert on the rendered Result
+ * Window (`page.getByLabel('Result Window')` with web-first matchers), which is
+ * what the user actually sees, rather than on the raw HTTP response body.
+ *
+ * @param page - The Playwright page object.
+ * @param query - The GraphQL query to execute.
+ */
 export async function runGraphQLQuery({
   page,
   query,
@@ -706,23 +926,18 @@ export async function runGraphQLQuery({
   page: Page;
   query: string;
 }) {
-  const queryEditor = page.getByLabel('Query Editor');
-  await queryEditor.click();
-  await page.keyboard.press('Control+a');
+  const queryEditor = page.getByRole('region', { name: 'Query Editor' });
+
+  await queryEditor.locator('.CodeMirror textarea').focus();
+  await page.keyboard.press('ControlOrMeta+a');
   await page.keyboard.press('Backspace');
   await page.keyboard.type(query, { delay: 5 });
 
-  await page.getByRole('button', { name: 'Execute GraphQL query' }).click();
-}
+  // Dismiss any open autocomplete dropdown so Enter/clicks do not get captured
+  // by a hint instead of executing the query.
+  await page.keyboard.press('Escape');
 
-export async function getGraphQLResult({
-  page,
-}: {
-  page: Page;
-}): Promise<string> {
-  const resultWindow = page.getByLabel('Result Window');
-  await expect(resultWindow).not.toBeEmpty({ timeout: 15000 });
-  return resultWindow.innerText();
+  await page.getByRole('button', { name: 'Execute GraphQL query' }).click();
 }
 
 export async function deleteRelationship({
@@ -745,6 +960,10 @@ export async function deleteRelationship({
   );
 
   await expect(
-    page.getByText(relationshipName, { exact: true }),
+    page.getByRole('heading', { name: /delete relationship/i }),
   ).not.toBeVisible();
+
+  await expect(page.getByTestId(`delete-rel-${relationshipName}`)).toHaveCount(
+    0,
+  );
 }

--- a/dashboard/package.json
+++ b/dashboard/package.json
@@ -22,9 +22,9 @@
     "format": "biome format --write src/",
     "install-browsers": "pnpm playwright install && pnpm playwright install-deps",
     "e2e:tests": "pnpm playwright test --config=playwright.config.ts -x",
-    "e2e": "echo 'e2e tests temporarily skipped' && exit 0",
-    "e2e:local": "echo 'e2e local tests temporarily skipped' && exit 0",
-    "e2e:onboarding": "echo 'e2e onboarding tests temporarily skipped' && exit 0"
+    "e2e": "pnpm e2e:tests --project=main --workers=1 && pnpm e2e:tests --project=main-parallelizable --workers=2",
+    "e2e:local": "pnpm e2e:tests --project=local",
+    "e2e:onboarding": "pnpm e2e:tests --project=onboarding"
   },
   "dependencies": {
     "@apollo/client": "^3.14.0",
@@ -134,7 +134,7 @@
     "@graphql-codegen/typescript-operations": "^3.0.4",
     "@graphql-codegen/typescript-react-apollo": "^3.3.7",
     "@next/bundle-analyzer": "^12.3.4",
-    "@playwright/test": "1.59.1",
+    "@playwright/test": "1.60.0",
     "@tailwindcss/typography": "^0.5.13",
     "@testing-library/dom": "^10.4.1",
     "@testing-library/jest-dom": "^5.17.0",

--- a/dashboard/pnpm-lock.yaml
+++ b/dashboard/pnpm-lock.yaml
@@ -297,13 +297,13 @@ importers:
         version: 0.552.0(react@19.2.3)
       next:
         specifier: ^16.2.6
-        version: 16.2.6(@babel/core@7.29.7)(@playwright/test@1.59.1)(react-dom@19.2.3(react@19.2.3))(react@19.2.3)
+        version: 16.2.6(@babel/core@7.29.7)(@playwright/test@1.60.0)(react-dom@19.2.3(react@19.2.3))(react@19.2.3)
       next-nprogress-bar:
         specifier: ^2.4.2
         version: 2.4.2
       next-seo:
         specifier: ^6.5.0
-        version: 6.5.0(next@16.2.6(@babel/core@7.29.7)(@playwright/test@1.59.1)(react-dom@19.2.3(react@19.2.3))(react@19.2.3))(react-dom@19.2.3(react@19.2.3))(react@19.2.3)
+        version: 6.5.0(next@16.2.6(@babel/core@7.29.7)(@playwright/test@1.60.0)(react-dom@19.2.3(react@19.2.3))(react@19.2.3))(react-dom@19.2.3(react@19.2.3))(react@19.2.3)
       node-pg-format:
         specifier: ^1.3.5
         version: 1.3.5
@@ -393,8 +393,8 @@ importers:
         specifier: ^12.3.4
         version: 12.3.4
       '@playwright/test':
-        specifier: 1.59.1
-        version: 1.59.1
+        specifier: 1.60.0
+        version: 1.60.0
       '@tailwindcss/typography':
         specifier: ^0.5.13
         version: 0.5.13(tailwindcss@3.4.16(ts-node@10.9.2(@types/node@20.14.8)(typescript@5.8.3)))
@@ -2206,8 +2206,8 @@ packages:
     resolution: {integrity: sha512-+1VkjdD0QBLPodGrJUeqarH8VAIvQODIbwh9XpP5Syisf7YoQgsJKPNFoqqLQlu+VQ/tVSshMR6loPMn8U+dPg==}
     engines: {node: '>=14'}
 
-  '@playwright/test@1.59.1':
-    resolution: {integrity: sha512-PG6q63nQg5c9rIi4/Z5lR5IVF7yU5MqmKaPOe0HSc0O2cX1fPi96sUQu5j7eo4gKCkB2AnNGoWt7y4/Xx3Kcqg==}
+  '@playwright/test@1.60.0':
+    resolution: {integrity: sha512-O71yZIbAh/PxDMNGns37GHBIfrVkEVyn+AXyIa5dOTfb4/xNvRWV+Vv/NMbNCtODB/pO7vLlF2OTmMVLhmr7Ag==}
     engines: {node: '>=18'}
     hasBin: true
 
@@ -5526,13 +5526,13 @@ packages:
     resolution: {integrity: sha512-saLsH7WeYYPiD25LDuLRRY/i+6HaPYr6G1OUlN39otzkSTxKnubR9RTxS3/Kk50s1g2JTgFwWQDQyplC5/SHZg==}
     engines: {node: '>= 6'}
 
-  playwright-core@1.59.1:
-    resolution: {integrity: sha512-HBV/RJg81z5BiiZ9yPzIiClYV/QMsDCKUyogwH9p3MCP6IYjUFu/MActgYAvK0oWyV9NlwM3GLBjADyWgydVyg==}
+  playwright-core@1.60.0:
+    resolution: {integrity: sha512-9bW6zvX/m0lEbgTKJ6YppOKx8H3VOPBMOCFh2irXFOT4BbHgrx5hPjwJYLT40Lu+4qtD36qKc/Hn56StUW57IA==}
     engines: {node: '>=18'}
     hasBin: true
 
-  playwright@1.59.1:
-    resolution: {integrity: sha512-C8oWjPR3F81yljW9o5OxcWzfh6avkVwDD2VYdwIGqTkl+OGFISgypqzfu7dOe4QNLL2aqcWBmI3PMtLIK233lw==}
+  playwright@1.60.0:
+    resolution: {integrity: sha512-hheHdokM8cdqCb0lcE3s+zT4t4W+vvjpGxsZlDnikarzx8tSzMebh3UiFtgqwFwnTnjYQcsyMF8ei2mCO/tpeA==}
     engines: {node: '>=18'}
     hasBin: true
 
@@ -8721,9 +8721,9 @@ snapshots:
   '@pkgjs/parseargs@0.11.0':
     optional: true
 
-  '@playwright/test@1.59.1':
+  '@playwright/test@1.60.0':
     dependencies:
-      playwright: 1.59.1
+      playwright: 1.60.0
 
   '@polka/url@1.0.0-next.25': {}
 
@@ -11799,13 +11799,13 @@ snapshots:
     dependencies:
       nprogress-v2: 1.0.4
 
-  next-seo@6.5.0(next@16.2.6(@babel/core@7.29.7)(@playwright/test@1.59.1)(react-dom@19.2.3(react@19.2.3))(react@19.2.3))(react-dom@19.2.3(react@19.2.3))(react@19.2.3):
+  next-seo@6.5.0(next@16.2.6(@babel/core@7.29.7)(@playwright/test@1.60.0)(react-dom@19.2.3(react@19.2.3))(react@19.2.3))(react-dom@19.2.3(react@19.2.3))(react@19.2.3):
     dependencies:
-      next: 16.2.6(@babel/core@7.29.7)(@playwright/test@1.59.1)(react-dom@19.2.3(react@19.2.3))(react@19.2.3)
+      next: 16.2.6(@babel/core@7.29.7)(@playwright/test@1.60.0)(react-dom@19.2.3(react@19.2.3))(react@19.2.3)
       react: 19.2.3
       react-dom: 19.2.3(react@19.2.3)
 
-  next@16.2.6(@babel/core@7.29.7)(@playwright/test@1.59.1)(react-dom@19.2.3(react@19.2.3))(react@19.2.3):
+  next@16.2.6(@babel/core@7.29.7)(@playwright/test@1.60.0)(react-dom@19.2.3(react@19.2.3))(react@19.2.3):
     dependencies:
       '@next/env': 16.2.6
       '@swc/helpers': 0.5.15
@@ -11824,7 +11824,7 @@ snapshots:
       '@next/swc-linux-x64-musl': 16.2.6
       '@next/swc-win32-arm64-msvc': 16.2.6
       '@next/swc-win32-x64-msvc': 16.2.6
-      '@playwright/test': 1.59.1
+      '@playwright/test': 1.60.0
       sharp: 0.34.5
     transitivePeerDependencies:
       - '@babel/core'
@@ -12040,11 +12040,11 @@ snapshots:
 
   pirates@4.0.6: {}
 
-  playwright-core@1.59.1: {}
+  playwright-core@1.60.0: {}
 
-  playwright@1.59.1:
+  playwright@1.60.0:
     dependencies:
-      playwright-core: 1.59.1
+      playwright-core: 1.60.0
     optionalDependencies:
       fsevents: 2.3.2
 

--- a/dashboard/project.nix
+++ b/dashboard/project.nix
@@ -73,7 +73,7 @@ let
   checkDeps = with pkgs; [
     nhost.nhost-cli
     lychee
-    playwright-driver
+    nhost.playwright-driver
   ];
 
   buildInputs = with pkgs; [ nhost.nodejs ];
@@ -136,7 +136,7 @@ let
         export HOME=$TMPDIR
         export SSL_CERT_FILE=${pkgs.cacert}/etc/ssl/certs/ca-bundle.crt
         export NIX_SSL_CERT_FILE=$SSL_CERT_FILE
-        export PLAYWRIGHT_BROWSERS_PATH=${pkgs.playwright-driver.browsers}
+        export PLAYWRIGHT_BROWSERS_PATH=${pkgs.nhost.playwright-driver.browsers}
         export PLAYWRIGHT_SKIP_VALIDATE_HOST_REQUIREMENTS=true
 
         cp -r ${src}/. .
@@ -182,7 +182,7 @@ rec {
       ++ nativeBuildInputs;
 
     shellHook = ''
-      export PLAYWRIGHT_BROWSERS_PATH=${pkgs.playwright-driver.browsers}
+      export PLAYWRIGHT_BROWSERS_PATH=${pkgs.nhost.playwright-driver.browsers}
       export PLAYWRIGHT_SKIP_VALIDATE_HOST_REQUIREMENTS=true
     '';
 

--- a/dashboard/src/components/layout/Header/OrgPagesComboBox.tsx
+++ b/dashboard/src/components/layout/Header/OrgPagesComboBox.tsx
@@ -33,6 +33,7 @@ export default function OrgPagesComboBox() {
 
   return (
     <HeaderCombobox
+      data-testid="org-pages-switcher"
       options={options}
       value={selectedOrgPage?.value ?? null}
       placeholder="Select a page"

--- a/dashboard/src/components/layout/Header/OrgsComboBox.tsx
+++ b/dashboard/src/components/layout/Header/OrgsComboBox.tsx
@@ -61,6 +61,7 @@ export default function OrgsComboBox() {
 
   return (
     <HeaderCombobox
+      data-testid="org-switcher"
       options={options}
       value={selectedOrg?.slug ?? null}
       triggerLabel={triggerLabel}

--- a/dashboard/src/features/orgs/projects/graphql/common/components/UserAndRoleSelect/UserAndRoleSelect.tsx
+++ b/dashboard/src/features/orgs/projects/graphql/common/components/UserAndRoleSelect/UserAndRoleSelect.tsx
@@ -59,7 +59,11 @@ export default function UserAndRoleSelect({
             onRoleChange(value);
           }}
         >
-          <SelectTrigger className="w-full">
+          <SelectTrigger
+            aria-label="Role"
+            data-testid="graphql-role-select"
+            className="w-full"
+          >
             <SelectValue placeholder="Select role" />
           </SelectTrigger>
           <SelectContent>

--- a/flake.nix
+++ b/flake.nix
@@ -244,7 +244,7 @@
 
               # dashboard
               nhost.vercel
-              playwright-driver
+              nhost.playwright-driver
               lychee
 
               # javascript
@@ -288,7 +288,7 @@
             ];
 
             shellHook = ''
-              export PLAYWRIGHT_BROWSERS_PATH=${pkgs.playwright-driver.browsers}
+              export PLAYWRIGHT_BROWSERS_PATH=${pkgs.nhost.playwright-driver.browsers}
               export PLAYWRIGHT_SKIP_VALIDATE_HOST_REQUIREMENTS=true
 
               export GOEXPERIMENT=jsonv2

--- a/flake.nix
+++ b/flake.nix
@@ -2,7 +2,7 @@
   nixConfig = {
     sandbox = "relaxed";
     extra-substituters = [
-      "s3://nhost-nix-cache?endpoint=https://14bc02755b64adb7c8c62b5420d0a457.eu.r2.cloudflarestorage.com&region=auto&profile=nhost-nix-cache"
+      "s3://nhost-nix-cache?endpoint=https://14bc02755b64adb7c8c62b5420d0a457.eu.r2.cloudflarestorage.com&region=auto&profile=nhost-nix-cache&priority=10"
       "https://cache.nixos.org"
     ];
     extra-trusted-public-keys = [

--- a/nixops/overlays/js.nix
+++ b/nixops/overlays/js.nix
@@ -125,5 +125,57 @@
       }
     );
 
+    # Pinned to match dashboard/package.json's @playwright/test; Chromium only.
+    playwright-driver =
+      let
+        chromiumRevision = "1223";
+        chromiumVersion = "148.0.7778.96";
+        cft = path: "https://cdn.playwright.dev/builds/cft/${chromiumVersion}/${path}";
+        components = prev.playwright-driver.components;
+        chromium = components.chromium.overrideAttrs (_: {
+          src = prev.fetchzip {
+            url = cft "linux64/chrome-linux64.zip";
+            stripRoot = true;
+            hash = "sha256-TnplS4C/PPcmyWrMCqWh7c1KrpevHJFKO0gfh46M3tk=";
+          };
+        });
+        chromium-headless-shell = components."chromium-headless-shell".overrideAttrs (_: {
+          src = prev.fetchzip {
+            url = cft "linux64/chrome-headless-shell-linux64.zip";
+            stripRoot = false;
+            hash = "sha256-Nr0/uczFTBTqvRPR0c/wflIqG5relgKfC9XsMOdE9iE=";
+          };
+        });
+        browsers = prev.linkFarm "playwright-browsers" [
+          {
+            name = "chromium-${chromiumRevision}";
+            path = chromium;
+          }
+          {
+            name = "chromium_headless_shell-${chromiumRevision}";
+            path = chromium-headless-shell;
+          }
+          {
+            name = "ffmpeg-1011";
+            path = components.ffmpeg;
+          }
+        ];
+      in
+      (prev.playwright-driver.overrideAttrs (old: rec {
+        version = "1.60.0";
+        src = prev.fetchFromGitHub {
+          owner = "Microsoft";
+          repo = "playwright";
+          rev = "v${version}";
+          hash = "sha256-jtQHyphdZsS8hf7uhe9zrx16Uf+kgLLha6dTCsCTT/8=";
+        };
+        npmDepsHash = "sha256-K1bCDURaq2+kaqGQcOL1tD6tQt/37pyDFWq2njUVNS4=";
+      })).overrideAttrs
+        (old: {
+          passthru = old.passthru // {
+            inherit browsers;
+          };
+        });
+
   }
 )

--- a/nixops/project.nix
+++ b/nixops/project.nix
@@ -38,6 +38,7 @@ let
       curl
       diffutils
       docker-client
+      geos
       gh
       git-cliff
       gnused

--- a/nixops/project.nix
+++ b/nixops/project.nix
@@ -58,7 +58,7 @@ let
       nhost.vercel
       nhost.oapi-codegen
       pkg-config
-      playwright-driver
+      nhost.playwright-driver
       nhost.pnpm
       nhost.postgresql_14-client
       nhost.postgresql_15


### PR DESCRIPTION
### Checklist

- [x] No breaking changes
- [ ] Tests pass
- [ ] New features have new tests
- [ ] Documentation is updated (if applicable)
- [ ] Title of the PR is in the correct format (see below)

<!-- nhost-reviewer:start -->
### **What this PR solves**
The dashboard's Playwright e2e suites had been stubbed out with `echo ... && exit 0`, so onboarding, permissions and other journeys were not actually being exercised in CI. This PR re-enables the suites, hardens the flaky test helpers to drive the real UI (role dropdown, Stripe checkout, org switcher) with web-first assertions, and pins the Nix `playwright-driver` browsers to match the npm `@playwright/test` version.

___

### **PR Type**
Tests

___

### **Description**
- Re-enable the `e2e`, `e2e:local` and `e2e:onboarding` package scripts to run the real Playwright projects instead of no-op stubs.
- Refactor `dashboard/e2e/utils.ts`: add `selectOrgByName`, `gotoOrgPageViaSwitcher`, `fillStripeCheckout`, `deleteOrganization`, `waitForPlaygroundRolesLoaded`, and replace `setGraphQLHeaders`/`getGraphQLResult` with `selectGraphQLRole` plus web-first Result Window assertions.
- Rewrite the onboarding test to use shared helpers, role/heading-based locators, and add an organization cleanup at the end of the upgrade flow.
- Harden the permissions GraphQL verification test: add an `afterAll` table drop, select the role via the dropdown, and use `toContainText` matchers; add a teardown to avoid `table already exists` on CI retries.
- Add `data-testid` hooks (`org-switcher`, `org-pages-switcher`, `graphql-role-select`) plus an `aria-label="Role"` to support the new locators.
- Bump `@playwright/test` to `1.60.0` and add a dedicated `nixpkgs-playwright` flake input that overlays `playwright-driver` so the Nix-provided browser revisions stay in lockstep with the npm version.

___

<details> <summary><h3> File Walkthrough</h3></summary>

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody>
<tr><td><strong>Tests</strong></td><td><details><summary>3 files</summary><table>
<tr>
  <td><strong>permissions-graphql-verification.test.ts</strong><dd><code>Drive role dropdown, add table teardown, web-first result assertions</code></dd></td>
  <td><a href="https://github.com/nhost/nhost/pull/4542/files#diff-03238bf6d86a7e8899c0902625adc616094300fac734fb6141403fd47474d179">+36/-27</a></td>
</tr>
<tr>
  <td><strong>onboarding.test.ts</strong><dd><code>Rewrite onboarding/upgrade flows on shared helpers and role locators</code></dd></td>
  <td><a href="https://github.com/nhost/nhost/pull/4542/files#diff-0263bde085f69167e7c84795fad78dd54c9ab50f534677ef60ccd2c31998d522">+69/-170</a></td>
</tr>
<tr>
  <td><strong>utils.ts</strong><dd><code>Add org/stripe/role helpers; replace header-based GraphQL helpers</code></dd></td>
  <td><a href="https://github.com/nhost/nhost/pull/4542/files#diff-490448aa83585151d8c61d698273c43486fdcac6a5d28a9b7e5be2729bbffd12">+209/-29</a></td>
</tr>
</table></details></td></tr>
<tr><td><strong>Source (test hooks)</strong></td><td><details><summary>3 files</summary><table>
<tr>
  <td><strong>OrgPagesComboBox.tsx</strong><dd><code>Add data-testid="org-pages-switcher"</code></dd></td>
  <td><a href="https://github.com/nhost/nhost/pull/4542/files#diff-b70a46a4233201c9a2650c930192b4417f35a27303ff5c78872c05a41a92c8ac">+1/-0</a></td>
</tr>
<tr>
  <td><strong>OrgsComboBox.tsx</strong><dd><code>Add data-testid="org-switcher"</code></dd></td>
  <td><a href="https://github.com/nhost/nhost/pull/4542/files#diff-0736dac185f4ed134d5b53be292c9a2ee4f6df65e965b801a2dbbc8a184b3687">+1/-0</a></td>
</tr>
<tr>
  <td><strong>UserAndRoleSelect.tsx</strong><dd><code>Add aria-label and data-testid to the role select trigger</code></dd></td>
  <td><a href="https://github.com/nhost/nhost/pull/4542/files#diff-8ebf5c616ffeaf84231d8aff2588b8f465c1464e8929aa1e1d61a4d4559976b4">+5/-1</a></td>
</tr>
</table></details></td></tr>
<tr><td><strong>Configuration</strong></td><td><details><summary>4 files</summary><table>
<tr>
  <td><strong>package.json</strong><dd><code>Re-enable e2e scripts; bump @playwright/test to 1.60.0</code></dd></td>
  <td><a href="https://github.com/nhost/nhost/pull/4542/files#diff-2d8d55c799cd71f1b35e831f075f8178ed1734c4820a2ad548b4dd24d6938d7c">+4/-4</a></td>
</tr>
<tr>
  <td><strong>pnpm-lock.yaml</strong><dd><code>Lockfile update for the Playwright bump</code></dd></td>
  <td><a href="https://github.com/nhost/nhost/pull/4542/files#diff-4af5d448df8277f6a883659150a0879bb6b4aa12da343316f1f3b41b27824405">+19/-19</a></td>
</tr>
<tr>
  <td><strong>flake.nix</strong><dd><code>Add nixpkgs-playwright input and overlay playwright-driver</code></dd></td>
  <td><a href="https://github.com/nhost/nhost/pull/4542/files#diff-206b9ce276ab5971a2489d75eb1b12999d4bf3843b7988cbe8d687cfde61dea0">+17/-0</a></td>
</tr>
<tr>
  <td><strong>flake.lock</strong><dd><code>Lock the new nixpkgs-playwright input</code></dd></td>
  <td><a href="https://github.com/nhost/nhost/pull/4542/files#diff-216b2b7bfde9416c79d133bacb031e95702a20bdedb548c0b055c837aa4f6a9c">+18/-1</a></td>
</tr>
</table></details></td></tr>
</tbody></table>

</details>

___

<!-- nhost-reviewer:end -->
