### PR TITLE
fix(docs): skip production self-links in broken-link check

### DIFF
--- a/docs/check_broken_links.sh
+++ b/docs/check_broken_links.sh
@@ -19,6 +19,9 @@ SKIP=(
 
   # Sign-in portals that reject automated requests with 4xx (false positives)
   'portal\.azure\.com'
+
+  # The site's own canonical/sitemap self-links; 404 until deployed.
+  '^https:\/\/docs\.nhost\.io'
 )
 
 skip_args=()


### PR DESCRIPTION
### Checklist

- [X] No breaking changes
- [X] Tests pass
- [X] New features have new tests
- [X] Documentation is updated (if applicable)
- [X] Title of the PR is in the correct format (see below)

<!-- nhost-reviewer:start -->
### **What this PR solves**
The docs broken-link checker (linkinator) was flagging the site's own absolute `https://docs.nhost.io` URLs — emitted in canonical `<link>` tags and sitemap entries — as broken, because the freshly-built content under review isn't deployed to production yet when CI runs. This adds a skip pattern so those self-links stop producing false-positive failures.

___

### **PR Type**
Bug fix

___

### **Description**
- Add `^https://docs.nhost.io` to the linkinator `SKIP` list in `docs/check_broken_links.sh`, excluding the docs site's own canonical/sitemap self-links from the broken-link check since they 404 until the build is deployed.

___

<details> <summary><h3> File Walkthrough</h3></summary>

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody>
<tr><td><strong>Configuration</strong></td><td><details><summary>1 files</summary><table>
<tr>
  <td><strong>check_broken_links.sh</strong><dd><code>Skip the site's own docs.nhost.io self-links in the link checker</code></dd></td>
  <td><a href="https://github.com/nhost/nhost/pull/4543/files#diff-c8b3d6b1fcf1a2e33a14c5549c5a8617089bc64a7b7e5ccac0791bac580d6fb3">+3/-0</a></td>
</tr>
</table></details></td></tr>
</tbody></table>

</details>

___

<!-- nhost-reviewer:end -->
