### PR TITLE
fix(dashboard): correct computed field name validation message

### DIFF
--- a/dashboard/src/features/orgs/projects/database/dataGrid/components/EditGraphQLSettingsForm/sections/ComputedFieldsSection/computedFieldFormTypes.ts
+++ b/dashboard/src/features/orgs/projects/database/dataGrid/components/EditGraphQLSettingsForm/sections/ComputedFieldsSection/computedFieldFormTypes.ts
@@ -9,13 +9,6 @@ export const COMPUTED_FIELDS_DIRTY_SOURCE_ID = 'edit-gql-computed-fields';
 
 const identifierPattern = /^[A-Za-z_][A-Za-z0-9_]*$/;
 
-const optionalIdentifier = z
-  .string()
-  .trim()
-  .refine((value) => value === '' || identifierPattern.test(value), {
-    message: 'Must be a valid identifier (letters, digits, underscores).',
-  });
-
 export const computedFieldValidationSchema = z.object({
   name: z
     .string()
@@ -23,12 +16,12 @@ export const computedFieldValidationSchema = z.object({
     .min(1, 'Computed field name is required.')
     .regex(
       identifierPattern,
-      'Must be a valid identifier (letters, digits, underscores).',
+      'Must start with a letter or underscore, followed by letters, digits, or underscores.',
     ),
   functionSchema: z.string().trim().min(1, 'Function schema is required.'),
   functionName: z.string().trim().min(1, 'Function name is required.'),
-  tableArgument: optionalIdentifier,
-  sessionArgument: optionalIdentifier,
+  tableArgument: z.string().trim(),
+  sessionArgument: z.string().trim(),
   comment: z.string(),
 });
 


### PR DESCRIPTION
This PR changes the error message in the computed field name into a more descriptive one.
| Before    | After |
| -------- | ------- |
|  <img width="420" height="140" alt="Screenshot 2026-06-18 at 15 10 15" src="https://github.com/user-attachments/assets/83503f76-ac46-4755-b004-51fbc2ef996c" /> |  <img width="434" height="155" alt="Screenshot 2026-06-18 at 15 09 47" src="https://github.com/user-attachments/assets/60c34dfc-208d-4f2f-8a86-1caa6b508c00" />  |


### Checklist

- [X] No breaking changes
- [X] Tests pass
- [X] New features have new tests
- [X] Documentation is updated (if applicable)
- [X] Title of the PR is in the correct format (see below)

<!-- nhost-reviewer:start -->
### **What this PR solves**
The computed-field `name` validation error read "Must be a valid identifier (letters, digits, underscores)", which wrongly implied a leading digit was allowed even though the regex requires the first character to be a letter or underscore. This corrects the message to describe the pattern accurately, and relaxes the optional table/session argument fields to plain trimmed strings, since their validity can only be checked against the real PostgreSQL function signature server-side.

___

### **PR Type**
Bug fix

___

### **Description**
- Rewrites the computed-field `name` regex error message to accurately describe the identifier pattern (`/^[A-Za-z_][A-Za-z0-9_]*$/`): must start with a letter or underscore, then letters, digits, or underscores.
- Removes the `optionalIdentifier` zod helper and relaxes `tableArgument` / `sessionArgument` from "empty-or-valid-identifier" to plain `z.string().trim()`; these must match an actual function argument name, which is validated on the backend.

___

<details> <summary><h3> File Walkthrough</h3></summary>

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody>
<tr><td><strong>Bug fix</strong></td><td><details><summary>1 files</summary><table>
<tr>
  <td><strong>computedFieldFormTypes.ts</strong><dd><code>Fix name error message; relax table/session argument validation</code></dd></td>
  <td><a href="https://github.com/nhost/nhost/pull/4558/files#diff-de4fac9725e2d6db12079e6597ad8c923fb1120eb247f88f7847fdbe03645521">+3/-10</a></td>
</tr>
</table></details></td></tr>
</tbody></table>

</details>

___

<!-- nhost-reviewer:end -->
