### PR TITLE
fix(dashboard): suggest Nhost functions in event, cron & scheduled events webhook

### DIFF
--- a/dashboard/src/features/orgs/projects/events/cron-triggers/components/BaseCronTriggerForm/BaseCronTriggerForm.tsx
+++ b/dashboard/src/features/orgs/projects/events/cron-triggers/components/BaseCronTriggerForm/BaseCronTriggerForm.tsx
@@ -245,7 +245,7 @@ export default function BaseCronTriggerForm({
                   <FormInput
                     control={form.control}
                     name="webhook"
-                    placeholder="https://httpbin.org/post or {{MY_WEBHOOK_URL}}/handler"
+                    placeholder="{{NHOST_FUNCTIONS_URL}}/handler or https://httpbin.org/post"
                     label={
                       <div className="flex flex-row items-center gap-2">
                         Webhook URL or template{' '}

--- a/dashboard/src/features/orgs/projects/events/event-triggers/components/BaseEventTriggerForm/BaseEventTriggerForm.tsx
+++ b/dashboard/src/features/orgs/projects/events/event-triggers/components/BaseEventTriggerForm/BaseEventTriggerForm.tsx
@@ -491,7 +491,7 @@ export default function BaseEventTriggerForm({
                     control={form.control}
                     name="webhook"
                     label="Webhook URL or template"
-                    placeholder="https://httpbin.org/post or {{MY_WEBHOOK_URL}}/handler"
+                    placeholder="{{NHOST_FUNCTIONS_URL}}/handler or https://httpbin.org/post"
                     className="max-w-lg text-foreground"
                   />
                 </div>

--- a/dashboard/src/features/orgs/projects/events/one-offs/components/CreateOneOffForm/CreateOneOffForm.tsx
+++ b/dashboard/src/features/orgs/projects/events/one-offs/components/CreateOneOffForm/CreateOneOffForm.tsx
@@ -81,7 +81,7 @@ export default function CreateOneOffForm() {
                   <FormInput
                     control={form.control}
                     name="webhook"
-                    placeholder="https://httpbin.org/post or {{MY_WEBHOOK_URL}}/handler"
+                    placeholder="{{NHOST_FUNCTIONS_URL}}/handler or https://httpbin.org/post"
                     label={
                       <div className="flex flex-row items-center gap-2">
                         Webhook URL or template{' '}


### PR DESCRIPTION
| Before    | After |
| -------- | ------- |
| <img width="565" height="114" alt="Screenshot 2026-06-18 at 15 21 46" src="https://github.com/user-attachments/assets/d79e99f9-7f16-4324-a4e1-82253439c497" />  |  <img width="560" height="110" alt="Screenshot 2026-06-18 at 15 21 20" src="https://github.com/user-attachments/assets/4294a065-c069-4998-8553-a6761aa5a315" />  |

### Checklist

- [X] No breaking changes
- [X] Tests pass
- [X] New features have new tests
- [X] Documentation is updated (if applicable)
- [X] Title of the PR is in the correct format (see below)

<!-- nhost-reviewer:start -->
### **What this PR solves**
Webhook URL fields in the event, cron, and scheduled (one-off) event forms previously led their placeholder with a generic `https://httpbin.org/post` example and an abstract `{{MY_WEBHOOK_URL}}` template. This PR reorders the placeholder to surface `{{NHOST_FUNCTIONS_URL}}/handler` first, guiding users toward the Nhost-native function endpoint that is the most common target for these webhooks.

___

### **PR Type**
Enhancement

___

### **Description**
- Reordered the `webhook` field placeholder in all three event-trigger forms (cron, event, one-off) to lead with `{{NHOST_FUNCTIONS_URL}}/handler` and follow with the `https://httpbin.org/post` example.
- Replaced the generic `{{MY_WEBHOOK_URL}}` token with the real `{{NHOST_FUNCTIONS_URL}}` system environment variable, which Nhost projects expose by default.

___

<details> <summary><h3> File Walkthrough</h3></summary>

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody>
<tr><td><strong>Enhancement</strong></td><td><details><summary>3 files</summary><table>
<tr>
  <td><strong>BaseCronTriggerForm.tsx</strong><dd><code>Lead cron webhook placeholder with Nhost functions URL</code></dd></td>
  <td><a href="https://github.com/nhost/nhost/pull/4559/files#diff-b891cf5ca30d0695b3ef039a8aa36e7df13eed91de59811442b47c55d9166861">+1/-1</a></td>
</tr>
<tr>
  <td><strong>BaseEventTriggerForm.tsx</strong><dd><code>Lead event webhook placeholder with Nhost functions URL</code></dd></td>
  <td><a href="https://github.com/nhost/nhost/pull/4559/files#diff-6de890ac4bf333bde860146c8b96795235c9a27f025aae3b156abf219fe0d1f1">+1/-1</a></td>
</tr>
<tr>
  <td><strong>CreateOneOffForm.tsx</strong><dd><code>Lead one-off webhook placeholder with Nhost functions URL</code></dd></td>
  <td><a href="https://github.com/nhost/nhost/pull/4559/files#diff-30199719a8f4a6d14956c06c4d40e4eeac7cdc879d5f506ffef6db4ccc6af01f">+1/-1</a></td>
</tr>
</table></details></td></tr>
</tbody></table>

</details>

___

<!-- nhost-reviewer:end -->
