### PR TITLE
fix(deps): fix undici advisories (GHSA-pr7r-676h-xcf6, GHSA-vmh5-mc38-953g)

### DIFF
--- a/dashboard/package.json
+++ b/dashboard/package.json
@@ -165,7 +165,7 @@
     "snake-case": "^3.0.4",
     "tailwindcss": "^3.4.16",
     "ts-node": "^10.9.2",
-    "undici": "^7.24.4",
+    "undici": "^7.28.0",
     "vite": "^8.0.16",
     "vitest": "^4.1.3"
   },

--- a/dashboard/pnpm-lock.yaml
+++ b/dashboard/pnpm-lock.yaml
@@ -486,8 +486,8 @@ importers:
         specifier: ^10.9.2
         version: 10.9.2(@types/node@20.14.8)(typescript@5.8.3)
       undici:
-        specifier: ^7.24.4
-        version: 7.24.4
+        specifier: ^7.28.0
+        version: 7.28.0
       vite:
         specifier: ^8.0.16
         version: 8.0.16(@types/node@20.14.8)(esbuild@0.28.1)(jiti@2.6.1)(yaml@2.8.3)
@@ -6310,8 +6310,8 @@ packages:
   undici-types@5.26.5:
     resolution: {integrity: sha512-JlCMO+ehdEIKqlFxk6IfVoAUVmgz7cU7zD/h9XZ0qzeosSHmUJVOzSQvvYSYWXkFXC+IfLKSIffhv0sVZup6pA==}
 
-  undici@7.24.4:
-    resolution: {integrity: sha512-BM/JzwwaRXxrLdElV2Uo6cTLEjhSb3WXboncJamZ15NgUURmvlXvxa6xkwIOILIjPNo9i8ku136ZvWV0Uly8+w==}
+  undici@7.28.0:
+    resolution: {integrity: sha512-cRZYrTDwWznlnRiPjggAGxZXanty6M8RV1ff8Wm4LWXBp7/IG8v5DnOm74DtUBp9OONpK75YlPnIjQqX0dBDtA==}
     engines: {node: '>=20.18.1'}
 
   unfetch@3.1.2:
@@ -12828,7 +12828,7 @@ snapshots:
 
   undici-types@5.26.5: {}
 
-  undici@7.24.4: {}
+  undici@7.28.0: {}
 
   unfetch@3.1.2: {}
 


### PR DESCRIPTION
Bumps the dashboard's direct `undici` dependency `^7.24.4` → `^7.28.0`, resolving two advisories (both fixed in undici `7.28.0`):

- [GHSA-pr7r-676h-xcf6](https://github.com/advisories/GHSA-pr7r-676h-xcf6) — cross-user information disclosure via shared cache whitespace bypass (`>=7.0.0 <7.28.0`)
- [GHSA-vmh5-mc38-953g](https://github.com/advisories/GHSA-vmh5-mc38-953g) — TLS certificate validation bypass via dropped `requestTls` in SOCKS5 ProxyAgent (`>=7.23.0 <7.28.0`)

`undici` is a direct devDependency of `dashboard`, so this is a direct bump rather than an override. `dashboard/pnpm-lock.yaml` was regenerated with `pnpm install --lockfile-only`; the only resolution change is `undici` 7.24.4 → 7.28.0.
