### PR TITLE
fix(dashboard): only show billing if user is admin

### DIFF
--- a/dashboard/src/features/orgs/components/billing/BillingEstimate/BillingEstimate.tsx
+++ b/dashboard/src/features/orgs/components/billing/BillingEstimate/BillingEstimate.tsx
@@ -1,10 +1,13 @@
 import { Divider } from '@/components/ui/v2/Divider';
+import { useIsOrgAdmin } from '@/features/orgs/hooks/useIsOrgAdmin';
 import { BillingCycle } from './components/BillingCycle';
 import { BillingDetails } from './components/BillingDetails';
 import { Estimate } from './components/Estimate';
 import { SpendingNotifications } from './components/SpendingNotifications';
 
 export default function BillingEstimate() {
+  const isOrgAdmin = useIsOrgAdmin();
+
   return (
     <div className="">
       <div className="flex w-full flex-col rounded-md border bg-background">
@@ -18,8 +21,12 @@ export default function BillingEstimate() {
           <Estimate />
           <Divider />
           <SpendingNotifications />
-          <Divider />
-          <BillingDetails />
+          {isOrgAdmin && (
+            <>
+              <Divider />
+              <BillingDetails />
+            </>
+          )}
         </div>
       </div>
     </div>

--- a/dashboard/src/features/orgs/components/billing/BillingEstimate/components/BillingDetails/BillingDetails.test.tsx
+++ b/dashboard/src/features/orgs/components/billing/BillingEstimate/components/BillingDetails/BillingDetails.test.tsx
@@ -1,0 +1,89 @@
+import { HttpResponse } from 'msw';
+import { setupServer } from 'msw/node';
+import { vi } from 'vitest';
+import { getOrganization } from '@/tests/msw/mocks/graphql/getOrganizationQuery';
+import nhostGraphQLLink from '@/tests/msw/mocks/graphql/nhostGraphQLLink';
+import {
+  createGraphqlMockResolver,
+  queryClient,
+  render,
+  screen,
+} from '@/tests/testUtils';
+import BillingDetails from './BillingDetails';
+
+const mocks = vi.hoisted(() => ({
+  useRouter: vi.fn(),
+}));
+
+vi.mock('next/router', () => ({
+  useRouter: mocks.useRouter,
+}));
+
+const server = setupServer();
+
+beforeAll(() => {
+  process.env.NEXT_PUBLIC_NHOST_PLATFORM = 'true';
+  process.env.NEXT_PUBLIC_ENV = 'production';
+  server.listen();
+});
+
+beforeEach(() => {
+  mocks.useRouter.mockReturnValue({
+    basePath: '',
+    pathname: '/orgs/xyz/billing',
+    route: '/orgs/[orgSlug]/billing',
+    asPath: '/orgs/xyz/billing',
+    isReady: true,
+    isLocaleDomain: false,
+    isPreview: false,
+    isFallback: false,
+    query: { orgSlug: 'xyz' },
+    push: vi.fn(),
+    replace: vi.fn(),
+    reload: vi.fn(),
+    back: vi.fn(),
+    forward: vi.fn(),
+    prefetch: vi.fn(),
+    beforePopState: vi.fn(),
+    events: { on: vi.fn(), off: vi.fn(), emit: vi.fn() },
+  });
+});
+
+afterEach(() => {
+  server.resetHandlers();
+  queryClient.clear();
+  vi.clearAllMocks();
+});
+
+afterAll(() => {
+  server.close();
+});
+
+describe('BillingDetails', () => {
+  it('shows a loading indicator while the next invoice is being fetched', async () => {
+    const invoice = createGraphqlMockResolver('billingGetNextInvoice', 'query');
+    server.use(getOrganization, invoice.handler);
+
+    render(<BillingDetails />);
+
+    expect(
+      await screen.findByText('Loading billing details...'),
+    ).toBeInTheDocument();
+  });
+
+  it('shows an error alert when the next invoice query fails', async () => {
+    server.use(
+      getOrganization,
+      nhostGraphQLLink.query('billingGetNextInvoice', () =>
+        HttpResponse.json({ errors: [{ message: 'Failed to fetch invoice' }] }),
+      ),
+    );
+
+    render(<BillingDetails />);
+
+    expect(
+      await screen.findByText('Failed to load billing details'),
+    ).toBeInTheDocument();
+    expect(screen.getByText(/Failed to fetch invoice/)).toBeInTheDocument();
+  });
+});

--- a/dashboard/src/features/orgs/components/billing/BillingEstimate/components/BillingDetails/BillingDetails.tsx
+++ b/dashboard/src/features/orgs/components/billing/BillingEstimate/components/BillingDetails/BillingDetails.tsx
@@ -5,6 +5,7 @@ import {
   AccordionItem,
   AccordionTrigger,
 } from '@/components/ui/v3/accordion';
+import { Alert, AlertDescription, AlertTitle } from '@/components/ui/v3/alert';
 import {
   Table,
   TableBody,
@@ -19,7 +20,7 @@ import { useBillingGetNextInvoiceQuery } from '@/utils/__generated__/graphql';
 
 export default function BillingDetails() {
   const { org } = useCurrentOrg();
-  const { data, loading } = useBillingGetNextInvoiceQuery({
+  const { data, loading, error } = useBillingGetNextInvoiceQuery({
     fetchPolicy: 'cache-first',
     variables: {
       organizationID: org?.id,
@@ -30,7 +31,7 @@ export default function BillingDetails() {
   const billingItems = data?.billingGetNextInvoice?.items ?? [];
   const amountDue = data?.billingGetNextInvoice?.AmountDue ?? null;
 
-  if (!data || loading) {
+  if (loading) {
     return (
       <div className="flex flex-col">
         <div className="flex flex-col gap-4 p-4">
@@ -43,6 +44,24 @@ export default function BillingDetails() {
         </div>
       </div>
     );
+  }
+
+  if (error) {
+    return (
+      <div className="p-4">
+        <Alert variant="destructive" className="text-left">
+          <AlertTitle>Failed to load billing details</AlertTitle>
+          <AlertDescription>
+            {error.message ||
+              'An error occurred while fetching the billing details. Please try again.'}
+          </AlertDescription>
+        </Alert>
+      </div>
+    );
+  }
+
+  if (!data) {
+    return null;
   }
 
   return (


### PR DESCRIPTION
### Checklist

- [x] No breaking changes
- [x] Tests pass
- [ ] New features have new tests
- [ ] Documentation is updated (if applicable)
- [x] Title of the PR is in the correct format (see below)

<!-- nhost-reviewer:start -->
### **What this PR solves**
The billing-details (next-invoice breakdown) section was shown to every org member and would spin on a loading indicator indefinitely whenever the invoice query returned no data, while a failed query showed nothing actionable. This PR restricts the section to org admins and replaces the single loading guard with explicit loading / error / empty-data handling so the section surfaces fetch errors and never hangs on a perpetual spinner.

___

### **PR Type**
Bug fix

___

### **Description**
- Gate the `BillingDetails` section (and its leading `Divider`) behind `useIsOrgAdmin` in `BillingEstimate`, matching the existing admin-gating pattern used by `SpendingNotifications`, `PendingInvites`, and `MembersList`.
- Split the old `if (!data || loading)` guard in `BillingDetails` into separate `loading`, `error`, and `!data` branches — fixing the indefinite spinner that occurred when the query resolved with no data.
- Render a destructive `Alert` (showing the error message, falling back to a generic message) when the next-invoice query fails.

___

### Diagram Walkthrough

```mermaid
flowchart LR
  A["BillingEstimate"] -->|isOrgAdmin| B["BillingDetails"]
  B --> C{"query state"}
  C -->|loading| D["ActivityIndicator"]
  C -->|error| E["destructive Alert"]
  C -->|no data| F["null"]
  C -->|data| G["Invoice table"]
```

<details> <summary><h3> File Walkthrough</h3></summary>

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody>
<tr><td><strong>Bug fix</strong></td><td><details><summary>2 files</summary><table>
<tr>
  <td><strong>BillingEstimate.tsx</strong><dd><code>Gate BillingDetails + divider behind useIsOrgAdmin</code></dd></td>
  <td><a href="https://github.com/nhost/nhost/pull/4568/files#diff-2300713498cf216c850ef2a28758a5fb856be297f073046d1b50001415ea84dd">+9/-2</a></td>
</tr>
<tr>
  <td><strong>BillingDetails.tsx</strong><dd><code>Add error alert + refine loading/empty guards</code></dd></td>
  <td><a href="https://github.com/nhost/nhost/pull/4568/files#diff-87baa19b5ebc4b6a0d75a7bf384ec6e10a1ae68ace507cdedbb7829484d67d9b">+21/-2</a></td>
</tr>
</table></details></td></tr>
</tbody></table>

</details>

___

<!-- nhost-reviewer:end -->
