### PR TITLE
fix(dashboard): keep lock icon inline in permission variables list

### DIFF
--- a/dashboard/src/features/orgs/projects/permissions/settings/components/PermissionVariableSettings/PermissionVariableSettings.tsx
+++ b/dashboard/src/features/orgs/projects/permissions/settings/components/PermissionVariableSettings/PermissionVariableSettings.tsx
@@ -238,7 +238,7 @@ export default function PermissionVariableSettings() {
                     <>
                       X-Hasura-{permissionVariable.key}{' '}
                       {permissionVariable.isSystemVariable && (
-                        <LockIcon className="h-4 w-4" />
+                        <LockIcon className="inline-block h-4 w-4" />
                       )}
                     </>
                   }


### PR DESCRIPTION
Before:
<img width="1010" height="458" alt="Screenshot 2026-06-19 at 16 23 22" src="https://github.com/user-attachments/assets/4b47e65d-fc31-49f4-97f7-c7a909f6e954" />

After:
<img width="1744" height="860" alt="image" src="https://github.com/user-attachments/assets/cc06e63f-5e33-46c0-8479-aedc88d1d161" />


### Checklist

- [X] No breaking changes
- [X] Tests pass
- [X] New features have new tests
- [X] Documentation is updated (if applicable)
- [X] Title of the PR is in the correct format (see below)

<!-- nhost-reviewer:start -->
### **What this PR solves**
In the Permission Variables settings list, the lock icon shown next to system permission variables rendered as a block-level element, pushing it onto its own line and misaligning it with the `X-Hasura-*` field name. Adding `inline-block` keeps the icon on the same line as the variable name (see the before/after screenshots above).

___

### **PR Type**
Bug fix

___

### **Description**
- Add the `inline-block` utility to the `LockIcon` className in `PermissionVariableSettings` so the system-variable lock icon stays inline with the variable name instead of breaking onto its own line.

___

<details> <summary><h3> File Walkthrough</h3></summary>

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody>
<tr><td><strong>Bug fix</strong></td><td><details><summary>1 files</summary><table>
<tr>
  <td><strong>PermissionVariableSettings.tsx</strong><dd><code>Render the system-variable lock icon inline-block so it stays beside the field name</code></dd></td>
  <td><a href="https://github.com/nhost/nhost/pull/4569/files#diff-ffbd1a0083e64318b68922362b6392090e24facc2a6476dc31e54e988a7599f6">+1/-1</a></td>
</tr>
</table></details></td></tr>
</tbody></table>

</details>

___

<!-- nhost-reviewer:end -->
