### PR TITLE
fix(dashboard): unify column types on specificType and fix date/time handling

### DIFF
--- a/dashboard/src/features/orgs/projects/common/components/DataGridFiltersPopover/DataGridFilter.tsx
+++ b/dashboard/src/features/orgs/projects/common/components/DataGridFiltersPopover/DataGridFilter.tsx
@@ -16,9 +16,9 @@ type FilterProps = {
 
 function DataGridFilter({ column, op, value, index }: FilterProps) {
   const { removeFilter } = useDataGridFilters();
-  const columns = useGetDataColumns<{ dataType: string }>();
-  const selectedColumnDataType = columns.find((col) => col.id === column)
-    ?.columnDef.meta?.dataType;
+  const columns = useGetDataColumns<{ specificType: string }>();
+  const selectedColumnSpecificType = columns.find((col) => col.id === column)
+    ?.columnDef.meta?.specificType;
 
   return (
     <div className="flex gap-2 p-1">
@@ -26,7 +26,7 @@ function DataGridFilter({ column, op, value, index }: FilterProps) {
       <DataGridFilterOperators
         value={op}
         index={index}
-        columnDataType={selectedColumnDataType}
+        columnSpecificType={selectedColumnSpecificType}
       />
       <DataGridFilterValue
         value={value}

--- a/dashboard/src/features/orgs/projects/common/components/DataGridFiltersPopover/DataGridFilterColumn.tsx
+++ b/dashboard/src/features/orgs/projects/common/components/DataGridFiltersPopover/DataGridFilterColumn.tsx
@@ -22,7 +22,7 @@ function DataGridFilterColumn({
   index,
   currentOp,
 }: DataFilterColumnProps) {
-  const columns = useGetDataColumns<{ dataType: string }>();
+  const columns = useGetDataColumns<{ specificType: string }>();
   const { setColumn, setOp, setValue } = useDataGridFilters();
   const selectRef = useRef<HTMLButtonElement | null>(null);
 
@@ -36,9 +36,9 @@ function DataGridFilterColumn({
       value={value}
       onValueChange={(newColumn) => {
         setColumn(index, newColumn);
-        const newDataType = columns.find((col) => col.id === newColumn)
-          ?.columnDef.meta?.dataType;
-        const availableOps = getAvailableOperators(newDataType);
+        const newSpecificType = columns.find((col) => col.id === newColumn)
+          ?.columnDef.meta?.specificType;
+        const availableOps = getAvailableOperators(newSpecificType);
         if (!availableOps.some((o) => o.op === currentOp)) {
           setOp(index, availableOps[0].op);
           setValue(index, '');
@@ -58,7 +58,7 @@ function DataGridFilterColumn({
           <SelectItem key={column.id} value={column.id}>
             {column.id}{' '}
             <Badge className="rounded-sm+ bg-secondary p-1 font-normal text-[0.75rem] leading-[0.75]">
-              {column.columnDef.meta?.dataType}
+              {column.columnDef.meta?.displayType}
             </Badge>
           </SelectItem>
         ))}

--- a/dashboard/src/features/orgs/projects/common/components/DataGridFiltersPopover/DataGridFilterOperators.tsx
+++ b/dashboard/src/features/orgs/projects/common/components/DataGridFiltersPopover/DataGridFilterOperators.tsx
@@ -13,13 +13,17 @@ import { useDataGridFilters } from './DataGridFiltersProvider';
 type DataFilterProps = {
   value: DataGridFilterOperator;
   index: number;
-  columnDataType?: string;
+  columnSpecificType?: string;
 };
 
-function DataGridOperators({ value, index, columnDataType }: DataFilterProps) {
+function DataGridOperators({
+  value,
+  index,
+  columnSpecificType,
+}: DataFilterProps) {
   const { setOp, setValue } = useDataGridFilters();
 
-  const availableOperators = getAvailableOperators(columnDataType);
+  const availableOperators = getAvailableOperators(columnSpecificType);
 
   function handleOpChange(newOp: DataGridFilterOperator) {
     setOp(index, newOp);

--- a/dashboard/src/features/orgs/projects/database/dataGrid/components/BaseRecordForm/BaseRecordForm.test.tsx
+++ b/dashboard/src/features/orgs/projects/database/dataGrid/components/BaseRecordForm/BaseRecordForm.test.tsx
@@ -17,9 +17,10 @@ const mockColumns: DataBrowserColumnMetadata[] = [
     isNullable: false,
     isIdentity: false,
     defaultValue: undefined,
-    type: 'text',
     specificType: 'text',
-    dataType: 'text',
+    baseType: 'text',
+    isArray: false,
+    displayType: 'text',
   },
 ];
 
@@ -49,9 +50,10 @@ const mockColumnsWithGenerated: DataBrowserColumnMetadata[] = [
     isIdentity: false,
     isGenerated: false,
     defaultValue: undefined,
-    type: 'number',
     specificType: 'numeric',
-    dataType: 'numeric',
+    baseType: 'numeric',
+    isArray: false,
+    displayType: 'numeric',
   },
   {
     id: 'total',
@@ -61,9 +63,10 @@ const mockColumnsWithGenerated: DataBrowserColumnMetadata[] = [
     isGenerated: true,
     generationExpression: 'price * quantity',
     defaultValue: undefined,
-    type: 'number',
     specificType: 'numeric',
-    dataType: 'numeric',
+    baseType: 'numeric',
+    isArray: false,
+    displayType: 'numeric',
   },
 ];
 
@@ -113,27 +116,30 @@ describe('BaseRecordForm handleSubmit', () => {
 
   const nullableColumnWithDefault: DataBrowserColumnMetadata = {
     id: 'col',
-    type: 'text',
     specificType: 'text',
-    dataType: 'text',
+    baseType: 'text',
+    isArray: false,
+    displayType: 'text',
     isNullable: true,
     defaultValue: 'some_default',
   };
 
   const requiredColumnWithDefault: DataBrowserColumnMetadata = {
     id: 'col',
-    type: 'text',
     specificType: 'text',
-    dataType: 'text',
+    baseType: 'text',
+    isArray: false,
+    displayType: 'text',
     isNullable: false,
     defaultValue: 'some_default',
   };
 
   const nullableColumnWithoutDefault: DataBrowserColumnMetadata = {
     id: 'col',
-    type: 'text',
     specificType: 'text',
-    dataType: 'text',
+    baseType: 'text',
+    isArray: false,
+    displayType: 'text',
     isNullable: true,
     defaultValue: undefined,
   };
@@ -219,7 +225,7 @@ describe('BaseRecordForm handleSubmit', () => {
     );
 
     expect(mocks.onSubmit).toHaveBeenCalledWith({
-      col: { value: '', specificType: 'text' },
+      col: { value: '', isArray: false },
     });
   });
 });

--- a/dashboard/src/features/orgs/projects/database/dataGrid/components/BaseRecordForm/BaseRecordForm.tsx
+++ b/dashboard/src/features/orgs/projects/database/dataGrid/components/BaseRecordForm/BaseRecordForm.tsx
@@ -9,6 +9,7 @@ import type {
   DataBrowserColumnMetadata,
 } from '@/features/orgs/projects/database/dataGrid/types/dataBrowser';
 import { POSTGRES_DEFAULT_PLACEHOLDER } from '@/features/orgs/projects/database/dataGrid/utils/postgresDefaultPlaceholder';
+import { serializeTemporalValue } from '@/features/orgs/projects/database/dataGrid/utils/serializeTemporalValue';
 import { cn } from '@/lib/utils';
 import type { DialogFormProps } from '@/types/common';
 
@@ -140,11 +141,8 @@ export default function BaseRecordForm({
         return {
           ...options,
           [columnId]: {
-            value:
-              gridColumn?.type === 'date' && value instanceof Date
-                ? value.toUTCString()
-                : value,
-            specificType: gridColumn?.specificType,
+            value: serializeTemporalValue(value, gridColumn?.baseType),
+            isArray: gridColumn?.isArray,
           },
         };
       }, {});

--- a/dashboard/src/features/orgs/projects/database/dataGrid/components/CreateRecordForm/CreateRecordForm.tsx
+++ b/dashboard/src/features/orgs/projects/database/dataGrid/components/CreateRecordForm/CreateRecordForm.tsx
@@ -38,7 +38,11 @@ export default function CreateRecordForm({
     defaultValues: props.columns.reduce((defaultValues, column) => {
       const hasDefault = !!(column.defaultValue || column.isIdentity);
 
-      if (column.type === 'boolean' && column.defaultValue) {
+      if (
+        column.baseType === 'boolean' &&
+        !column.isArray &&
+        column.defaultValue
+      ) {
         return { ...defaultValues, [column.id]: column.defaultValue };
       }
 

--- a/dashboard/src/features/orgs/projects/database/dataGrid/components/DataBrowserGrid/DataBrowserGrid.tsx
+++ b/dashboard/src/features/orgs/projects/database/dataGrid/components/DataBrowserGrid/DataBrowserGrid.tsx
@@ -26,15 +26,18 @@ import type {
   DataBrowserGridColumnDef,
   NormalizedQueryDataRow,
 } from '@/features/orgs/projects/database/dataGrid/types/dataBrowser';
+import { getBaseType } from '@/features/orgs/projects/database/dataGrid/utils/getBaseType';
+import { getDisplayType } from '@/features/orgs/projects/database/dataGrid/utils/getDisplayType';
+import { isArray } from '@/features/orgs/projects/database/dataGrid/utils/isArray';
 import { isGeneratedColumn } from '@/features/orgs/projects/database/dataGrid/utils/isGeneratedColumn';
 import { normalizeDefaultValue } from '@/features/orgs/projects/database/dataGrid/utils/normalizeDefaultValue';
 import {
   POSTGRESQL_CHARACTER_TYPES,
-  POSTGRESQL_DATE_TIME_TYPES,
   POSTGRESQL_JSON_TYPES,
   POSTGRESQL_NUMERIC_TYPES,
   POSTGRESQL_UNSORTABLE_TYPES,
 } from '@/features/orgs/projects/database/dataGrid/utils/postgresqlConstants';
+import { isTemporalType } from '@/features/orgs/projects/database/dataGrid/utils/temporalTypeHelpers';
 import {
   DataGrid,
   type DataGridProps,
@@ -81,19 +84,10 @@ export function extractColumnMetadata(
     primaryConstraints: column.primary_constraints,
     foreignKeyRelation: column.foreign_key_relation,
     specificType: column.full_data_type,
-    dataType: column.data_type,
-    type: 'text',
+    baseType: getBaseType(column.full_data_type),
+    isArray: isArray(column.full_data_type),
+    displayType: getDisplayType(column.full_data_type),
   };
-
-  if (POSTGRESQL_NUMERIC_TYPES.includes(column.data_type)) {
-    metadata.type = 'number';
-  } else if (column.data_type === 'boolean') {
-    metadata.type = 'boolean';
-  } else if (column.udt_name === 'uuid') {
-    metadata.type = 'uuid';
-  } else if (POSTGRESQL_DATE_TIME_TYPES.includes(column.data_type)) {
-    metadata.type = 'date';
-  }
 
   return metadata;
 }
@@ -123,7 +117,7 @@ export function createDataGridColumn(
           {column.column_name}
         </span>
 
-        <InlineCode>{column.full_data_type}</InlineCode>
+        <InlineCode>{meta.displayType}</InlineCode>
       </div>
     ),
     id: column.column_name,
@@ -136,7 +130,17 @@ export function createDataGridColumn(
     ),
   };
 
-  if (meta.type === 'number') {
+  if (meta.isArray) {
+    return {
+      ...defaultColumnConfiguration,
+      size: 250,
+      cell: (props: CellContext<UnknownDataGridRow, string>) => (
+        <DataGridTextCell {...props} />
+      ),
+    };
+  }
+
+  if (POSTGRESQL_NUMERIC_TYPES.includes(meta.baseType)) {
     return {
       ...defaultColumnConfiguration,
       size: 250,
@@ -146,7 +150,7 @@ export function createDataGridColumn(
     };
   }
 
-  if (meta.type === 'boolean') {
+  if (meta.baseType === 'boolean') {
     return {
       ...defaultColumnConfiguration,
       size: 140,
@@ -157,8 +161,8 @@ export function createDataGridColumn(
   }
 
   if (
-    POSTGRESQL_CHARACTER_TYPES.includes(column.data_type) ||
-    POSTGRESQL_JSON_TYPES.includes(column.data_type)
+    POSTGRESQL_CHARACTER_TYPES.includes(meta.baseType) ||
+    POSTGRESQL_JSON_TYPES.includes(meta.baseType)
   ) {
     return {
       ...defaultColumnConfiguration,
@@ -169,7 +173,7 @@ export function createDataGridColumn(
     };
   }
 
-  if (meta.type === 'uuid') {
+  if (meta.baseType === 'uuid') {
     return {
       ...defaultColumnConfiguration,
       size: 318,
@@ -179,7 +183,7 @@ export function createDataGridColumn(
     };
   }
 
-  if (meta.type === 'date') {
+  if (isTemporalType(meta.baseType)) {
     return {
       ...defaultColumnConfiguration,
       size: 200,

--- a/dashboard/src/features/orgs/projects/database/dataGrid/components/DataBrowserGrid/DataGridQueryParamsProvider/operators.ts
+++ b/dashboard/src/features/orgs/projects/database/dataGrid/components/DataBrowserGrid/DataGridQueryParamsProvider/operators.ts
@@ -57,9 +57,9 @@ const defaultColumnOperators = [
 ] as const;
 
 export function getAvailableOperators(
-  dataType?: string,
+  specificType?: string,
 ): readonly { op: DataGridFilterOperator; label: string }[] {
-  if (dataType === 'jsonb') {
+  if (specificType === 'jsonb') {
     return jsonbColumnOperators;
   }
 

--- a/dashboard/src/features/orgs/projects/database/dataGrid/components/DatabaseRecordInputGroup/DatabaseRecordInputGroup.tsx
+++ b/dashboard/src/features/orgs/projects/database/dataGrid/components/DatabaseRecordInputGroup/DatabaseRecordInputGroup.tsx
@@ -110,8 +110,10 @@ export default function DatabaseRecordInputGroup({
         {columns.map((column, index) => {
           const {
             id: columnId,
-            type,
             specificType,
+            baseType,
+            isArray,
+            displayType,
             defaultValue,
             isPrimary,
             isNullable,
@@ -122,11 +124,13 @@ export default function DatabaseRecordInputGroup({
           const hasDefault = !!(defaultValue || isIdentity);
 
           const isMultiline =
-            specificType === 'text' ||
-            specificType === 'bpchar' ||
-            specificType?.includes('character varying') ||
-            specificType === 'json' ||
-            specificType === 'jsonb';
+            isArray ||
+            baseType === 'text' ||
+            baseType === 'bpchar' ||
+            baseType === 'character' ||
+            baseType === 'character varying' ||
+            baseType === 'json' ||
+            baseType === 'jsonb';
 
           const inputLabel = (
             <span className="inline-grid grid-flow-col gap-1">
@@ -141,12 +145,12 @@ export default function DatabaseRecordInputGroup({
                 className="h-[1.125rem] overflow-hidden whitespace-nowrap leading-[1.125rem]"
                 title={specificType}
               >
-                {specificType}
+                {displayType}
               </InlineCode>
             </span>
           );
 
-          if (type === 'boolean') {
+          if (!isArray && baseType === 'boolean') {
             return (
               <FormSelect
                 key={columnId}
@@ -191,14 +195,21 @@ export default function DatabaseRecordInputGroup({
                 helperText={comment}
                 multiline={isMultiline}
                 className={cn({ 'focus-visible:ring-0': isMultiline })}
-                type={getInputType({ type, specificType })}
+                type={getInputType(baseType)}
               />
             );
           }
 
+          let fallbackPlaceholder: string | undefined;
+          if (isArray) {
+            fallbackPlaceholder = 'e.g. [1, 2, 3]';
+          } else if (isNullable) {
+            fallbackPlaceholder = 'NULL';
+          }
+
           const placeholder =
             getDefaultPlaceholder(defaultValue, isIdentity) ??
-            (isNullable ? 'NULL' : undefined);
+            fallbackPlaceholder;
           const InputComponent = isMultiline ? FormTextarea : FormInput;
           return (
             <InputComponent
@@ -218,7 +229,7 @@ export default function DatabaseRecordInputGroup({
                 { 'resize-none': isMultiline },
                 'focus-visible:ring-0',
               )}
-              type={getInputType({ type, specificType })}
+              type={getInputType(baseType)}
             />
           );
         })}

--- a/dashboard/src/features/orgs/projects/database/dataGrid/components/EditGraphQLSettingsForm/sections/ColumnsNameCustomizationSection/ColumnsNameCustomizationSection.tsx
+++ b/dashboard/src/features/orgs/projects/database/dataGrid/components/EditGraphQLSettingsForm/sections/ColumnsNameCustomizationSection/ColumnsNameCustomizationSection.tsx
@@ -12,6 +12,7 @@ import { useTableSchemaQuery } from '@/features/orgs/projects/database/common/ho
 import { useSetTableCustomizationMutation } from '@/features/orgs/projects/database/dataGrid/hooks/useSetTableCustomizationMutation';
 import { useTableCustomizationQuery } from '@/features/orgs/projects/database/dataGrid/hooks/useTableCustomizationQuery';
 import { convertSnakeToCamelCase } from '@/features/orgs/projects/database/dataGrid/utils/convertSnakeToCamelCase';
+import { getDisplayType } from '@/features/orgs/projects/database/dataGrid/utils/getDisplayType';
 import { prepareCustomGraphQLColumnNameDTO } from '@/features/orgs/projects/database/dataGrid/utils/prepareCustomGraphQLColumnNameDTO';
 import { execPromiseWithErrorToast } from '@/features/orgs/utils/execPromiseWithErrorToast';
 import { cn, isEmptyValue } from '@/lib/utils';
@@ -259,8 +260,9 @@ export default function ColumnsNameCustomizationSection({
                       return null;
                     }
 
-                    const dataType: string =
-                      column.full_data_type || column.data_type || 'unknown';
+                    const displayType: string = getDisplayType(
+                      column.full_data_type,
+                    );
                     const fieldPath =
                       `columns.${columnName}.graphqlFieldName` satisfies GraphQLFieldNamePath;
 
@@ -276,7 +278,7 @@ export default function ColumnsNameCustomizationSection({
                         </div>
 
                         <span className="font-mono text-foreground text-sm">
-                          {dataType}
+                          {displayType}
                         </span>
 
                         <FormInput

--- a/dashboard/src/features/orgs/projects/database/dataGrid/hooks/useCreateRecordMutation/createRecord.test.ts
+++ b/dashboard/src/features/orgs/projects/database/dataGrid/hooks/useCreateRecordMutation/createRecord.test.ts
@@ -48,7 +48,7 @@ describe('createRecord', () => {
     await createRecord({
       ...defaultOptions,
       columnValues: {
-        tags: { value: '["a","b","c"]', specificType: 'text[]' },
+        tags: { value: '["a","b","c"]', isArray: true },
       },
     });
 
@@ -65,7 +65,7 @@ describe('createRecord', () => {
     await createRecord({
       ...defaultOptions,
       columnValues: {
-        scores: { value: '[1,2,3]', specificType: 'integer[]' },
+        scores: { value: '[1,2,3]', isArray: true },
       },
     });
 
@@ -103,7 +103,7 @@ describe('createRecord', () => {
       createRecord({
         ...defaultOptions,
         columnValues: {
-          tags: { value: '{a,b}', specificType: 'text[]' },
+          tags: { value: '{a,b}', isArray: true },
         },
       }),
     ).rejects.toThrow('Invalid array value for column "tags"');

--- a/dashboard/src/features/orgs/projects/database/dataGrid/hooks/useCreateRecordMutation/createRecord.ts
+++ b/dashboard/src/features/orgs/projects/database/dataGrid/hooks/useCreateRecordMutation/createRecord.ts
@@ -34,13 +34,13 @@ export default async function createRecord<TData extends object = {}>({
 
   const values = columnIds
     .map((columnId) => {
-      const { value, fallbackValue, specificType } = columnValues[columnId];
+      const { value, fallbackValue, isArray } = columnValues[columnId];
 
       if (!value && fallbackValue) {
         return fallbackValue;
       }
 
-      if (specificType?.endsWith('[]')) {
+      if (isArray) {
         try {
           return format('ARRAY[%L]', JSON.parse(value as string));
         } catch {

--- a/dashboard/src/features/orgs/projects/database/dataGrid/hooks/useUpdateRecordMutation/updateRecord.test.ts
+++ b/dashboard/src/features/orgs/projects/database/dataGrid/hooks/useUpdateRecordMutation/updateRecord.test.ts
@@ -1,6 +1,7 @@
 import { HttpResponse, http } from 'msw';
 import { setupServer } from 'msw/node';
 import type { DataBrowserGridRow } from '@/features/orgs/projects/database/dataGrid/types/dataBrowser';
+import { isArray } from '@/features/orgs/projects/database/dataGrid/utils/isArray';
 import updateRecord from './updateRecord';
 
 const defaultOptions = {
@@ -31,6 +32,7 @@ function makeRow(cells: RowCell[]): DataBrowserGridRow {
               id: c.id,
               isPrimary: c.isPrimary ?? false,
               specificType: c.specificType,
+              isArray: isArray(c.specificType),
             },
           },
         },

--- a/dashboard/src/features/orgs/projects/database/dataGrid/hooks/useUpdateRecordMutation/updateRecord.ts
+++ b/dashboard/src/features/orgs/projects/database/dataGrid/hooks/useUpdateRecordMutation/updateRecord.ts
@@ -81,7 +81,7 @@ export default async function updateRecord<
           (column.columnDef.meta as DataBrowserColumnMetadata)?.id === key,
       )!.column.columnDef.meta as DataBrowserColumnMetadata;
 
-      if (col.specificType.endsWith('[]')) {
+      if (col.isArray) {
         try {
           return format('%I = ARRAY[%L]', key, JSON.parse(value));
         } catch {

--- a/dashboard/src/features/orgs/projects/database/dataGrid/types/dataBrowser/dataBrowser.ts
+++ b/dashboard/src/features/orgs/projects/database/dataGrid/types/dataBrowser/dataBrowser.ts
@@ -285,10 +285,11 @@ export interface ColumnInsertOptions {
    */
   fallbackValue?: 'NULL' | 'DEFAULT';
   /**
-   * PostgreSQL specific type of the column (e.g. `text`, `integer[]`).
-   * Used to determine special SQL formatting such as ARRAY[...] literals.
+   * Whether the column is a PostgreSQL array. When true the value is emitted as
+   * an `ARRAY[...]` literal instead of a plain literal. Derived once on the
+   * column metadata (`isArray`); the mutation never re-parses a type string.
    */
-  specificType?: string;
+  isArray?: boolean;
 }
 
 /**
@@ -311,7 +312,10 @@ export type BooleanColumnType = 'bool';
 export type UUIDColumnType = 'uuid';
 
 /**
- * User defined column type of a date / time field in PostgreSQL.
+ * User defined column type of a date / time field in PostgreSQL — the short
+ * picker / DDL names. The long `FORMAT_TYPE` spellings (e.g. `timestamp with
+ * time zone`) are introspection output and live in plain `string` fields, not
+ * in `ColumnType`.
  */
 export type DateColumnType =
   | 'date'
@@ -319,11 +323,7 @@ export type DateColumnType =
   | 'timestamptz'
   | 'time'
   | 'timetz'
-  | 'interval'
-  | 'timestamp without time zone'
-  | 'timestamp with time zone'
-  | 'time without time zone'
-  | 'time with time zone';
+  | 'interval';
 
 /**
  * User defined column type of a numeric field in PostgreSQL.
@@ -540,17 +540,32 @@ export interface DataBrowserColumnMetadata {
    */
   id: string;
   /**
-   * Simple type of the column.
+   * PostgreSQL type as returned by FORMAT_TYPE (e.g. `timestamp with time
+   * zone`, `character varying(12)`, `integer[]`). Raw source of truth for type
+   * logic; the `baseType` / `isArray` siblings are derived from it once at
+   * metadata-build time so views never re-parse it.
    */
-  type: 'text' | 'number' | 'boolean' | 'date' | 'uuid';
+  specificType: string;
   /**
-   * Specific database type of the column (e.g. `timestamptz`).
+   * Element family of `specificType` with the `[]` array suffix and any `(…)`
+   * precision modifier stripped (e.g. `integer`, `timestamp with time zone`),
+   * derived via `getBaseType`. Pair with `isArray` for the shape axis — never
+   * re-derive this from `specificType` in a view.
    */
-  specificType: ColumnType;
+  baseType: string;
   /**
-   * Data type of the column (e.g. `timestamp with time zone`).
+   * Whether the column is a PostgreSQL array (`integer[]`). The shape axis that
+   * `baseType` discards; check this before any `baseType` branch so arrays are
+   * not treated as their scalar element.
    */
-  dataType: string;
+  isArray: boolean;
+  /**
+   * Short, user-facing label for the type (e.g. `timestamptz`, `varchar(12)`),
+   * derived from `specificType` via `getDisplayType` when the metadata is
+   * built. Render this — not `specificType` — so the displayed type is
+   * consistent everywhere.
+   */
+  displayType: string;
   /**
    * Default value of the column. `null` when the column has no default.
    */

--- a/dashboard/src/features/orgs/projects/database/dataGrid/utils/getBaseType/getBaseType.test.ts
+++ b/dashboard/src/features/orgs/projects/database/dataGrid/utils/getBaseType/getBaseType.test.ts
@@ -1,0 +1,57 @@
+import getBaseType from './getBaseType';
+
+it('returns an empty string for empty, null or undefined input', () => {
+  expect(getBaseType(undefined)).toBe('');
+  expect(getBaseType(null)).toBe('');
+  expect(getBaseType('')).toBe('');
+});
+
+it('passes a bare type through unchanged', () => {
+  expect(getBaseType('integer')).toBe('integer');
+  expect(getBaseType('text')).toBe('text');
+  expect(getBaseType('timestamp with time zone')).toBe(
+    'timestamp with time zone',
+  );
+});
+
+it('strips length and precision modifiers', () => {
+  expect(getBaseType('character varying(12)')).toBe('character varying');
+  expect(getBaseType('numeric(10,2)')).toBe('numeric');
+});
+
+it('strips modifiers that appear in the middle of the name', () => {
+  expect(getBaseType('timestamp(3) with time zone')).toBe(
+    'timestamp with time zone',
+  );
+  expect(getBaseType('time(6) without time zone')).toBe(
+    'time without time zone',
+  );
+});
+
+it('strips a trailing array marker', () => {
+  expect(getBaseType('integer[]')).toBe('integer');
+  expect(getBaseType('text[]')).toBe('text');
+});
+
+it('strips array markers and modifiers together', () => {
+  expect(getBaseType('character varying(12)[]')).toBe('character varying');
+  expect(getBaseType('numeric(10,2)[]')).toBe('numeric');
+});
+
+it('leaves custom and schema-qualified type names intact', () => {
+  expect(getBaseType('my_enum')).toBe('my_enum');
+  expect(getBaseType('public.my_status')).toBe('public.my_status');
+});
+
+it('preserves parentheses inside double-quoted (custom) type names', () => {
+  expect(getBaseType('"my(type)"')).toBe('"my(type)"');
+  expect(getBaseType('public."my(type)"')).toBe('public."my(type)"');
+});
+
+it('strips only a trailing array marker from quoted type names', () => {
+  expect(getBaseType('"my(type)"[]')).toBe('"my(type)"');
+});
+
+it('preserves internal whitespace in quoted type names', () => {
+  expect(getBaseType('"My  Enum"')).toBe('"My  Enum"');
+});

--- a/dashboard/src/features/orgs/projects/database/dataGrid/utils/getBaseType/getBaseType.ts
+++ b/dashboard/src/features/orgs/projects/database/dataGrid/utils/getBaseType/getBaseType.ts
@@ -1,0 +1,35 @@
+/**
+ * Reduces a PostgreSQL type string to its bare base type name by removing a
+ * trailing array marker (`[]`) and length / precision modifiers (`(…)`), which
+ * may appear at the end (`character varying(12)`, `numeric(10,2)`) or in the
+ * middle (`timestamp(3) with time zone`).
+ *
+ * Casing is preserved so custom (and schema-qualified) type names survive
+ * untouched. Parentheses inside a double-quoted identifier are part of the
+ * name — a type can legally be named `"my(type)"` — so quoted names keep
+ * everything but a trailing array marker, since built-in types that carry a
+ * real modifier are never quoted.
+ *
+ * @example
+ * getBaseType('character varying(12)')       // 'character varying'
+ * getBaseType('integer[]')                   // 'integer'
+ * getBaseType('timestamp(3) with time zone') // 'timestamp with time zone'
+ * getBaseType('public.my_status')            // 'public.my_status'
+ * getBaseType('"my(type)"')                  // '"my(type)"'
+ */
+export default function getBaseType(specificType?: string | null): string {
+  if (!specificType) {
+    return '';
+  }
+
+  const withoutArray = specificType.replace(/(\[\])+$/, '');
+
+  if (withoutArray.includes('"')) {
+    return withoutArray.trim();
+  }
+
+  return withoutArray
+    .replace(/\([^)]*\)/g, '')
+    .replace(/\s+/g, ' ')
+    .trim();
+}

--- a/dashboard/src/features/orgs/projects/database/dataGrid/utils/getBaseType/index.ts
+++ b/dashboard/src/features/orgs/projects/database/dataGrid/utils/getBaseType/index.ts
@@ -1,0 +1,1 @@
+export { default as getBaseType } from './getBaseType';

--- a/dashboard/src/features/orgs/projects/database/dataGrid/utils/getDisplayType/getDisplayType.test.ts
+++ b/dashboard/src/features/orgs/projects/database/dataGrid/utils/getDisplayType/getDisplayType.test.ts
@@ -1,0 +1,63 @@
+import getDisplayType from './getDisplayType';
+
+it('returns an empty string for empty, null or undefined input', () => {
+  expect(getDisplayType(undefined)).toBe('');
+  expect(getDisplayType(null)).toBe('');
+  expect(getDisplayType('')).toBe('');
+});
+
+it('shortens the verbose multi-word names', () => {
+  expect(getDisplayType('timestamp with time zone')).toBe('timestamptz');
+  expect(getDisplayType('timestamp without time zone')).toBe('timestamp');
+  expect(getDisplayType('time with time zone')).toBe('timetz');
+  expect(getDisplayType('time without time zone')).toBe('time');
+  expect(getDisplayType('character varying')).toBe('varchar');
+});
+
+it('normalizes short udt names to their readable SQL name', () => {
+  expect(getDisplayType('int2')).toBe('smallint');
+  expect(getDisplayType('int4')).toBe('integer');
+  expect(getDisplayType('int8')).toBe('bigint');
+  expect(getDisplayType('float4')).toBe('real');
+  expect(getDisplayType('bool')).toBe('boolean');
+  expect(getDisplayType('bpchar')).toBe('character');
+});
+
+it('leaves readable names unchanged', () => {
+  expect(getDisplayType('integer')).toBe('integer');
+  expect(getDisplayType('numeric')).toBe('numeric');
+  expect(getDisplayType('text')).toBe('text');
+  expect(getDisplayType('uuid')).toBe('uuid');
+  expect(getDisplayType('jsonb')).toBe('jsonb');
+  expect(getDisplayType('date')).toBe('date');
+  expect(getDisplayType('interval')).toBe('interval');
+  expect(getDisplayType('boolean')).toBe('boolean');
+});
+
+it('keeps double precision long, from either spelling', () => {
+  expect(getDisplayType('double precision')).toBe('double precision');
+  expect(getDisplayType('float8')).toBe('double precision');
+});
+
+it('preserves length and precision modifiers', () => {
+  expect(getDisplayType('character varying(12)')).toBe('varchar(12)');
+  expect(getDisplayType('numeric(10,2)')).toBe('numeric(10,2)');
+  expect(getDisplayType('character(5)')).toBe('character(5)');
+});
+
+it('preserves array suffixes and shortens the element type', () => {
+  expect(getDisplayType('integer[]')).toBe('integer[]');
+  expect(getDisplayType('timestamp with time zone[]')).toBe('timestamptz[]');
+  expect(getDisplayType('character varying(255)[]')).toBe('varchar(255)[]');
+});
+
+it('drops fractional-seconds precision on timestamp / time types', () => {
+  expect(getDisplayType('timestamp(3) with time zone')).toBe('timestamptz');
+  expect(getDisplayType('time(6) without time zone')).toBe('time');
+});
+
+it('passes custom, schema-qualified and quoted type names through unchanged', () => {
+  expect(getDisplayType('my_enum')).toBe('my_enum');
+  expect(getDisplayType('public.my_status')).toBe('public.my_status');
+  expect(getDisplayType('"my(type)"')).toBe('"my(type)"');
+});

--- a/dashboard/src/features/orgs/projects/database/dataGrid/utils/getDisplayType/getDisplayType.ts
+++ b/dashboard/src/features/orgs/projects/database/dataGrid/utils/getDisplayType/getDisplayType.ts
@@ -1,0 +1,61 @@
+import { getBaseType } from '@/features/orgs/projects/database/dataGrid/utils/getBaseType';
+
+/**
+ * Maps the type spellings used across the app to a single canonical display
+ * name per type, so the same column reads identically in the column editor
+ * (short `udt_name` forms) and the data browser (`FORMAT_TYPE` long forms).
+ *
+ * Two rules are folded together:
+ *  - short internal names normalize to their readable SQL name
+ *    (`int4` → `integer`, `bool` → `boolean`), and
+ *  - genuinely verbose multi-word names are shortened
+ *    (`timestamp with time zone` → `timestamptz`, `character varying` →
+ *    `varchar`).
+ *
+ * `double precision` is intentionally left long, and anything not listed
+ * (custom types, geometric / network / object-identifier types, …) passes
+ * through unchanged — including its original casing.
+ */
+const TYPE_DISPLAY_NAMES: Record<string, string> = {
+  int2: 'smallint',
+  int4: 'integer',
+  int8: 'bigint',
+  float4: 'real',
+  float8: 'double precision',
+  bool: 'boolean',
+  bpchar: 'character',
+  'character varying': 'varchar',
+  'timestamp with time zone': 'timestamptz',
+  'timestamp without time zone': 'timestamp',
+  'time with time zone': 'timetz',
+  'time without time zone': 'time',
+};
+
+/**
+ * Builds the user-facing label for a column type from its `specificType`,
+ * preserving length / precision modifiers (`varchar(12)`) and array suffixes
+ * (`integer[]`). Fractional-seconds precision on timestamp / time types is
+ * dropped (it sits mid-name and is purely informational), matching what the
+ * column editor offers.
+ *
+ * @example
+ * getDisplayType('timestamp with time zone') // 'timestamptz'
+ * getDisplayType('character varying(12)')    // 'varchar(12)'
+ * getDisplayType('integer[]')                // 'integer[]'
+ * getDisplayType('int4')                     // 'integer'
+ * getDisplayType('public.my_status')         // 'public.my_status'
+ */
+export default function getDisplayType(specificType?: string | null): string {
+  if (!specificType) {
+    return '';
+  }
+
+  const isArray = /(\[\])+$/.test(specificType);
+  const withoutArray = specificType.replace(/(\[\])+$/, '');
+  const trailingModifier = withoutArray.match(/\([^)]*\)$/)?.[0] ?? '';
+
+  const base = getBaseType(specificType);
+  const displayBase = TYPE_DISPLAY_NAMES[base] ?? base;
+
+  return `${displayBase}${trailingModifier}${isArray ? '[]' : ''}`;
+}

--- a/dashboard/src/features/orgs/projects/database/dataGrid/utils/getDisplayType/index.ts
+++ b/dashboard/src/features/orgs/projects/database/dataGrid/utils/getDisplayType/index.ts
@@ -1,0 +1,1 @@
+export { default as getDisplayType } from './getDisplayType';

--- a/dashboard/src/features/orgs/projects/database/dataGrid/utils/inputHelpers/getInputType/getInputType.test.ts
+++ b/dashboard/src/features/orgs/projects/database/dataGrid/utils/inputHelpers/getInputType/getInputType.test.ts
@@ -1,61 +1,35 @@
-import { describe, expect, test } from 'vitest';
 import getInputType from './getInputType';
 
 describe('getInputType', () => {
-  test('should return "number" if the column is numeric', () => {
-    expect(getInputType({ type: 'number' })).toBe('number');
-    expect(getInputType({ type: 'number', specificType: 'numeric' })).toBe(
-      'number',
-    );
-    expect(getInputType({ type: 'number', specificType: 'int4' })).toBe(
-      'number',
-    );
+  it('returns "datetime-local" for timestamp types', () => {
+    expect(getInputType('timestamp')).toBe('datetime-local');
+    expect(getInputType('timestamptz')).toBe('datetime-local');
+    expect(getInputType('timestamp without time zone')).toBe('datetime-local');
+    expect(getInputType('timestamp with time zone')).toBe('datetime-local');
   });
 
-  test('should return "text" if the column is text based', () => {
-    expect(getInputType({ type: 'text', specificType: 'text' })).toBe('text');
-    expect(
-      getInputType({ type: 'text', specificType: 'character varying' }),
-    ).toBe('text');
-    expect(getInputType({ type: 'text', specificType: 'bpchar' })).toBe('text');
+  it('returns "time" for time-of-day types', () => {
+    expect(getInputType('time')).toBe('time');
+    expect(getInputType('timetz')).toBe('time');
+    expect(getInputType('time without time zone')).toBe('time');
+    expect(getInputType('time with time zone')).toBe('time');
   });
 
-  test('should return "date" if the column has "date" type, but not time', () => {
-    expect(getInputType({ type: 'date' })).toBe('date');
-    expect(getInputType({ type: 'date', specificType: 'time' })).not.toBe(
-      'date',
-    );
+  it('returns "date" for the calendar date type', () => {
+    expect(getInputType('date')).toBe('date');
   });
 
-  test('should return "datetime-local" if the column has a "datetime" type, but not time', () => {
-    expect(getInputType({ type: 'date', specificType: 'timestamp' })).toBe(
-      'datetime-local',
-    );
-    expect(getInputType({ type: 'date', specificType: 'timestamptz' })).toBe(
-      'datetime-local',
-    );
-    expect(
-      getInputType({
-        type: 'date',
-        specificType: 'timestamp without time zone',
-      }),
-    ).toBe('datetime-local');
-    expect(
-      getInputType({ type: 'date', specificType: 'timestamp with time zone' }),
-    ).toBe('datetime-local');
-    expect(getInputType({ type: 'date', specificType: 'time' })).not.toBe(
-      'date',
-    );
+  it('returns "number" for numeric types', () => {
+    expect(getInputType('integer')).toBe('number');
+    expect(getInputType('numeric')).toBe('number');
+    expect(getInputType('double precision')).toBe('number');
   });
 
-  test('should return "time" if the column has a "time" type', () => {
-    expect(getInputType({ type: 'date', specificType: 'time' })).toBe('time');
-    expect(getInputType({ type: 'date', specificType: 'timetz' })).toBe('time');
-    expect(
-      getInputType({ type: 'date', specificType: 'time without time zone' }),
-    ).toBe('time');
-    expect(
-      getInputType({ type: 'date', specificType: 'time with time zone' }),
-    ).toBe('time');
+  it('returns "text" for text, interval and unknown types', () => {
+    expect(getInputType('text')).toBe('text');
+    expect(getInputType('character varying')).toBe('text');
+    expect(getInputType('interval')).toBe('text');
+    expect(getInputType('uuid')).toBe('text');
+    expect(getInputType(undefined)).toBe('text');
   });
 });

--- a/dashboard/src/features/orgs/projects/database/dataGrid/utils/inputHelpers/getInputType/getInputType.ts
+++ b/dashboard/src/features/orgs/projects/database/dataGrid/utils/inputHelpers/getInputType/getInputType.ts
@@ -1,54 +1,35 @@
 import type { InputProps } from '@/components/ui/v2/Input';
-import type { ColumnType } from '@/features/orgs/projects/database/dataGrid/types/dataBrowser';
-
-function isTimestampType(specificType?: string | null) {
-  if (!specificType) {
-    return false;
-  }
-  return (
-    ['timestamp', 'timestamptz'].includes(specificType) ||
-    specificType.includes('timestamp')
-  );
-}
-
-function isTimeType(specificType?: string | null) {
-  if (!specificType) {
-    return false;
-  }
-  return (
-    ['time', 'timetz'].includes(specificType) ||
-    (specificType.includes('time') && !specificType.includes('timestamp'))
-  );
-}
+import { POSTGRESQL_NUMERIC_TYPES } from '@/features/orgs/projects/database/dataGrid/utils/postgresqlConstants';
+import {
+  isDateType,
+  isTimestampType,
+  isTimeType,
+} from '@/features/orgs/projects/database/dataGrid/utils/temporalTypeHelpers';
 
 /**
- * Get the input type based on the column type.
- *
- * @param column - Column
- * @returns Input type
+ * Picks the HTML input type for a scalar column from its `baseType`:
+ * `datetime-local` for timestamps, `time` for time-of-day types, `date` for
+ * calendar dates, `number` for numeric types, and `text` for everything else
+ * (including `interval`, which has no native control). Array columns do reach
+ * this function, but the returned type is unused: the input group forces them
+ * to a multiline textarea, where the `type` prop has no effect.
  */
-export default function getInputType({
-  type,
-  specificType,
-}: {
-  type?: string;
-  specificType?: ColumnType | null;
-}): InputProps['type'] {
-  const specType = specificType as string;
-
-  if (type === 'date' && isTimestampType(specType)) {
+export default function getInputType(
+  baseType?: string | null,
+): InputProps['type'] {
+  if (isTimestampType(baseType)) {
     return 'datetime-local';
   }
 
-  if (type === 'date' && isTimeType(specType)) {
+  if (isTimeType(baseType)) {
     return 'time';
   }
 
-  if (type === 'date' && specType !== 'interval') {
+  if (isDateType(baseType)) {
     return 'date';
   }
 
-  if (type === 'number') {
+  if (POSTGRESQL_NUMERIC_TYPES.includes(baseType ?? '')) {
     return 'number';
   }
 

--- a/dashboard/src/features/orgs/projects/database/dataGrid/utils/isArray/index.ts
+++ b/dashboard/src/features/orgs/projects/database/dataGrid/utils/isArray/index.ts
@@ -1,0 +1,1 @@
+export { default as isArray } from './isArray';

--- a/dashboard/src/features/orgs/projects/database/dataGrid/utils/isArray/isArray.test.ts
+++ b/dashboard/src/features/orgs/projects/database/dataGrid/utils/isArray/isArray.test.ts
@@ -1,0 +1,26 @@
+import isArray from './isArray';
+
+describe('isArray', () => {
+  it('returns true for array types', () => {
+    expect(isArray('integer[]')).toBe(true);
+    expect(isArray('text[]')).toBe(true);
+    expect(isArray('character varying(255)[]')).toBe(true);
+    expect(isArray('timestamp with time zone[]')).toBe(true);
+  });
+
+  it('returns true for multi-dimensional arrays', () => {
+    expect(isArray('integer[][]')).toBe(true);
+  });
+
+  it('returns false for scalar types', () => {
+    expect(isArray('integer')).toBe(false);
+    expect(isArray('character varying(255)')).toBe(false);
+    expect(isArray('uuid')).toBe(false);
+  });
+
+  it('returns false for empty or nullish input', () => {
+    expect(isArray('')).toBe(false);
+    expect(isArray(null)).toBe(false);
+    expect(isArray(undefined)).toBe(false);
+  });
+});

--- a/dashboard/src/features/orgs/projects/database/dataGrid/utils/isArray/isArray.ts
+++ b/dashboard/src/features/orgs/projects/database/dataGrid/utils/isArray/isArray.ts
@@ -1,0 +1,15 @@
+const ARRAY_SUFFIX_REGEX = /(\[\])+$/;
+
+/**
+ * Whether a PostgreSQL `specificType` denotes an array (`integer[]`,
+ * `text[][]`, …). This is the *shape* axis of a column type; pair it with
+ * `getBaseType` (the *family* axis) to describe a column without losing
+ * information — `getBaseType` strips the `[]`, this keeps it.
+ *
+ * @example
+ * isArray('integer[]')  // true
+ * isArray('integer')    // false
+ */
+export default function isArray(specificType?: string | null): boolean {
+  return ARRAY_SUFFIX_REGEX.test(specificType ?? '');
+}

--- a/dashboard/src/features/orgs/projects/database/dataGrid/utils/postgresqlConstants/postgresqlConstants.ts
+++ b/dashboard/src/features/orgs/projects/database/dataGrid/utils/postgresqlConstants/postgresqlConstants.ts
@@ -70,18 +70,36 @@ export const POSTGRESQL_UNSORTABLE_TYPES = [
 ];
 
 /**
- * Date / Time types in PostgreSQL.
- *
- * @docs https://www.postgresql.org/docs/current/datatype-datetime.html
+ * Timestamp types in PostgreSQL, in both the `information_schema` /
+ * `FORMAT_TYPE` long form and the short `udt_name` form.
  */
-export const POSTGRESQL_DATE_TIME_TYPES = [
-  'timestamp without time zone',
+export const POSTGRESQL_TIMESTAMP_TYPES = [
   'timestamp with time zone',
-  'date',
-  'time without time zone',
-  'time with time zone',
-  'interval',
+  'timestamp without time zone',
+  'timestamptz',
+  'timestamp',
 ];
+
+/**
+ * Time-of-day types in PostgreSQL (long and short spellings).
+ */
+export const POSTGRESQL_TIME_TYPES = [
+  'time with time zone',
+  'time without time zone',
+  'timetz',
+  'time',
+];
+
+/**
+ * Calendar date type in PostgreSQL.
+ */
+export const POSTGRESQL_DATE_TYPES = ['date'];
+
+/**
+ * Interval type in PostgreSQL. Interval columns may also carry a field
+ * qualifier (e.g. `interval day to second`), matched by `isIntervalType`.
+ */
+export const POSTGRESQL_INTERVAL_TYPES = ['interval'];
 
 /**
  * Types grouped by category in PostgreSQL.

--- a/dashboard/src/features/orgs/projects/database/dataGrid/utils/serializeTemporalValue/index.ts
+++ b/dashboard/src/features/orgs/projects/database/dataGrid/utils/serializeTemporalValue/index.ts
@@ -1,0 +1,1 @@
+export { default as serializeTemporalValue } from './serializeTemporalValue';

--- a/dashboard/src/features/orgs/projects/database/dataGrid/utils/serializeTemporalValue/serializeTemporalValue.test.ts
+++ b/dashboard/src/features/orgs/projects/database/dataGrid/utils/serializeTemporalValue/serializeTemporalValue.test.ts
@@ -1,0 +1,37 @@
+import serializeTemporalValue from './serializeTemporalValue';
+
+describe('serializeTemporalValue', () => {
+  it('passes non-Date values through unchanged', () => {
+    expect(serializeTemporalValue('1 day', 'interval')).toBe('1 day');
+    expect(serializeTemporalValue('10:30', 'time without time zone')).toBe(
+      '10:30',
+    );
+    expect(serializeTemporalValue('hello', 'text')).toBe('hello');
+    expect(serializeTemporalValue(null, 'date')).toBe(null);
+    expect(
+      serializeTemporalValue(undefined, 'timestamp with time zone'),
+    ).toBeUndefined();
+  });
+
+  it('formats a date as local yyyy-MM-dd without shifting the day', () => {
+    const localMidnight = new Date(2024, 0, 15, 0, 0, 0);
+
+    expect(serializeTemporalValue(localMidnight, 'date')).toBe('2024-01-15');
+  });
+
+  it('keeps the local wall-clock for timestamp without time zone', () => {
+    const local = new Date(2024, 0, 15, 10, 30, 0);
+
+    expect(serializeTemporalValue(local, 'timestamp without time zone')).toBe(
+      '2024-01-15T10:30:00',
+    );
+  });
+
+  it('serializes timestamp with time zone as the UTC instant', () => {
+    const local = new Date(2024, 0, 15, 10, 30, 0);
+
+    expect(serializeTemporalValue(local, 'timestamp with time zone')).toBe(
+      local.toISOString(),
+    );
+  });
+});

--- a/dashboard/src/features/orgs/projects/database/dataGrid/utils/serializeTemporalValue/serializeTemporalValue.ts
+++ b/dashboard/src/features/orgs/projects/database/dataGrid/utils/serializeTemporalValue/serializeTemporalValue.ts
@@ -1,0 +1,44 @@
+import { format } from 'date-fns-v4';
+import {
+  isDateType,
+  isTimestampType,
+} from '@/features/orgs/projects/database/dataGrid/utils/temporalTypeHelpers';
+
+/**
+ * Serializes a temporal record-form value into the string PostgreSQL expects
+ * for the column's type. Non-temporal values — and the string-based `time` /
+ * `timetz` / `interval` types — are returned unchanged.
+ *
+ * Date/time inputs arrive here as a **local** `Date` (the picker / yup cast
+ * them), so converting through UTC — as `toUTCString()` did — shifts the value
+ * for anyone outside UTC: a `date` rolls to the previous day and a wall-clock
+ * `timestamp` moves by the offset. Instead, format from local components:
+ *  - `date` → `yyyy-MM-dd` (keeps the picked calendar day),
+ *  - `timestamp without time zone` → `yyyy-MM-dd'T'HH:mm:ss` (keeps the typed
+ *    wall-clock),
+ *  - `timestamp with time zone` → `toISOString()` (the instant is what matters
+ *    and round-trips correctly).
+ */
+export default function serializeTemporalValue(
+  value: unknown,
+  baseType?: string | null,
+): unknown {
+  if (!(value instanceof Date)) {
+    return value;
+  }
+
+  if (isDateType(baseType)) {
+    return format(value, 'yyyy-MM-dd');
+  }
+
+  if (isTimestampType(baseType)) {
+    const hasTimeZone =
+      baseType === 'timestamp with time zone' || baseType === 'timestamptz';
+
+    return hasTimeZone
+      ? value.toISOString()
+      : format(value, "yyyy-MM-dd'T'HH:mm:ss");
+  }
+
+  return value;
+}

--- a/dashboard/src/features/orgs/projects/database/dataGrid/utils/temporalTypeHelpers/index.ts
+++ b/dashboard/src/features/orgs/projects/database/dataGrid/utils/temporalTypeHelpers/index.ts
@@ -1,0 +1,1 @@
+export * from './temporalTypeHelpers';

--- a/dashboard/src/features/orgs/projects/database/dataGrid/utils/temporalTypeHelpers/temporalTypeHelpers.test.ts
+++ b/dashboard/src/features/orgs/projects/database/dataGrid/utils/temporalTypeHelpers/temporalTypeHelpers.test.ts
@@ -1,0 +1,73 @@
+import {
+  isDateType,
+  isIntervalType,
+  isTemporalType,
+  isTimestampType,
+  isTimeType,
+} from './temporalTypeHelpers';
+
+describe('isTimestampType', () => {
+  it('matches timestamp types in long and short form', () => {
+    expect(isTimestampType('timestamp with time zone')).toBe(true);
+    expect(isTimestampType('timestamp without time zone')).toBe(true);
+    expect(isTimestampType('timestamptz')).toBe(true);
+    expect(isTimestampType('timestamp')).toBe(true);
+  });
+
+  it('does not match time, date or non-temporal types', () => {
+    expect(isTimestampType('time with time zone')).toBe(false);
+    expect(isTimestampType('date')).toBe(false);
+    expect(isTimestampType('text')).toBe(false);
+    expect(isTimestampType(undefined)).toBe(false);
+  });
+});
+
+describe('isTimeType', () => {
+  it('matches time-of-day types in long and short form', () => {
+    expect(isTimeType('time with time zone')).toBe(true);
+    expect(isTimeType('time without time zone')).toBe(true);
+    expect(isTimeType('timetz')).toBe(true);
+    expect(isTimeType('time')).toBe(true);
+  });
+
+  it('does not match timestamp types', () => {
+    expect(isTimeType('timestamp with time zone')).toBe(false);
+    expect(isTimeType('timestamptz')).toBe(false);
+  });
+});
+
+describe('isDateType', () => {
+  it('matches only the calendar date type', () => {
+    expect(isDateType('date')).toBe(true);
+    expect(isDateType('timestamp with time zone')).toBe(false);
+    expect(isDateType('interval')).toBe(false);
+  });
+});
+
+describe('isIntervalType', () => {
+  it('matches interval and field-qualified variants', () => {
+    expect(isIntervalType('interval')).toBe(true);
+    expect(isIntervalType('interval day to second')).toBe(true);
+  });
+
+  it('does not match other temporal types', () => {
+    expect(isIntervalType('time with time zone')).toBe(false);
+    expect(isIntervalType('date')).toBe(false);
+  });
+});
+
+describe('isTemporalType', () => {
+  it('is true for any date/time type', () => {
+    expect(isTemporalType('timestamp with time zone')).toBe(true);
+    expect(isTemporalType('time with time zone')).toBe(true);
+    expect(isTemporalType('date')).toBe(true);
+    expect(isTemporalType('interval')).toBe(true);
+  });
+
+  it('is false for non-temporal types', () => {
+    expect(isTemporalType('text')).toBe(false);
+    expect(isTemporalType('integer')).toBe(false);
+    expect(isTemporalType('uuid')).toBe(false);
+    expect(isTemporalType(undefined)).toBe(false);
+  });
+});

--- a/dashboard/src/features/orgs/projects/database/dataGrid/utils/temporalTypeHelpers/temporalTypeHelpers.ts
+++ b/dashboard/src/features/orgs/projects/database/dataGrid/utils/temporalTypeHelpers/temporalTypeHelpers.ts
@@ -1,0 +1,60 @@
+import {
+  POSTGRESQL_DATE_TYPES,
+  POSTGRESQL_INTERVAL_TYPES,
+  POSTGRESQL_TIME_TYPES,
+  POSTGRESQL_TIMESTAMP_TYPES,
+} from '@/features/orgs/projects/database/dataGrid/utils/postgresqlConstants';
+
+// These predicates operate on the already-derived `baseType` (the element
+// family, with `[]` and `(…)` stripped — see `getBaseType`), not on a raw
+// `specificType`. They answer the *family* axis only; check `isArray`
+// separately for shape.
+
+/**
+ * Whether `baseType` is a PostgreSQL timestamp family (`timestamp` /
+ * `timestamptz`).
+ */
+export function isTimestampType(baseType?: string | null): boolean {
+  return POSTGRESQL_TIMESTAMP_TYPES.includes(baseType ?? '');
+}
+
+/**
+ * Whether `baseType` is a PostgreSQL time-of-day family (`time` / `timetz`).
+ */
+export function isTimeType(baseType?: string | null): boolean {
+  return POSTGRESQL_TIME_TYPES.includes(baseType ?? '');
+}
+
+/**
+ * Whether `baseType` is the PostgreSQL calendar `date`.
+ */
+export function isDateType(baseType?: string | null): boolean {
+  return POSTGRESQL_DATE_TYPES.includes(baseType ?? '');
+}
+
+/**
+ * Whether `baseType` is a PostgreSQL `interval`, including field-qualified
+ * variants such as `interval day to second`.
+ */
+export function isIntervalType(baseType?: string | null): boolean {
+  const base = baseType ?? '';
+
+  return (
+    POSTGRESQL_INTERVAL_TYPES.includes(base) || base.startsWith('interval ')
+  );
+}
+
+/**
+ * Whether `baseType` is any PostgreSQL date/time family. Prefer the specific
+ * predicates when the distinction matters (input control, validation,
+ * serialization) — they are no longer interchangeable as they were under the
+ * old coarse `'date'` bucket.
+ */
+export function isTemporalType(baseType?: string | null): boolean {
+  return (
+    isTimestampType(baseType) ||
+    isTimeType(baseType) ||
+    isDateType(baseType) ||
+    isIntervalType(baseType)
+  );
+}

--- a/dashboard/src/features/orgs/projects/database/dataGrid/utils/validationSchemaHelpers/validationSchemaHelpers.test.ts
+++ b/dashboard/src/features/orgs/projects/database/dataGrid/utils/validationSchemaHelpers/validationSchemaHelpers.test.ts
@@ -1,0 +1,128 @@
+import type { DataBrowserColumnMetadata } from '@/features/orgs/projects/database/dataGrid/types/dataBrowser/dataBrowser';
+import { getBaseType } from '@/features/orgs/projects/database/dataGrid/utils/getBaseType';
+import { isArray } from '@/features/orgs/projects/database/dataGrid/utils/isArray';
+import { createDynamicValidationSchema } from './validationSchemaHelpers';
+
+function makeColumn(
+  specificType: string,
+  overrides: Partial<DataBrowserColumnMetadata> = {},
+): DataBrowserColumnMetadata {
+  return {
+    id: 'col',
+    specificType,
+    baseType: getBaseType(specificType),
+    isArray: isArray(specificType),
+    displayType: specificType,
+    isNullable: true,
+    isIdentity: false,
+    isEditable: true,
+    isPrimary: false,
+    isUnique: false,
+    isGenerated: false,
+    generationExpression: null,
+    defaultValue: null,
+    isDefaultValueCustom: false,
+    comment: null,
+    uniqueConstraints: [],
+    primaryConstraints: [],
+    foreignKeyRelation: null,
+    ...overrides,
+  } as DataBrowserColumnMetadata;
+}
+
+describe('interval columns', () => {
+  it('accepts valid PostgreSQL interval syntax', async () => {
+    const schema = createDynamicValidationSchema([makeColumn('interval')]);
+
+    await expect(schema.validate({ col: '1 day' })).resolves.toBeTruthy();
+    await expect(
+      schema.validate({ col: '2 hours 30 minutes' }),
+    ).resolves.toBeTruthy();
+    await expect(schema.validate({ col: '-3 days' })).resolves.toBeTruthy();
+    await expect(schema.validate({ col: '1 mon' })).resolves.toBeTruthy();
+    await expect(schema.validate({ col: '01:30:00' })).resolves.toBeTruthy();
+  });
+});
+
+describe('time columns', () => {
+  it('accepts HH:MM and HH:MM:SS', async () => {
+    const schema = createDynamicValidationSchema([makeColumn('time')]);
+
+    await expect(schema.validate({ col: '14:30' })).resolves.toBeTruthy();
+    await expect(schema.validate({ col: '14:30:00' })).resolves.toBeTruthy();
+  });
+
+  it('rejects values that are not time strings', async () => {
+    const schema = createDynamicValidationSchema([
+      makeColumn('time', { isNullable: false }),
+    ]);
+
+    await expect(schema.validate({ col: '1 day' })).rejects.toThrow(
+      'This is not a valid time',
+    );
+  });
+
+  it('applies to timetz too', async () => {
+    const schema = createDynamicValidationSchema([makeColumn('timetz')]);
+
+    await expect(schema.validate({ col: '14:30' })).resolves.toBeTruthy();
+  });
+});
+
+describe('timestamp columns', () => {
+  it('accepts a date value', async () => {
+    const schema = createDynamicValidationSchema([makeColumn('timestamptz')]);
+
+    await expect(
+      schema.validate({ col: new Date('2024-01-15') }),
+    ).resolves.toBeTruthy();
+  });
+});
+
+describe('uuid columns', () => {
+  it('rejects a non-UUID string', async () => {
+    const schema = createDynamicValidationSchema([
+      makeColumn('uuid', { isNullable: false }),
+    ]);
+
+    await expect(schema.validate({ col: 'not-a-uuid' })).rejects.toThrow(
+      'This is not a valid UUID.',
+    );
+  });
+});
+
+describe('json/jsonb columns', () => {
+  it('rejects invalid JSON', async () => {
+    const schema = createDynamicValidationSchema([
+      makeColumn('jsonb', { isNullable: false }),
+    ]);
+
+    await expect(schema.validate({ col: '{bad json' })).rejects.toThrow(
+      'This is not a valid JSON.',
+    );
+  });
+});
+
+describe('array columns', () => {
+  it.each([
+    'integer[]',
+    'uuid[]',
+    'boolean[]',
+    'timestamptz[]',
+    'text[]',
+  ])('treats %s as free text, not its scalar element', async (specificType) => {
+    const schema = createDynamicValidationSchema([makeColumn(specificType)]);
+
+    await expect(schema.validate({ col: '[1, 2, 3]' })).resolves.toBeTruthy();
+  });
+
+  it('does not apply scalar uuid validation to a uuid[] value', async () => {
+    const schema = createDynamicValidationSchema([
+      makeColumn('uuid[]', { isNullable: false }),
+    ]);
+
+    await expect(
+      schema.validate({ col: '["not-a-uuid"]' }),
+    ).resolves.toBeTruthy();
+  });
+});

--- a/dashboard/src/features/orgs/projects/database/dataGrid/utils/validationSchemaHelpers/validationSchemaHelpers.ts
+++ b/dashboard/src/features/orgs/projects/database/dataGrid/utils/validationSchemaHelpers/validationSchemaHelpers.ts
@@ -1,6 +1,12 @@
 import * as yup from 'yup';
 import type { DataBrowserColumnMetadata } from '@/features/orgs/projects/database/dataGrid/types/dataBrowser/dataBrowser';
 import { POSTGRES_DEFAULT_PLACEHOLDER } from '@/features/orgs/projects/database/dataGrid/utils/postgresDefaultPlaceholder';
+import {
+  isDateType,
+  isIntervalType,
+  isTimestampType,
+  isTimeType,
+} from '@/features/orgs/projects/database/dataGrid/utils/temporalTypeHelpers';
 
 export interface ColumnDetails {
   isNullable: boolean;
@@ -108,20 +114,26 @@ export function createDynamicValidationSchema(
       hasDefaultValue,
     };
 
-    if (column.type === 'uuid') {
+    const { baseType } = column;
+
+    // Arrays are entered as a JSON-array literal in a free-text box; the server
+    // validates the element contents. Checked first so an `integer[]` is never
+    // mistaken for a scalar `integer`.
+    if (column.isArray) {
+      return {
+        ...currentSchema,
+        [column.id]: createTextValidationSchema(details),
+      };
+    }
+
+    if (baseType === 'uuid') {
       return {
         ...currentSchema,
         [column.id]: createUUIDValidationSchema(details),
       };
     }
-    const isTimeOrIntervalType =
-      column.specificType &&
-      (['time', 'timetz', 'interval'].includes(column.specificType) ||
-        (column.specificType.includes('time') &&
-          !column.specificType.includes('timestamp')) ||
-        column.specificType.includes('interval'));
 
-    if (column.type === 'date' && isTimeOrIntervalType) {
+    if (isTimeType(baseType)) {
       return {
         ...currentSchema,
         [column.id]: createTextValidationSchema(details).matches(
@@ -131,24 +143,31 @@ export function createDynamicValidationSchema(
       };
     }
 
-    if (column.type === 'date') {
+    // interval has no native input control and accepts free-form PostgreSQL
+    // interval syntax ('1 day', '2 hours 30 minutes', …) — let the server
+    // validate rather than constraining client-side.
+    if (isIntervalType(baseType)) {
+      return {
+        ...currentSchema,
+        [column.id]: createTextValidationSchema(details),
+      };
+    }
+
+    if (isTimestampType(baseType) || isDateType(baseType)) {
       return {
         ...currentSchema,
         [column.id]: createDateValidationSchema(details),
       };
     }
 
-    if (column.type === 'boolean') {
+    if (baseType === 'boolean') {
       return {
         ...currentSchema,
         [column.id]: createBooleanValidationSchema(details),
       };
     }
 
-    if (
-      column.type === 'text' &&
-      (column.specificType === 'jsonb' || column.specificType === 'json')
-    ) {
+    if (baseType === 'json' || baseType === 'jsonb') {
       return {
         ...currentSchema,
         [column.id]: createJSONValidationSchema(details),

--- a/dashboard/src/features/orgs/projects/storage/dataGrid/components/DataGridCell/DataGridCell.tsx
+++ b/dashboard/src/features/orgs/projects/storage/dataGrid/components/DataGridCell/DataGridCell.tsx
@@ -75,7 +75,9 @@ function DataGridCellContent<
     column: { id, columnDef },
     row,
   } = cell;
-  const { onCellEdit, isNullable, type, isEditable } = columnDef.meta || {};
+  const { onCellEdit, isNullable, isEditable, baseType, isArray } =
+    columnDef.meta || {};
+  const isBooleanColumn = baseType === 'boolean' && !isArray;
   const { openAlertDialog } = useDialog();
 
   const [optimisticValue, setOptimisticValue] = useState(originalValue);
@@ -106,7 +108,7 @@ function DataGridCellContent<
   function activateInput() {
     editCell();
 
-    if (type === 'boolean') {
+    if (isBooleanColumn) {
       clickInput();
     } else {
       focusInput();
@@ -118,7 +120,7 @@ function DataGridCellContent<
       return;
     }
 
-    if (event.detail === 2 && type !== 'boolean') {
+    if (event.detail === 2 && !isBooleanColumn) {
       editCell();
       await focusInput();
     }
@@ -206,12 +208,12 @@ function DataGridCellContent<
     if (
       !isEditable ||
       event.currentTarget.contains(event.relatedTarget) ||
-      (isEditing && type === 'boolean' && isTargetDropdownMenu)
+      (isEditing && isBooleanColumn && isTargetDropdownMenu)
     ) {
       return;
     }
 
-    if (type !== 'boolean') {
+    if (!isBooleanColumn) {
       await handleSave(temporaryValue);
     }
     deselectCell();
@@ -329,7 +331,7 @@ function DataGridCellContent<
     >
       {flexRender(cell.column.columnDef.cell, cellProps)}
       {id !== 'preview-column' &&
-        type !== 'boolean' &&
+        !isBooleanColumn &&
         isNotEmptyValue(optimisticValue) && (
           <Button
             variant="outline"
@@ -355,7 +357,7 @@ function DataGridCellContent<
 
   if (
     id === 'preview-column' ||
-    type === 'boolean' ||
+    isBooleanColumn ||
     !isNotEmptyValue(optimisticValue)
   ) {
     return content;

--- a/dashboard/src/features/orgs/projects/storage/dataGrid/components/DataGridNumericCell/DataGridNumericCell.tsx
+++ b/dashboard/src/features/orgs/projects/storage/dataGrid/components/DataGridNumericCell/DataGridNumericCell.tsx
@@ -23,7 +23,7 @@ export default function DataGridNumericCell<TData extends UnknownDataGridRow>({
 }: DataGridNumericCellProps<TData>) {
   const { inputRef, isEditing } = useDataGridCell<HTMLInputElement>();
 
-  const dataType = column.columnDef.meta?.dataType;
+  const baseType = column.columnDef.meta?.baseType;
   const isNullable = column.columnDef.meta?.isNullable;
   const hasDefault = column.columnDef.meta?.defaultValue != null;
 
@@ -77,7 +77,7 @@ export default function DataGridNumericCell<TData extends UnknownDataGridRow>({
   }
 
   if (isEditing) {
-    const step = dataType === 'integer' ? 1 : 0.1;
+    const step = baseType === 'integer' ? 1 : 0.1;
 
     return (
       <div className="absolute top-0 left-0 z-10 h-full w-full">

--- a/dashboard/src/features/orgs/projects/storage/dataGrid/components/DataGridTextCell/DataGridTextCell.tsx
+++ b/dashboard/src/features/orgs/projects/storage/dataGrid/components/DataGridTextCell/DataGridTextCell.tsx
@@ -22,16 +22,19 @@ export default function DataGridTextCell<
   onTemporaryValueChange,
   cell: { column },
 }: DataGridTextCellProps<TData>) {
-  const specificType = column.columnDef.meta?.specificType;
+  const baseType = column.columnDef.meta?.baseType;
+  const isArray = column.columnDef.meta?.isArray;
   const isNullable = column.columnDef.meta?.isNullable;
   const hasDefault = column.columnDef.meta?.defaultValue != null;
 
   const isMultiline =
-    specificType === 'text' ||
-    specificType === 'bpchar' ||
-    specificType?.includes('character varying') ||
-    specificType === 'json' ||
-    specificType === 'jsonb';
+    isArray ||
+    baseType === 'text' ||
+    baseType === 'bpchar' ||
+    baseType === 'character' ||
+    baseType === 'character varying' ||
+    baseType === 'json' ||
+    baseType === 'jsonb';
 
   const normalizedOptimisticValue =
     optimisticValue !== null && typeof optimisticValue === 'object'

--- a/dashboard/src/features/orgs/projects/storage/dataGrid/components/FilesDataGrid/FilesDataGrid.tsx
+++ b/dashboard/src/features/orgs/projects/storage/dataGrid/components/FilesDataGrid/FilesDataGrid.tsx
@@ -7,6 +7,9 @@ import { ReadOnlyToggle } from '@/components/presentational/ReadOnlyToggle';
 import { Button } from '@/components/ui/v3/button';
 import { usePageBoundsRedirect } from '@/features/orgs/projects/common/hooks/usePageBoundsRedirect';
 import { useDataGridQueryParams } from '@/features/orgs/projects/database/dataGrid/components/DataBrowserGrid/DataGridQueryParamsProvider';
+import { getBaseType } from '@/features/orgs/projects/database/dataGrid/utils/getBaseType';
+import { getDisplayType } from '@/features/orgs/projects/database/dataGrid/utils/getDisplayType';
+import { isArray } from '@/features/orgs/projects/database/dataGrid/utils/isArray';
 import { useAppClient } from '@/features/orgs/projects/hooks/useAppClient';
 import { useProject } from '@/features/orgs/projects/hooks/useProject';
 import type { DataGridProps } from '@/features/orgs/projects/storage/dataGrid/components/DataGrid';
@@ -56,8 +59,8 @@ export default function FilesDataGrid({
   bucket,
   ...dataGridProps
 }: FilesDataGridProps) {
-  const columns = useMemo<ColumnDef<StoredFile>[]>(
-    () => [
+  const columns = useMemo<ColumnDef<StoredFile>[]>(() => {
+    const definitions: ColumnDef<StoredFile>[] = [
       {
         id: 'preview-column',
         header: PreviewHeader,
@@ -88,7 +91,7 @@ export default function FilesDataGrid({
       {
         header: 'id',
         accessorKey: 'id',
-        meta: { dataType: 'uuid' },
+        meta: { specificType: 'uuid' },
         cell: (props) => (
           <DataGridTextCell {...(props as CellContext<StoredFile, string>)} />
         ),
@@ -97,25 +100,25 @@ export default function FilesDataGrid({
       {
         header: 'name',
         accessorKey: 'name',
-        meta: { dataType: 'text' },
+        meta: { specificType: 'text' },
         size: 200,
       },
       {
         header: 'size',
         accessorKey: 'size',
-        meta: { dataType: 'integer' },
+        meta: { specificType: 'integer' },
         size: 80,
       },
       {
         header: 'mimeType',
         accessorKey: 'mimeType',
-        meta: { dataType: 'text' },
+        meta: { specificType: 'text' },
         size: 120,
       },
       {
         header: 'createdAt',
         accessorKey: 'createdAt',
-        meta: { dataType: 'timestamptz' },
+        meta: { specificType: 'timestamp with time zone' },
         size: 120,
         cell: ({ getValue }) => (
           <FilesDataGridDateCell value={getValue<string>()} />
@@ -124,7 +127,7 @@ export default function FilesDataGrid({
       {
         header: 'updatedAt',
         accessorKey: 'updatedAt',
-        meta: { dataType: 'timestamptz' },
+        meta: { specificType: 'timestamp with time zone' },
         size: 120,
         cell: ({ getValue }) => (
           <FilesDataGridDateCell value={getValue<string>()} />
@@ -139,13 +142,13 @@ export default function FilesDataGrid({
       {
         header: 'etag',
         accessorKey: 'etag',
-        meta: { dataType: 'text' },
+        meta: { specificType: 'text' },
         size: 280,
       },
       {
         header: 'isUploaded',
         accessorKey: 'isUploaded',
-        meta: { dataType: 'boolean' },
+        meta: { specificType: 'boolean' },
         size: 100,
         cell: ({ getValue }) => (
           <ReadOnlyToggle checked={getValue<boolean>()} />
@@ -154,12 +157,25 @@ export default function FilesDataGrid({
       {
         header: 'uploadedByUserId',
         accessorKey: 'uploadedByUserId',
-        meta: { dataType: 'uuid' },
+        meta: { specificType: 'uuid' },
         size: 318,
       },
-    ],
-    [bucket.downloadExpiration],
-  );
+    ];
+
+    return definitions.map((definition) =>
+      definition.meta?.specificType
+        ? {
+            ...definition,
+            meta: {
+              ...definition.meta,
+              baseType: getBaseType(definition.meta.specificType),
+              isArray: isArray(definition.meta.specificType),
+              displayType: getDisplayType(definition.meta.specificType),
+            },
+          }
+        : definition,
+    );
+  }, [bucket.downloadExpiration]);
   const router = useRouter();
   const { project } = useProject();
   const appClient = useAppClient();

--- a/dashboard/src/types/react-table.d.ts
+++ b/dashboard/src/types/react-table.d.ts
@@ -1,7 +1,6 @@
 import '@tanstack/react-table';
 import type { Row, RowData } from '@tanstack/react-table';
 import type {
-  ColumnType,
   ColumnUpdateOptions,
   ForeignKeyRelation,
 } from '@/features/orgs/projects/database/dataGrid/types/dataBrowser';
@@ -23,12 +22,9 @@ declare module '@tanstack/react-table' {
     uniqueConstraints?: string[];
     primaryConstraints?: string[];
     foreignKeyRelation?: ForeignKeyRelation | null;
-    specificType?: ColumnType;
-    dataType?: string;
-    /**
-     * More generic type of the column. Determines what type of input field is
-     * rendered.
-     */
-    type?: string;
+    specificType?: string;
+    baseType?: string;
+    isArray?: boolean;
+    displayType?: string;
   }
 }


### PR DESCRIPTION
### Checklist

- [x] No breaking changes
- [ ] Tests pass
- [ ] New features have new tests
- [ ] Documentation is updated (if applicable)
- [ ] Title of the PR is in the correct format (see below)
<!-- pi-reviewer:start -->

### **What this change solves**

The data-grid column model carried three overlapping type fields (`type`, `specificType`, `dataType`) that drifted between the data browser (long `FORMAT_TYPE` spellings) and the column editor (short `udt_name` spellings), causing inconsistent type labels, mis-routed input controls, and a timezone bug where `date`/`timestamp` values shifted a day when serialized via `toUTCString()`. This change collapses the model onto a single source of truth (`specificType`) with derived `baseType`/`isArray`/`displayType`, and fixes date/time serialization to preserve the picked local value.

___

### **Change Type**
Bug fix

___

### **Description**
- Replace the `type` / `dataType` column-metadata fields with a single raw `specificType` plus three derived siblings: `baseType` (family, `[]` and `(…)` stripped), `isArray` (shape axis), and `displayType` (canonical user-facing label).
- Add focused utilities: `getBaseType`, `getDisplayType`, `isArray`, `serializeTemporalValue`, and `temporalTypeHelpers` (`isTimestampType`/`isTimeType`/`isDateType`/`isIntervalType`/`isTemporalType`), each with unit tests.
- Fix temporal serialization: format `date` as local `yyyy-MM-dd`, `timestamp without time zone` as local wall-clock, and `timestamp with time zone` as the UTC instant — replacing the previous `toUTCString()` path that shifted the day for non-UTC users.
- Split the coarse `POSTGRESQL_DATE_TIME_TYPES` constant into timestamp / time / date / interval sets covering both long and short spellings.
- Route input controls, validation schemas, and cell renderers off `baseType` + `isArray` instead of the removed `type` field; treat arrays as free-text JSON literals before scalar branches.
- Update the storage `FilesDataGrid` and cell components to declare `specificType` and derive the same metadata, and update the `react-table` module augmentation accordingly.

___

<details> <summary><h3> File Walkthrough</h3></summary>

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody>
<tr><td><strong>Type model</strong></td><td><details><summary>2 files</summary><table>
<tr><td><strong>dataBrowser.ts</strong><dd><code>Replace type/dataType with specificType + derived baseType/isArray/displayType; narrow ColumnInsertOptions to isArray</code></dd></td><td>+30/-15</td></tr>
<tr><td><strong>react-table.d.ts</strong><dd><code>Update column-meta augmentation to the new field set</code></dd></td><td>+4/-8</td></tr>
</table></details></td></tr>
<tr><td><strong>New utilities</strong></td><td><details><summary>6 files</summary><table>
<tr><td><strong>getBaseType.ts</strong><dd><code>Strip array marker and precision modifiers to the base type name</code></dd></td><td>+35/-0</td></tr>
<tr><td><strong>getDisplayType.ts</strong><dd><code>Map type spellings to a single canonical display label</code></dd></td><td>+61/-0</td></tr>
<tr><td><strong>isArray.ts</strong><dd><code>Detect a trailing array marker</code></dd></td><td>+15/-0</td></tr>
<tr><td><strong>serializeTemporalValue.ts</strong><dd><code>Serialize Date values per temporal type without timezone shift</code></dd></td><td>+44/-0</td></tr>
<tr><td><strong>temporalTypeHelpers.ts</strong><dd><code>Family predicates over baseType for timestamp/time/date/interval</code></dd></td><td>+60/-0</td></tr>
<tr><td><strong>index.ts (x4)</strong><dd><code>Barrel re-exports for the new utils</code></dd></td><td>+7/-0</td></tr>
</table></details></td></tr>
<tr><td><strong>Changed utilities</strong></td><td><details><summary>3 files</summary><table>
<tr><td><strong>getInputType.ts</strong><dd><code>Pick HTML input type from baseType; drop the type param</code></dd></td><td>+18/-38</td></tr>
<tr><td><strong>postgresqlConstants.ts</strong><dd><code>Split date/time constant into timestamp/time/date/interval sets</code></dd></td><td>+26/-8</td></tr>
<tr><td><strong>validationSchemaHelpers.ts</strong><dd><code>Branch validation on baseType/isArray; arrays validated as free text</code></dd></td><td>+34/-15</td></tr>
</table></details></td></tr>
<tr><td><strong>Database components</strong></td><td><details><summary>9 files</summary><table>
<tr><td><strong>DataBrowserGrid.tsx</strong><dd><code>Build metadata via getBaseType/isArray/getDisplayType; route cells off baseType</code></dd></td><td>+24/-20</td></tr>
<tr><td><strong>DatabaseRecordInputGroup.tsx</strong><dd><code>Use baseType/isArray for multiline, input type, and array placeholder</code></dd></td><td>+22/-11</td></tr>
<tr><td><strong>BaseRecordForm.tsx</strong><dd><code>Serialize temporal values via serializeTemporalValue; emit isArray</code></dd></td><td>+3/-5</td></tr>
<tr><td><strong>CreateRecordForm.tsx</strong><dd><code>Guard boolean-default branch on baseType + !isArray</code></dd></td><td>+5/-1</td></tr>
<tr><td><strong>ColumnsNameCustomizationSection.tsx</strong><dd><code>Render displayType instead of raw data type</code></dd></td><td>+5/-3</td></tr>
<tr><td><strong>operators.ts</strong><dd><code>Rename dataType param to specificType</code></dd></td><td>+2/-2</td></tr>
<tr><td><strong>createRecord.ts</strong><dd><code>Emit ARRAY literal off isArray instead of specificType suffix</code></dd></td><td>+2/-2</td></tr>
<tr><td><strong>updateRecord.ts</strong><dd><code>Emit ARRAY literal off isArray</code></dd></td><td>+1/-1</td></tr>
<tr><td><strong>DataGridFilter*.tsx</strong><dd><code>Pass specificType for operators, displayType for the badge</code></dd></td><td>+10/-10</td></tr>
</table></details></td></tr>
<tr><td><strong>Storage grid</strong></td><td><details><summary>4 files</summary><table>
<tr><td><strong>FilesDataGrid.tsx</strong><dd><code>Declare specificType and derive baseType/isArray/displayType per column</code></dd></td><td>+30/-14</td></tr>
<tr><td><strong>DataGridCell.tsx</strong><dd><code>Compute isBooleanColumn from baseType + !isArray</code></dd></td><td>+9/-7</td></tr>
<tr><td><strong>DataGridTextCell.tsx</strong><dd><code>Compute multiline from baseType/isArray</code></dd></td><td>+9/-6</td></tr>
<tr><td><strong>DataGridNumericCell.tsx</strong><dd><code>Use baseType for the integer step</code></dd></td><td>+2/-2</td></tr>
</table></details></td></tr>
<tr><td><strong>Tests</strong></td><td><details><summary>8 files</summary><table>
<tr><td><strong>validationSchemaHelpers.test.ts</strong><dd><code>New: interval/time/timestamp/uuid/json/array validation coverage</code></dd></td><td>+128/-0</td></tr>
<tr><td><strong>temporalTypeHelpers.test.ts</strong><dd><code>New: predicate coverage for each temporal family</code></dd></td><td>+73/-0</td></tr>
<tr><td><strong>getDisplayType / getBaseType / isArray / serializeTemporalValue tests</strong><dd><code>New unit tests for each utility</code></dd></td><td>+193/-0</td></tr>
<tr><td><strong>getInputType.test.ts</strong><dd><code>Rewrite around the baseType signature</code></dd></td><td>+22/-48</td></tr>
<tr><td><strong>BaseRecordForm / createRecord / updateRecord tests</strong><dd><code>Update fixtures to the new metadata shape</code></dd></td><td>+27/-18</td></tr>
</table></details></td></tr>
</tbody></table>

</details>

___

<!-- pi-reviewer:end -->

