### PR TITLE
chore(ci): add .worktrees to gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -77,3 +77,6 @@ letsencrypt/*
 /.review/
 /.nhost-code/review/
 /.nhost-code/tmp/
+
+# Local git worktrees for parallel AI/dev sessions
+/.worktrees/


### PR DESCRIPTION
Adds `.worktrees` to `.gitignore` file, to allow for parallel local AI dev without polluting local external file structures.

---
### Checklist

- [x] No breaking changes
- [x] Tests pass
- [x] Title of the PR is in the correct format (see below)

