### PR TITLE
fix(dashboard): migrate backups page to v3

### DIFF
--- a/dashboard/src/features/orgs/projects/backups/components/ScheduledBackupTabContent/BackupList.tsx
+++ b/dashboard/src/features/orgs/projects/backups/components/ScheduledBackupTabContent/BackupList.tsx
@@ -1,11 +1,12 @@
-import { ActivityIndicator } from '@/components/ui/v2/ActivityIndicator';
-import { Table } from '@/components/ui/v2/Table';
-import { TableBody } from '@/components/ui/v2/TableBody';
-import { TableCell } from '@/components/ui/v2/TableCell';
-import { TableContainer } from '@/components/ui/v2/TableContainer';
-import { TableHead } from '@/components/ui/v2/TableHead';
-import { TableRow } from '@/components/ui/v2/TableRow';
-import { Text } from '@/components/ui/v2/Text';
+import { Spinner } from '@/components/ui/v3/spinner';
+import {
+  Table,
+  TableBody,
+  TableCell,
+  TableHead,
+  TableHeader,
+  TableRow,
+} from '@/components/ui/v3/table';
 import { useProject } from '@/features/orgs/projects/hooks/useProject';
 import { useGetApplicationBackupsQuery } from '@/utils/__generated__/graphql';
 import BackupListItem from './BackupListItem';
@@ -23,13 +24,7 @@ export default function BackupList() {
   });
 
   if (loadingProject || loadingBackups) {
-    return (
-      <ActivityIndicator
-        delay={500}
-        className="my-5"
-        label="Loading backups..."
-      />
-    );
+    return <Spinner delay={500}>Loading backups...</Spinner>;
   }
 
   if (error) {
@@ -39,40 +34,38 @@ export default function BackupList() {
   const backups = data?.app?.backups;
 
   return (
-    <TableContainer sx={{ backgroundColor: 'background.paper' }}>
-      <Table>
-        <TableHead>
+    <Table containerClassName="rounded-md bg-background">
+      <TableHeader>
+        <TableRow>
+          <TableHead className="text-foreground">Date</TableHead>
+          <TableHead className="text-foreground">Size</TableHead>
+          <TableHead className="text-foreground">Backed up</TableHead>
+          <TableHead />
+        </TableRow>
+      </TableHeader>
+
+      <TableBody>
+        {backups?.length === 0 && (
           <TableRow>
-            <TableCell>Date</TableCell>
-            <TableCell>Size</TableCell>
-            <TableCell>Backed up</TableCell>
+            <TableCell>
+              <p className="text-muted-foreground text-xs">
+                No backups are available.
+              </p>
+            </TableCell>
+            <TableCell />
+            <TableCell />
             <TableCell />
           </TableRow>
-        </TableHead>
+        )}
 
-        <TableBody>
-          {backups?.length === 0 && (
-            <TableRow>
-              <TableCell>
-                <Text className="text-xs" color="secondary">
-                  No backups are available.
-                </Text>
-              </TableCell>
-              <TableCell />
-              <TableCell />
-              <TableCell />
-            </TableRow>
-          )}
-
-          {backups?.map((backup) => (
-            <BackupListItem
-              key={backup.id}
-              backup={backup}
-              projectId={project?.id}
-            />
-          ))}
-        </TableBody>
-      </Table>
-    </TableContainer>
+        {backups?.map((backup) => (
+          <BackupListItem
+            key={backup.id}
+            backup={backup}
+            projectId={project?.id}
+          />
+        ))}
+      </TableBody>
+    </Table>
   );
 }

--- a/dashboard/src/features/orgs/projects/backups/components/ScheduledBackupTabContent/BackupListItem.tsx
+++ b/dashboard/src/features/orgs/projects/backups/components/ScheduledBackupTabContent/BackupListItem.tsx
@@ -1,9 +1,8 @@
 import { format, formatDistanceStrict, parseISO } from 'date-fns';
 import { twMerge } from 'tailwind-merge';
 import { useDialog } from '@/components/common/DialogProvider';
-import { Button } from '@/components/ui/v2/Button';
-import { TableCell } from '@/components/ui/v2/TableCell';
-import { TableRow } from '@/components/ui/v2/TableRow';
+import { Button, ButtonWithLoading } from '@/components/ui/v3/button';
+import { TableCell, TableRow } from '@/components/ui/v3/table';
 import type { Backup } from '@/types/application';
 import { useGetBackupPresignedUrlLazyQuery } from '@/utils/__generated__/graphql';
 import { prettifySize } from '@/utils/prettifySize';
@@ -72,22 +71,28 @@ export default function BackupListItem({
         })}
       </TableCell>
       <TableCell
-        className={twMerge(
-          'grid grid-flow-col justify-end gap-2',
-          !loadingPresignedUrl && 'pl-8',
-        )}
+        className={twMerge('text-right', !loadingPresignedUrl && 'pl-8')}
       >
-        <Button
-          variant="borderless"
-          onClick={downloadBackup}
-          loading={loadingPresignedUrl}
-        >
-          Download
-        </Button>
+        <div className="flex flex-row justify-end gap-2">
+          <ButtonWithLoading
+            variant="ghost"
+            size="sm"
+            className="text-primary hover:text-primary"
+            onClick={downloadBackup}
+            loading={loadingPresignedUrl}
+          >
+            Download
+          </ButtonWithLoading>
 
-        <Button variant="borderless" onClick={restoreBackup}>
-          Restore
-        </Button>
+          <Button
+            variant="ghost"
+            size="sm"
+            className="text-primary hover:text-primary"
+            onClick={restoreBackup}
+          >
+            Restore
+          </Button>
+        </div>
       </TableCell>
     </TableRow>
   );

--- a/dashboard/src/features/orgs/projects/backups/components/ScheduledBackupTabContent/RestoreBackupModal.tsx
+++ b/dashboard/src/features/orgs/projects/backups/components/ScheduledBackupTabContent/RestoreBackupModal.tsx
@@ -1,8 +1,6 @@
 import { format, parseISO } from 'date-fns';
 import { useState } from 'react';
-import { Box } from '@/components/ui/v2/Box';
-import { Button } from '@/components/ui/v2/Button';
-import { Text } from '@/components/ui/v2/Text';
+import { Button, ButtonWithLoading } from '@/components/ui/v3/button';
 import { Checkbox } from '@/components/ui/v3/checkbox';
 import { Label } from '@/components/ui/v3/label';
 import { useProject } from '@/features/orgs/projects/hooks/useProject';
@@ -54,25 +52,25 @@ export default function RestoreBackupModal({
 
   if (restoreCompleted) {
     return (
-      <Box className="grid grid-flow-row gap-4 px-6 pb-6">
-        <Text>The backup has been restored successfully.</Text>
+      <div className="grid grid-flow-row gap-4 px-6 pb-6">
+        <p>The backup has been restored successfully.</p>
 
         <Button onClick={close}>OK</Button>
-      </Box>
+      </div>
     );
   }
 
   return (
-    <Box className="grid grid-flow-row gap-2 px-6 pb-6">
-      <Text>
+    <div className="grid grid-flow-row gap-2 px-6 pb-6">
+      <p>
         You current database will be deleted, and the backup created at{' '}
         <span className="font-semibold">
           {format(parseISO(createdAt), 'yyyy-MM-dd HH:mm:ss')}
         </span>{' '}
         will be restored.
-      </Text>
+      </p>
 
-      <Box className="pt-1 pb-2.5">
+      <div className="pt-1 pb-2.5">
         <div className="flex items-center gap-2">
           <Checkbox
             id="restore-confirm"
@@ -86,15 +84,19 @@ export default function RestoreBackupModal({
             I'm sure I want to restore this backup
           </Label>
         </div>
-      </Box>
+      </div>
 
-      <Button onClick={handleSubmit} disabled={!isSure} loading={loading}>
+      <ButtonWithLoading
+        onClick={handleSubmit}
+        disabled={!isSure}
+        loading={loading}
+      >
         Restore
-      </Button>
+      </ButtonWithLoading>
 
-      <Button variant="outlined" color="secondary" onClick={close}>
+      <Button variant="outline" onClick={close}>
         Cancel
       </Button>
-    </Box>
+    </div>
   );
 }

--- a/dashboard/src/features/orgs/projects/backups/components/ScheduledBackupTabContent/ScheduledBackupTabContent.tsx
+++ b/dashboard/src/features/orgs/projects/backups/components/ScheduledBackupTabContent/ScheduledBackupTabContent.tsx
@@ -1,4 +1,3 @@
-import { Text } from '@/components/ui/v2/Text';
 import { Spinner } from '@/components/ui/v3/spinner';
 import { TabsContent } from '@/components/ui/v3/tabs';
 import { useIsPiTREnabled } from '@/features/orgs/hooks/useIsPiTREnabled';
@@ -12,13 +11,11 @@ function ScheduledBackupTabContent() {
   ) : (
     <>
       <div>
-        <Text variant="h3" className="pb-2">
-          Database
-        </Text>
-        <Text color="secondary">
+        <h3 className="pb-2 font-medium text-lg">Database</h3>
+        <p className="text-muted-foreground">
           The database backup includes database schema, database data and Hasura
           metadata. It does not include the actual files in Storage.
-        </Text>
+        </p>
       </div>
 
       <BackupList />

--- a/dashboard/src/pages/orgs/[orgSlug]/projects/[appSubdomain]/backups.tsx
+++ b/dashboard/src/pages/orgs/[orgSlug]/projects/[appSubdomain]/backups.tsx
@@ -2,8 +2,7 @@ import type { ReactElement } from 'react';
 import { UpgradeToProBanner } from '@/components/common/UpgradeToProBanner';
 import { Container } from '@/components/layout/Container';
 import { RetryableErrorBoundary } from '@/components/presentational/RetryableErrorBoundary';
-import { ActivityIndicator } from '@/components/ui/v2/ActivityIndicator';
-import { Text } from '@/components/ui/v2/Text';
+import { Spinner } from '@/components/ui/v3/spinner';
 import { useIsPiTREnabled } from '@/features/orgs/hooks/useIsPiTREnabled';
 import { OrgLayout } from '@/features/orgs/layout/OrgLayout';
 import { BackupsContent } from '@/features/orgs/projects/backups/components/BackupsContent';
@@ -14,7 +13,7 @@ export default function BackupsPage() {
   const { isPiTREnabled, loading: isPiTREnabledLoading } = useIsPiTREnabled();
 
   if (loading || isPiTREnabledLoading) {
-    return <ActivityIndicator label="Loading project..." delay={1000} />;
+    return <Spinner delay={1000}>Loading project...</Spinner>;
   }
 
   const isPlanFree = org!.plan.isFree;
@@ -36,9 +35,7 @@ export default function BackupsPage() {
   return (
     <Container className="grid max-w-5xl grid-flow-row gap-y-6 bg-transparent">
       <div className="grid grid-flow-col justify-between gap-2">
-        <Text className="font-medium text-2xl" variant="h1">
-          Backups
-        </Text>
+        <h1 className="font-medium text-2xl">Backups</h1>
       </div>
 
       <RetryableErrorBoundary>


### PR DESCRIPTION
### Checklist

- [x] No breaking changes
- [x] Tests pass
- [ ] New features have new tests
- [ ] Documentation is updated (if applicable)
- [x] Title of the PR is in the correct format (see below)

<!-- pi-reviewer:start -->
### **What this change solves**
The scheduled-backups UI still used legacy v2 (MUI) components. This migrates the backups page and its scheduled-backup tab to the preferred v3 (Tailwind + Radix) component set for visual and architectural consistency.

___

### **Change Type**
Refactoring

___

### **Description**
- Replace v2 `Table`/`TableContainer`/`TableHead`/`TableCell`/`TableRow` with the v3 `table` primitives (including new `TableHeader`).
- Swap v2 `ActivityIndicator` for the v3 `Spinner` on loading states.
- Replace v2 `Button` with v3 `Button`/`ButtonWithLoading`, mapping `variant`/`color` props to v3 equivalents.
- Replace v2 `Box`/`Text` wrappers with native `div`/`p`/`h1`/`h3` plus Tailwind classes.

___

<details> <summary><h3> File Walkthrough</h3></summary>

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody>
<tr><td><strong>UI migration</strong></td><td><details><summary>5 files</summary><table>
<tr>
  <td><strong>BackupList.tsx</strong><dd><code>Migrate backup table + loading spinner to v3 primitives</code></dd></td>
  <td>+39/-46</td>
</tr>
<tr>
  <td><strong>BackupListItem.tsx</strong><dd><code>Migrate row buttons/cells to v3 Button/ButtonWithLoading + table</code></dd></td>
  <td>+22/-17</td>
</tr>
<tr>
  <td><strong>RestoreBackupModal.tsx</strong><dd><code>Replace Box/Text/Button with div/p and v3 buttons</code></dd></td>
  <td>+17/-15</td>
</tr>
<tr>
  <td><strong>ScheduledBackupTabContent.tsx</strong><dd><code>Replace v2 Text headings with native h3/p + Tailwind</code></dd></td>
  <td>+3/-6</td>
</tr>
<tr>
  <td><strong>backups.tsx</strong><dd><code>Swap ActivityIndicator/Text for v3 Spinner and native h1</code></dd></td>
  <td>+3/-6</td>
</tr>
</table></details></td></tr>
</tbody></table>

</details>

___

<!-- pi-reviewer:end -->
