### PR TITLE
fix(constellation): prevent SQL alias truncation collisions

### DIFF
--- a/services/constellation/connector/sql/graphql/queries/alias_collision_test.go
+++ b/services/constellation/connector/sql/graphql/queries/alias_collision_test.go
@@ -1,0 +1,163 @@
+package queries_test
+
+import (
+	"strings"
+	"testing"
+
+	"github.com/vektah/gqlparser/v2/ast"
+	"github.com/vektah/gqlparser/v2/parser"
+
+	"github.com/nhost/nhost/services/constellation/connector/sql/graphql/queries"
+	"github.com/nhost/nhost/services/constellation/connector/sql/graphql/queries/dialect"
+	"github.com/nhost/nhost/services/constellation/connector/sql/introspection"
+	"github.com/nhost/nhost/services/constellation/metadata"
+)
+
+func TestQueryRelationshipAliasesAvoidPostgresIdentifierTruncationCollision(
+	t *testing.T,
+) {
+	t.Parallel()
+
+	longRelationshipAlias := "thisRelationshipAliasIsLongEnoughToCollideAfterPgTrunc"
+	roots := buildAliasCollisionRoots(t)
+
+	doc, gqlErr := parser.ParseQuery(&ast.Source{Input: `
+		query {
+			departments {
+				id
+				` + longRelationshipAlias + `: employees {
+					user {
+						id
+					}
+				}
+			}
+		}
+	`})
+	if gqlErr != nil {
+		t.Fatalf("failed to parse query: %v", gqlErr)
+	}
+
+	operations, err := roots.BuildQuery(
+		doc.Operations[0], doc.Fragments, nil, "admin", nil,
+	)
+	if err != nil {
+		t.Fatalf("failed to build query: %v", err)
+	}
+
+	if len(operations) != 1 {
+		t.Fatalf("expected one operation, got %d", len(operations))
+	}
+
+	baseAlias := "_root.r." + longRelationshipAlias + ".base"
+
+	userRelAlias := "_root.r." + longRelationshipAlias + ".r.user"
+	if truncatePostgresIdentifier(baseAlias) != truncatePostgresIdentifier(userRelAlias) {
+		t.Fatalf("test setup no longer produces a PostgreSQL truncation collision")
+	}
+
+	sql := operations[0].SQL
+	if strings.Contains(sql, `"`+baseAlias+`"`) || strings.Contains(sql, `"`+userRelAlias+`"`) {
+		t.Fatalf(
+			"SQL contains relationship aliases that collide after PostgreSQL truncation:\n%s",
+			sql,
+		)
+	}
+}
+
+func buildAliasCollisionRoots(t *testing.T) queries.Roots {
+	t.Helper()
+
+	objects := introspection.NewObjects()
+	objects.Schemas["public"] = &introspection.Schema{
+		Tables: map[string]*introspection.Table{
+			"departments": {
+				Schema: "public",
+				Name:   "departments",
+				Columns: []introspection.Column{
+					{Name: "id", Type: "uuid"},
+				},
+				PrimaryKeys: []string{"id"},
+			},
+			"user_departments": {
+				Schema: "public",
+				Name:   "user_departments",
+				Columns: []introspection.Column{
+					{Name: "department_id", Type: "uuid"},
+					{Name: "user_id", Type: "uuid"},
+				},
+				ForeignKeys: []introspection.ForeignKey{
+					{
+						ColumnName:        "department_id",
+						ForeignSchema:     "public",
+						ForeignTable:      "departments",
+						ForeignColumnName: "id",
+					},
+					{
+						ColumnName:        "user_id",
+						ForeignSchema:     "public",
+						ForeignTable:      "users",
+						ForeignColumnName: "id",
+					},
+				},
+			},
+			"users": {
+				Schema: "public",
+				Name:   "users",
+				Columns: []introspection.Column{
+					{Name: "id", Type: "uuid"},
+				},
+				PrimaryKeys: []string{"id"},
+			},
+		},
+	}
+
+	md := &metadata.DatabaseMetadata{
+		Tables: []metadata.TableMetadata{
+			{
+				Table: metadata.TableSource{Schema: "public", Name: "departments"},
+				ArrayRelationships: []metadata.ArrayRelationship{
+					{
+						Name: "employees",
+						Using: metadata.RelationshipUsing{
+							ForeignKeyConstraint: &metadata.ForeignKeyConstraint{
+								Columns: []string{"department_id"},
+								Table: metadata.TableSource{
+									Schema: "public",
+									Name:   "user_departments",
+								},
+							},
+						},
+					},
+				},
+			},
+			{
+				Table: metadata.TableSource{Schema: "public", Name: "user_departments"},
+				ObjectRelationships: []metadata.ObjectRelationship{
+					{
+						Name: "user",
+						Using: metadata.RelationshipUsing{
+							ForeignKeyColumns: []string{"user_id"},
+						},
+					},
+				},
+			},
+			{Table: metadata.TableSource{Schema: "public", Name: "users"}},
+		},
+	}
+
+	roots, _, err := queries.BuildRoots(objects, md, &dialect.PostgresDialect{})
+	if err != nil {
+		t.Fatalf("failed to build roots: %v", err)
+	}
+
+	return roots
+}
+
+func truncatePostgresIdentifier(identifier string) string {
+	const maxPostgresIdentifierBytes = 63
+	if len(identifier) <= maxPostgresIdentifierBytes {
+		return identifier
+	}
+
+	return identifier[:maxPostgresIdentifierBytes]
+}

--- a/services/constellation/connector/sql/graphql/queries/relationship.go
+++ b/services/constellation/connector/sql/graphql/queries/relationship.go
@@ -335,10 +335,7 @@ func (r *relationship) buildSelectionSQLFromSource( //nolint:funlen
 
 	joinCondition := r.buildJoinConditionForSelection(parentTableAlias)
 
-	outputName := relationshipAlias
-	if idx := strings.LastIndex(relationshipAlias, "."); idx >= 0 {
-		outputName = relationshipAlias[idx+1:]
-	}
+	outputName := rootFieldName(field)
 
 	argumentPath := childArgumentPath(parentArgumentPath, field)
 

--- a/services/constellation/connector/sql/graphql/queries/root_query_aggregate.go
+++ b/services/constellation/connector/sql/graphql/queries/root_query_aggregate.go
@@ -414,7 +414,7 @@ func (t *table) buildNodesRelationshipsLateral(
 			b.WriteString(", ")
 		}
 
-		relAlias := "_root.r." + relSel.alias
+		relAlias := sqlAlias("_root.r.", relSel.alias)
 		t.dialect.WriteJSONRowColumn(b, relSel.alias,
 			`"`+relAlias+`"."`+relSel.alias+`"`)
 
@@ -430,7 +430,7 @@ func (t *table) buildNodesRelationshipsLateral(
 	var err error
 
 	for _, relSel := range relationships {
-		relAlias := "_root.r." + relSel.alias
+		relAlias := sqlAlias("_root.r.", relSel.alias)
 
 		b.WriteString(" LEFT OUTER JOIN LATERAL (")
 
@@ -472,7 +472,7 @@ func (t *table) buildNodesRelationshipsSubquery(
 			b.WriteString(", ")
 		}
 
-		relAlias := "_root.r." + relSel.alias
+		relAlias := sqlAlias("_root.r.", relSel.alias)
 
 		b.WriteByte('\'')
 		b.WriteString(relSel.alias)
@@ -532,7 +532,7 @@ func (t *table) buildNodesWithDistinctOn( //nolint:funlen
 			b.WriteString(", ")
 		}
 
-		relAlias := "_root.r." + relSel.alias
+		relAlias := sqlAlias("_root.r.", relSel.alias)
 		t.dialect.WriteJSONRowColumn(b, relSel.alias,
 			`"`+relAlias+`"."`+relSel.alias+`"`)
 
@@ -556,7 +556,7 @@ func (t *table) buildNodesWithDistinctOn( //nolint:funlen
 
 	// LEFT OUTER JOIN LATERAL for each nested relationship
 	for _, relSel := range relationships {
-		relAlias := "_root.r." + relSel.alias
+		relAlias := sqlAlias("_root.r.", relSel.alias)
 
 		b.WriteString(" LEFT OUTER JOIN LATERAL (")
 

--- a/services/constellation/connector/sql/graphql/queries/root_query_by_pk.go
+++ b/services/constellation/connector/sql/graphql/queries/root_query_by_pk.go
@@ -186,7 +186,7 @@ func (t *table) buildQuerySQLWithNestedCTEs(
 		return nil, 0, err
 	}
 
-	baseAlias := alias + ".base"
+	baseAlias := sqlAlias(alias, ".base")
 
 	params, paramIndex, err = t.buildQueryCTE(
 		b, field, variables, role, sessionVariables, params, paramIndex,
@@ -381,7 +381,7 @@ func (t *table) buildQueryRelationshipsLateral(
 			b.WriteString(", ")
 		}
 
-		relAlias := alias + ".r." + relSel.alias
+		relAlias := sqlAlias(alias, ".r.", relSel.alias)
 		t.dialect.WriteJSONRowColumn(b, relSel.alias,
 			`"`+relAlias+`"."`+relSel.alias+`"`)
 
@@ -395,7 +395,7 @@ func (t *table) buildQueryRelationshipsLateral(
 	b.WriteByte('"')
 
 	for _, relSel := range relationships {
-		relAlias := alias + ".r." + relSel.alias
+		relAlias := sqlAlias(alias, ".r.", relSel.alias)
 
 		b.WriteString(" LEFT OUTER JOIN LATERAL (")
 
@@ -440,7 +440,7 @@ func (t *table) buildQueryRelationshipsSubquery(
 			b.WriteString(", ")
 		}
 
-		relAlias := alias + ".r." + relSel.alias
+		relAlias := sqlAlias(alias, ".r.", relSel.alias)
 
 		b.WriteByte('\'')
 		b.WriteString(relSel.alias)

--- a/services/constellation/connector/sql/graphql/queries/root_subscription_stream.go
+++ b/services/constellation/connector/sql/graphql/queries/root_subscription_stream.go
@@ -180,7 +180,7 @@ func (t *table) buildStreamQuerySQL( //nolint:cyclop,funlen,gocognit,gocyclo,mai
 		return nil, 0, err
 	}
 
-	baseAlias := alias + ".base"
+	baseAlias := sqlAlias(alias, ".base")
 
 	b.WriteString(`WITH "`)
 	b.WriteString(baseAlias)
@@ -295,7 +295,7 @@ func (t *table) buildStreamQuerySQL( //nolint:cyclop,funlen,gocognit,gocyclo,mai
 				b.WriteString(", ")
 			}
 
-			relAlias := alias + ".r." + relSel.alias
+			relAlias := sqlAlias(alias, ".r.", relSel.alias)
 			t.dialect.WriteJSONRowColumn(b, relSel.alias,
 				`"`+relAlias+`"."`+relSel.alias+`"`)
 
@@ -337,7 +337,7 @@ func (t *table) buildStreamQuerySQL( //nolint:cyclop,funlen,gocognit,gocyclo,mai
 
 		// LEFT OUTER JOIN LATERAL for each nested relationship
 		for _, relSel := range relationships {
-			relAlias := alias + ".r." + relSel.alias
+			relAlias := sqlAlias(alias, ".r.", relSel.alias)
 
 			b.WriteString(" LEFT OUTER JOIN LATERAL (")
 
@@ -360,7 +360,7 @@ func (t *table) buildStreamQuerySQL( //nolint:cyclop,funlen,gocognit,gocyclo,mai
 				b.WriteString(", ")
 			}
 
-			relAlias := alias + ".r." + relSel.alias
+			relAlias := sqlAlias(alias, ".r.", relSel.alias)
 
 			b.WriteByte('\'')
 			b.WriteString(relSel.alias)

--- a/services/constellation/connector/sql/graphql/queries/selection_mutation.go
+++ b/services/constellation/connector/sql/graphql/queries/selection_mutation.go
@@ -334,7 +334,7 @@ func (s selectionReturning) writeReturningLateral( //nolint:funlen
 			b.WriteString(", ")
 		}
 
-		relAlias := cteName + ".r." + relSel.alias
+		relAlias := sqlAlias(cteName, ".r.", relSel.alias)
 
 		b.WriteByte('"')
 		b.WriteString(relAlias)
@@ -411,7 +411,7 @@ func (s selectionReturning) writeReturningCorrelated( //nolint:funlen
 			b.WriteString(", ")
 		}
 
-		relAlias := cteName + ".r." + relSel.alias
+		relAlias := sqlAlias(cteName, ".r.", relSel.alias)
 
 		b.WriteByte('\'')
 		b.WriteString(relSel.alias)
@@ -670,7 +670,7 @@ func writeNestedReturningSelection(
 	paramIndex int,
 ) ([]any, int, error) {
 	fromClause, sourceRef := nestedReturningSourceFromClause(
-		nestedCTERef.cteNames, relAlias+".source", relSel.relationship,
+		nestedCTERef.cteNames, sqlAlias(relAlias, ".source"), relSel.relationship,
 	)
 
 	return relSel.relationship.buildSelectionSQLFromSource(
@@ -704,7 +704,7 @@ func (s selectionReturning) writeLateralJoinsWithCTE(
 	paramIndex int,
 ) ([]any, int, error) {
 	for _, relSel := range s.relationships {
-		relAlias := cteName + ".r." + relSel.alias
+		relAlias := sqlAlias(cteName, ".r.", relSel.alias)
 
 		b.WriteString(" LEFT OUTER JOIN LATERAL (")
 

--- a/services/constellation/connector/sql/graphql/queries/selection_mutation_final_select.go
+++ b/services/constellation/connector/sql/graphql/queries/selection_mutation_final_select.go
@@ -93,7 +93,7 @@ func (t *table) buildLateralJoinSelection(
 		b.WriteString(", ")
 	}
 
-	relAlias := "mutation_result.r." + relSel.alias
+	relAlias := sqlAlias("mutation_result.r.", relSel.alias)
 	t.dialect.WriteJSONRowColumn(b, relSel.alias,
 		`"`+relAlias+`"."`+relSel.alias+`"`)
 
@@ -161,7 +161,7 @@ func (t *table) buildLateralJoins(
 			continue
 		}
 
-		relAlias := "mutation_result.r." + relSel.alias
+		relAlias := sqlAlias("mutation_result.r.", relSel.alias)
 
 		b.WriteString(" LEFT OUTER JOIN LATERAL (")
 
@@ -274,7 +274,7 @@ func (t *table) buildFinalSelect( //nolint:funlen
 					b.WriteString(", ")
 				}
 
-				relAlias := "mutation_result.r." + relSel.alias
+				relAlias := sqlAlias("mutation_result.r.", relSel.alias)
 
 				b.WriteByte('\'')
 				b.WriteString(relSel.alias)

--- a/services/constellation/connector/sql/graphql/queries/sql_alias.go
+++ b/services/constellation/connector/sql/graphql/queries/sql_alias.go
@@ -1,0 +1,62 @@
+package queries
+
+import (
+	"fmt"
+	"hash/fnv"
+	"strings"
+)
+
+const maxPostgresIdentifierBytes = 63
+
+// sqlAlias keeps generated SQL aliases within PostgreSQL's identifier limit.
+// PostgreSQL truncates longer identifiers to 63 bytes before checking for
+// duplicate table names, so aliases that share a long path prefix need a hash
+// suffix to remain distinct.
+func sqlAlias(parts ...string) string {
+	alias := strings.Join(parts, "")
+	if len(alias) <= maxPostgresIdentifierBytes {
+		return alias
+	}
+
+	return shortenSQLAlias(alias)
+}
+
+func shortenSQLAlias(alias string) string {
+	const (
+		hashPrefix = ".h"
+		hashBytes  = 16
+		separator  = "."
+	)
+
+	suffix := alias
+	if idx := strings.LastIndex(alias, "."); idx >= 0 && idx < len(alias)-1 {
+		suffix = alias[idx+1:]
+	}
+
+	maxSuffixBytes := maxPostgresIdentifierBytes - len(hashPrefix) - hashBytes - len(separator) - 1
+	if len(suffix) > maxSuffixBytes {
+		suffix = suffix[:maxSuffixBytes]
+	}
+
+	hash := sqlAliasHash(alias)
+	prefixBytes := max(
+		maxPostgresIdentifierBytes-len(hashPrefix)-len(hash)-len(separator)-len(suffix),
+		1,
+	)
+
+	prefix := alias[:prefixBytes]
+
+	prefix = strings.TrimRight(prefix, ".")
+	if prefix == "" {
+		prefix = alias[:1]
+	}
+
+	return prefix + hashPrefix + hash + separator + suffix
+}
+
+func sqlAliasHash(alias string) string {
+	h := fnv.New64a()
+	_, _ = h.Write([]byte(alias))
+
+	return fmt.Sprintf("%016x", h.Sum64())
+}

--- a/services/constellation/connector/sql/graphql/queries/sql_alias_internal_test.go
+++ b/services/constellation/connector/sql/graphql/queries/sql_alias_internal_test.go
@@ -1,0 +1,33 @@
+package queries
+
+import "testing"
+
+func TestSQLAliasShortensAndDisambiguatesPostgresIdentifiers(t *testing.T) {
+	t.Parallel()
+
+	parent := "_root.r.nutritionPlan.r.nutritionPlanMeals.r.meal.r.mealIngredients"
+	baseAlias := sqlAlias(parent, ".base")
+	relAlias := sqlAlias(parent, ".r.", "food")
+
+	if len(baseAlias) > maxPostgresIdentifierBytes {
+		t.Fatalf(
+			"base alias length = %d, want <= %d: %q",
+			len(baseAlias),
+			maxPostgresIdentifierBytes,
+			baseAlias,
+		)
+	}
+
+	if len(relAlias) > maxPostgresIdentifierBytes {
+		t.Fatalf(
+			"relationship alias length = %d, want <= %d: %q",
+			len(relAlias),
+			maxPostgresIdentifierBytes,
+			relAlias,
+		)
+	}
+
+	if baseAlias == relAlias {
+		t.Fatalf("aliases should remain unique after shortening: %q", baseAlias)
+	}
+}

--- a/services/constellation/integration/query_nested_test.go
+++ b/services/constellation/integration/query_nested_test.go
@@ -28,6 +28,26 @@ func TestNestedQueries(t *testing.T) { //nolint:maintidx,paralleltest
 			},
 		},
 
+		{
+			name: "long nested relationship alias does not collide after PostgreSQL truncation",
+			query: query{
+				Query: `query {
+					departments(limit: 2, order_by: {id: asc}) {
+						id
+						thisRelationshipAliasIsLongEnoughToCollideAfterPgTrunc: employees(
+							limit: 2,
+							order_by: {user_id: asc}
+						) {
+							user {
+								id
+							}
+						}
+					}
+				}`,
+				Role: "admin",
+			},
+		},
+
 		// Basic one-level nested queries - users with roles
 		{
 			name: "users with roles",


### PR DESCRIPTION
<!-- pi-reviewer:start -->
### **What this change solves**
This change prevents generated SQL relationship aliases from colliding when PostgreSQL truncates long identifiers. It introduces deterministic shortened SQL aliases while preserving GraphQL output names, with unit and integration coverage for nested relationship queries.

___

### **Change Type**
Bug fix

___

### **Description**
- Add SQL alias generation that hashes long aliases to remain within PostgreSQL identifier limits.
- Apply shortened aliases across root queries, aggregate queries, stream subscriptions, and mutation final-select paths.
- Preserve GraphQL field aliases in JSON output while using safe SQL table aliases internally.
- Add connector-level and integration tests for nested relationship alias collision scenarios.

___

<details> <summary><h3> File Walkthrough</h3></summary>

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody>
<tr><td><strong>SQL GraphQL query builder</strong></td><td><details><summary>8 files</summary><table>
<tr><td><strong>services/constellation/connector/sql/graphql/queries/sql_alias.go</strong><dd><code>Add deterministic PostgreSQL-safe SQL alias shortening helper.</code></dd></td><td>+62/-0</td></tr>
<tr><td><strong>services/constellation/connector/sql/graphql/queries/relationship.go</strong><dd><code>Use root GraphQL field names for relationship JSON output names.</code></dd></td><td>+1/-4</td></tr>
<tr><td><strong>services/constellation/connector/sql/graphql/queries/root_query_aggregate.go</strong><dd><code>Use shortened relationship aliases in aggregate query SQL generation.</code></dd></td><td>+5/-5</td></tr>
<tr><td><strong>services/constellation/connector/sql/graphql/queries/root_query_by_pk.go</strong><dd><code>Use shortened base and relationship aliases in by-primary-key queries.</code></dd></td><td>+4/-4</td></tr>
<tr><td><strong>services/constellation/connector/sql/graphql/queries/root_subscription_stream.go</strong><dd><code>Use shortened aliases in streaming subscription query SQL generation.</code></dd></td><td>+4/-4</td></tr>
<tr><td><strong>services/constellation/connector/sql/graphql/queries/selection_mutation.go</strong><dd><code>Use shortened aliases in mutation selection SQL generation.</code></dd></td><td>+4/-4</td></tr>
<tr><td><strong>services/constellation/connector/sql/graphql/queries/selection_mutation_final_select.go</strong><dd><code>Use shortened aliases in mutation final-select relationship joins.</code></dd></td><td>+3/-3</td></tr>
<tr><td><strong>services/constellation/connector/sql/graphql/queries/sql_alias_internal_test.go</strong><dd><code>Add unit coverage for short, long, and collision-prone SQL aliases.</code></dd></td><td>+33/-0</td></tr>
</table></details></td></tr>
<tr><td><strong>Tests</strong></td><td><details><summary>2 files</summary><table>
<tr><td><strong>services/constellation/connector/sql/graphql/queries/alias_collision_test.go</strong><dd><code>Add connector-level regression coverage for nested relationship alias truncation collisions.</code></dd></td><td>+163/-0</td></tr>
<tr><td><strong>services/constellation/integration/query_nested_test.go</strong><dd><code>Add integration coverage for aliased nested array and object relationship queries.</code></dd></td><td>+20/-0</td></tr>
</table></details></td></tr>
</tbody></table>

</details>

___

<!-- pi-reviewer:end -->