### PR TITLE
fix(ci): allow fork PR checkout in gated pull_request_target workflows

### DIFF
--- a/.github/workflows/cli_wf_test_new_project.yaml
+++ b/.github/workflows/cli_wf_test_new_project.yaml
@@ -47,6 +47,7 @@ jobs:
         uses: actions/checkout@v7
         with:
           ref: ${{ inputs.GIT_REF }}
+          allow-unsafe-pr-checkout: true
 
       - name: Collect Workflow Telemetry
         uses: catchpoint/workflow-telemetry-action@v2

--- a/.github/workflows/dashboard_wf_e2e_staging.yaml
+++ b/.github/workflows/dashboard_wf_e2e_staging.yaml
@@ -119,6 +119,7 @@ jobs:
         uses: actions/checkout@v7
         with:
           ref: ${{ inputs.GIT_REF }}
+          allow-unsafe-pr-checkout: true
 
       - name: Collect Workflow Telemetry
         uses: catchpoint/workflow-telemetry-action@v2

--- a/.github/workflows/wf_build_artifacts.yaml
+++ b/.github/workflows/wf_build_artifacts.yaml
@@ -69,6 +69,7 @@ jobs:
         uses: actions/checkout@v7
         with:
           ref: ${{ inputs.GIT_REF }}
+          allow-unsafe-pr-checkout: true
 
       - name: Configure aws
         uses: aws-actions/configure-aws-credentials@v6

--- a/.github/workflows/wf_check.yaml
+++ b/.github/workflows/wf_check.yaml
@@ -14,7 +14,7 @@ on:
       ENV:
         type: string
         required: false
-        default: ''
+        default: ""
     secrets:
       AWS_ACCOUNT_ID:
         required: true
@@ -47,77 +47,78 @@ jobs:
       actions: read
 
     steps:
-    - name: "Set custom env"
-      if: ${{ inputs.ENV != '' }}
-      run: echo "${{ inputs.ENV }}" >> $GITHUB_ENV
-      working-directory: .
+      - name: "Set custom env"
+        if: ${{ inputs.ENV != '' }}
+        run: echo "${{ inputs.ENV }}" >> $GITHUB_ENV
+        working-directory: .
 
-    - name: "Check out repository"
-      uses: actions/checkout@v7
-      with:
-        ref: ${{ inputs.GIT_REF }}
+      - name: "Check out repository"
+        uses: actions/checkout@v7
+        with:
+          ref: ${{ inputs.GIT_REF }}
+          allow-unsafe-pr-checkout: true
 
-    - name: Collect Workflow Telemetry
-      uses: catchpoint/workflow-telemetry-action@v2
-      with:
-        comment_on_pr: false
+      - name: Collect Workflow Telemetry
+        uses: catchpoint/workflow-telemetry-action@v2
+        with:
+          comment_on_pr: false
 
-    - name: Configure aws
-      uses: aws-actions/configure-aws-credentials@v6
-      with:
-        role-to-assume: arn:aws:iam::${{ secrets.AWS_ACCOUNT_ID }}:role/github-actions-nhost-${{ github.event.repository.name }}
-        aws-region: eu-central-1
+      - name: Configure aws
+        uses: aws-actions/configure-aws-credentials@v6
+        with:
+          role-to-assume: arn:aws:iam::${{ secrets.AWS_ACCOUNT_ID }}:role/github-actions-nhost-${{ github.event.repository.name }}
+          aws-region: eu-central-1
 
-    - name: Setup Nix with Cache
-      uses: ./.github/actions/setup-nix
-      with:
-        NAME: ${{ inputs.NAME }}
-        NIX_CACHE_PUB_KEY: ${{ secrets.NIX_CACHE_PUB_KEY }}
-        NIX_CACHE_ACCESS_KEY_ID: ${{ secrets.NIX_CACHE_ACCESS_KEY_ID }}
-        NIX_CACHE_SECRET_ACCESS_KEY: ${{ secrets.NIX_CACHE_SECRET_ACCESS_KEY }}
-        GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+      - name: Setup Nix with Cache
+        uses: ./.github/actions/setup-nix
+        with:
+          NAME: ${{ inputs.NAME }}
+          NIX_CACHE_PUB_KEY: ${{ secrets.NIX_CACHE_PUB_KEY }}
+          NIX_CACHE_ACCESS_KEY_ID: ${{ secrets.NIX_CACHE_ACCESS_KEY_ID }}
+          NIX_CACHE_SECRET_ACCESS_KEY: ${{ secrets.NIX_CACHE_SECRET_ACCESS_KEY }}
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
-    - name: "Verify if we need to build"
-      id: verify-build
-      run: |
-        # `nix build --dry-run` (inside `make check-dry-run`) walks the
-        # full build graph and reports what would be built locally vs
-        # fetched from configured substituters (cache.nixos.org + our
-        # S3 cache). If any derivation would be built we have new paths
-        # worth uploading. This catches the case where the top-level
-        # output is cached but transitive build deps aren't — `nix
-        # path-info --recursive` only sees the runtime closure, which
-        # misses build-time intermediates.
-        stderr_log=$(mktemp)
-        if ! drvPath=$(make check-dry-run 2>"$stderr_log"); then
-          cat "$stderr_log" >&2
+      - name: "Verify if we need to build"
+        id: verify-build
+        run: |
+          # `nix build --dry-run` (inside `make check-dry-run`) walks the
+          # full build graph and reports what would be built locally vs
+          # fetched from configured substituters (cache.nixos.org + our
+          # S3 cache). If any derivation would be built we have new paths
+          # worth uploading. This catches the case where the top-level
+          # output is cached but transitive build deps aren't — `nix
+          # path-info --recursive` only sees the runtime closure, which
+          # misses build-time intermediates.
+          stderr_log=$(mktemp)
+          if ! drvPath=$(make check-dry-run 2>"$stderr_log"); then
+            cat "$stderr_log" >&2
+            rm -f "$stderr_log"
+            exit 1
+          fi
+          export drvPath
+          echo "Derivation path: $drvPath"
+          if grep -q "will be built" "$stderr_log"; then
+            export BUILD_NEEDED=yes
+          else
+            export BUILD_NEEDED=no
+          fi
           rm -f "$stderr_log"
-          exit 1
-        fi
-        export drvPath
-        echo "Derivation path: $drvPath"
-        if grep -q "will be built" "$stderr_log"; then
-          export BUILD_NEEDED=yes
-        else
-          export BUILD_NEEDED=no
-        fi
-        rm -f "$stderr_log"
-        echo BUILD_NEEDED=$BUILD_NEEDED >> $GITHUB_OUTPUT
-        echo DERIVATION_PATH=$drvPath >> $GITHUB_OUTPUT
+          echo BUILD_NEEDED=$BUILD_NEEDED >> $GITHUB_OUTPUT
+          echo DERIVATION_PATH=$drvPath >> $GITHUB_OUTPUT
 
-    - name: "Start containters for integration tests"
-      run: |
-        nix develop .\#${{ inputs.NAME }} -c make dev-env-up
-      if: ${{ steps.verify-build.outputs.BUILD_NEEDED == 'yes' }}
+      - name: "Start containters for integration tests"
+        run: |
+          nix develop .\#${{ inputs.NAME }} -c make dev-env-up
+        if: ${{ steps.verify-build.outputs.BUILD_NEEDED == 'yes' }}
 
-    - name: "Run checks"
-      run: make check
-      if: ${{ steps.verify-build.outputs.BUILD_NEEDED == 'yes' }}
+      - name: "Run checks"
+        run: make check
+        if: ${{ steps.verify-build.outputs.BUILD_NEEDED == 'yes' }}
 
-    - name: "Store Nix cache"
-      uses: ./.github/actions/cache-nix
-      with:
-        NIX_CACHE_PRIV_KEY: ${{ secrets.NIX_CACHE_PRIV_KEY }}
-        NIX_CACHE_ACCESS_KEY_ID: ${{ secrets.NIX_CACHE_ACCESS_KEY_ID }}
-        NIX_CACHE_SECRET_ACCESS_KEY: ${{ secrets.NIX_CACHE_SECRET_ACCESS_KEY }}
-      if: ${{ always() && steps.verify-build.outputs.BUILD_NEEDED == 'yes' }}
+      - name: "Store Nix cache"
+        uses: ./.github/actions/cache-nix
+        with:
+          NIX_CACHE_PRIV_KEY: ${{ secrets.NIX_CACHE_PRIV_KEY }}
+          NIX_CACHE_ACCESS_KEY_ID: ${{ secrets.NIX_CACHE_ACCESS_KEY_ID }}
+          NIX_CACHE_SECRET_ACCESS_KEY: ${{ secrets.NIX_CACHE_SECRET_ACCESS_KEY }}
+        if: ${{ always() && steps.verify-build.outputs.BUILD_NEEDED == 'yes' }}

--- a/.github/workflows/wf_check.yaml
+++ b/.github/workflows/wf_check.yaml
@@ -14,7 +14,7 @@ on:
       ENV:
         type: string
         required: false
-        default: ""
+        default: ''
     secrets:
       AWS_ACCOUNT_ID:
         required: true
@@ -47,78 +47,78 @@ jobs:
       actions: read
 
     steps:
-      - name: "Set custom env"
-        if: ${{ inputs.ENV != '' }}
-        run: echo "${{ inputs.ENV }}" >> $GITHUB_ENV
-        working-directory: .
+    - name: "Set custom env"
+      if: ${{ inputs.ENV != '' }}
+      run: echo "${{ inputs.ENV }}" >> $GITHUB_ENV
+      working-directory: .
 
-      - name: "Check out repository"
-        uses: actions/checkout@v7
-        with:
-          ref: ${{ inputs.GIT_REF }}
-          allow-unsafe-pr-checkout: true
+    - name: "Check out repository"
+      uses: actions/checkout@v7
+      with:
+        ref: ${{ inputs.GIT_REF }}
+        allow-unsafe-pr-checkout: true
 
-      - name: Collect Workflow Telemetry
-        uses: catchpoint/workflow-telemetry-action@v2
-        with:
-          comment_on_pr: false
+    - name: Collect Workflow Telemetry
+      uses: catchpoint/workflow-telemetry-action@v2
+      with:
+        comment_on_pr: false
 
-      - name: Configure aws
-        uses: aws-actions/configure-aws-credentials@v6
-        with:
-          role-to-assume: arn:aws:iam::${{ secrets.AWS_ACCOUNT_ID }}:role/github-actions-nhost-${{ github.event.repository.name }}
-          aws-region: eu-central-1
+    - name: Configure aws
+      uses: aws-actions/configure-aws-credentials@v6
+      with:
+        role-to-assume: arn:aws:iam::${{ secrets.AWS_ACCOUNT_ID }}:role/github-actions-nhost-${{ github.event.repository.name }}
+        aws-region: eu-central-1
 
-      - name: Setup Nix with Cache
-        uses: ./.github/actions/setup-nix
-        with:
-          NAME: ${{ inputs.NAME }}
-          NIX_CACHE_PUB_KEY: ${{ secrets.NIX_CACHE_PUB_KEY }}
-          NIX_CACHE_ACCESS_KEY_ID: ${{ secrets.NIX_CACHE_ACCESS_KEY_ID }}
-          NIX_CACHE_SECRET_ACCESS_KEY: ${{ secrets.NIX_CACHE_SECRET_ACCESS_KEY }}
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+    - name: Setup Nix with Cache
+      uses: ./.github/actions/setup-nix
+      with:
+        NAME: ${{ inputs.NAME }}
+        NIX_CACHE_PUB_KEY: ${{ secrets.NIX_CACHE_PUB_KEY }}
+        NIX_CACHE_ACCESS_KEY_ID: ${{ secrets.NIX_CACHE_ACCESS_KEY_ID }}
+        NIX_CACHE_SECRET_ACCESS_KEY: ${{ secrets.NIX_CACHE_SECRET_ACCESS_KEY }}
+        GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
-      - name: "Verify if we need to build"
-        id: verify-build
-        run: |
-          # `nix build --dry-run` (inside `make check-dry-run`) walks the
-          # full build graph and reports what would be built locally vs
-          # fetched from configured substituters (cache.nixos.org + our
-          # S3 cache). If any derivation would be built we have new paths
-          # worth uploading. This catches the case where the top-level
-          # output is cached but transitive build deps aren't — `nix
-          # path-info --recursive` only sees the runtime closure, which
-          # misses build-time intermediates.
-          stderr_log=$(mktemp)
-          if ! drvPath=$(make check-dry-run 2>"$stderr_log"); then
-            cat "$stderr_log" >&2
-            rm -f "$stderr_log"
-            exit 1
-          fi
-          export drvPath
-          echo "Derivation path: $drvPath"
-          if grep -q "will be built" "$stderr_log"; then
-            export BUILD_NEEDED=yes
-          else
-            export BUILD_NEEDED=no
-          fi
+    - name: "Verify if we need to build"
+      id: verify-build
+      run: |
+        # `nix build --dry-run` (inside `make check-dry-run`) walks the
+        # full build graph and reports what would be built locally vs
+        # fetched from configured substituters (cache.nixos.org + our
+        # S3 cache). If any derivation would be built we have new paths
+        # worth uploading. This catches the case where the top-level
+        # output is cached but transitive build deps aren't — `nix
+        # path-info --recursive` only sees the runtime closure, which
+        # misses build-time intermediates.
+        stderr_log=$(mktemp)
+        if ! drvPath=$(make check-dry-run 2>"$stderr_log"); then
+          cat "$stderr_log" >&2
           rm -f "$stderr_log"
-          echo BUILD_NEEDED=$BUILD_NEEDED >> $GITHUB_OUTPUT
-          echo DERIVATION_PATH=$drvPath >> $GITHUB_OUTPUT
+          exit 1
+        fi
+        export drvPath
+        echo "Derivation path: $drvPath"
+        if grep -q "will be built" "$stderr_log"; then
+          export BUILD_NEEDED=yes
+        else
+          export BUILD_NEEDED=no
+        fi
+        rm -f "$stderr_log"
+        echo BUILD_NEEDED=$BUILD_NEEDED >> $GITHUB_OUTPUT
+        echo DERIVATION_PATH=$drvPath >> $GITHUB_OUTPUT
 
-      - name: "Start containters for integration tests"
-        run: |
-          nix develop .\#${{ inputs.NAME }} -c make dev-env-up
-        if: ${{ steps.verify-build.outputs.BUILD_NEEDED == 'yes' }}
+    - name: "Start containters for integration tests"
+      run: |
+        nix develop .\#${{ inputs.NAME }} -c make dev-env-up
+      if: ${{ steps.verify-build.outputs.BUILD_NEEDED == 'yes' }}
 
-      - name: "Run checks"
-        run: make check
-        if: ${{ steps.verify-build.outputs.BUILD_NEEDED == 'yes' }}
+    - name: "Run checks"
+      run: make check
+      if: ${{ steps.verify-build.outputs.BUILD_NEEDED == 'yes' }}
 
-      - name: "Store Nix cache"
-        uses: ./.github/actions/cache-nix
-        with:
-          NIX_CACHE_PRIV_KEY: ${{ secrets.NIX_CACHE_PRIV_KEY }}
-          NIX_CACHE_ACCESS_KEY_ID: ${{ secrets.NIX_CACHE_ACCESS_KEY_ID }}
-          NIX_CACHE_SECRET_ACCESS_KEY: ${{ secrets.NIX_CACHE_SECRET_ACCESS_KEY }}
-        if: ${{ always() && steps.verify-build.outputs.BUILD_NEEDED == 'yes' }}
+    - name: "Store Nix cache"
+      uses: ./.github/actions/cache-nix
+      with:
+        NIX_CACHE_PRIV_KEY: ${{ secrets.NIX_CACHE_PRIV_KEY }}
+        NIX_CACHE_ACCESS_KEY_ID: ${{ secrets.NIX_CACHE_ACCESS_KEY_ID }}
+        NIX_CACHE_SECRET_ACCESS_KEY: ${{ secrets.NIX_CACHE_SECRET_ACCESS_KEY }}
+      if: ${{ always() && steps.verify-build.outputs.BUILD_NEEDED == 'yes' }}

--- a/.github/workflows/wf_deploy_vercel.yaml
+++ b/.github/workflows/wf_deploy_vercel.yaml
@@ -1,4 +1,4 @@
-name: "deploy to vercel"
+name: 'deploy to vercel'
 
 on:
   workflow_call:

--- a/.github/workflows/wf_deploy_vercel.yaml
+++ b/.github/workflows/wf_deploy_vercel.yaml
@@ -1,4 +1,4 @@
-name: 'deploy to vercel'
+name: "deploy to vercel"
 
 on:
   workflow_call:
@@ -56,6 +56,7 @@ jobs:
         uses: actions/checkout@v7
         with:
           ref: ${{ inputs.GIT_REF }}
+          allow-unsafe-pr-checkout: true
 
       - name: Configure aws
         uses: aws-actions/configure-aws-credentials@v6


### PR DESCRIPTION
### Checklist

- [X] No breaking changes
- [X] Tests pass
- [X] New features have new tests
- [X] Documentation is updated (if applicable)
- [X] Title of the PR is in the correct format (see below)


<!-- pi-reviewer:start -->
### **What this change solves**
Gated `pull_request_target` check/build/deploy workflows could not check out fork PR head commits because the pinned `actions/checkout@v7` refuses to check out an unsafe PR ref by default. After the `check-permissions` gate has already authorized the run (author has write+ or a maintainer added `safe_to_test`), these reusable workflows now opt in to checking out the fork PR head SHA.

___

### **Change Type**
Configuration

___

### **Description**
- Add `allow-unsafe-pr-checkout: true` to the `actions/checkout@v7` step in five reusable workflows that receive an untrusted `GIT_REF` (fork PR head SHA) as input.
- Affects `wf_check`, `wf_build_artifacts`, `wf_deploy_vercel`, `cli_wf_test_new_project`, and `dashboard_wf_e2e_staging`.
- All five reusable workflows are only invoked downstream of the `check-permissions` gate in their caller `*_checks.yaml` workflows, so the unsafe checkout is reachable only after authorization.

___

<details> <summary><h3> File Walkthrough</h3></summary>

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody>
<tr><td><strong>Configuration</strong></td><td><details><summary>5 files</summary><table>
<tr>
  <td><strong>wf_check.yaml</strong><dd><code>Opt in to fork PR head checkout in the shared check/build workflow</code></dd></td>
  <td>+1/-0</td>
</tr>
<tr>
  <td><strong>wf_build_artifacts.yaml</strong><dd><code>Opt in to fork PR head checkout in the artifact build workflow</code></dd></td>
  <td>+1/-0</td>
</tr>
<tr>
  <td><strong>wf_deploy_vercel.yaml</strong><dd><code>Opt in to fork PR head checkout in the Vercel deploy workflow</code></dd></td>
  <td>+1/-0</td>
</tr>
<tr>
  <td><strong>cli_wf_test_new_project.yaml</strong><dd><code>Opt in to fork PR head checkout in the CLI new-project test workflow</code></dd></td>
  <td>+1/-0</td>
</tr>
<tr>
  <td><strong>dashboard_wf_e2e_staging.yaml</strong><dd><code>Opt in to fork PR head checkout in the dashboard staging e2e workflow</code></dd></td>
  <td>+1/-0</td>
</tr>
</table></details></td></tr>
</tbody></table>

</details>

___

<!-- pi-reviewer:end -->
