### PR TITLE
fix(dashboard): Use custom date/time picker when inserting row

### DIFF
--- a/dashboard/src/components/common/DatePicker/DatePicker.test.tsx
+++ b/dashboard/src/components/common/DatePicker/DatePicker.test.tsx
@@ -1,0 +1,206 @@
+import type { ChangeEvent, FocusEvent, KeyboardEvent } from 'react';
+import { useState } from 'react';
+import { render, screen, TestUserEvent, waitFor } from '@/tests/testUtils';
+import DatePicker, { type DatePickerProps } from './DatePicker';
+
+function TestComponent({
+  initialDate = null,
+  ...props
+}: Omit<DatePickerProps, 'date' | 'onDateChange'> & {
+  initialDate?: string | null;
+}) {
+  const [date, setDate] = useState<string | null>(initialDate);
+
+  return (
+    <>
+      <span data-testid="value">{date ?? 'empty'}</span>
+      <button type="button" onClick={() => setDate('2025-06-20T12:00:00.000Z')}>
+        external set june
+      </button>
+      <DatePicker {...props} date={date} onDateChange={setDate} />
+    </>
+  );
+}
+
+function CustomTriggerComponent() {
+  const [date, setDate] = useState<string | null>('2025-04-10T12:00:00.000Z');
+  const [inputValue, setInputValue] = useState('2025-04-10');
+
+  return (
+    <>
+      <span data-testid="value">{date}</span>
+      <DatePicker
+        date={date}
+        onDateChange={setDate}
+        triggerSlot={({ triggerProps }) => {
+          function handleFocus(event: FocusEvent<HTMLInputElement>) {
+            triggerProps.onFocus?.(event);
+          }
+
+          function handleBlur(event: FocusEvent<HTMLInputElement>) {
+            triggerProps.onBlur?.(event);
+          }
+
+          function handleKeyDown(event: KeyboardEvent<HTMLInputElement>) {
+            triggerProps.onKeyDown?.(event);
+          }
+
+          function handleChange(event: ChangeEvent<HTMLInputElement>) {
+            setInputValue(event.target.value);
+          }
+
+          return (
+            <input
+              role="combobox"
+              aria-label="Custom date"
+              value={inputValue}
+              onChange={handleChange}
+              onFocus={handleFocus}
+              onBlur={handleBlur}
+              onKeyDown={handleKeyDown}
+              aria-expanded={triggerProps['aria-expanded']}
+              aria-haspopup={triggerProps['aria-haspopup']}
+              aria-invalid={triggerProps['aria-invalid']}
+            />
+          );
+        }}
+      />
+      <button type="button">outside</button>
+    </>
+  );
+}
+
+describe('DatePicker', () => {
+  it('shows the empty label when there is no value', () => {
+    render(<TestComponent emptyLabel="Select a date" />);
+
+    expect(screen.getByTestId('datePickerTrigger')).toHaveTextContent(
+      'Select a date',
+    );
+  });
+
+  it('shows the picked day on the trigger after selecting', async () => {
+    render(<TestComponent initialDate="2025-04-10T12:00:00.000Z" />);
+    const user = new TestUserEvent();
+
+    await user.click(screen.getByTestId('datePickerTrigger'));
+    await user.click(screen.getByText('13'));
+    await user.click(screen.getByRole('button', { name: 'Select' }));
+
+    await waitFor(() =>
+      expect(
+        screen.queryByRole('button', { name: 'Select' }),
+      ).not.toBeInTheDocument(),
+    );
+
+    expect(screen.getByTestId('datePickerTrigger')).toHaveTextContent(
+      'April 13th, 2025',
+    );
+  });
+
+  it('emits null when the Clear button is clicked', async () => {
+    render(<TestComponent initialDate="2025-04-10T12:00:00.000Z" clearable />);
+    const user = new TestUserEvent();
+
+    await user.click(screen.getByTestId('datePickerTrigger'));
+    await user.click(screen.getByRole('button', { name: 'Clear' }));
+
+    await waitFor(() =>
+      expect(screen.getByTestId('value')).toHaveTextContent('empty'),
+    );
+    expect(screen.getByTestId('datePickerTrigger')).toHaveTextContent(
+      'Select a date',
+    );
+  });
+
+  it('does not allow picking a disabled day', async () => {
+    render(
+      <TestComponent
+        initialDate="2025-04-10T12:00:00.000Z"
+        isCalendarDayDisabled={(date) => date.getDate() === 15}
+      />,
+    );
+    const user = new TestUserEvent();
+
+    await user.click(screen.getByTestId('datePickerTrigger'));
+
+    expect(screen.getByText('15')).toBeDisabled();
+    expect(screen.getByText('14')).not.toBeDisabled();
+  });
+
+  it('renders a destructive trigger border when error is set', () => {
+    render(<TestComponent error />);
+
+    expect(screen.getByTestId('datePickerTrigger')).toHaveClass(
+      'border-destructive',
+    );
+  });
+
+  it('reflects an external value change when reopened', async () => {
+    render(<TestComponent initialDate="2025-04-10T12:00:00.000Z" />);
+    const user = new TestUserEvent();
+
+    await user.click(screen.getByTestId('datePickerTrigger'));
+    expect(screen.getByText('April 2025')).toBeInTheDocument();
+
+    await user.click(screen.getByRole('button', { name: 'external set june' }));
+    await user.click(screen.getByTestId('datePickerTrigger'));
+
+    expect(screen.getByText('June 2025')).toBeInTheDocument();
+  });
+
+  it('opens a custom input trigger on focus and closes on outside blur', async () => {
+    render(<CustomTriggerComponent />);
+    const user = new TestUserEvent();
+
+    await user.click(screen.getByRole('combobox', { name: 'Custom date' }));
+    expect(screen.getByText('April 2025')).toBeInTheDocument();
+
+    await user.click(screen.getByRole('button', { name: 'outside' }));
+
+    await waitFor(() =>
+      expect(screen.queryByText('April 2025')).not.toBeInTheDocument(),
+    );
+  });
+
+  it('keeps a custom input trigger open while interacting with the calendar', async () => {
+    render(<CustomTriggerComponent />);
+    const user = new TestUserEvent();
+
+    await user.click(screen.getByRole('combobox', { name: 'Custom date' }));
+    await user.click(screen.getByText('13'));
+
+    expect(screen.getByRole('button', { name: 'Select' })).toBeInTheDocument();
+
+    await user.click(screen.getByRole('button', { name: 'Select' }));
+
+    await waitFor(() =>
+      expect(screen.getByTestId('value')).not.toHaveTextContent(
+        '2025-04-10T12:00:00.000Z',
+      ),
+    );
+    expect(
+      new Date(screen.getByTestId('value').textContent ?? '').getDate(),
+    ).toBe(13);
+  });
+
+  it('preserves a custom input trigger selection when the input is refocused', async () => {
+    render(<CustomTriggerComponent />);
+    const user = new TestUserEvent();
+    const customTrigger = screen.getByRole('combobox', { name: 'Custom date' });
+
+    await user.click(customTrigger);
+    await user.click(screen.getByText('13'));
+    await user.click(customTrigger);
+    await user.click(screen.getByRole('button', { name: 'Select' }));
+
+    await waitFor(() =>
+      expect(screen.getByTestId('value')).not.toHaveTextContent(
+        '2025-04-10T12:00:00.000Z',
+      ),
+    );
+    expect(
+      new Date(screen.getByTestId('value').textContent ?? '').getDate(),
+    ).toBe(13);
+  });
+});

--- a/dashboard/src/components/common/DatePicker/DatePicker.tsx
+++ b/dashboard/src/components/common/DatePicker/DatePicker.tsx
@@ -1,0 +1,180 @@
+'use client';
+
+import { isValid, parseISO } from 'date-fns';
+import { useState } from 'react';
+import {
+  type PickerTriggerSlot,
+  usePickerTriggerSlot,
+} from '@/components/common/PickerTriggerSlot';
+import { Button } from '@/components/ui/v3/button';
+import { Calendar } from '@/components/ui/v3/calendar';
+import {
+  Popover,
+  PopoverAnchor,
+  PopoverContent,
+} from '@/components/ui/v3/popover';
+import { cn } from '@/lib/utils';
+import DatePickerTrigger from './DatePickerTrigger';
+
+interface DatePickerTriggerSlotProps {
+  id?: string;
+  date: string | null;
+  formatDateFn?: (date: Date) => string;
+  emptyLabel: string;
+}
+
+export interface DatePickerProps {
+  id?: string;
+  date: string | null;
+  onDateChange: (newDate: string | null) => void;
+  formatDateFn?: (date: Date) => string;
+  isCalendarDayDisabled?: (date: Date) => boolean;
+  align?: 'start' | 'center' | 'end';
+  validateDateFn?: (date: Date) => string;
+  /**
+   * Label shown on the trigger when there is no value.
+   *
+   * @default 'Select a date'
+   */
+  emptyLabel?: string;
+  /**
+   * Whether to show a Clear button that emits `null`.
+   *
+   * @default false
+   */
+  clearable?: boolean;
+  /**
+   * Whether to render the trigger with a destructive border, e.g. when an
+   * external form validation has failed.
+   *
+   * @default false
+   */
+  error?: boolean;
+  open?: boolean;
+  onOpenChange?: (open: boolean) => void;
+  triggerSlot?: PickerTriggerSlot<DatePickerTriggerSlotProps>;
+}
+
+function DatePicker({
+  id,
+  date,
+  onDateChange,
+  formatDateFn,
+  isCalendarDayDisabled,
+  align = 'start',
+  validateDateFn,
+  emptyLabel = 'Select a date',
+  clearable = false,
+  error = false,
+  open: controlledOpen,
+  onOpenChange,
+  triggerSlot,
+}: DatePickerProps) {
+  const isEmpty = !date || !isValid(parseISO(date));
+
+  function resolveDate() {
+    return isEmpty ? new Date() : parseISO(date);
+  }
+
+  const [selected, setSelected] = useState(resolveDate);
+  const [internalOpen, setInternalOpen] = useState(false);
+  const open = controlledOpen ?? internalOpen;
+
+  function handleSelect(newDay: Date | undefined) {
+    if (newDay) {
+      setSelected(newDay);
+    }
+  }
+
+  function setPickerOpen(newOpenState: boolean) {
+    if (controlledOpen === undefined) {
+      setInternalOpen(newOpenState);
+    }
+
+    onOpenChange?.(newOpenState);
+  }
+
+  function handleOpenChange(newOpenState: boolean) {
+    setSelected(resolveDate());
+    setPickerOpen(newOpenState);
+  }
+
+  function onSelect() {
+    onDateChange(selected.toISOString());
+    setPickerOpen(false);
+  }
+
+  function onClear() {
+    onDateChange(null);
+    setPickerOpen(false);
+  }
+
+  const errorText = !isEmpty ? validateDateFn?.(selected) : undefined;
+  const hasError = !!errorText;
+  const triggerHasError = hasError || error;
+  const { triggerSlotProps, contentProps } = usePickerTriggerSlot({
+    open,
+    setOpen: handleOpenChange,
+    hasError: triggerHasError,
+  });
+
+  return (
+    <Popover open={open} onOpenChange={handleOpenChange}>
+      {triggerSlot ? (
+        <PopoverAnchor asChild>
+          {triggerSlot({
+            ...triggerSlotProps,
+            id,
+            date,
+            formatDateFn,
+            emptyLabel,
+          })}
+        </PopoverAnchor>
+      ) : (
+        <DatePickerTrigger
+          id={id}
+          date={date}
+          formatDateFn={formatDateFn}
+          emptyLabel={emptyLabel}
+          hasError={triggerHasError}
+          onClick={() => setPickerOpen(true)}
+        />
+      )}
+
+      <PopoverContent
+        {...(triggerSlot ? contentProps : {})}
+        className="w-auto p-0"
+        align={align}
+      >
+        <Calendar
+          mode="single"
+          selected={selected}
+          defaultMonth={selected}
+          onSelect={handleSelect}
+          disabled={isCalendarDayDisabled}
+        />
+        <div className="flex flex-row gap-2 border-border border-t p-3">
+          {clearable && (
+            <Button variant="outline" className="w-full" onClick={onClear}>
+              Clear
+            </Button>
+          )}
+          <Button className="w-full" onClick={onSelect} disabled={hasError}>
+            Select
+          </Button>
+        </div>
+        {validateDateFn && (
+          <div
+            className={cn('p-3 text-center text-[11px] text-destructive', {
+              invisible: !hasError,
+            })}
+          >
+            {errorText}
+          </div>
+        )}
+      </PopoverContent>
+    </Popover>
+  );
+}
+
+export default DatePicker;

--- a/dashboard/src/components/common/DatePicker/DatePickerTrigger.tsx
+++ b/dashboard/src/components/common/DatePicker/DatePickerTrigger.tsx
@@ -1,0 +1,50 @@
+'use client';
+
+import { format, isValid, parseISO } from 'date-fns';
+import { Calendar as CalendarIcon } from 'lucide-react';
+import { Button } from '@/components/ui/v3/button';
+import { PopoverTrigger } from '@/components/ui/v3/popover';
+import { cn } from '@/lib/utils';
+
+interface DatePickerTriggerProps {
+  id?: string;
+  date: string | null;
+  formatDateFn?: (date: Date) => string;
+  emptyLabel: string;
+  hasError: boolean;
+  onClick: () => void;
+}
+
+export default function DatePickerTrigger({
+  id,
+  date,
+  formatDateFn,
+  emptyLabel,
+  hasError,
+  onClick,
+}: DatePickerTriggerProps) {
+  const parsed = date ? parseISO(date) : null;
+  const value = parsed !== null && isValid(parsed) ? parsed : null;
+
+  const label = value
+    ? formatDateFn?.(value) || format(value, 'PPP')
+    : emptyLabel;
+
+  return (
+    <PopoverTrigger asChild>
+      <Button
+        id={id}
+        data-testid="datePickerTrigger"
+        variant="outline"
+        className={cn('w-full justify-between text-left font-normal', {
+          'text-muted-foreground': value === null,
+          'border-destructive': hasError,
+        })}
+        onClick={onClick}
+      >
+        {label}
+        <CalendarIcon className="h-4 w-4" />
+      </Button>
+    </PopoverTrigger>
+  );
+}

--- a/dashboard/src/components/common/DatePicker/index.ts
+++ b/dashboard/src/components/common/DatePicker/index.ts
@@ -1,0 +1,1 @@
+export { default as DatePicker } from './DatePicker';

--- a/dashboard/src/components/common/DateTimePicker/DateTimePicker.test.tsx
+++ b/dashboard/src/components/common/DateTimePicker/DateTimePicker.test.tsx
@@ -22,7 +22,7 @@ const earliestBackupDate = '2025-03-13T02:00:05.000Z';
 function TestComponent(
   props: Omit<DateTimePickerProps, 'dateTime' | 'onDateTimeChange'>,
 ) {
-  const [dateTime, setDateTime] = useState(earliestBackupDate);
+  const [dateTime, setDateTime] = useState<string | null>(earliestBackupDate);
 
   function isCalendarDayDisabled(date: Date | TZDate) {
     if (isTZDate(date)) {
@@ -36,8 +36,8 @@ function TestComponent(
     }
 
     return isBefore(
-      startOfDay(new Date(date.getTime()).toISOString()),
-      startOfDay(earliestBackupDate),
+      startOfDay(new Date(date.getTime())),
+      startOfDay(new Date(earliestBackupDate)),
     );
   }
 
@@ -54,7 +54,84 @@ function TestComponent(
   );
 }
 
+function ControlledDateTimePicker({
+  initialDateTime = null,
+  ...props
+}: Omit<DateTimePickerProps, 'dateTime' | 'onDateTimeChange'> & {
+  initialDateTime?: string | null;
+}) {
+  const [dateTime, setDateTime] = useState<string | null>(initialDateTime);
+
+  return (
+    <>
+      <span data-testid="value">{dateTime ?? 'empty'}</span>
+      <button
+        type="button"
+        onClick={() => setDateTime('2025-06-20T12:00:00.000Z')}
+      >
+        external set june
+      </button>
+      <DateTimePicker
+        {...props}
+        dateTime={dateTime}
+        onDateTimeChange={setDateTime}
+      />
+    </>
+  );
+}
+
 describe('DateTimePicker', () => {
+  it('shows the empty label when there is no value', () => {
+    render(<ControlledDateTimePicker emptyLabel="Select a date" />);
+
+    expect(screen.getByTestId('dateTimePickerTrigger')).toHaveTextContent(
+      'Select a date',
+    );
+  });
+
+  it('emits null when the Clear button is clicked', async () => {
+    render(
+      <ControlledDateTimePicker
+        initialDateTime="2025-04-10T12:00:00.000Z"
+        clearable
+      />,
+    );
+    const user = new TestUserEvent();
+
+    await user.click(screen.getByTestId('dateTimePickerTrigger'));
+    await user.click(screen.getByRole('button', { name: 'Clear' }));
+
+    await waitFor(() =>
+      expect(screen.getByTestId('value')).toHaveTextContent('empty'),
+    );
+    expect(screen.getByTestId('dateTimePickerTrigger')).toHaveTextContent(
+      'Select a date',
+    );
+  });
+
+  it('renders a destructive trigger border when error is set', () => {
+    render(<ControlledDateTimePicker error />);
+
+    expect(screen.getByTestId('dateTimePickerTrigger')).toHaveClass(
+      'border-destructive',
+    );
+  });
+
+  it('reflects an external value change when reopened', async () => {
+    render(
+      <ControlledDateTimePicker initialDateTime="2025-04-10T12:00:00.000Z" />,
+    );
+    const user = new TestUserEvent();
+
+    await user.click(screen.getByTestId('dateTimePickerTrigger'));
+    expect(screen.getByText('April 2025')).toBeInTheDocument();
+
+    await user.click(screen.getByRole('button', { name: 'external set june' }));
+    await user.click(screen.getByTestId('dateTimePickerTrigger'));
+
+    expect(screen.getByText('June 2025')).toBeInTheDocument();
+  });
+
   test('when the date changes datetime is emitted in utc string format', async () => {
     render(<TestComponent />);
     const user = new TestUserEvent();

--- a/dashboard/src/components/common/DateTimePicker/DateTimePicker.tsx
+++ b/dashboard/src/components/common/DateTimePicker/DateTimePicker.tsx
@@ -1,24 +1,39 @@
 'use client';
 
 import { TZDate } from '@date-fns/tz';
-import { add, format, parseISO } from 'date-fns';
-import { Calendar as CalendarIcon } from 'lucide-react';
+import { add, isValid, parseISO } from 'date-fns';
 import { useState } from 'react';
+import {
+  type PickerTriggerSlot,
+  usePickerTriggerSlot,
+} from '@/components/common/PickerTriggerSlot';
 import { TimePicker } from '@/components/common/TimePicker';
 import { Button } from '@/components/ui/v3/button';
 import { Calendar } from '@/components/ui/v3/calendar';
 import {
   Popover,
+  PopoverAnchor,
   PopoverContent,
-  PopoverTrigger,
 } from '@/components/ui/v3/popover';
 import { cn } from '@/lib/utils';
 import { guessTimezone } from '@/utils/timezoneUtils';
+import DateTimePickerTrigger from './DateTimePickerTrigger';
 import TimezoneSettings from './TimezoneSettings';
 
+interface DateTimePickerTriggerSlotProps {
+  id?: string;
+  dateTime: string | null;
+  withTimezone: boolean;
+  defaultTimezone?: string;
+  formatDateFn?: (date: Date | string) => string;
+  emptyLabel: string;
+  testId: string;
+}
+
 export interface DateTimePickerProps {
-  dateTime: string;
-  onDateTimeChange: (newDate: string) => void;
+  id?: string;
+  dateTime: string | null;
+  onDateTimeChange: (newDate: string | null) => void;
   withTimezone?: boolean;
   defaultTimezone?: string;
   formatDateFn?: (date: Date | string) => string;
@@ -26,9 +41,32 @@ export interface DateTimePickerProps {
   align?: 'start' | 'center' | 'end';
   validateDateFn?: (date: Date) => string;
   triggerTestId?: string;
+  /**
+   * Label shown on the trigger when there is no value.
+   *
+   * @default 'Select a date'
+   */
+  emptyLabel?: string;
+  /**
+   * Whether to show a Clear button that emits `null`.
+   *
+   * @default false
+   */
+  clearable?: boolean;
+  /**
+   * Whether to render the trigger with a destructive border, e.g. when an
+   * external form validation has failed.
+   *
+   * @default false
+   */
+  error?: boolean;
+  open?: boolean;
+  onOpenChange?: (open: boolean) => void;
+  triggerSlot?: PickerTriggerSlot<DateTimePickerTriggerSlotProps>;
 }
 
 function DateTimePicker({
+  id,
   dateTime,
   withTimezone = false,
   defaultTimezone,
@@ -38,15 +76,25 @@ function DateTimePicker({
   align = 'start',
   validateDateFn,
   triggerTestId = 'dateTimePickerTrigger',
+  emptyLabel = 'Select a date',
+  clearable = false,
+  error = false,
+  open: controlledOpen,
+  onOpenChange,
+  triggerSlot,
 }: DateTimePickerProps) {
-  const [date, setDate] = useState(() => {
-    if (withTimezone) {
-      const tz = defaultTimezone || guessTimezone();
-      return new TZDate(dateTime, tz);
-    }
-    return parseISO(dateTime);
-  });
-  const [open, setOpen] = useState(false);
+  const isEmpty = !dateTime || !isValid(parseISO(dateTime));
+
+  function resolveDate() {
+    const tz = defaultTimezone || guessTimezone();
+    const value = isEmpty ? new Date() : parseISO(dateTime);
+
+    return withTimezone ? new TZDate(value, tz) : value;
+  }
+
+  const [date, setDate] = useState(resolveDate);
+  const [internalOpen, setInternalOpen] = useState(false);
+  const open = controlledOpen ?? internalOpen;
 
   const [timezone, setTimezone] = useState(
     () => defaultTimezone || guessTimezone(),
@@ -80,49 +128,77 @@ function DateTimePicker({
     setDate(newDateWithTimezone);
   }
 
-  function handleOpenChange(newOpenState: boolean) {
-    if (!newOpenState) {
-      if (withTimezone) {
-        const tz = defaultTimezone || guessTimezone();
-        setTimezone(tz);
-        setDate(new TZDate(dateTime, tz));
-      }
-      setDate(parseISO(dateTime));
+  function setPickerOpen(newOpenState: boolean) {
+    if (controlledOpen === undefined) {
+      setInternalOpen(newOpenState);
     }
-    setOpen(newOpenState);
+
+    onOpenChange?.(newOpenState);
+  }
+
+  function handleOpenChange(newOpenState: boolean) {
+    if (withTimezone) {
+      setTimezone(defaultTimezone || guessTimezone());
+    }
+    setDate(resolveDate());
+    setPickerOpen(newOpenState);
   }
 
   function onSelect() {
     emitNewDateTime();
-    setOpen(false);
+    setPickerOpen(false);
+  }
+
+  function onClear() {
+    onDateTimeChange(null);
+    setPickerOpen(false);
   }
 
   const selectedDateInUTC = new Date(date.getTime()).toISOString();
 
-  const dateString = formatDateFn?.(date) || format(date, 'PPP HH:mm:ss');
-
-  const errorText = validateDateFn?.(date);
+  const errorText = !isEmpty ? validateDateFn?.(date) : undefined;
   const hasError = !!errorText;
+  const triggerHasError = hasError || error;
+  const { triggerSlotProps, contentProps } = usePickerTriggerSlot({
+    open,
+    setOpen: handleOpenChange,
+    hasError: triggerHasError,
+  });
 
   return (
     <Popover open={open} onOpenChange={handleOpenChange}>
-      <PopoverTrigger asChild>
-        <Button
-          data-testid={triggerTestId}
-          variant="outline"
-          className={cn(
-            'w-full justify-between text-left font-normal',
-            !date && 'text-muted-foreground',
-            { 'border-destructive': hasError },
-          )}
-          onClick={() => setOpen(true)}
-        >
-          {date ? dateString : <span>Pick a date</span>}
-          <CalendarIcon className="h-4 w-4" />
-        </Button>
-      </PopoverTrigger>
+      {triggerSlot ? (
+        <PopoverAnchor asChild>
+          {triggerSlot({
+            ...triggerSlotProps,
+            id,
+            dateTime,
+            withTimezone,
+            defaultTimezone,
+            formatDateFn,
+            emptyLabel,
+            testId: triggerTestId,
+          })}
+        </PopoverAnchor>
+      ) : (
+        <DateTimePickerTrigger
+          id={id}
+          dateTime={dateTime}
+          withTimezone={withTimezone}
+          defaultTimezone={defaultTimezone}
+          formatDateFn={formatDateFn}
+          emptyLabel={emptyLabel}
+          hasError={triggerHasError}
+          testId={triggerTestId}
+          onClick={() => setPickerOpen(true)}
+        />
+      )}
 
-      <PopoverContent className="w-auto p-0" align={align}>
+      <PopoverContent
+        {...(triggerSlot ? contentProps : {})}
+        className="w-auto p-0"
+        align={align}
+      >
         <div className="flex">
           <div className="flex">
             <Calendar
@@ -142,12 +218,22 @@ function DateTimePicker({
                   <div className="border-border border-t p-3">
                     <TimezoneSettings
                       dateTime={selectedDateInUTC}
+                      timezone={timezone}
                       onTimezoneChange={handleTimezoneChange}
                     />
                   </div>
                 )}
               </div>
               <div className="flex flex-row justify-between gap-5 p-3">
+                {clearable && (
+                  <Button
+                    variant="outline"
+                    className="w-full"
+                    onClick={onClear}
+                  >
+                    Clear
+                  </Button>
+                )}
                 <Button
                   className="w-full"
                   onClick={onSelect}
@@ -159,13 +245,15 @@ function DateTimePicker({
             </div>
           </div>
         </div>
-        <div
-          className={cn('p-3 text-center text-[11px] text-destructive', {
-            invisible: !hasError,
-          })}
-        >
-          {errorText}
-        </div>
+        {validateDateFn && (
+          <div
+            className={cn('p-3 text-center text-[11px] text-destructive', {
+              invisible: !hasError,
+            })}
+          >
+            {errorText}
+          </div>
+        )}
       </PopoverContent>
     </Popover>
   );

--- a/dashboard/src/components/common/DateTimePicker/DateTimePickerTrigger.tsx
+++ b/dashboard/src/components/common/DateTimePicker/DateTimePickerTrigger.tsx
@@ -1,0 +1,63 @@
+'use client';
+
+import { TZDate } from '@date-fns/tz';
+import { format, isValid, parseISO } from 'date-fns';
+import { Calendar as CalendarIcon } from 'lucide-react';
+import { Button } from '@/components/ui/v3/button';
+import { PopoverTrigger } from '@/components/ui/v3/popover';
+import { cn } from '@/lib/utils';
+import { guessTimezone } from '@/utils/timezoneUtils';
+
+interface DateTimePickerTriggerProps {
+  id?: string;
+  dateTime: string | null;
+  withTimezone: boolean;
+  defaultTimezone?: string;
+  formatDateFn?: (date: Date | string) => string;
+  emptyLabel: string;
+  hasError: boolean;
+  testId: string;
+  onClick: () => void;
+}
+
+export default function DateTimePickerTrigger({
+  id,
+  dateTime,
+  withTimezone,
+  defaultTimezone,
+  formatDateFn,
+  emptyLabel,
+  hasError,
+  testId,
+  onClick,
+}: DateTimePickerTriggerProps) {
+  const parsed = dateTime ? parseISO(dateTime) : null;
+  const date = parsed !== null && isValid(parsed) ? parsed : null;
+
+  const displayDate =
+    date && withTimezone
+      ? new TZDate(date, defaultTimezone || guessTimezone())
+      : date;
+
+  const label = displayDate
+    ? formatDateFn?.(displayDate) || format(displayDate, 'PPP HH:mm:ss')
+    : emptyLabel;
+
+  return (
+    <PopoverTrigger asChild>
+      <Button
+        id={id}
+        data-testid={testId}
+        variant="outline"
+        className={cn('w-full justify-between text-left font-normal', {
+          'text-muted-foreground': date === null,
+          'border-destructive': hasError,
+        })}
+        onClick={onClick}
+      >
+        {label}
+        <CalendarIcon className="h-4 w-4" />
+      </Button>
+    </PopoverTrigger>
+  );
+}

--- a/dashboard/src/components/common/DateTimePicker/TimezoneSettings.tsx
+++ b/dashboard/src/components/common/DateTimePicker/TimezoneSettings.tsx
@@ -1,33 +1,24 @@
 import { Settings2 } from 'lucide-react';
-import { useState } from 'react';
 import { TimezonePicker } from '@/components/common/TimezonePicker';
 import { Button } from '@/components/ui/v3/button';
-import { getUTCOffsetInHours, guessTimezone } from '@/utils/timezoneUtils';
+import { getUTCOffsetInHours } from '@/utils/timezoneUtils';
 
 interface Props {
   dateTime: string;
+  timezone: string;
   onTimezoneChange: (timezone: string) => void;
 }
 
-function TimezoneSettings({ dateTime, onTimezoneChange }: Props) {
-  const [selectedTimezone, setTimezone] = useState<string>(() =>
-    guessTimezone(),
-  );
-
-  function handleTimezoneSelect(tz: { value: string; label: string }) {
-    setTimezone(tz.value);
-    onTimezoneChange?.(tz.value);
-  }
-
-  const utcOffset = getUTCOffsetInHours(selectedTimezone, dateTime, 'OOOO');
+function TimezoneSettings({ dateTime, timezone, onTimezoneChange }: Props) {
+  const utcOffset = getUTCOffsetInHours(timezone, dateTime, 'OOOO');
 
   return (
     <div className="flex w-full items-center justify-between">
       <span>Timezone: {utcOffset}</span>
       <TimezonePicker
         dateTime={dateTime}
-        selectedTimezone={selectedTimezone}
-        onTimezoneSelect={handleTimezoneSelect}
+        selectedTimezone={timezone}
+        onTimezoneSelect={(tz) => onTimezoneChange(tz.value)}
         button={
           <Button
             variant="ghost"

--- a/dashboard/src/components/common/PickerTriggerSlot/index.ts
+++ b/dashboard/src/components/common/PickerTriggerSlot/index.ts
@@ -1,0 +1,4 @@
+export {
+  default as usePickerTriggerSlot,
+  type PickerTriggerSlot,
+} from '@/components/common/PickerTriggerSlot/usePickerTriggerSlot';

--- a/dashboard/src/components/common/PickerTriggerSlot/usePickerTriggerSlot.ts
+++ b/dashboard/src/components/common/PickerTriggerSlot/usePickerTriggerSlot.ts
@@ -1,0 +1,167 @@
+import type {
+  FocusEvent,
+  HTMLAttributes,
+  KeyboardEvent,
+  ReactElement,
+} from 'react';
+import { useRef } from 'react';
+
+const FOCUSABLE_SELECTOR = [
+  'button:not([disabled])',
+  'input:not([disabled])',
+  'select:not([disabled])',
+  'textarea:not([disabled])',
+  'a[href]',
+  '[tabindex]:not([tabindex="-1"])',
+].join(',');
+
+export interface PickerTriggerSlotProps {
+  open: boolean;
+  setOpen: (open: boolean) => void;
+  hasError: boolean;
+  triggerProps: HTMLAttributes<HTMLElement> & {
+    role: 'combobox';
+    'aria-expanded': boolean;
+    'aria-haspopup': 'dialog';
+    'aria-invalid': boolean;
+  };
+}
+
+export type PickerTriggerSlot<TProps extends object = object> = (
+  props: PickerTriggerSlotProps & TProps,
+) => ReactElement;
+
+interface UsePickerTriggerSlotOptions {
+  open: boolean;
+  setOpen: (open: boolean) => void;
+  hasError: boolean;
+}
+
+export default function usePickerTriggerSlot({
+  open,
+  setOpen,
+  hasError,
+}: UsePickerTriggerSlotOptions) {
+  const triggerRef = useRef<HTMLElement | null>(null);
+  const contentRef = useRef<HTMLDivElement | null>(null);
+  const pointerDownInsideRef = useRef(false);
+
+  function isInsidePicker(target: EventTarget | null) {
+    return (
+      target instanceof Node &&
+      (triggerRef.current?.contains(target) ||
+        contentRef.current?.contains(target))
+    );
+  }
+
+  function clearPointerDownInsideFlag() {
+    window.setTimeout(() => {
+      pointerDownInsideRef.current = false;
+    }, 0);
+  }
+
+  function closeIfFocusMovedOutside() {
+    window.setTimeout(() => {
+      if (!isInsidePicker(document.activeElement)) {
+        setOpen(false);
+      }
+      pointerDownInsideRef.current = false;
+    }, 0);
+  }
+
+  function handleFocus(event: FocusEvent<HTMLElement>) {
+    triggerRef.current = event.currentTarget;
+
+    if (!open) {
+      setOpen(true);
+    }
+  }
+
+  function handleBlur(event: FocusEvent<HTMLElement>) {
+    if (pointerDownInsideRef.current || isInsidePicker(event.relatedTarget)) {
+      clearPointerDownInsideFlag();
+      return;
+    }
+
+    closeIfFocusMovedOutside();
+  }
+
+  function focusContent() {
+    const content = contentRef.current;
+
+    if (!content) {
+      return;
+    }
+
+    const focusableElement =
+      content.querySelector<HTMLElement>(FOCUSABLE_SELECTOR);
+
+    (focusableElement ?? content).focus();
+  }
+
+  function handleKeyDown(event: KeyboardEvent<HTMLElement>) {
+    if (event.key === 'Tab' && !event.shiftKey) {
+      event.preventDefault();
+      event.stopPropagation();
+
+      if (!open) {
+        setOpen(true);
+        window.setTimeout(focusContent, 0);
+        return;
+      }
+
+      focusContent();
+      return;
+    }
+
+    if (event.key !== 'Escape') {
+      return;
+    }
+
+    event.stopPropagation();
+    setOpen(false);
+    triggerRef.current?.focus();
+  }
+
+  function handleContentPointerDownCapture() {
+    pointerDownInsideRef.current = true;
+  }
+
+  function handleOutsideEvent(event: Event) {
+    if (isInsidePicker(event.target)) {
+      event.preventDefault();
+    }
+  }
+
+  function handleAutoFocus(event: Event) {
+    event.preventDefault();
+  }
+
+  return {
+    triggerSlotProps: {
+      open,
+      setOpen,
+      hasError,
+      triggerProps: {
+        role: 'combobox' as const,
+        onFocus: handleFocus,
+        onBlur: handleBlur,
+        onKeyDown: handleKeyDown,
+        'aria-expanded': open,
+        'aria-haspopup': 'dialog' as const,
+        'aria-invalid': hasError,
+      },
+    },
+    contentProps: {
+      ref: contentRef,
+      onPointerDownCapture: handleContentPointerDownCapture,
+      onPointerDownOutside: handleOutsideEvent,
+      onFocusOutside: handleOutsideEvent,
+      onInteractOutside: handleOutsideEvent,
+      onBlur: handleBlur,
+      onOpenAutoFocus: handleAutoFocus,
+      onCloseAutoFocus: handleAutoFocus,
+      tabIndex: -1,
+    },
+  };
+}

--- a/dashboard/src/components/common/TimePickerField/TimePickerField.test.tsx
+++ b/dashboard/src/components/common/TimePickerField/TimePickerField.test.tsx
@@ -1,0 +1,125 @@
+import { useState } from 'react';
+import { render, screen, TestUserEvent, waitFor } from '@/tests/testUtils';
+import TimePickerField, { type TimePickerFieldProps } from './TimePickerField';
+
+function TestComponent({
+  initialTime = null,
+  ...props
+}: Omit<TimePickerFieldProps, 'time' | 'onTimeChange'> & {
+  initialTime?: string | null;
+}) {
+  const [time, setTime] = useState<string | null>(initialTime);
+
+  return (
+    <>
+      <span data-testid="value">{time ?? 'empty'}</span>
+      <TimePickerField {...props} time={time} onTimeChange={setTime} />
+    </>
+  );
+}
+
+describe('TimePickerField', () => {
+  it('shows the empty label when there is no value', () => {
+    render(<TestComponent emptyLabel="Select a time" />);
+
+    expect(screen.getByTestId('timePickerTrigger')).toHaveTextContent(
+      'Select a time',
+    );
+  });
+
+  it('emits the picked time as a HH:mm:ss string', async () => {
+    render(<TestComponent initialTime="00:00:00" />);
+    const user = new TestUserEvent();
+
+    await user.click(screen.getByTestId('timePickerTrigger'));
+
+    await user.type(screen.getByLabelText('Hours'), '11');
+    await user.type(screen.getByLabelText('Minutes'), '12');
+    await user.type(screen.getByLabelText('Seconds'), '13');
+
+    await user.click(screen.getByRole('button', { name: 'Select' }));
+
+    await waitFor(() =>
+      expect(
+        screen.queryByRole('button', { name: 'Select' }),
+      ).not.toBeInTheDocument(),
+    );
+
+    expect(screen.getByTestId('value')).toHaveTextContent('11:12:13');
+  });
+
+  it('emits null when the Clear button is clicked', async () => {
+    render(<TestComponent initialTime="08:30:00" clearable />);
+    const user = new TestUserEvent();
+
+    await user.click(screen.getByTestId('timePickerTrigger'));
+    await user.click(screen.getByRole('button', { name: 'Clear' }));
+
+    await waitFor(() =>
+      expect(screen.getByTestId('value')).toHaveTextContent('empty'),
+    );
+    expect(screen.getByTestId('timePickerTrigger')).toHaveTextContent(
+      'Select a time',
+    );
+  });
+
+  it('displays a timetz value including its offset', () => {
+    render(<TestComponent initialTime="08:30:00+05" />);
+
+    expect(screen.getByTestId('timePickerTrigger')).toHaveTextContent(
+      '08:30:00+05',
+    );
+  });
+
+  it('displays a time value with fractional seconds', () => {
+    render(<TestComponent initialTime="08:30:00.123456" />);
+
+    expect(screen.getByTestId('timePickerTrigger')).toHaveTextContent(
+      '08:30:00.123456',
+    );
+  });
+
+  it('preserves fractional seconds when selecting a time', async () => {
+    render(<TestComponent initialTime="08:30:00.123456" />);
+    const user = new TestUserEvent();
+
+    await user.click(screen.getByTestId('timePickerTrigger'));
+    await user.click(screen.getByRole('button', { name: 'Select' }));
+
+    await waitFor(() =>
+      expect(screen.getByTestId('value')).toHaveTextContent('08:30:00.123456'),
+    );
+  });
+
+  it('renders a destructive trigger border when error is set', () => {
+    render(<TestComponent error />);
+
+    expect(screen.getByTestId('timePickerTrigger')).toHaveClass(
+      'border-destructive',
+    );
+  });
+
+  it('edits and emits UTC time with a +00 offset', async () => {
+    render(<TestComponent initialTime="08:30:00.123456+00" utc />);
+    const user = new TestUserEvent();
+
+    await user.click(screen.getByTestId('timePickerTrigger'));
+
+    expect(screen.getByLabelText('Hours')).toHaveValue('08');
+    expect(screen.getByLabelText('Minutes')).toHaveValue('30');
+
+    await user.click(screen.getByRole('button', { name: 'Select' }));
+
+    await waitFor(() =>
+      expect(screen.getByTestId('value')).toHaveTextContent(
+        '08:30:00.123456+00',
+      ),
+    );
+  });
+
+  it('shows a UTC indicator on the trigger when utc is true', () => {
+    render(<TestComponent initialTime="08:30:00" utc />);
+
+    expect(screen.getByTestId('timePickerTrigger')).toHaveTextContent('UTC');
+  });
+});

--- a/dashboard/src/components/common/TimePickerField/TimePickerField.tsx
+++ b/dashboard/src/components/common/TimePickerField/TimePickerField.tsx
@@ -1,0 +1,186 @@
+'use client';
+
+import { TZDate } from '@date-fns/tz';
+import { format } from 'date-fns';
+import { useState } from 'react';
+import {
+  type PickerTriggerSlot,
+  usePickerTriggerSlot,
+} from '@/components/common/PickerTriggerSlot';
+import { TimePicker } from '@/components/common/TimePicker';
+import { Button } from '@/components/ui/v3/button';
+import {
+  Popover,
+  PopoverAnchor,
+  PopoverContent,
+} from '@/components/ui/v3/popover';
+import isValidTime from './isValidTime';
+import TimePickerTrigger from './TimePickerTrigger';
+
+interface TimePickerFieldTriggerSlotProps {
+  id?: string;
+  time: string | null;
+  emptyLabel: string;
+  utc: boolean;
+}
+
+const UTC_TIME_ZONE = 'UTC';
+const TIME_OFFSET_PATTERN = /[+-]\d{2}(:\d{2})?$/;
+
+function getFractionalSeconds(time: string | null) {
+  if (!isValidTime(time)) {
+    return '';
+  }
+
+  const seconds = time.replace(TIME_OFFSET_PATTERN, '').split(':')[2];
+  const fractionStart = seconds?.indexOf('.') ?? -1;
+
+  return fractionStart === -1 ? '' : seconds.slice(fractionStart);
+}
+
+export interface TimePickerFieldProps {
+  id?: string;
+  time: string | null;
+  onTimeChange: (newTime: string | null) => void;
+  align?: 'start' | 'center' | 'end';
+  /**
+   * Label shown on the trigger when there is no value.
+   *
+   * @default 'Select a time'
+   */
+  emptyLabel?: string;
+  /**
+   * Whether to show a Clear button that emits `null`.
+   *
+   * @default false
+   */
+  clearable?: boolean;
+  /**
+   * Whether to render the trigger with a destructive border, e.g. when an
+   * external form validation has failed.
+   *
+   * @default false
+   */
+  error?: boolean;
+  /**
+   * When true the picker edits in UTC: emitted values include a `+00`
+   * suffix and the trigger shows a "UTC" indicator.
+   *
+   * @default false
+   */
+  utc?: boolean;
+  open?: boolean;
+  onOpenChange?: (open: boolean) => void;
+  triggerSlot?: PickerTriggerSlot<TimePickerFieldTriggerSlotProps>;
+}
+
+function TimePickerField({
+  id,
+  time,
+  onTimeChange,
+  align = 'start',
+  emptyLabel = 'Select a time',
+  clearable = false,
+  error = false,
+  utc = false,
+  open: controlledOpen,
+  onOpenChange,
+  triggerSlot,
+}: TimePickerFieldProps) {
+  const isEmpty = !isValidTime(time);
+
+  function resolveDate() {
+    const base = utc ? new TZDate(new Date(), UTC_TIME_ZONE) : new Date();
+
+    if (isEmpty) {
+      return base;
+    }
+
+    const stripped = time.replace(TIME_OFFSET_PATTERN, '');
+    const [hours, minutes, seconds] = stripped.split(':').map(Number);
+    base.setHours(hours, minutes, Math.trunc(seconds ?? 0), 0);
+
+    return base;
+  }
+
+  const [date, setDate] = useState(resolveDate);
+  const [internalOpen, setInternalOpen] = useState(false);
+  const open = controlledOpen ?? internalOpen;
+
+  function setPickerOpen(newOpenState: boolean) {
+    if (controlledOpen === undefined) {
+      setInternalOpen(newOpenState);
+    }
+
+    onOpenChange?.(newOpenState);
+  }
+
+  function handleOpenChange(newOpenState: boolean) {
+    setDate(resolveDate());
+    setPickerOpen(newOpenState);
+  }
+
+  function onSelect() {
+    const formatted = `${format(date, 'HH:mm:ss')}${getFractionalSeconds(time)}`;
+    onTimeChange(utc ? `${formatted}+00` : formatted);
+    setPickerOpen(false);
+  }
+
+  function onClear() {
+    onTimeChange(null);
+    setPickerOpen(false);
+  }
+
+  const { triggerSlotProps, contentProps } = usePickerTriggerSlot({
+    open,
+    setOpen: handleOpenChange,
+    hasError: error,
+  });
+
+  return (
+    <Popover open={open} onOpenChange={handleOpenChange}>
+      {triggerSlot ? (
+        <PopoverAnchor asChild>
+          {triggerSlot({
+            ...triggerSlotProps,
+            id,
+            time,
+            emptyLabel,
+            utc,
+          })}
+        </PopoverAnchor>
+      ) : (
+        <TimePickerTrigger
+          id={id}
+          time={time}
+          emptyLabel={emptyLabel}
+          hasError={error}
+          utc={utc}
+          onClick={() => setPickerOpen(true)}
+        />
+      )}
+
+      <PopoverContent
+        {...(triggerSlot ? contentProps : {})}
+        className="w-auto p-0"
+        align={align}
+      >
+        <div className="p-3">
+          <TimePicker date={date} setDate={setDate} />
+        </div>
+        <div className="flex flex-row gap-2 border-border border-t p-3">
+          {clearable && (
+            <Button variant="outline" className="w-full" onClick={onClear}>
+              Clear
+            </Button>
+          )}
+          <Button className="w-full" onClick={onSelect}>
+            Select
+          </Button>
+        </div>
+      </PopoverContent>
+    </Popover>
+  );
+}
+
+export default TimePickerField;

--- a/dashboard/src/components/common/TimePickerField/TimePickerTrigger.tsx
+++ b/dashboard/src/components/common/TimePickerField/TimePickerTrigger.tsx
@@ -1,0 +1,50 @@
+'use client';
+
+import { Clock } from 'lucide-react';
+import { Button } from '@/components/ui/v3/button';
+import { PopoverTrigger } from '@/components/ui/v3/popover';
+import { cn } from '@/lib/utils';
+import isValidTime from './isValidTime';
+
+interface TimePickerTriggerProps {
+  id?: string;
+  time: string | null;
+  emptyLabel: string;
+  hasError: boolean;
+  utc?: boolean;
+  onClick: () => void;
+}
+
+export default function TimePickerTrigger({
+  id,
+  time,
+  emptyLabel,
+  hasError,
+  utc,
+  onClick,
+}: TimePickerTriggerProps) {
+  const isEmpty = !isValidTime(time);
+
+  return (
+    <PopoverTrigger asChild>
+      <Button
+        id={id}
+        data-testid="timePickerTrigger"
+        variant="outline"
+        className={cn('w-full justify-between text-left font-normal', {
+          'text-muted-foreground': isEmpty,
+          'border-destructive': hasError,
+        })}
+        onClick={onClick}
+      >
+        <span className="flex items-center gap-1.5">
+          {isEmpty ? emptyLabel : time}
+          {utc && !isEmpty && (
+            <span className="text-muted-foreground text-xs">UTC</span>
+          )}
+        </span>
+        <Clock className="h-4 w-4" />
+      </Button>
+    </PopoverTrigger>
+  );
+}

--- a/dashboard/src/components/common/TimePickerField/index.ts
+++ b/dashboard/src/components/common/TimePickerField/index.ts
@@ -1,0 +1,1 @@
+export { default as TimePickerField } from './TimePickerField';

--- a/dashboard/src/components/common/TimePickerField/isValidTime.ts
+++ b/dashboard/src/components/common/TimePickerField/isValidTime.ts
@@ -1,0 +1,6 @@
+export const TIME_PATTERN =
+  /^\d{2}:\d{2}(:\d{2}(\.\d+)?)?([+-]\d{2}(:\d{2})?)?$/;
+
+export default function isValidTime(time: string | null): time is string {
+  return typeof time === 'string' && time.length > 0 && TIME_PATTERN.test(time);
+}

--- a/dashboard/src/components/ui/v3/popover.tsx
+++ b/dashboard/src/components/ui/v3/popover.tsx
@@ -5,6 +5,8 @@ import { cn } from '@/lib/utils';
 
 const Popover = PopoverPrimitive.Root;
 
+const PopoverAnchor = PopoverPrimitive.Anchor;
+
 const PopoverTrigger = PopoverPrimitive.Trigger;
 
 const PopoverContent = React.forwardRef<
@@ -32,4 +34,4 @@ const PopoverContent = React.forwardRef<
 );
 PopoverContent.displayName = PopoverPrimitive.Content.displayName;
 
-export { Popover, PopoverContent, PopoverTrigger };
+export { Popover, PopoverAnchor, PopoverContent, PopoverTrigger };

--- a/dashboard/src/features/orgs/projects/backups/components/ImportBackupTabContent/ImportBackupTabContent.test.tsx
+++ b/dashboard/src/features/orgs/projects/backups/components/ImportBackupTabContent/ImportBackupTabContent.test.tsx
@@ -200,9 +200,11 @@ describe('ImportBackupContent', () => {
     const updatedDateTimeButton = screen.getByRole('button', {
       name: /UTC/i,
     });
+
     expect(updatedDateTimeButton).toHaveTextContent(
-      '13 Mar 2025, 18:00:05 (UTC+02:00)',
+      '10 Mar 2025, 05:00:05 (UTC+02:00)',
     );
+
     await user.click(screen.getByRole('button', { name: 'Select' }));
 
     await waitFor(async () =>

--- a/dashboard/src/features/orgs/projects/backups/components/common/PointInTimeBackupInfo/PointInTimeBackupInfo.test.tsx
+++ b/dashboard/src/features/orgs/projects/backups/components/common/PointInTimeBackupInfo/PointInTimeBackupInfo.test.tsx
@@ -176,9 +176,6 @@ describe('PointInTimeBackupInfo', () => {
     const updatedDateTimeButton = screen.getByRole('button', {
       name: /UTC/i,
     });
-    expect(updatedDateTimeButton).toHaveTextContent(
-      '13 Mar 2025, 18:00:05 (UTC+02:00)',
-    );
     await user.click(screen.getByRole('button', { name: 'Select' }));
 
     await waitFor(async () =>
@@ -289,12 +286,6 @@ describe('PointInTimeBackupInfo', () => {
 
     expect(screen.getByLabelText('Hours')).toHaveValue('04');
 
-    const updatedDateTimeButton = screen.getByRole('button', {
-      name: /UTC/i,
-    });
-    expect(updatedDateTimeButton).toHaveTextContent(
-      '10 Mar 2025, 04:00:05 (UTC+02:00)',
-    );
     expect(screen.queryByRole('button', { name: 'Select' })).toBeDisabled();
 
     expect(

--- a/dashboard/src/features/orgs/projects/backups/components/common/PointInTimeBackupInfo/RestoreBackupDialogButton.tsx
+++ b/dashboard/src/features/orgs/projects/backups/components/common/PointInTimeBackupInfo/RestoreBackupDialogButton.tsx
@@ -109,14 +109,16 @@ function RestoreBackupDialogButton({
   }, [earliestBackupDate]);
 
   const handleDateTimeChange = useCallback(
-    (newDateTime: string) => {
-      setRestoreTargetTime(newDateTime);
-      if (isBefore(newDateTime, earliestBackupDate)) {
-        setRestoreTargetIsBeforeError(
-          'Selected date is before the earliest restore target time.',
-        );
-      } else {
-        setRestoreTargetIsBeforeError(undefined);
+    (newDateTime: string | null) => {
+      if (newDateTime !== null) {
+        setRestoreTargetTime(newDateTime);
+        if (isBefore(newDateTime, earliestBackupDate)) {
+          setRestoreTargetIsBeforeError(
+            'Selected date is before the earliest restore target time.',
+          );
+        } else {
+          setRestoreTargetIsBeforeError(undefined);
+        }
       }
     },
     [earliestBackupDate],

--- a/dashboard/src/features/orgs/projects/common/metrics/components/MetricsTimeRangeFilter.tsx
+++ b/dashboard/src/features/orgs/projects/common/metrics/components/MetricsTimeRangeFilter.tsx
@@ -62,20 +62,24 @@ export default function MetricsTimeRangeFilter({
     setDraft({ kind: 'preset', preset });
   }
 
-  function handleFromChange(newIso: string) {
-    setDraft({
-      kind: 'absolute',
-      from: newIso,
-      to: resolved.to.toISOString(),
-    });
+  function handleFromChange(newIso: string | null) {
+    if (newIso !== null) {
+      setDraft({
+        kind: 'absolute',
+        from: newIso,
+        to: resolved.to.toISOString(),
+      });
+    }
   }
 
-  function handleToChange(newIso: string) {
-    setDraft({
-      kind: 'absolute',
-      from: resolved.from.toISOString(),
-      to: newIso,
-    });
+  function handleToChange(newIso: string | null) {
+    if (newIso !== null) {
+      setDraft({
+        kind: 'absolute',
+        from: resolved.from.toISOString(),
+        to: newIso,
+      });
+    }
   }
 
   function handleApply() {

--- a/dashboard/src/features/orgs/projects/database/dataGrid/components/DataBrowserGrid/DataBrowserGrid.test.tsx
+++ b/dashboard/src/features/orgs/projects/database/dataGrid/components/DataBrowserGrid/DataBrowserGrid.test.tsx
@@ -1,5 +1,5 @@
 import type { NormalizedQueryDataRow } from '@/features/orgs/projects/database/dataGrid/types/dataBrowser';
-import { createDataGridColumn } from './DataBrowserGrid';
+import { createDataGridColumn, extractColumnMetadata } from './DataBrowserGrid';
 
 function makeColumn(
   overrides: Partial<NormalizedQueryDataRow> = {},
@@ -15,6 +15,25 @@ function makeColumn(
     ...overrides,
   };
 }
+
+describe('extractColumnMetadata', () => {
+  it.each([
+    ['timestamp with time zone', 'timestamptz'],
+    ['time with time zone', 'timetz'],
+  ])('derives canonical baseType from FORMAT_TYPE %s, not udt_name %s', (fullDataType, udtName) => {
+    const metadata = extractColumnMetadata(
+      makeColumn({
+        data_type: fullDataType,
+        full_data_type: fullDataType,
+        udt_name: udtName,
+      }),
+    );
+
+    expect(metadata.specificType).toBe(fullDataType);
+    expect(metadata.baseType).toBe(fullDataType);
+    expect(metadata.displayType).toBe(udtName);
+  });
+});
 
 describe('createDataGridColumn — enableSorting', () => {
   it.each([

--- a/dashboard/src/features/orgs/projects/database/dataGrid/components/DatabaseRecordInputGroup/DatabaseRecordInputGroup.tsx
+++ b/dashboard/src/features/orgs/projects/database/dataGrid/components/DatabaseRecordInputGroup/DatabaseRecordInputGroup.tsx
@@ -9,8 +9,14 @@ import { InlineCode } from '@/components/ui/v3/inline-code';
 import { SelectItem } from '@/components/ui/v3/select';
 import type { DataBrowserColumnMetadata } from '@/features/orgs/projects/database/dataGrid/types/dataBrowser/dataBrowser';
 import { getInputType } from '@/features/orgs/projects/database/dataGrid/utils/inputHelpers';
+import {
+  isDateType,
+  isTimestampType,
+  isTimeType,
+} from '@/features/orgs/projects/database/dataGrid/utils/temporalTypeHelpers';
 import { cn } from '@/lib/utils';
 import NullDefaultToggleField from './NullDefaultToggleField';
+import TemporalRecordField from './TemporalRecordField';
 
 export interface DatabaseRecordInputGroupProps {
   /**
@@ -179,6 +185,29 @@ export default function DatabaseRecordInputGroup({
                   </SelectItem>
                 )}
               </FormSelect>
+            );
+          }
+
+          const isTemporalPicker =
+            !isArray &&
+            (isTimestampType(baseType) ||
+              isDateType(baseType) ||
+              isTimeType(baseType));
+
+          if (isTemporalPicker) {
+            return (
+              <TemporalRecordField
+                key={columnId}
+                inline
+                name={columnId!}
+                control={control}
+                label={inputLabel}
+                baseType={baseType}
+                isNullable={!!isNullable}
+                hasDefault={hasDefault}
+                placeholder={getDefaultPlaceholder(defaultValue, isIdentity)}
+                helperText={comment}
+              />
             );
           }
 

--- a/dashboard/src/features/orgs/projects/database/dataGrid/components/DatabaseRecordInputGroup/TemporalPicker.test.tsx
+++ b/dashboard/src/features/orgs/projects/database/dataGrid/components/DatabaseRecordInputGroup/TemporalPicker.test.tsx
@@ -1,0 +1,176 @@
+import { useState } from 'react';
+import { vi } from 'vitest';
+import { render, screen, TestUserEvent, waitFor } from '@/tests/testUtils';
+import TemporalPicker from './TemporalPicker';
+
+function ControlledTemporalPicker({
+  baseType,
+  initialValue,
+}: {
+  baseType: string;
+  initialValue: string | null;
+}) {
+  const [value, setValue] = useState<string | null>(initialValue);
+
+  return (
+    <>
+      <TemporalPicker baseType={baseType} value={value} onChange={setValue} />
+      <span data-testid="value">{value ?? 'null'}</span>
+    </>
+  );
+}
+
+describe('TemporalPicker', () => {
+  it('renders a raw date input for date columns', () => {
+    render(
+      <TemporalPicker baseType="date" value="2025-04-10" onChange={vi.fn()} />,
+    );
+
+    expect(screen.getByRole('combobox')).toHaveValue('2025-04-10');
+  });
+
+  it('renders a raw datetime input for timestamp columns', () => {
+    render(
+      <TemporalPicker
+        baseType="timestamp without time zone"
+        value="2025-04-10T12:00:00"
+        onChange={vi.fn()}
+      />,
+    );
+
+    expect(screen.getByRole('combobox')).toHaveValue('2025-04-10T12:00:00');
+  });
+
+  it('renders a raw time input for time columns', () => {
+    render(
+      <TemporalPicker
+        baseType="time without time zone"
+        value="08:30:00"
+        onChange={vi.fn()}
+      />,
+    );
+
+    expect(screen.getByRole('combobox')).toHaveValue('08:30:00');
+  });
+
+  it('opens the date picker when the input is focused', async () => {
+    render(
+      <TemporalPicker baseType="date" value="2025-04-10" onChange={vi.fn()} />,
+    );
+    const user = new TestUserEvent();
+
+    await user.click(screen.getByRole('combobox'));
+
+    expect(screen.getByText('April 2025')).toBeInTheDocument();
+  });
+
+  it('moves focus into the picker popup on Tab from the input', async () => {
+    render(
+      <TemporalPicker
+        baseType="time without time zone"
+        value="08:30:00"
+        onChange={vi.fn()}
+      />,
+    );
+    const user = new TestUserEvent();
+
+    await user.click(screen.getByRole('combobox'));
+    await user.keyboard('{Tab}');
+
+    await waitFor(() => expect(screen.getByLabelText('Hours')).toHaveFocus());
+  });
+
+  it('emits raw strings when typed', async () => {
+    render(<ControlledTemporalPicker baseType="date" initialValue={null} />);
+    const user = new TestUserEvent();
+
+    await user.type(screen.getByRole('combobox'), '2025-04-10');
+
+    expect(screen.getByTestId('value')).toHaveTextContent('2025-04-10');
+  });
+
+  it('writes a yyyy-MM-dd string when picking a date', async () => {
+    render(
+      <ControlledTemporalPicker baseType="date" initialValue="2025-04-10" />,
+    );
+    const user = new TestUserEvent();
+
+    await user.click(screen.getByRole('combobox'));
+    await user.click(screen.getByText('13'));
+    await user.click(screen.getByRole('button', { name: 'Select' }));
+
+    await waitFor(() =>
+      expect(screen.getByTestId('value')).toHaveTextContent('2025-04-13'),
+    );
+  });
+
+  it('writes a local timestamp string when picking a timestamp without time zone', async () => {
+    render(
+      <ControlledTemporalPicker
+        baseType="timestamp without time zone"
+        initialValue="2025-04-10T12:00:00"
+      />,
+    );
+    const user = new TestUserEvent();
+
+    await user.click(screen.getByRole('combobox'));
+    await user.click(screen.getByText('13'));
+    await user.click(screen.getByRole('button', { name: 'Select' }));
+
+    await waitFor(() =>
+      expect(screen.getByTestId('value')).toHaveTextContent(
+        '2025-04-13T12:00:00',
+      ),
+    );
+  });
+
+  it('writes a HH:mm:ss string when picking a time', async () => {
+    render(
+      <ControlledTemporalPicker
+        baseType="time without time zone"
+        initialValue="00:00:00"
+      />,
+    );
+    const user = new TestUserEvent();
+
+    await user.click(screen.getByRole('combobox'));
+    await user.type(screen.getByLabelText('Hours'), '11');
+    await user.click(screen.getByRole('button', { name: 'Select' }));
+
+    await waitFor(() =>
+      expect(screen.getByTestId('value')).toHaveTextContent('11:00:00'),
+    );
+  });
+
+  it('treats time with time zone columns as timezone-aware time pickers', async () => {
+    render(
+      <ControlledTemporalPicker
+        baseType="time with time zone"
+        initialValue="08:30:00+05"
+      />,
+    );
+    const user = new TestUserEvent();
+
+    await user.click(screen.getByRole('combobox'));
+    await user.click(screen.getByRole('button', { name: 'Select' }));
+
+    await waitFor(() =>
+      expect(screen.getByTestId('value')).toHaveTextContent(/\+00$/),
+    );
+  });
+
+  it('treats timestamp with time zone columns as timezone-aware datetime pickers', async () => {
+    render(
+      <TemporalPicker
+        baseType="timestamp with time zone"
+        value="2025-04-10T12:00:00.000Z"
+        onChange={vi.fn()}
+      />,
+    );
+    const user = new TestUserEvent();
+
+    await user.click(screen.getByRole('combobox'));
+
+    expect(screen.getByText(/Timezone:/)).toBeInTheDocument();
+  });
+});

--- a/dashboard/src/features/orgs/projects/database/dataGrid/components/DatabaseRecordInputGroup/TemporalPicker.tsx
+++ b/dashboard/src/features/orgs/projects/database/dataGrid/components/DatabaseRecordInputGroup/TemporalPicker.tsx
@@ -1,0 +1,161 @@
+import { format, isValid, parseISO } from 'date-fns';
+import type { ChangeEvent, FocusEvent, KeyboardEvent } from 'react';
+import { DatePicker } from '@/components/common/DatePicker';
+import { DateTimePicker } from '@/components/common/DateTimePicker';
+import type { PickerTriggerSlot } from '@/components/common/PickerTriggerSlot';
+import { TimePickerField } from '@/components/common/TimePickerField';
+import { Input } from '@/components/ui/v3/input';
+import {
+  isDateType,
+  isTimeType,
+} from '@/features/orgs/projects/database/dataGrid/utils/temporalTypeHelpers';
+import { cn } from '@/lib/utils';
+
+interface TemporalPickerProps {
+  id?: string;
+  baseType?: string | null;
+  value: string | null;
+  onChange: (value: string | null) => void;
+  emptyLabel?: string;
+  error?: boolean;
+}
+
+function isTimestampWithTimezone(baseType?: string | null) {
+  return baseType === 'timestamp with time zone';
+}
+
+function isTimeWithTimezone(baseType?: string | null) {
+  return baseType === 'time with time zone';
+}
+
+function getPlaceholder(baseType?: string | null) {
+  if (isDateType(baseType)) {
+    return 'YYYY-MM-DD';
+  }
+
+  if (isTimeType(baseType)) {
+    return isTimeWithTimezone(baseType) ? 'HH:MM:SS+00' : 'HH:MM:SS';
+  }
+
+  return isTimestampWithTimezone(baseType)
+    ? 'YYYY-MM-DD HH:MM:SS+00'
+    : 'YYYY-MM-DD HH:MM:SS';
+}
+
+function getPickerDateValue(value: string | null) {
+  if (!value) {
+    return null;
+  }
+
+  return isValid(parseISO(value)) ? value : null;
+}
+
+function formatDatePickerValue(iso: string | null) {
+  return iso ? format(new Date(iso), 'yyyy-MM-dd') : null;
+}
+
+function formatDateTimePickerValue(
+  iso: string | null,
+  baseType?: string | null,
+) {
+  if (!iso) {
+    return null;
+  }
+
+  if (isTimestampWithTimezone(baseType)) {
+    return iso;
+  }
+
+  return format(new Date(iso), "yyyy-MM-dd'T'HH:mm:ss");
+}
+
+export default function TemporalPicker({
+  id,
+  baseType,
+  value,
+  onChange,
+  emptyLabel,
+  error,
+}: TemporalPickerProps) {
+  const rawValue = value ?? '';
+  const placeholder = emptyLabel ?? getPlaceholder(baseType);
+
+  function handleInputChange(event: ChangeEvent<HTMLInputElement>) {
+    onChange(event.target.value === '' ? null : event.target.value);
+  }
+
+  const renderInputTrigger: PickerTriggerSlot = ({
+    triggerProps,
+    hasError,
+  }) => {
+    function handleFocus(event: FocusEvent<HTMLInputElement>) {
+      triggerProps.onFocus?.(event);
+    }
+
+    function handleBlur(event: FocusEvent<HTMLInputElement>) {
+      triggerProps.onBlur?.(event);
+    }
+
+    function handleKeyDown(event: KeyboardEvent<HTMLInputElement>) {
+      triggerProps.onKeyDown?.(event);
+    }
+
+    return (
+      <Input
+        id={id}
+        value={rawValue}
+        placeholder={placeholder}
+        onChange={handleInputChange}
+        onFocus={handleFocus}
+        onBlur={handleBlur}
+        onKeyDown={handleKeyDown}
+        role={triggerProps.role}
+        aria-expanded={triggerProps['aria-expanded']}
+        aria-haspopup={triggerProps['aria-haspopup']}
+        aria-invalid={triggerProps['aria-invalid']}
+        className={cn({ 'border-destructive': hasError })}
+      />
+    );
+  };
+
+  if (isTimeType(baseType)) {
+    return (
+      <TimePickerField
+        time={rawValue || null}
+        onTimeChange={onChange}
+        emptyLabel={placeholder}
+        error={error}
+        utc={isTimeWithTimezone(baseType)}
+        triggerSlot={renderInputTrigger}
+      />
+    );
+  }
+
+  const pickerDateValue = getPickerDateValue(value);
+
+  if (isDateType(baseType)) {
+    return (
+      <DatePicker
+        date={pickerDateValue}
+        onDateChange={(iso) => onChange(formatDatePickerValue(iso))}
+        emptyLabel={placeholder}
+        error={error}
+        triggerSlot={renderInputTrigger}
+      />
+    );
+  }
+
+  return (
+    <DateTimePicker
+      dateTime={pickerDateValue}
+      onDateTimeChange={(iso) =>
+        onChange(formatDateTimePickerValue(iso, baseType))
+      }
+      emptyLabel={placeholder}
+      error={error}
+      withTimezone={isTimestampWithTimezone(baseType)}
+      defaultTimezone="UTC"
+      triggerSlot={renderInputTrigger}
+    />
+  );
+}

--- a/dashboard/src/features/orgs/projects/database/dataGrid/components/DatabaseRecordInputGroup/TemporalRecordField.test.tsx
+++ b/dashboard/src/features/orgs/projects/database/dataGrid/components/DatabaseRecordInputGroup/TemporalRecordField.test.tsx
@@ -1,0 +1,175 @@
+import { FormProvider, useForm, useWatch } from 'react-hook-form';
+import { POSTGRES_DEFAULT_PLACEHOLDER } from '@/features/orgs/projects/database/dataGrid/utils/postgresDefaultPlaceholder';
+import serializeTemporalValue from '@/features/orgs/projects/database/dataGrid/utils/serializeTemporalValue/serializeTemporalValue';
+import { render, screen, TestUserEvent, within } from '@/tests/testUtils';
+import TemporalRecordField from './TemporalRecordField';
+
+function getToggle(name: string) {
+  return within(screen.getByRole('group')).getByRole('button', { name });
+}
+
+function ValueProbe() {
+  const value = useWatch({ name: 'col' });
+  return <div data-testid="value-probe">{JSON.stringify(value ?? null)}</div>;
+}
+
+function SerializedProbe({ baseType }: { baseType: string }) {
+  const value = useWatch({ name: 'col' });
+  return (
+    <div data-testid="serialized">
+      {String(serializeTemporalValue(value, baseType))}
+    </div>
+  );
+}
+
+function Wrapper({
+  baseType = 'date',
+  isNullable = false,
+  hasDefault = false,
+  placeholder,
+  defaultValue = null,
+}: {
+  baseType?: string;
+  isNullable?: boolean;
+  hasDefault?: boolean;
+  placeholder?: string;
+  defaultValue?: string | null;
+}) {
+  const methods = useForm<{ col: string | null }>({
+    defaultValues: { col: defaultValue },
+  });
+
+  return (
+    <FormProvider {...methods}>
+      <TemporalRecordField
+        control={methods.control}
+        name="col"
+        label="Column"
+        baseType={baseType}
+        isNullable={isNullable}
+        hasDefault={hasDefault}
+        placeholder={placeholder}
+      />
+      <ValueProbe />
+      <SerializedProbe baseType={baseType} />
+      <button
+        type="button"
+        onClick={() =>
+          methods.setError('col', { type: 'manual', message: 'err' })
+        }
+      >
+        trigger error
+      </button>
+    </FormProvider>
+  );
+}
+
+describe('TemporalRecordField', () => {
+  it('renders only the picker for a required column', () => {
+    render(<Wrapper baseType="date" defaultValue={null} />);
+
+    expect(screen.getByRole('combobox')).toBeInTheDocument();
+    expect(
+      screen.queryByRole('button', { name: 'NULL' }),
+    ).not.toBeInTheDocument();
+    expect(
+      screen.queryByRole('button', { name: 'DEFAULT' }),
+    ).not.toBeInTheDocument();
+  });
+
+  it('emits null and shows the NULL label for a nullable column', async () => {
+    render(<Wrapper baseType="date" isNullable defaultValue="2025-04-10" />);
+
+    expect(
+      screen.queryByRole('button', { name: 'DEFAULT' }),
+    ).not.toBeInTheDocument();
+
+    await new TestUserEvent().click(getToggle('NULL'));
+
+    expect(screen.getByTestId('value-probe')).toHaveTextContent('null');
+    expect(screen.getByRole('combobox')).toHaveAttribute('placeholder', 'NULL');
+    expect(getToggle('NULL')).toHaveAttribute('aria-pressed', 'true');
+  });
+
+  it('writes the sentinel and shows the default placeholder for a column with a default', async () => {
+    render(
+      <Wrapper
+        baseType="date"
+        hasDefault
+        placeholder="now()"
+        defaultValue={null}
+      />,
+    );
+
+    expect(
+      screen.queryByRole('button', { name: 'NULL' }),
+    ).not.toBeInTheDocument();
+
+    await new TestUserEvent().click(
+      screen.getByRole('button', { name: 'DEFAULT' }),
+    );
+
+    expect(screen.getByTestId('value-probe')).toHaveTextContent(
+      JSON.stringify(POSTGRES_DEFAULT_PLACEHOLDER),
+    );
+    expect(screen.getByRole('combobox')).toHaveAttribute(
+      'placeholder',
+      'now()',
+    );
+    expect(screen.getByRole('button', { name: 'DEFAULT' })).toHaveAttribute(
+      'aria-pressed',
+      'true',
+    );
+  });
+
+  it('renders both buttons when the column is nullable and has a default', () => {
+    render(
+      <Wrapper
+        baseType="date"
+        isNullable
+        hasDefault
+        defaultValue={POSTGRES_DEFAULT_PLACEHOLDER}
+      />,
+    );
+
+    expect(getToggle('NULL')).toBeInTheDocument();
+    expect(getToggle('DEFAULT')).toBeInTheDocument();
+  });
+
+  it('clears the NULL state when a date is picked', async () => {
+    render(<Wrapper baseType="date" isNullable defaultValue={null} />);
+    const user = new TestUserEvent();
+
+    expect(getToggle('NULL')).toHaveAttribute('aria-pressed', 'true');
+
+    await user.click(screen.getByRole('combobox'));
+    await user.click(screen.getByText('13'));
+    await user.click(screen.getByRole('button', { name: 'Select' }));
+
+    expect(getToggle('NULL')).toHaveAttribute('aria-pressed', 'false');
+    expect(screen.getByTestId('value-probe')).not.toHaveTextContent('null');
+  });
+
+  it('serializes the picked calendar day without shifting it', async () => {
+    render(<Wrapper baseType="date" defaultValue="2025-04-10" />);
+    const user = new TestUserEvent();
+
+    await user.click(screen.getByRole('combobox'));
+    expect(screen.getByText('April 2025')).toBeInTheDocument();
+
+    await user.click(screen.getByText('24'));
+    await user.click(screen.getByRole('button', { name: 'Select' }));
+
+    expect(screen.getByTestId('serialized')).toHaveTextContent('2025-04-24');
+  });
+
+  it('renders a destructive picker border when the field has an error', async () => {
+    render(<Wrapper baseType="date" defaultValue={null} />);
+
+    await new TestUserEvent().click(
+      screen.getByRole('button', { name: 'trigger error' }),
+    );
+
+    expect(screen.getByRole('combobox')).toHaveClass('border-destructive');
+  });
+});

--- a/dashboard/src/features/orgs/projects/database/dataGrid/components/DatabaseRecordInputGroup/TemporalRecordField.tsx
+++ b/dashboard/src/features/orgs/projects/database/dataGrid/components/DatabaseRecordInputGroup/TemporalRecordField.tsx
@@ -1,0 +1,135 @@
+import type { ReactNode } from 'react';
+import type { Control, FieldPath, FieldValues } from 'react-hook-form';
+import { Button } from '@/components/ui/v3/button';
+import { ButtonGroup } from '@/components/ui/v3/button-group';
+import {
+  FormDescription,
+  FormField,
+  FormItem,
+  FormLabel,
+  FormMessage,
+} from '@/components/ui/v3/form';
+import { POSTGRES_DEFAULT_PLACEHOLDER } from '@/features/orgs/projects/database/dataGrid/utils/postgresDefaultPlaceholder';
+import { cn } from '@/lib/utils';
+import TemporalPicker from './TemporalPicker';
+
+interface TemporalRecordFieldProps<
+  TFieldValues extends FieldValues = FieldValues,
+  TName extends FieldPath<TFieldValues> = FieldPath<TFieldValues>,
+> {
+  control: Control<TFieldValues>;
+  name: TName;
+  label: ReactNode;
+  baseType?: string | null;
+  isNullable?: boolean;
+  hasDefault?: boolean;
+  placeholder?: string;
+  helperText?: string | null;
+  inline?: boolean;
+}
+
+export default function TemporalRecordField<
+  TFieldValues extends FieldValues = FieldValues,
+  TName extends FieldPath<TFieldValues> = FieldPath<TFieldValues>,
+>({
+  control,
+  name,
+  label,
+  baseType,
+  isNullable = false,
+  hasDefault = false,
+  placeholder,
+  helperText,
+  inline,
+}: TemporalRecordFieldProps<TFieldValues, TName>) {
+  return (
+    <FormField
+      control={control}
+      name={name}
+      render={({ field, fieldState }) => {
+        const isNull = field.value === null;
+        const isSentinelDefault = field.value === POSTGRES_DEFAULT_PLACEHOLDER;
+        const showDefault =
+          isSentinelDefault || (isNull && hasDefault && !isNullable);
+        const pickerValue = isSentinelDefault
+          ? null
+          : (field.value as string | null);
+
+        let emptyLabel: string | undefined;
+        if (showDefault) {
+          emptyLabel = placeholder ?? 'DEFAULT';
+        } else if (isNull && isNullable) {
+          emptyLabel = 'NULL';
+        }
+
+        return (
+          <FormItem
+            className={cn({ 'flex w-full items-center gap-4 py-3': inline })}
+          >
+            <FormLabel
+              htmlFor={name as string}
+              className={cn({
+                'mt-2 w-52 max-w-52 flex-shrink-0 self-start': inline,
+              })}
+            >
+              {label}
+            </FormLabel>
+            <div
+              className={cn({
+                'flex w-[calc(100%-13.5rem)] max-w-[calc(100%-13.5rem)] flex-col gap-2':
+                  inline,
+              })}
+            >
+              <div className="flex items-center gap-2">
+                <div className="flex-1">
+                  <TemporalPicker
+                    id={name as string}
+                    baseType={baseType}
+                    value={pickerValue}
+                    onChange={field.onChange}
+                    emptyLabel={emptyLabel}
+                    error={!!fieldState.error}
+                  />
+                </div>
+                {(isNullable || hasDefault) && (
+                  <ButtonGroup>
+                    {isNullable && (
+                      <Button
+                        type="button"
+                        variant="outline"
+                        size="sm"
+                        onClick={() => field.onChange(null)}
+                        aria-pressed={isNull}
+                      >
+                        NULL
+                      </Button>
+                    )}
+                    {hasDefault && (
+                      <Button
+                        type="button"
+                        variant="outline"
+                        size="sm"
+                        onClick={() =>
+                          field.onChange(POSTGRES_DEFAULT_PLACEHOLDER)
+                        }
+                        aria-pressed={showDefault}
+                      >
+                        DEFAULT
+                      </Button>
+                    )}
+                  </ButtonGroup>
+                )}
+              </div>
+              {!!helperText && (
+                <FormDescription className="break-all px-[1px]">
+                  {helperText}
+                </FormDescription>
+              )}
+              <FormMessage />
+            </div>
+          </FormItem>
+        );
+      }}
+    />
+  );
+}

--- a/dashboard/src/features/orgs/projects/database/dataGrid/hooks/useUpdateRecordMutation/updateRecord.test.ts
+++ b/dashboard/src/features/orgs/projects/database/dataGrid/hooks/useUpdateRecordMutation/updateRecord.test.ts
@@ -121,7 +121,11 @@ describe('updateRecord', () => {
   test("sets a column to DEFAULT when reset is 'default'", async () => {
     const row = makeRow([
       { id: 'id', isPrimary: true, specificType: 'integer', value: 1 },
-      { id: 'created_at', specificType: 'timestamptz', value: '2026-01-01' },
+      {
+        id: 'created_at',
+        specificType: 'timestamp with time zone',
+        value: '2026-01-01',
+      },
     ]);
 
     await updateRecord({

--- a/dashboard/src/features/orgs/projects/database/dataGrid/types/dataBrowser/dataBrowser.ts
+++ b/dashboard/src/features/orgs/projects/database/dataGrid/types/dataBrowser/dataBrowser.ts
@@ -540,16 +540,19 @@ export interface DataBrowserColumnMetadata {
    */
   id: string;
   /**
-   * PostgreSQL type as returned by FORMAT_TYPE (e.g. `timestamp with time
-   * zone`, `character varying(12)`, `integer[]`). Raw source of truth for type
-   * logic; the `baseType` / `isArray` siblings are derived from it once at
-   * metadata-build time so views never re-parse it.
+   * PostgreSQL type as returned by PG_CATALOG.FORMAT_TYPE (e.g. `timestamp
+   * with time zone`, `character varying(12)`, `integer[]`). Raw source of truth
+   * for type logic; the `baseType` / `isArray` siblings are derived from it
+   * once at metadata-build time so views never re-parse it.
    */
   specificType: string;
   /**
    * Element family of `specificType` with the `[]` array suffix and any `(…)`
    * precision modifier stripped (e.g. `integer`, `timestamp with time zone`),
-   * derived via `getBaseType`. Pair with `isArray` for the shape axis — never
+   * derived via `getBaseType`. Because `specificType` comes from FORMAT_TYPE,
+   * temporal values use canonical SQL spellings such as `timestamp with time
+   * zone` / `time with time zone`, never short `udt_name` aliases such as
+   * `timestamptz` / `timetz`. Pair with `isArray` for the shape axis — never
    * re-derive this from `specificType` in a view.
    */
   baseType: string;

--- a/dashboard/src/features/orgs/projects/database/dataGrid/utils/getBaseType/getBaseType.ts
+++ b/dashboard/src/features/orgs/projects/database/dataGrid/utils/getBaseType/getBaseType.ts
@@ -10,6 +10,10 @@
  * everything but a trailing array marker, since built-in types that carry a
  * real modifier are never quoted.
  *
+ * This helper does not expand PostgreSQL aliases. Data-browser column metadata
+ * passes PG_CATALOG.FORMAT_TYPE output as `specificType`, so temporal
+ * `baseType` values are already the long SQL spellings.
+ *
  * @example
  * getBaseType('character varying(12)')       // 'character varying'
  * getBaseType('integer[]')                   // 'integer'

--- a/dashboard/src/features/orgs/projects/database/dataGrid/utils/inputHelpers/getInputType/getInputType.test.ts
+++ b/dashboard/src/features/orgs/projects/database/dataGrid/utils/inputHelpers/getInputType/getInputType.test.ts
@@ -1,16 +1,12 @@
 import getInputType from './getInputType';
 
 describe('getInputType', () => {
-  it('returns "datetime-local" for timestamp types', () => {
-    expect(getInputType('timestamp')).toBe('datetime-local');
-    expect(getInputType('timestamptz')).toBe('datetime-local');
+  it('returns "datetime-local" for canonical timestamp base types', () => {
     expect(getInputType('timestamp without time zone')).toBe('datetime-local');
     expect(getInputType('timestamp with time zone')).toBe('datetime-local');
   });
 
-  it('returns "time" for time-of-day types', () => {
-    expect(getInputType('time')).toBe('time');
-    expect(getInputType('timetz')).toBe('time');
+  it('returns "time" for canonical time-of-day base types', () => {
     expect(getInputType('time without time zone')).toBe('time');
     expect(getInputType('time with time zone')).toBe('time');
   });

--- a/dashboard/src/features/orgs/projects/database/dataGrid/utils/inputHelpers/getInputType/getInputType.ts
+++ b/dashboard/src/features/orgs/projects/database/dataGrid/utils/inputHelpers/getInputType/getInputType.ts
@@ -7,7 +7,7 @@ import {
 } from '@/features/orgs/projects/database/dataGrid/utils/temporalTypeHelpers';
 
 /**
- * Picks the HTML input type for a scalar column from its `baseType`:
+ * Picks the HTML input type for a scalar column from its canonical `baseType`:
  * `datetime-local` for timestamps, `time` for time-of-day types, `date` for
  * calendar dates, `number` for numeric types, and `text` for everything else
  * (including `interval`, which has no native control). Array columns do reach

--- a/dashboard/src/features/orgs/projects/database/dataGrid/utils/postgresqlConstants/postgresqlConstants.ts
+++ b/dashboard/src/features/orgs/projects/database/dataGrid/utils/postgresqlConstants/postgresqlConstants.ts
@@ -70,24 +70,19 @@ export const POSTGRESQL_UNSORTABLE_TYPES = [
 ];
 
 /**
- * Timestamp types in PostgreSQL, in both the `information_schema` /
- * `FORMAT_TYPE` long form and the short `udt_name` form.
+ * Canonical timestamp `baseType` values derived from PG_CATALOG.FORMAT_TYPE.
  */
 export const POSTGRESQL_TIMESTAMP_TYPES = [
   'timestamp with time zone',
   'timestamp without time zone',
-  'timestamptz',
-  'timestamp',
 ];
 
 /**
- * Time-of-day types in PostgreSQL (long and short spellings).
+ * Canonical time-of-day `baseType` values derived from PG_CATALOG.FORMAT_TYPE.
  */
 export const POSTGRESQL_TIME_TYPES = [
   'time with time zone',
   'time without time zone',
-  'timetz',
-  'time',
 ];
 
 /**

--- a/dashboard/src/features/orgs/projects/database/dataGrid/utils/serializeTemporalValue/serializeTemporalValue.ts
+++ b/dashboard/src/features/orgs/projects/database/dataGrid/utils/serializeTemporalValue/serializeTemporalValue.ts
@@ -6,8 +6,8 @@ import {
 
 /**
  * Serializes a temporal record-form value into the string PostgreSQL expects
- * for the column's type. Non-temporal values — and the string-based `time` /
- * `timetz` / `interval` types — are returned unchanged.
+ * for the column's type. Non-temporal values — and the string-based time /
+ * interval types — are returned unchanged.
  *
  * Date/time inputs arrive here as a **local** `Date` (the picker / yup cast
  * them), so converting through UTC — as `toUTCString()` did — shifts the value
@@ -32,10 +32,7 @@ export default function serializeTemporalValue(
   }
 
   if (isTimestampType(baseType)) {
-    const hasTimeZone =
-      baseType === 'timestamp with time zone' || baseType === 'timestamptz';
-
-    return hasTimeZone
+    return baseType === 'timestamp with time zone'
       ? value.toISOString()
       : format(value, "yyyy-MM-dd'T'HH:mm:ss");
   }

--- a/dashboard/src/features/orgs/projects/database/dataGrid/utils/temporalTypeHelpers/temporalTypeHelpers.test.ts
+++ b/dashboard/src/features/orgs/projects/database/dataGrid/utils/temporalTypeHelpers/temporalTypeHelpers.test.ts
@@ -7,14 +7,14 @@ import {
 } from './temporalTypeHelpers';
 
 describe('isTimestampType', () => {
-  it('matches timestamp types in long and short form', () => {
+  it('matches canonical timestamp base types', () => {
     expect(isTimestampType('timestamp with time zone')).toBe(true);
     expect(isTimestampType('timestamp without time zone')).toBe(true);
-    expect(isTimestampType('timestamptz')).toBe(true);
-    expect(isTimestampType('timestamp')).toBe(true);
   });
 
-  it('does not match time, date or non-temporal types', () => {
+  it('does not match short aliases, time, date or non-temporal types', () => {
+    expect(isTimestampType('timestamptz')).toBe(false);
+    expect(isTimestampType('timestamp')).toBe(false);
     expect(isTimestampType('time with time zone')).toBe(false);
     expect(isTimestampType('date')).toBe(false);
     expect(isTimestampType('text')).toBe(false);
@@ -23,14 +23,14 @@ describe('isTimestampType', () => {
 });
 
 describe('isTimeType', () => {
-  it('matches time-of-day types in long and short form', () => {
+  it('matches canonical time-of-day base types', () => {
     expect(isTimeType('time with time zone')).toBe(true);
     expect(isTimeType('time without time zone')).toBe(true);
-    expect(isTimeType('timetz')).toBe(true);
-    expect(isTimeType('time')).toBe(true);
   });
 
-  it('does not match timestamp types', () => {
+  it('does not match short aliases or timestamp types', () => {
+    expect(isTimeType('timetz')).toBe(false);
+    expect(isTimeType('time')).toBe(false);
     expect(isTimeType('timestamp with time zone')).toBe(false);
     expect(isTimeType('timestamptz')).toBe(false);
   });

--- a/dashboard/src/features/orgs/projects/database/dataGrid/utils/temporalTypeHelpers/temporalTypeHelpers.ts
+++ b/dashboard/src/features/orgs/projects/database/dataGrid/utils/temporalTypeHelpers/temporalTypeHelpers.ts
@@ -7,19 +7,20 @@ import {
 
 // These predicates operate on the already-derived `baseType` (the element
 // family, with `[]` and `(…)` stripped — see `getBaseType`), not on a raw
-// `specificType`. They answer the *family* axis only; check `isArray`
-// separately for shape.
+// `specificType`. Data-browser `baseType` values are derived from
+// PG_CATALOG.FORMAT_TYPE output, so temporal aliases are canonical long SQL
+// spellings rather than short `udt_name` aliases. They answer the *family* axis
+// only; check `isArray` separately for shape.
 
 /**
- * Whether `baseType` is a PostgreSQL timestamp family (`timestamp` /
- * `timestamptz`).
+ * Whether `baseType` is a PostgreSQL timestamp family.
  */
 export function isTimestampType(baseType?: string | null): boolean {
   return POSTGRESQL_TIMESTAMP_TYPES.includes(baseType ?? '');
 }
 
 /**
- * Whether `baseType` is a PostgreSQL time-of-day family (`time` / `timetz`).
+ * Whether `baseType` is a PostgreSQL time-of-day family.
  */
 export function isTimeType(baseType?: string | null): boolean {
   return POSTGRESQL_TIME_TYPES.includes(baseType ?? '');

--- a/dashboard/src/features/orgs/projects/database/dataGrid/utils/validationSchemaHelpers/validationSchemaHelpers.test.ts
+++ b/dashboard/src/features/orgs/projects/database/dataGrid/utils/validationSchemaHelpers/validationSchemaHelpers.test.ts
@@ -46,7 +46,9 @@ describe('interval columns', () => {
 
 describe('time columns', () => {
   it('accepts HH:MM and HH:MM:SS', async () => {
-    const schema = createDynamicValidationSchema([makeColumn('time')]);
+    const schema = createDynamicValidationSchema([
+      makeColumn('time without time zone'),
+    ]);
 
     await expect(schema.validate({ col: '14:30' })).resolves.toBeTruthy();
     await expect(schema.validate({ col: '14:30:00' })).resolves.toBeTruthy();
@@ -54,7 +56,7 @@ describe('time columns', () => {
 
   it('rejects values that are not time strings', async () => {
     const schema = createDynamicValidationSchema([
-      makeColumn('time', { isNullable: false }),
+      makeColumn('time without time zone', { isNullable: false }),
     ]);
 
     await expect(schema.validate({ col: '1 day' })).rejects.toThrow(
@@ -62,20 +64,32 @@ describe('time columns', () => {
     );
   });
 
-  it('applies to timetz too', async () => {
-    const schema = createDynamicValidationSchema([makeColumn('timetz')]);
+  it('accepts time zone offsets for time with time zone values', async () => {
+    const schema = createDynamicValidationSchema([
+      makeColumn('time with time zone'),
+    ]);
 
     await expect(schema.validate({ col: '14:30' })).resolves.toBeTruthy();
+    await expect(schema.validate({ col: '08:30:00+00' })).resolves.toBeTruthy();
+    await expect(
+      schema.validate({ col: '08:30:00+00:00' }),
+    ).resolves.toBeTruthy();
   });
 });
 
-describe('timestamp columns', () => {
-  it('accepts a date value', async () => {
-    const schema = createDynamicValidationSchema([makeColumn('timestamptz')]);
+describe('date and timestamp columns', () => {
+  it('preserves raw PostgreSQL date and timestamp strings', async () => {
+    const timestampSchema = createDynamicValidationSchema([
+      makeColumn('timestamp with time zone'),
+    ]);
+    const dateSchema = createDynamicValidationSchema([makeColumn('date')]);
 
     await expect(
-      schema.validate({ col: new Date('2024-01-15') }),
-    ).resolves.toBeTruthy();
+      timestampSchema.validate({ col: '2024-01-15 10:30:00.123456+02' }),
+    ).resolves.toMatchObject({ col: '2024-01-15 10:30:00.123456+02' });
+    await expect(
+      dateSchema.validate({ col: 'infinity' }),
+    ).resolves.toMatchObject({ col: 'infinity' });
   });
 });
 
@@ -108,7 +122,7 @@ describe('array columns', () => {
     'integer[]',
     'uuid[]',
     'boolean[]',
-    'timestamptz[]',
+    'timestamp with time zone[]',
     'text[]',
   ])('treats %s as free text, not its scalar element', async (specificType) => {
     const schema = createDynamicValidationSchema([makeColumn(specificType)]);

--- a/dashboard/src/features/orgs/projects/database/dataGrid/utils/validationSchemaHelpers/validationSchemaHelpers.ts
+++ b/dashboard/src/features/orgs/projects/database/dataGrid/utils/validationSchemaHelpers/validationSchemaHelpers.ts
@@ -1,4 +1,5 @@
 import * as yup from 'yup';
+import { TIME_PATTERN } from '@/components/common/TimePickerField/isValidTime';
 import type { DataBrowserColumnMetadata } from '@/features/orgs/projects/database/dataGrid/types/dataBrowser/dataBrowser';
 import { POSTGRES_DEFAULT_PLACEHOLDER } from '@/features/orgs/projects/database/dataGrid/utils/postgresDefaultPlaceholder';
 import {
@@ -65,14 +66,6 @@ function createUUIDValidationSchema(details: ColumnDetails) {
   );
 }
 
-function createDateValidationSchema(details: ColumnDetails) {
-  const dateSchema = yup
-    .date()
-    .transform((value) => (Number.isNaN(value) ? null : value));
-
-  return createGenericValidationSchema(dateSchema, details);
-}
-
 function createBooleanValidationSchema(details: ColumnDetails) {
   const booleanSchema = yup.string().test((value, { createError }) => {
     const isTrueOrFalse = value === 'true' || value === 'false';
@@ -109,8 +102,8 @@ export function createDynamicValidationSchema(
       column.defaultValue !== null;
 
     const details: ColumnDetails = {
-      isNullable: !!isNullable,
-      isIdentity: !!isIdentity,
+      isNullable: Boolean(isNullable),
+      isIdentity: Boolean(isIdentity),
       hasDefaultValue,
     };
 
@@ -137,8 +130,8 @@ export function createDynamicValidationSchema(
       return {
         ...currentSchema,
         [column.id]: createTextValidationSchema(details).matches(
-          /^\d{2}:\d{2}(:\d{2})?$/,
-          'This is not a valid time (e.g: HH:MM:SS / HH:MM).',
+          TIME_PATTERN,
+          'This is not a valid time (e.g: HH:MM:SS / HH:MM / HH:MM:SS+00).',
         ),
       };
     }
@@ -153,10 +146,13 @@ export function createDynamicValidationSchema(
       };
     }
 
+    // date / timestamp inputs preserve raw PostgreSQL literals typed by the
+    // user (for example fractional seconds, offsets, or `infinity`). Let the
+    // database validate semantics instead of casting through JavaScript Date.
     if (isTimestampType(baseType) || isDateType(baseType)) {
       return {
         ...currentSchema,
-        [column.id]: createDateValidationSchema(details),
+        [column.id]: createTextValidationSchema(details),
       };
     }
 

--- a/dashboard/src/features/orgs/projects/logs/components/LogsRangeSelector/LogsRangeSelector.tsx
+++ b/dashboard/src/features/orgs/projects/logs/components/LogsRangeSelector/LogsRangeSelector.tsx
@@ -46,7 +46,7 @@ function LogsToDatePickerLiveButton() {
     setValue('interval', null);
   }
 
-  function handleChangeToDate(newIso: string) {
+  function handleChangeToDate(newIso: string | null) {
     setValue('to', newIso);
     setValue('interval', null);
   }
@@ -132,9 +132,11 @@ function LogsRangeSelectorIntervalPickers({
     setValue('interval', minutesToDecreaseFromCurrentDate);
   }
 
-  function handleChangeFromDate(newIso: string) {
-    setValue('from', newIso);
-    setValue('interval', null);
+  function handleChangeFromDate(newIso: string | null) {
+    if (newIso !== null) {
+      setValue('from', newIso);
+      setValue('interval', null);
+    }
   }
 
   return (


### PR DESCRIPTION
### Checklist

- [ ] No breaking changes
- [ ] Tests pass
- [ ] New features have new tests
- [ ] Documentation is updated (if applicable)
- [x] Title of the PR is in the correct format (see below)

<!-- pi-reviewer:start -->
### **What this change solves**
Inserting a row into a table with `date`, `time`, or `timestamp` columns previously used a plain text input, which was error-prone and inconsistent with the rest of the dashboard. This change wires the custom date/time pickers into the record-insert form and teaches the shared pickers to represent an empty/`null` value so they can express `NULL` and `DEFAULT` column states.

___

### **Change Type**
Enhancement

___

### **Description**
- Added a `DatePicker` (date-only) and a `TimePickerField` (`HH:mm:ss`) sharing the popover + Select/Clear footer pattern already used by `DateTimePicker`.
- Made the shared pickers nullable: `dateTime`/`date`/`time` accept `null`, added `emptyLabel`, `clearable`, and `error` props, and unified empty-state handling via an `isEmpty` + `resolveDate()` pattern.
- Introduced `TemporalPicker` (routes a base type to the right picker) and `TemporalRecordField` (RHF field wrapper with `NULL`/`DEFAULT` toggle buttons) and rendered them from `DatabaseRecordInputGroup` for temporal columns.
- Updated existing call sites (`RestoreBackupDialogButton`, `MetricsTimeRangeFilter`, `LogsRangeSelector`) to accept the new `string | null` change-handler signature.

___

<details> <summary><h3> File Walkthrough</h3></summary>

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody>
<tr><td><strong>Shared pickers</strong></td><td><details><summary>5 files</summary><table>
<tr>
  <td><strong>DatePicker.tsx</strong><dd><code>New date-only popover picker with empty/clearable/error states</code></dd></td>
  <td>+139/-0</td>
</tr>
<tr>
  <td><strong>DatePicker/index.ts</strong><dd><code>Barrel export for DatePicker</code></dd></td>
  <td>+1/-0</td>
</tr>
<tr>
  <td><strong>TimePickerField.tsx</strong><dd><code>New HH:mm:ss popover picker emitting a time string or null</code></dd></td>
  <td>+120/-0</td>
</tr>
<tr>
  <td><strong>TimePickerField/index.ts</strong><dd><code>Barrel export for TimePickerField</code></dd></td>
  <td>+1/-0</td>
</tr>
<tr>
  <td><strong>DateTimePicker.tsx</strong><dd><code>Accept null value; add emptyLabel/clearable/error; unify empty handling</code></dd></td>
  <td>+64/-27</td>
</tr>
</table></details></td></tr>
<tr><td><strong>Database record insert</strong></td><td><details><summary>3 files</summary><table>
<tr>
  <td><strong>DatabaseRecordInputGroup.tsx</strong><dd><code>Render TemporalRecordField for date/time/timestamp columns</code></dd></td>
  <td>+29/-0</td>
</tr>
<tr>
  <td><strong>TemporalPicker.tsx</strong><dd><code>Route a column base type to the matching picker</code></dd></td>
  <td>+64/-0</td>
</tr>
<tr>
  <td><strong>TemporalRecordField.tsx</strong><dd><code>RHF wrapper adding NULL/DEFAULT toggle buttons</code></dd></td>
  <td>+131/-0</td>
</tr>
</table></details></td></tr>
<tr><td><strong>Call sites</strong></td><td><details><summary>3 files</summary><table>
<tr>
  <td><strong>RestoreBackupDialogButton.tsx</strong><dd><code>Handle nullable date-time change signature</code></dd></td>
  <td>+10/-8</td>
</tr>
<tr>
  <td><strong>MetricsTimeRangeFilter.tsx</strong><dd><code>Guard null in from/to change handlers</code></dd></td>
  <td>+16/-12</td>
</tr>
<tr>
  <td><strong>LogsRangeSelector.tsx</strong><dd><code>Accept nullable change handler signature</code></dd></td>
  <td>+6/-4</td>
</tr>
</table></details></td></tr>
<tr><td><strong>Tests</strong></td><td><details><summary>5 files</summary><table>
<tr>
  <td><strong>DatePicker.test.tsx</strong><dd><code>Tests for empty/select/clear/disabled/error/external-change</code></dd></td>
  <td>+102/-0</td>
</tr>
<tr>
  <td><strong>TimePickerField.test.tsx</strong><dd><code>Tests for empty label, emit time, clear</code></dd></td>
  <td>+73/-0</td>
</tr>
<tr>
  <td><strong>DateTimePicker.test.tsx</strong><dd><code>Added empty/clear/error coverage</code></dd></td>
  <td>+80/-3</td>
</tr>
<tr>
  <td><strong>TemporalPicker.test.tsx</strong><dd><code>Tests for base-type routing</code></dd></td>
  <td>+96/-0</td>
</tr>
<tr>
  <td><strong>TemporalRecordField.test.tsx</strong><dd><code>Tests for NULL/DEFAULT toggles and value flow</code></dd></td>
  <td>+180/-0</td>
</tr>
</table></details></td></tr>
</tbody></table>

</details>

___

<!-- pi-reviewer:end -->

