### PR TITLE
chore(dashboard): use jsdom localStorage in tests

### DIFF
--- a/dashboard/src/features/orgs/projects/database/dataGrid/components/DataBrowserGrid/DataBrowserGridContainer.test.tsx
+++ b/dashboard/src/features/orgs/projects/database/dataGrid/components/DataBrowserGrid/DataBrowserGridContainer.test.tsx
@@ -5,14 +5,7 @@ import { getProjectQuery } from '@/tests/msw/mocks/graphql/getProjectQuery';
 import hasuraMetadataQuery from '@/tests/msw/mocks/rest/hasuraMetadataQuery';
 import tableQuery from '@/tests/msw/mocks/rest/tableQuery';
 import tokenQuery from '@/tests/msw/mocks/rest/tokenQuery';
-import {
-  localStorageMock,
-  queryClient,
-  render,
-  screen,
-  setInitialStore,
-  waitFor,
-} from '@/tests/testUtils';
+import { queryClient, render, screen, waitFor } from '@/tests/testUtils';
 import DataBrowserGridContainer from './DataBrowserGridContainer';
 
 const mocks = vi.hoisted(() => ({
@@ -62,7 +55,6 @@ function createRouterValue(tableSlug: string) {
 
 describe('DataBrowserGridContainer', () => {
   beforeAll(() => {
-    global.localStorage = localStorageMock();
     window.HTMLElement.prototype.scrollTo = vi.fn();
     server.listen();
   });
@@ -83,8 +75,9 @@ describe('DataBrowserGridContainer', () => {
     const authorsTablePath = 'default.public.authors';
     const townTablePath = 'default.public.town';
 
-    setInitialStore({
-      [COLUMN_CONFIGURATION_STORAGE_KEY]: JSON.stringify({
+    localStorage.setItem(
+      COLUMN_CONFIGURATION_STORAGE_KEY,
+      JSON.stringify({
         [authorsTablePath]: {
           columnVisibility: { name: true },
           columnOrder: [],
@@ -94,7 +87,7 @@ describe('DataBrowserGridContainer', () => {
           columnOrder: [],
         },
       }),
-    });
+    );
 
     mocks.useRouter.mockReturnValue(createRouterValue('authors'));
 

--- a/dashboard/src/features/orgs/projects/storage/dataGrid/components/DataGridPreviewCell/DataGridPreviewCell.test.tsx
+++ b/dashboard/src/features/orgs/projects/storage/dataGrid/components/DataGridPreviewCell/DataGridPreviewCell.test.tsx
@@ -1,12 +1,6 @@
 import { vi } from 'vitest';
 import { mockMatchMediaValue } from '@/tests/mocks';
-import {
-  localStorageMock,
-  render,
-  screen,
-  TestUserEvent,
-  waitFor,
-} from '@/tests/testUtils';
+import { render, screen, TestUserEvent, waitFor } from '@/tests/testUtils';
 import DataGridPreviewCell from './DataGridPreviewCell';
 
 Object.defineProperty(window, 'matchMedia', {
@@ -30,10 +24,6 @@ vi.mock('@/features/orgs/projects/hooks/useAppClient', () => ({
 describe('DataGridPreviewCell and FilePreviewDialog Fallbacks', () => {
   const adminSecret = 'my-admin-secret';
   const fileId = 'test-file-id';
-
-  beforeAll(() => {
-    global.localStorage = localStorageMock();
-  });
 
   beforeEach(() => {
     vi.restoreAllMocks();

--- a/dashboard/src/features/orgs/projects/storage/dataGrid/components/FilesDataGrid/FilesDataGrid.test.tsx
+++ b/dashboard/src/features/orgs/projects/storage/dataGrid/components/FilesDataGrid/FilesDataGrid.test.tsx
@@ -6,7 +6,7 @@ import { DATA_GRID_FILTER_STORAGE_KEY } from '@/features/orgs/projects/database/
 import { getProjectQuery } from '@/tests/msw/mocks/graphql/getProjectQuery';
 import nhostGraphQLLink from '@/tests/msw/mocks/graphql/nhostGraphQLLink';
 import tokenQuery from '@/tests/msw/mocks/rest/tokenQuery';
-import { localStorageMock, render, screen, waitFor } from '@/tests/testUtils';
+import { render, screen, waitFor } from '@/tests/testUtils';
 import FilesDataGrid from './FilesDataGrid';
 
 const mocks = vi.hoisted(() => {
@@ -71,7 +71,6 @@ const server = setupServer(
 
 beforeAll(() => {
   server.listen();
-  global.localStorage = localStorageMock();
 });
 afterEach(() => {
   server.resetHandlers();

--- a/dashboard/src/features/orgs/projects/storage/dataGrid/utils/PersistentDataTableConfigurationStorage.test.ts
+++ b/dashboard/src/features/orgs/projects/storage/dataGrid/utils/PersistentDataTableConfigurationStorage.test.ts
@@ -1,4 +1,3 @@
-import { localStorageMock, setInitialStore } from '@/tests/testUtils';
 import {
   COLUMN_CONFIGURATION_STORAGE_KEY,
   convertToV8IfNeeded,
@@ -9,15 +8,19 @@ import {
   toggleColumnVisibility,
 } from './PersistentDataTableConfigurationStorage';
 
+function seedLocalStorage(initialState: Record<string, string>) {
+  localStorage.clear();
+
+  for (const [key, value] of Object.entries(initialState)) {
+    localStorage.setItem(key, value);
+  }
+}
+
 describe('PersistentDataTableConfigurationStorage', () => {
   const TABLE_PATH = 'default.public.myTable';
-  beforeAll(() => {
-    global.localStorage = localStorageMock();
-  });
 
   beforeEach(() => {
-    localStorage.clear();
-    setInitialStore({
+    seedLocalStorage({
       [COLUMN_CONFIGURATION_STORAGE_KEY]: JSON.stringify({
         [TABLE_PATH]: {
           columnVisibility: { column1: false, column2: false },
@@ -104,11 +107,28 @@ describe('PersistentDataTableConfigurationStorage', () => {
     expect(newColumnOrder).toStrictEqual(['column2', 'column1']);
   });
 
+  it('should persist the new column order in jsdom localStorage', () => {
+    saveColumnOrder(TABLE_PATH, ['column2', 'column1']);
+
+    const storedConfiguration = localStorage.getItem(
+      COLUMN_CONFIGURATION_STORAGE_KEY,
+    );
+
+    expect(storedConfiguration).toBe(
+      JSON.stringify({
+        [TABLE_PATH]: {
+          columnVisibility: { column1: false, column2: false },
+          columnOrder: ['column2', 'column1'],
+        },
+      }),
+    );
+  });
+
   it('should convert old hiddenColumns format to v8 columnVisibility', () => {
     const MOVIES_TABLE = 'default.public.movies';
     const BOOKS_TABLE = 'default.public.books';
 
-    setInitialStore({
+    seedLocalStorage({
       [COLUMN_CONFIGURATION_STORAGE_KEY]: JSON.stringify({
         [MOVIES_TABLE]: {
           hiddenColumns: ['director', 'rating'],
@@ -133,7 +153,7 @@ describe('PersistentDataTableConfigurationStorage', () => {
   it('should convert columnOrder even when there are no hiddenColumns', () => {
     const MOVIES_TABLE = 'default.public.movies';
 
-    setInitialStore({
+    seedLocalStorage({
       [COLUMN_CONFIGURATION_STORAGE_KEY]: JSON.stringify({
         [MOVIES_TABLE]: {
           hiddenColumns: [],
@@ -156,7 +176,7 @@ describe('PersistentDataTableConfigurationStorage', () => {
   it('should convert both hiddenColumns and columnOrder independently', () => {
     const MOVIES_TABLE = 'default.public.movies';
 
-    setInitialStore({
+    seedLocalStorage({
       [COLUMN_CONFIGURATION_STORAGE_KEY]: JSON.stringify({
         [MOVIES_TABLE]: {
           hiddenColumns: ['director'],
@@ -182,7 +202,7 @@ describe('PersistentDataTableConfigurationStorage', () => {
   it('should be idempotent — calling convertToV8IfNeeded twice should not duplicate selection-column', () => {
     const MOVIES_TABLE = 'default.public.movies';
 
-    setInitialStore({
+    seedLocalStorage({
       [COLUMN_CONFIGURATION_STORAGE_KEY]: JSON.stringify({
         [MOVIES_TABLE]: {
           hiddenColumns: ['director'],
@@ -210,7 +230,7 @@ describe('PersistentDataTableConfigurationStorage', () => {
     const MOVIES_TABLE = 'default.public.movies';
     const BOOKS_TABLE = 'default.public.books';
 
-    setInitialStore({
+    seedLocalStorage({
       [COLUMN_CONFIGURATION_STORAGE_KEY]: JSON.stringify({
         [MOVIES_TABLE]: {
           hiddenColumns: ['director'],
@@ -245,7 +265,7 @@ describe('PersistentDataTableConfigurationStorage', () => {
   it('should not convert if data is already in v8 format', () => {
     const MOVIES_TABLE = 'default.public.movies';
 
-    setInitialStore({
+    seedLocalStorage({
       [COLUMN_CONFIGURATION_STORAGE_KEY]: JSON.stringify({
         [MOVIES_TABLE]: {
           columnVisibility: { director: false },

--- a/dashboard/src/tests/testUtils.tsx
+++ b/dashboard/src/tests/testUtils.tsx
@@ -275,33 +275,6 @@ export class TestUserEvent {
     });
   }
 }
-let store: any;
-
-export function setInitialStore(initialState: any) {
-  store = initialState;
-}
-
-export function localStorageMock(initialStore: any = {}) {
-  store = initialStore;
-  return {
-    getItem: vi.fn((key) => store[key] || null),
-    setItem: vi.fn((key, value) => {
-      store[key] = value.toString();
-    }),
-    removeItem: vi.fn((key) => {
-      delete store[key];
-    }),
-    clear: vi.fn(() => {
-      store = {};
-    }),
-    get length() {
-      return Object.keys(store).length;
-    },
-    key(index: number) {
-      return Object.keys(store)[index] ?? null;
-    },
-  };
-}
 
 // Asserts that the given string is rendered as the visible textContent of
 // some element. Useful for components like TruncatedText / TextWithTooltip


### PR DESCRIPTION
### Checklist

- [x] No breaking changes
- [x] Tests pass
- [ ] New features have new tests
- [x] Documentation is updated (if applicable)
- [x] Title of the PR is in the correct format (see below)

<!-- pi-reviewer:start -->
### **What this change solves**
Moves dashboard tests away from a bespoke `localStorage` mock so they exercise jsdom's built-in storage behavior. This keeps shared test utilities smaller while preserving data-grid persistence coverage.

___

### **Change Type**
Tests

___

### **Description**
- Remove the custom `localStorageMock` and `setInitialStore` helpers from shared dashboard test utilities.
- Update dashboard data-grid tests to seed and clear jsdom `localStorage` directly.
- Add explicit coverage that column-order changes are persisted through jsdom `localStorage`.

___

<details> <summary><h3> File Walkthrough</h3></summary>

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody>
<tr><td><strong>Dashboard tests</strong></td><td><details><summary>5 files</summary><table>
<tr>
  <td><strong>dashboard/src/features/orgs/projects/database/dataGrid/components/DataBrowserGrid/DataBrowserGridContainer.test.tsx</strong><dd><code>Seeds table column configuration directly through jsdom localStorage.</code></dd></td>
  <td>+5/-12</td>
</tr>
<tr>
  <td><strong>dashboard/src/features/orgs/projects/storage/dataGrid/components/DataGridPreviewCell/DataGridPreviewCell.test.tsx</strong><dd><code>Drops the custom localStorage mock setup from preview-cell tests.</code></dd></td>
  <td>+1/-11</td>
</tr>
<tr>
  <td><strong>dashboard/src/features/orgs/projects/storage/dataGrid/components/FilesDataGrid/FilesDataGrid.test.tsx</strong><dd><code>Relies on the default jsdom localStorage in storage data-grid tests.</code></dd></td>
  <td>+1/-2</td>
</tr>
<tr>
  <td><strong>dashboard/src/features/orgs/projects/storage/dataGrid/utils/PersistentDataTableConfigurationStorage.test.ts</strong><dd><code>Adds local test seeding helper and verifies persisted column order.</code></dd></td>
  <td>+32/-11</td>
</tr>
<tr>
  <td><strong>dashboard/src/tests/testUtils.tsx</strong><dd><code>Removes shared localStorage mock and initial-store helpers.</code></dd></td>
  <td>+0/-27</td>
</tr>
</table></details></td></tr>
</tbody></table>

</details>

___

<!-- pi-reviewer:end -->
