### PR TITLE
fix(dashboard): migrate settings page spinners

### DIFF
--- a/dashboard/src/components/ui/v3/spinner.tsx
+++ b/dashboard/src/components/ui/v3/spinner.tsx
@@ -1,6 +1,6 @@
 import { cva, type VariantProps } from 'class-variance-authority';
 import { Loader2 } from 'lucide-react';
-import { type ReactNode, useEffect, useState } from 'react';
+import type { ReactNode } from 'react';
 import { cn } from '@/lib/utils';
 
 const spinnerVariants = cva('flex-col items-center justify-center', {
@@ -35,7 +35,6 @@ interface SpinnerContentProps
   className?: string;
   children?: ReactNode;
   wrapperClassName?: string;
-  delay?: number;
 }
 
 export function Spinner({
@@ -44,29 +43,9 @@ export function Spinner({
   children,
   className,
   wrapperClassName,
-  delay = 0,
 }: SpinnerContentProps) {
-  const [isDelayed, setIsDelayed] = useState(delay > 0);
-
-  useEffect(() => {
-    if (delay <= 0) {
-      setIsDelayed(false);
-      return;
-    }
-
-    const timer = setTimeout(() => {
-      setIsDelayed(false);
-    }, delay);
-
-    return () => clearTimeout(timer);
-  }, [delay]);
-
-  const shouldShow = show && !isDelayed;
-
   return (
-    <span
-      className={cn(spinnerVariants({ show: shouldShow }), wrapperClassName)}
-    >
+    <span className={cn(spinnerVariants({ show }), wrapperClassName)}>
       <Loader2
         role="progressbar"
         className={cn(

--- a/dashboard/src/features/orgs/projects/backups/components/ScheduledBackupTabContent/BackupList.tsx
+++ b/dashboard/src/features/orgs/projects/backups/components/ScheduledBackupTabContent/BackupList.tsx
@@ -24,7 +24,7 @@ export default function BackupList() {
   });
 
   if (loadingProject || loadingBackups) {
-    return <Spinner delay={500}>Loading backups...</Spinner>;
+    return <Spinner>Loading backups...</Spinner>;
   }
 
   if (error) {

--- a/dashboard/src/features/orgs/projects/database/dataGrid/components/EditTableForm/EditTableForm.tsx
+++ b/dashboard/src/features/orgs/projects/database/dataGrid/components/EditTableForm/EditTableForm.tsx
@@ -206,7 +206,6 @@ export default function EditTableForm({
     return (
       <div className="px-6">
         <Spinner
-          delay={1000}
           wrapperClassName="flex-row text-[12px] leading-[1.66] font-normal gap-1"
           className="h-4 w-4 justify-center"
         >
@@ -220,7 +219,6 @@ export default function EditTableForm({
     return (
       <div className="px-6">
         <Spinner
-          delay={1000}
           wrapperClassName="flex-row text-[12px] leading-[1.66] font-normal gap-1"
           className="h-4 w-4 justify-center"
         >

--- a/dashboard/src/features/orgs/projects/logs/components/LogsBody/LogsBody.tsx
+++ b/dashboard/src/features/orgs/projects/logs/components/LogsBody/LogsBody.tsx
@@ -27,7 +27,6 @@ import { useEffect, useMemo, useRef, useState } from 'react';
 const loadingIndicator = (
   <div className="h-full w-full px-4 py-2">
     <Spinner
-      delay={500}
       wrapperClassName="mx-auto flex-row items-center gap-2"
       className="h-5 w-5"
     >

--- a/dashboard/src/pages/orgs/[orgSlug]/projects/[appSubdomain]/backups.tsx
+++ b/dashboard/src/pages/orgs/[orgSlug]/projects/[appSubdomain]/backups.tsx
@@ -13,7 +13,7 @@ export default function BackupsPage() {
   const { isPiTREnabled, loading: isPiTREnabledLoading } = useIsPiTREnabled();
 
   if (loading || isPiTREnabledLoading) {
-    return <Spinner delay={1000}>Loading project...</Spinner>;
+    return <Spinner>Loading project...</Spinner>;
   }
 
   const isPlanFree = org!.plan.isFree;

--- a/dashboard/src/pages/orgs/[orgSlug]/projects/[appSubdomain]/settings/ai.tsx
+++ b/dashboard/src/pages/orgs/[orgSlug]/projects/[appSubdomain]/settings/ai.tsx
@@ -1,24 +1,13 @@
 import type { ReactElement } from 'react';
 import { UpgradeToProBanner } from '@/components/common/UpgradeToProBanner';
 import { Container } from '@/components/layout/Container';
-import { ActivityIndicator } from '@/components/ui/v2/ActivityIndicator';
 import { OrgLayout } from '@/features/orgs/layout/OrgLayout';
 import { SettingsLayout } from '@/features/orgs/layout/SettingsLayout';
 import { AISettings } from '@/features/orgs/projects/ai/settings/components';
 import { useCurrentOrg } from '@/features/orgs/projects/hooks/useCurrentOrg';
 
 export default function AISettingsPage() {
-  const { org, loading, error } = useCurrentOrg();
-
-  if (loading) {
-    return (
-      <ActivityIndicator
-        delay={1000}
-        label="Loading AI settings..."
-        className="justify-center"
-      />
-    );
-  }
+  const { org, error } = useCurrentOrg();
 
   if (org?.plan?.isFree) {
     return (

--- a/dashboard/src/pages/orgs/[orgSlug]/projects/[appSubdomain]/settings/authentication.tsx
+++ b/dashboard/src/pages/orgs/[orgSlug]/projects/[appSubdomain]/settings/authentication.tsx
@@ -1,6 +1,6 @@
 import type { ReactElement } from 'react';
 import { Container } from '@/components/layout/Container';
-import { ActivityIndicator } from '@/components/ui/v2/ActivityIndicator';
+import { Spinner } from '@/components/ui/v3/spinner';
 import { OrgLayout } from '@/features/orgs/layout/OrgLayout';
 import { SettingsLayout } from '@/features/orgs/layout/SettingsLayout';
 import { AllowedEmailSettings } from '@/features/orgs/projects/authentication/settings/components/AllowedEmailSettings';
@@ -32,11 +32,9 @@ export default function SettingsAuthenticationPage() {
 
   if (!data || loadingProject || loading) {
     return (
-      <ActivityIndicator
-        delay={1000}
-        label="Loading authentication settings..."
-        className="justify-center"
-      />
+      <Spinner size="medium" wrapperClassName="gap-2">
+        Loading authentication settings...
+      </Spinner>
     );
   }
 

--- a/dashboard/src/pages/orgs/[orgSlug]/projects/[appSubdomain]/settings/compute-resources.tsx
+++ b/dashboard/src/pages/orgs/[orgSlug]/projects/[appSubdomain]/settings/compute-resources.tsx
@@ -1,20 +1,13 @@
 import type { ReactElement } from 'react';
 import { UpgradeToProBanner } from '@/components/common/UpgradeToProBanner';
 import { Container } from '@/components/layout/Container';
-import { ActivityIndicator } from '@/components/ui/v2/ActivityIndicator';
 import { OrgLayout } from '@/features/orgs/layout/OrgLayout';
 import { SettingsLayout } from '@/features/orgs/layout/SettingsLayout';
 import { useCurrentOrg } from '@/features/orgs/projects/hooks/useCurrentOrg';
-import { useProject } from '@/features/orgs/projects/hooks/useProject';
 import { ResourcesForm } from '@/features/orgs/projects/resources/settings/components/ResourcesForm';
 
 export default function ResourceSettingsPage() {
-  const { org, loading: loadingOrg } = useCurrentOrg();
-  const { loading: loadingProject } = useProject();
-
-  if (loadingOrg || loadingProject) {
-    return <ActivityIndicator delay={1000} label="Loading project..." />;
-  }
+  const { org } = useCurrentOrg();
 
   if (org?.plan?.isFree) {
     return (

--- a/dashboard/src/pages/orgs/[orgSlug]/projects/[appSubdomain]/settings/custom-domains.tsx
+++ b/dashboard/src/pages/orgs/[orgSlug]/projects/[appSubdomain]/settings/custom-domains.tsx
@@ -1,7 +1,6 @@
 import type { ReactElement } from 'react';
 import { UpgradeToProBanner } from '@/components/common/UpgradeToProBanner';
 import { Container } from '@/components/layout/Container';
-import { ActivityIndicator } from '@/components/ui/v2/ActivityIndicator';
 import { Box } from '@/components/ui/v2/Box';
 import { Text } from '@/components/ui/v2/Text';
 import { TextLink } from '@/components/ui/v3/text-link';
@@ -15,11 +14,7 @@ import { ServerlessFunctionsDomain } from '@/features/orgs/projects/custom-domai
 import { useCurrentOrg } from '@/features/orgs/projects/hooks/useCurrentOrg';
 
 export default function CustomDomains() {
-  const { org, loading: loadingOrg } = useCurrentOrg();
-
-  if (loadingOrg) {
-    return <ActivityIndicator delay={1000} label="Loading project..." />;
-  }
+  const { org } = useCurrentOrg();
 
   if (org?.plan?.isFree) {
     return (

--- a/dashboard/src/pages/orgs/[orgSlug]/projects/[appSubdomain]/settings/database.tsx
+++ b/dashboard/src/pages/orgs/[orgSlug]/projects/[appSubdomain]/settings/database.tsx
@@ -1,6 +1,6 @@
 import type { ReactElement } from 'react';
 import { Container } from '@/components/layout/Container';
-import { ActivityIndicator } from '@/components/ui/v2/ActivityIndicator';
+import { Spinner } from '@/components/ui/v3/spinner';
 import { OrgLayout } from '@/features/orgs/layout/OrgLayout';
 import { SettingsLayout } from '@/features/orgs/layout/SettingsLayout';
 import { useIsPlatform } from '@/features/orgs/projects/common/hooks/useIsPlatform';
@@ -27,11 +27,9 @@ export default function DatabaseSettingsPage() {
 
   if (loadingProject || loading) {
     return (
-      <ActivityIndicator
-        delay={1000}
-        label="Loading Postgres settings..."
-        className="justify-center"
-      />
+      <Spinner size="medium" wrapperClassName="gap-2">
+        Loading Postgres settings...
+      </Spinner>
     );
   }
 

--- a/dashboard/src/pages/orgs/[orgSlug]/projects/[appSubdomain]/settings/environment-variables.tsx
+++ b/dashboard/src/pages/orgs/[orgSlug]/projects/[appSubdomain]/settings/environment-variables.tsx
@@ -1,6 +1,6 @@
 import type { ReactElement } from 'react';
 import { Container } from '@/components/layout/Container';
-import { ActivityIndicator } from '@/components/ui/v2/ActivityIndicator';
+import { Spinner } from '@/components/ui/v3/spinner';
 import { OrgLayout } from '@/features/orgs/layout/OrgLayout';
 import { SettingsLayout } from '@/features/orgs/layout/SettingsLayout';
 import { useIsPlatform } from '@/features/orgs/projects/common/hooks/useIsPlatform';
@@ -23,10 +23,9 @@ export default function EnvironmentVariablesPage() {
 
   if (loading) {
     return (
-      <ActivityIndicator
-        delay={1000}
-        label="Loading environment variables..."
-      />
+      <Spinner size="medium" wrapperClassName="gap-2">
+        Loading environment variables...
+      </Spinner>
     );
   }
 

--- a/dashboard/src/pages/orgs/[orgSlug]/projects/[appSubdomain]/settings/hasura.tsx
+++ b/dashboard/src/pages/orgs/[orgSlug]/projects/[appSubdomain]/settings/hasura.tsx
@@ -1,6 +1,6 @@
 import type { ReactElement } from 'react';
 import { Container } from '@/components/layout/Container';
-import { ActivityIndicator } from '@/components/ui/v2/ActivityIndicator';
+import { Spinner } from '@/components/ui/v3/spinner';
 import { OrgLayout } from '@/features/orgs/layout/OrgLayout';
 import { SettingsLayout } from '@/features/orgs/layout/SettingsLayout';
 import { useIsPlatform } from '@/features/orgs/projects/common/hooks/useIsPlatform';
@@ -32,11 +32,9 @@ export default function HasuraSettingsPage() {
 
   if (!data && loading) {
     return (
-      <ActivityIndicator
-        delay={1000}
-        label="Loading Hasura settings..."
-        className="justify-center"
-      />
+      <Spinner size="medium" wrapperClassName="gap-2">
+        Loading Hasura settings...
+      </Spinner>
     );
   }
 

--- a/dashboard/src/pages/orgs/[orgSlug]/projects/[appSubdomain]/settings/jwt.tsx
+++ b/dashboard/src/pages/orgs/[orgSlug]/projects/[appSubdomain]/settings/jwt.tsx
@@ -1,6 +1,6 @@
 import type { ReactElement } from 'react';
 import { Container } from '@/components/layout/Container';
-import { ActivityIndicator } from '@/components/ui/v2/ActivityIndicator';
+import { Spinner } from '@/components/ui/v3/spinner';
 import { OrgLayout } from '@/features/orgs/layout/OrgLayout';
 import { SettingsLayout } from '@/features/orgs/layout/SettingsLayout';
 import { useIsPlatform } from '@/features/orgs/projects/common/hooks/useIsPlatform';
@@ -23,11 +23,9 @@ export default function SettingsJWTPage() {
 
   if (loading || !data) {
     return (
-      <ActivityIndicator
-        delay={1000}
-        label="Loading JWT settings..."
-        className="justify-center"
-      />
+      <Spinner size="medium" wrapperClassName="gap-2">
+        Loading JWT settings...
+      </Spinner>
     );
   }
 

--- a/dashboard/src/pages/orgs/[orgSlug]/projects/[appSubdomain]/settings/oauth2-provider.tsx
+++ b/dashboard/src/pages/orgs/[orgSlug]/projects/[appSubdomain]/settings/oauth2-provider.tsx
@@ -1,10 +1,10 @@
 import { useRouter } from 'next/router';
 import type { ReactElement } from 'react';
 import { Container } from '@/components/layout/Container';
-import { ActivityIndicator } from '@/components/ui/v2/ActivityIndicator';
 import { Box } from '@/components/ui/v2/Box';
 import { Button } from '@/components/ui/v2/Button';
 import { Text } from '@/components/ui/v2/Text';
+import { Spinner } from '@/components/ui/v3/spinner';
 import { OrgLayout } from '@/features/orgs/layout/OrgLayout';
 import { SettingsLayout } from '@/features/orgs/layout/SettingsLayout';
 import { MIN_AUTH_VERSION_OAUTH2 } from '@/features/orgs/projects/authentication/oauth2/constants';
@@ -20,14 +20,9 @@ export default function SettingsOAuth2ProviderPage() {
 
   if (isPlatform && loadingVersions) {
     return (
-      <Container
-        className="flex h-full max-w-5xl flex-col"
-        rootClassName="h-full"
-      >
-        <div className="flex flex-auto items-center justify-center overflow-hidden">
-          <ActivityIndicator label="Loading..." />
-        </div>
-      </Container>
+      <Spinner size="medium" wrapperClassName="gap-2">
+        Loading...
+      </Spinner>
     );
   }
 

--- a/dashboard/src/pages/orgs/[orgSlug]/projects/[appSubdomain]/settings/roles-and-permissions.tsx
+++ b/dashboard/src/pages/orgs/[orgSlug]/projects/[appSubdomain]/settings/roles-and-permissions.tsx
@@ -1,6 +1,6 @@
 import type { ReactElement } from 'react';
 import { Container } from '@/components/layout/Container';
-import { ActivityIndicator } from '@/components/ui/v2/ActivityIndicator';
+import { Spinner } from '@/components/ui/v3/spinner';
 import { OrgLayout } from '@/features/orgs/layout/OrgLayout';
 import { SettingsLayout } from '@/features/orgs/layout/SettingsLayout';
 import { useIsPlatform } from '@/features/orgs/projects/common/hooks/useIsPlatform';
@@ -25,10 +25,9 @@ export default function RolesAndPermissionsPage() {
 
   if (loading) {
     return (
-      <ActivityIndicator
-        delay={1000}
-        label="Loading roles and permission variables..."
-      />
+      <Spinner size="medium" wrapperClassName="gap-2">
+        Loading roles and permission variables...
+      </Spinner>
     );
   }
 

--- a/dashboard/src/pages/orgs/[orgSlug]/projects/[appSubdomain]/settings/secrets.tsx
+++ b/dashboard/src/pages/orgs/[orgSlug]/projects/[appSubdomain]/settings/secrets.tsx
@@ -8,7 +8,6 @@ import { useDialog } from '@/components/common/DialogProvider';
 import { Container } from '@/components/layout/Container';
 import { SettingsContainer } from '@/components/layout/SettingsContainer';
 import { InlineCode } from '@/components/presentational/InlineCode';
-import { ActivityIndicator } from '@/components/ui/v2/ActivityIndicator';
 import { Box } from '@/components/ui/v2/Box';
 import { Button } from '@/components/ui/v2/Button';
 import { Divider } from '@/components/ui/v2/Divider';
@@ -22,6 +21,7 @@ import {
   DropdownMenuItem,
   DropdownMenuTrigger,
 } from '@/components/ui/v3/dropdown-menu';
+import { Spinner } from '@/components/ui/v3/spinner';
 import { OrgLayout } from '@/features/orgs/layout/OrgLayout';
 import { SettingsLayout } from '@/features/orgs/layout/SettingsLayout';
 import { useIsPlatform } from '@/features/orgs/projects/common/hooks/useIsPlatform';
@@ -57,7 +57,11 @@ export default function SecretsPage() {
   });
 
   if (networkStatus === NetworkStatus.loading) {
-    return <ActivityIndicator delay={1000} label="Loading secrets..." />;
+    return (
+      <Spinner size="medium" wrapperClassName="gap-2">
+        Loading secrets...
+      </Spinner>
+    );
   }
 
   if (error) {

--- a/dashboard/src/pages/orgs/[orgSlug]/projects/[appSubdomain]/settings/sign-in-methods.tsx
+++ b/dashboard/src/pages/orgs/[orgSlug]/projects/[appSubdomain]/settings/sign-in-methods.tsx
@@ -1,6 +1,6 @@
 import type { ReactElement } from 'react';
 import { Container } from '@/components/layout/Container';
-import { ActivityIndicator } from '@/components/ui/v2/ActivityIndicator';
+import { Spinner } from '@/components/ui/v3/spinner';
 import { OrgLayout } from '@/features/orgs/layout/OrgLayout';
 import { SettingsLayout } from '@/features/orgs/layout/SettingsLayout';
 import { AnonymousSignInSettings } from '@/features/orgs/projects/authentication/settings/components/AnonymousSignInSettings';
@@ -40,11 +40,9 @@ export default function SettingsSignInMethodsPage() {
 
   if (loading) {
     return (
-      <ActivityIndicator
-        delay={1000}
-        label="Loading sign-in method settings..."
-        className="justify-center"
-      />
+      <Spinner size="medium" wrapperClassName="gap-2">
+        Loading sign-in method settings...
+      </Spinner>
     );
   }
 

--- a/dashboard/src/pages/orgs/[orgSlug]/projects/[appSubdomain]/settings/smtp.tsx
+++ b/dashboard/src/pages/orgs/[orgSlug]/projects/[appSubdomain]/settings/smtp.tsx
@@ -1,7 +1,6 @@
 import { type ReactElement, useEffect, useState } from 'react';
 import { UpgradeToProBanner } from '@/components/common/UpgradeToProBanner';
 import { Container } from '@/components/layout/Container';
-import { ActivityIndicator } from '@/components/ui/v2/ActivityIndicator';
 import {
   Select,
   SelectContent,
@@ -9,6 +8,7 @@ import {
   SelectTrigger,
   SelectValue,
 } from '@/components/ui/v3/select';
+import { Spinner } from '@/components/ui/v3/spinner';
 import { OrgLayout } from '@/features/orgs/layout/OrgLayout';
 import { SettingsLayout } from '@/features/orgs/layout/SettingsLayout';
 import DeleteSMTPSettings from '@/features/orgs/projects/authentication/settings/components/DeleteSMTPSettings/DeleteSMTPSettings';
@@ -40,6 +40,14 @@ export default function SMTPSettingsPage() {
     setMode(host !== 'postmark' ? 'smtp' : 'postmark');
   }, [host]);
 
+  if (loading) {
+    return (
+      <Spinner size="medium" wrapperClassName="gap-2">
+        Loading SMTP settings...
+      </Spinner>
+    );
+  }
+
   if (isPlatform && org?.plan?.isFree) {
     return (
       <Container
@@ -51,16 +59,6 @@ export default function SMTPSettingsPage() {
           description=""
         />
       </Container>
-    );
-  }
-
-  if (loading) {
-    return (
-      <ActivityIndicator
-        delay={1000}
-        label="Loading SMTP settings..."
-        className="justify-center"
-      />
     );
   }
 

--- a/dashboard/src/pages/orgs/[orgSlug]/projects/[appSubdomain]/settings/storage.tsx
+++ b/dashboard/src/pages/orgs/[orgSlug]/projects/[appSubdomain]/settings/storage.tsx
@@ -1,6 +1,6 @@
 import type { ReactElement } from 'react';
 import { Container } from '@/components/layout/Container';
-import { ActivityIndicator } from '@/components/ui/v2/ActivityIndicator';
+import { Spinner } from '@/components/ui/v3/spinner';
 import { OrgLayout } from '@/features/orgs/layout/OrgLayout';
 import { SettingsLayout } from '@/features/orgs/layout/SettingsLayout';
 import { useIsPlatform } from '@/features/orgs/projects/common/hooks/useIsPlatform';
@@ -23,11 +23,9 @@ export default function StorageSettingsPage() {
 
   if (loading) {
     return (
-      <ActivityIndicator
-        delay={1000}
-        label="Loading Storage settings..."
-        className="justify-center"
-      />
+      <Spinner size="medium" wrapperClassName="gap-2">
+        Loading Storage settings...
+      </Spinner>
     );
   }
 


### PR DESCRIPTION
### Checklist

- [x] No breaking changes
- [ ] Tests pass
- [ ] New features have new tests
- [ ] Documentation is updated (if applicable)
- [x] Title of the PR is in the correct format (see below)

<!-- pi-reviewer:start -->
### **What this change solves**
This change standardizes dashboard loading states around the v3 `Spinner` component and removes the spinner delay API. It also migrates project settings pages away from the older `ActivityIndicator` loading UI where applicable.

___

### **Change Type**
Refactoring

___

### **Description**
- Remove delayed-render support from the v3 `Spinner` component.
- Drop `delay` props from existing spinner call sites.
- Replace or remove settings-page `ActivityIndicator` loading branches as part of the spinner migration.

___

<details> <summary><h3> File Walkthrough</h3></summary>

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody>
<tr><td><strong>UI component</strong></td><td><details><summary>1 file</summary><table>
<tr>
  <td><strong>dashboard/src/components/ui/v3/spinner.tsx</strong><dd><code>Removes the delay prop/state/effect and renders directly from the show prop.</code></dd></td>
  <td>+2/-23</td>
</tr>
</table></details></td></tr>
<tr><td><strong>Project loading states</strong></td><td><details><summary>4 files</summary><table>
<tr>
  <td><strong>dashboard/src/features/orgs/projects/backups/components/ScheduledBackupTabContent/BackupList.tsx</strong><dd><code>Removes the delayed spinner prop from the scheduled backups loading state.</code></dd></td>
  <td>+1/-1</td>
</tr>
<tr>
  <td><strong>dashboard/src/features/orgs/projects/database/dataGrid/components/EditTableForm/EditTableForm.tsx</strong><dd><code>Removes delayed spinner props from table edit loading placeholders.</code></dd></td>
  <td>+0/-2</td>
</tr>
<tr>
  <td><strong>dashboard/src/features/orgs/projects/logs/components/LogsBody/LogsBody.tsx</strong><dd><code>Removes the delayed spinner prop from the logs loading indicator.</code></dd></td>
  <td>+0/-1</td>
</tr>
<tr>
  <td><strong>dashboard/src/pages/orgs/[orgSlug]/projects/[appSubdomain]/backups.tsx</strong><dd><code>Removes the delayed spinner prop from the backups page loading state.</code></dd></td>
  <td>+1/-1</td>
</tr>
</table></details></td></tr>
<tr><td><strong>Settings pages</strong></td><td><details><summary>14 files</summary><table>
<tr>
  <td><strong>dashboard/src/pages/orgs/[orgSlug]/projects/[appSubdomain]/settings/ai.tsx</strong><dd><code>Removes the ActivityIndicator loading branch from AI settings.</code></dd></td>
  <td>+1/-12</td>
</tr>
<tr>
  <td><strong>dashboard/src/pages/orgs/[orgSlug]/projects/[appSubdomain]/settings/authentication.tsx</strong><dd><code>Switches authentication settings loading UI from ActivityIndicator to Spinner.</code></dd></td>
  <td>+4/-6</td>
</tr>
<tr>
  <td><strong>dashboard/src/pages/orgs/[orgSlug]/projects/[appSubdomain]/settings/compute-resources.tsx</strong><dd><code>Removes the ActivityIndicator loading branch from compute resources settings.</code></dd></td>
  <td>+1/-8</td>
</tr>
<tr>
  <td><strong>dashboard/src/pages/orgs/[orgSlug]/projects/[appSubdomain]/settings/custom-domains.tsx</strong><dd><code>Removes the ActivityIndicator loading branch from custom domains settings.</code></dd></td>
  <td>+1/-6</td>
</tr>
<tr>
  <td><strong>dashboard/src/pages/orgs/[orgSlug]/projects/[appSubdomain]/settings/database.tsx</strong><dd><code>Switches database settings loading UI from ActivityIndicator to Spinner.</code></dd></td>
  <td>+4/-6</td>
</tr>
<tr>
  <td><strong>dashboard/src/pages/orgs/[orgSlug]/projects/[appSubdomain]/settings/environment-variables.tsx</strong><dd><code>Switches environment variables settings loading UI from ActivityIndicator to Spinner.</code></dd></td>
  <td>+4/-5</td>
</tr>
<tr>
  <td><strong>dashboard/src/pages/orgs/[orgSlug]/projects/[appSubdomain]/settings/hasura.tsx</strong><dd><code>Switches Hasura settings loading UI from ActivityIndicator to Spinner.</code></dd></td>
  <td>+5/-7</td>
</tr>
<tr>
  <td><strong>dashboard/src/pages/orgs/[orgSlug]/projects/[appSubdomain]/settings/jwt.tsx</strong><dd><code>Switches JWT settings loading UI from ActivityIndicator to Spinner.</code></dd></td>
  <td>+4/-6</td>
</tr>
<tr>
  <td><strong>dashboard/src/pages/orgs/[orgSlug]/projects/[appSubdomain]/settings/oauth2-provider.tsx</strong><dd><code>Switches OAuth2 provider settings loading UI from ActivityIndicator to Spinner and simplifies page loading data.</code></dd></td>
  <td>+4/-9</td>
</tr>
<tr>
  <td><strong>dashboard/src/pages/orgs/[orgSlug]/projects/[appSubdomain]/settings/roles-and-permissions.tsx</strong><dd><code>Switches roles and permissions settings loading UI from ActivityIndicator to Spinner.</code></dd></td>
  <td>+4/-5</td>
</tr>
<tr>
  <td><strong>dashboard/src/pages/orgs/[orgSlug]/projects/[appSubdomain]/settings/secrets.tsx</strong><dd><code>Switches secrets settings loading UI from ActivityIndicator to Spinner.</code></dd></td>
  <td>+6/-2</td>
</tr>
<tr>
  <td><strong>dashboard/src/pages/orgs/[orgSlug]/projects/[appSubdomain]/settings/sign-in-methods.tsx</strong><dd><code>Switches sign-in methods settings loading UI from ActivityIndicator to Spinner.</code></dd></td>
  <td>+4/-6</td>
</tr>
<tr>
  <td><strong>dashboard/src/pages/orgs/[orgSlug]/projects/[appSubdomain]/settings/smtp.tsx</strong><dd><code>Switches SMTP settings loading UI from ActivityIndicator to Spinner and simplifies loading copy.</code></dd></td>
  <td>+9/-11</td>
</tr>
<tr>
  <td><strong>dashboard/src/pages/orgs/[orgSlug]/projects/[appSubdomain]/settings/storage.tsx</strong><dd><code>Switches storage settings loading UI from ActivityIndicator to Spinner.</code></dd></td>
  <td>+4/-6</td>
</tr>
</table></details></td></tr>
</tbody></table>

</details>

___

<!-- pi-reviewer:end -->
