### PR TITLE
fix(dashboard): migrate X icon in DialogTitle

### DIFF
--- a/dashboard/src/components/ui/v2/Dialog/DialogTitle.tsx
+++ b/dashboard/src/components/ui/v2/Dialog/DialogTitle.tsx
@@ -1,9 +1,9 @@
 import { styled } from '@mui/material';
 import type { DialogTitleProps as MaterialDialogTitleProps } from '@mui/material/DialogTitle';
 import MaterialDialogTitle from '@mui/material/DialogTitle';
+import { XIcon } from 'lucide-react';
 import type { MouseEventHandler } from 'react';
 import { Button } from '@/components/ui/v2/Button';
-import { XIcon } from '@/components/ui/v2/icons/XIcon';
 
 export interface DialogTitleProps extends MaterialDialogTitleProps {
   /**
@@ -41,7 +41,7 @@ function DialogTitle({ children, onClose, ...props }: DialogTitleProps) {
           onClick={onClose}
           sx={{ padding: (theme) => theme.spacing(0.5), minWidth: 'initial' }}
         >
-          <XIcon fontSize="small" />
+          <XIcon className="h-5 w-5" />
         </Button>
       ) : null}
     </StyledDialogTitle>


### PR DESCRIPTION
### Checklist

- [x] No breaking changes
- [x] Tests pass
- [ ] New features have new tests
- [ ] Documentation is updated (if applicable)
- [x] Title of the PR is in the correct format (see below)

<!-- pi-reviewer:start -->
### **What this change solves**
Updates the dashboard DialogTitle close button to use the lucide React X icon while preserving the intended compact visual size.

___

### **Change Type**
Bug fix

___

### **Description**
- Replaces the DialogTitle close icon import with `lucide-react`'s `XIcon`.
- Updates the close icon sizing from the MUI `fontSize` prop to explicit height/width classes.

___

<details> <summary><h3> File Walkthrough</h3></summary>

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody>
<tr><td><strong>Dashboard UI</strong></td><td><details><summary>1 file</summary><table>
<tr>
  <td><strong>dashboard/src/components/ui/v2/Dialog/DialogTitle.tsx</strong><dd><code>Migrates the close button from the local X icon component to lucide-react with explicit sizing.</code></dd></td>
  <td>+2/-2</td>
</tr>
</table></details></td></tr>
</tbody></table>

</details>

___

<!-- pi-reviewer:end -->
