### PR TITLE
fix(dashboard): send support ticket services as strings

### DIFF
--- a/dashboard/src/pages/api/support/create-ticket.test.ts
+++ b/dashboard/src/pages/api/support/create-ticket.test.ts
@@ -75,7 +75,7 @@ describe('POST /api/support/create-ticket', () => {
       headers: { authorization: 'Bearer valid-token' },
       body: {
         project: 'test-subdomain',
-        services: [{ label: 'Authentication', value: 'Authentication' }],
+        services: ['Authentication'],
         priority: 'low',
         subject: 'Something is broken',
         description: 'Details about the problem',

--- a/dashboard/src/pages/api/support/create-ticket.ts
+++ b/dashboard/src/pages/api/support/create-ticket.ts
@@ -5,7 +5,7 @@ import { nhostRoutesClient } from '@/utils/nhost';
 
 export type CreateTicketRequest = {
   project: string;
-  services: Array<{ label: string; value: string }>;
+  services: string[];
   priority: string;
   subject: string;
   description: string;
@@ -184,7 +184,7 @@ export default async function handler(
               },
               {
                 id: 19922709880978, // field Affected Services
-                value: services.map((service) => service.value?.toLowerCase()),
+                value: services.map((service) => service.toLowerCase()),
               },
               {
                 id: 30691138027538, // field SLA

--- a/dashboard/src/pages/support/ticket.tsx
+++ b/dashboard/src/pages/support/ticket.tsx
@@ -45,7 +45,7 @@ const validationSchema = Yup.object({
   organization: Yup.string().label('Organization').required(),
   project: Yup.string().label('Project').required(),
   services: Yup.array()
-    .of(Yup.object({ label: Yup.string(), value: Yup.string() }))
+    .of(Yup.string().required())
     .label('Services')
     .required(),
   priority: Yup.string().label('Priority').required(),
@@ -221,15 +221,8 @@ function TicketPage() {
                       <FormItem className="flex flex-col gap-2">
                         <FormLabel className="font-bold">Services</FormLabel>
                         <MultiSelect
-                          values={(field.value || []).map(
-                            // biome-ignore lint/suspicious/noExplicitAny: Will be fixed later.
-                            (v: any) => v.value,
-                          )}
-                          onValuesChange={(nextValues) =>
-                            field.onChange(
-                              nextValues.map((v) => ({ label: v, value: v })),
-                            )
-                          }
+                          values={field.value ?? []}
+                          onValuesChange={field.onChange}
                         >
                           <FormControl>
                             <MultiSelectTrigger className="w-full rounded-sm hover:bg-accent-background dark:border-[#2f363d] dark:bg-[#171d26] dark:hover:bg-[#1b2534]">


### PR DESCRIPTION
### Checklist

- [ ] No breaking changes
- [ ] Tests pass
- [ ] New features have new tests
- [x] Documentation is updated (if applicable)
- [x] Title of the PR is in the correct format (see below)


<!-- pi-reviewer:start -->
### **What this change solves**
This change aligns the support ticket service selections with the string values emitted by the dashboard multi-select component. It sends affected services to the support ticket API as strings and lowercases them when building the external ticket payload.

___

### **Change Type**
Bug fix

___

### **Description**
- Update the support ticket request type so selected services are submitted as `string[]` instead of label/value objects.
- Validate service selections as required strings in the support ticket form schema.
- Pass multi-select values directly through the form and lower-case each selected service when creating the ticket payload.

___

<details> <summary><h3> File Walkthrough</h3></summary>

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody>
<tr><td><strong>Dashboard support</strong></td><td><details><summary>2 files</summary><table>
<tr>
  <td><strong>dashboard/src/pages/api/support/create-ticket.ts</strong><dd><code>Accepts services as strings and lowercases them for the affected-services ticket field.</code></dd></td>
  <td>+2/-2</td>
</tr>
<tr>
  <td><strong>dashboard/src/pages/support/ticket.tsx</strong><dd><code>Validates and stores support ticket service selections as strings from the multi-select.</code></dd></td>
  <td>+3/-10</td>
</tr>
</table></details></td></tr>
</tbody></table>

</details>

___

<!-- pi-reviewer:end -->
