### PR TITLE
fix(dashboard): migrate remote schema and data grid spinners

### DIFF
--- a/dashboard/src/features/orgs/projects/database/dataGrid/components/EditRelationshipsForm/EditRelationshipsForm.tsx
+++ b/dashboard/src/features/orgs/projects/database/dataGrid/components/EditRelationshipsForm/EditRelationshipsForm.tsx
@@ -1,8 +1,8 @@
 import { ArrowDown, Link2, Plug as PlugIcon, Split } from 'lucide-react';
 import { useRouter } from 'next/router';
-import { ActivityIndicator } from '@/components/ui/v2/ActivityIndicator';
 import { Alert } from '@/components/ui/v2/Alert';
 import { Button } from '@/components/ui/v3/button';
+import { Spinner } from '@/components/ui/v3/spinner';
 import {
   Table,
   TableBody,
@@ -73,7 +73,11 @@ export default function EditRelationshipsForm({
   if (isRelationshipsLoading || tableStatus === 'loading') {
     return (
       <div className="px-6">
-        <ActivityIndicator label="Loading relationships..." delay={1000} />
+        <Spinner size="xs" wrapperClassName="flex-row gap-1.5">
+          <span className="text-muted-foreground text-xs">
+            Loading relationships...
+          </span>
+        </Spinner>
       </div>
     );
   }

--- a/dashboard/src/features/orgs/projects/database/dataGrid/components/SQLEditor/SQLEditor.tsx
+++ b/dashboard/src/features/orgs/projects/database/dataGrid/components/SQLEditor/SQLEditor.tsx
@@ -8,7 +8,6 @@ import { InfoIcon, PlayIcon, XIcon } from 'lucide-react';
 import { useCallback, useState } from 'react';
 import { useResizable } from 'react-resizable-layout';
 import { Pagination } from '@/components/common/Pagination';
-import { ActivityIndicator } from '@/components/ui/v2/ActivityIndicator';
 import { Alert } from '@/components/ui/v2/Alert';
 import { Box } from '@/components/ui/v2/Box';
 import { Button } from '@/components/ui/v2/Button';
@@ -29,6 +28,7 @@ import {
   SelectTrigger,
   SelectValue,
 } from '@/components/ui/v3/select';
+import { Spinner } from '@/components/ui/v3/spinner';
 import { useIsPlatform } from '@/features/orgs/projects/common/hooks/useIsPlatform';
 import { useRunSQL } from '@/features/orgs/projects/database/dataGrid/hooks/useRunSQL';
 import {
@@ -263,9 +263,7 @@ export default function SQLEditor({
 
             {loading && (
               <Box className="flex flex-1 items-center justify-center p-4">
-                <ActivityIndicator
-                  circularProgressProps={{ className: 'w-5 h-5' }}
-                />
+                <Spinner className="h-5 w-5" />
               </Box>
             )}
 

--- a/dashboard/src/features/orgs/projects/remote-schemas/components/BaseRemoteSchemaRelationshipForm/sections/RemoteSchemaRelationshipForm.tsx
+++ b/dashboard/src/features/orgs/projects/remote-schemas/components/BaseRemoteSchemaRelationshipForm/sections/RemoteSchemaRelationshipForm.tsx
@@ -3,7 +3,6 @@ import { Anchor, InfoIcon } from 'lucide-react';
 import { useForm } from 'react-hook-form';
 import { z } from 'zod';
 import { FormCombobox } from '@/components/form/FormCombobox';
-import { ActivityIndicator } from '@/components/ui/v2/ActivityIndicator';
 import { Tooltip } from '@/components/ui/v2/Tooltip';
 import { Button } from '@/components/ui/v3/button';
 import {
@@ -115,11 +114,11 @@ export default function RemoteSchemaRelationshipForm({
 
   if (remoteSchemasQueryStatus === 'loading' || !remoteSchemas) {
     return (
-      <ActivityIndicator
-        delay={1000}
-        label="Loading remote schemas..."
-        className="justify-center"
-      />
+      <Spinner size="xs" wrapperClassName="flex-row gap-1.5 justify-center">
+        <span className="text-muted-foreground text-xs">
+          Loading remote schemas...
+        </span>
+      </Spinner>
     );
   }
 

--- a/dashboard/src/features/orgs/projects/remote-schemas/components/EditRemoteSchemaPermissionsForm/EditRemoteSchemaPermissionsForm.tsx
+++ b/dashboard/src/features/orgs/projects/remote-schemas/components/EditRemoteSchemaPermissionsForm/EditRemoteSchemaPermissionsForm.tsx
@@ -2,7 +2,6 @@ import Link from 'next/link';
 import { useState } from 'react';
 import { twMerge } from 'tailwind-merge';
 import { NavLink } from '@/components/common/NavLink';
-import { ActivityIndicator } from '@/components/ui/v2/ActivityIndicator';
 import { Alert } from '@/components/ui/v2/Alert';
 import { Box } from '@/components/ui/v2/Box';
 import { Button } from '@/components/ui/v2/Button';
@@ -16,6 +15,7 @@ import { Text } from '@/components/ui/v2/Text';
 import { FullPermissionIcon } from '@/components/ui/v3/icons/FullPermissionIcon';
 import { NoPermissionIcon } from '@/components/ui/v3/icons/NoPermissionIcon';
 import { PartialPermissionIcon } from '@/components/ui/v3/icons/PartialPermissionIcon';
+import { Spinner } from '@/components/ui/v3/spinner';
 import { useRemoteApplicationGQLClient } from '@/features/orgs/hooks/useRemoteApplicationGQLClient';
 import { useIsPlatform } from '@/features/orgs/projects/common/hooks/useIsPlatform';
 import { useCurrentOrg } from '@/features/orgs/projects/hooks/useCurrentOrg';
@@ -102,7 +102,11 @@ export default function EditRemoteSchemaPermissionsForm({
   ) {
     return (
       <div className="p-6">
-        <ActivityIndicator label="Loading available roles..." />
+        <Spinner size="xs" wrapperClassName="flex-row gap-1.5">
+          <span className="text-muted-foreground text-xs">
+            Loading available roles...
+          </span>
+        </Spinner>
       </div>
     );
   }

--- a/dashboard/src/features/orgs/projects/remote-schemas/components/EditRemoteSchemaPermissionsForm/RemoteSchemaRolePermissionsEditorForm.tsx
+++ b/dashboard/src/features/orgs/projects/remote-schemas/components/EditRemoteSchemaPermissionsForm/RemoteSchemaRolePermissionsEditorForm.tsx
@@ -8,7 +8,6 @@ import { useCallback, useEffect, useMemo, useState } from 'react';
 import { useForm } from 'react-hook-form';
 import { z } from 'zod';
 import { useDialog } from '@/components/common/DialogProvider';
-import { ActivityIndicator } from '@/components/ui/v2/ActivityIndicator';
 import { Alert } from '@/components/ui/v2/Alert';
 import { Box } from '@/components/ui/v2/Box';
 import { Button } from '@/components/ui/v2/Button';
@@ -22,6 +21,7 @@ import {
 import { Checkbox } from '@/components/ui/v3/checkbox';
 import { Form } from '@/components/ui/v3/form';
 import { Input } from '@/components/ui/v3/input';
+import { Spinner } from '@/components/ui/v3/spinner';
 import { useGetMetadataResourceVersion } from '@/features/orgs/projects/common/hooks/useGetMetadataResourceVersion';
 import { useIsPlatform } from '@/features/orgs/projects/common/hooks/useIsPlatform';
 import { useLocalMimirClient } from '@/features/orgs/projects/hooks/useLocalMimirClient';
@@ -518,7 +518,11 @@ export default function RemoteSchemaRolePermissionsEditorForm({
   if (isLoadingSchema) {
     return (
       <div className="p-6">
-        <ActivityIndicator label="Loading schema..." />
+        <Spinner size="xs" wrapperClassName="flex-row gap-1.5">
+          <span className="text-muted-foreground text-xs">
+            Loading schema...
+          </span>
+        </Spinner>
       </div>
     );
   }

--- a/dashboard/src/features/orgs/projects/remote-schemas/components/EditRemoteSchemaRelationships/EditRemoteSchemaRelationships.tsx
+++ b/dashboard/src/features/orgs/projects/remote-schemas/components/EditRemoteSchemaRelationships/EditRemoteSchemaRelationships.tsx
@@ -1,5 +1,5 @@
 import { useState } from 'react';
-import { ActivityIndicator } from '@/components/ui/v2/ActivityIndicator';
+import { Spinner } from '@/components/ui/v3/spinner';
 import { CreateRemoteSchemaRelationshipForm } from '@/features/orgs/projects/remote-schemas/components/CreateRemoteSchemaRelationshipForm';
 import { EditRemoteSchemaRelationshipForm } from '@/features/orgs/projects/remote-schemas/components/EditRemoteSchemaRelationshipForm';
 import { useGetRemoteSchemas } from '@/features/orgs/projects/remote-schemas/hooks/useGetRemoteSchemas';
@@ -52,11 +52,11 @@ export default function EditRemoteSchemaRelationships({
 
   if (status === 'loading') {
     return (
-      <ActivityIndicator
-        delay={1000}
-        label="Loading remote schema relationships..."
-        className="justify-center"
-      />
+      <Spinner size="xs" wrapperClassName="flex-row gap-1.5 justify-center">
+        <span className="text-muted-foreground text-xs">
+          Loading remote schema relationships...
+        </span>
+      </Spinner>
     );
   }
 

--- a/dashboard/src/features/orgs/projects/remote-schemas/components/RemoteSchemaBrowserSidebar/RemoteSchemaBrowserSidebar.tsx
+++ b/dashboard/src/features/orgs/projects/remote-schemas/components/RemoteSchemaBrowserSidebar/RemoteSchemaBrowserSidebar.tsx
@@ -15,7 +15,6 @@ import { ListNavLink } from '@/components/common/NavLink';
 import { FormActivityIndicator } from '@/components/form/FormActivityIndicator';
 import { FeatureSidebar } from '@/components/layout/FeatureSidebar';
 import { InlineCode } from '@/components/presentational/InlineCode';
-import { ActivityIndicator } from '@/components/ui/v2/ActivityIndicator';
 import { Box } from '@/components/ui/v2/Box';
 import { Button } from '@/components/ui/v2/Button';
 import { IconButton } from '@/components/ui/v2/IconButton';
@@ -28,6 +27,7 @@ import {
   DropdownMenuItem,
   DropdownMenuTrigger,
 } from '@/components/ui/v3/dropdown-menu';
+import { Spinner } from '@/components/ui/v3/spinner';
 import { useIsPlatform } from '@/features/orgs/projects/common/hooks/useIsPlatform';
 import { useProject } from '@/features/orgs/projects/hooks/useProject';
 import useGetRemoteSchemas from '@/features/orgs/projects/remote-schemas/hooks/useGetRemoteSchemas/useGetRemoteSchemas';
@@ -106,11 +106,11 @@ function RemoteSchemaBrowserSidebarContent({
 
   if (status === 'loading') {
     return (
-      <ActivityIndicator
-        delay={1000}
-        label="Loading remote schemas..."
-        className="justify-center"
-      />
+      <Spinner size="xs" wrapperClassName="flex-row gap-1.5 justify-center">
+        <span className="text-muted-foreground text-xs">
+          Loading remote schemas...
+        </span>
+      </Spinner>
     );
   }
 


### PR DESCRIPTION
<!-- pi-reviewer:start -->
### **What this change solves**
Migrates dashboard loading states in data grid and remote schema screens from the legacy ActivityIndicator to the v3 Spinner component while preserving the existing loading copy.

___

### **Change Type**
Refactoring

___

### **Description**
- Replaces ActivityIndicator imports and usages with v3 Spinner in data grid relationship and SQL loading states.
- Updates remote schema relationship, permission, and browser sidebar loading states to render Spinner with equivalent labels.
- Keeps existing loading messages and layout intent through Spinner sizing and wrapper classes.

___

<details> <summary><h3> File Walkthrough</h3></summary>

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody>
<tr><td><strong>Data grid loading states</strong></td><td><details><summary>2 files</summary><table>
<tr><td><strong>dashboard/src/features/orgs/projects/database/dataGrid/components/EditRelationshipsForm/EditRelationshipsForm.tsx</strong><dd><code>Uses v3 Spinner for the relationships loading state.</code></dd></td><td>+6/-2</td></tr>
<tr><td><strong>dashboard/src/features/orgs/projects/database/dataGrid/components/SQLEditor/SQLEditor.tsx</strong><dd><code>Uses v3 Spinner for SQL result loading feedback.</code></dd></td><td>+2/-4</td></tr>
</table></details></td></tr>
<tr><td><strong>Remote schema loading states</strong></td><td><details><summary>5 files</summary><table>
<tr><td><strong>dashboard/src/features/orgs/projects/remote-schemas/components/BaseRemoteSchemaRelationshipForm/sections/RemoteSchemaRelationshipForm.tsx</strong><dd><code>Uses v3 Spinner for remote schema relationship form loading.</code></dd></td><td>+5/-6</td></tr>
<tr><td><strong>dashboard/src/features/orgs/projects/remote-schemas/components/EditRemoteSchemaPermissionsForm/EditRemoteSchemaPermissionsForm.tsx</strong><dd><code>Uses v3 Spinner for available roles loading.</code></dd></td><td>+6/-2</td></tr>
<tr><td><strong>dashboard/src/features/orgs/projects/remote-schemas/components/EditRemoteSchemaPermissionsForm/RemoteSchemaRolePermissionsEditorForm.tsx</strong><dd><code>Uses v3 Spinner for schema loading in permissions editing.</code></dd></td><td>+6/-2</td></tr>
<tr><td><strong>dashboard/src/features/orgs/projects/remote-schemas/components/EditRemoteSchemaRelationships/EditRemoteSchemaRelationships.tsx</strong><dd><code>Uses v3 Spinner for remote schema relationships loading.</code></dd></td><td>+6/-6</td></tr>
<tr><td><strong>dashboard/src/features/orgs/projects/remote-schemas/components/RemoteSchemaBrowserSidebar/RemoteSchemaBrowserSidebar.tsx</strong><dd><code>Uses v3 Spinner for sidebar remote schema loading.</code></dd></td><td>+6/-6</td></tr>
</table></details></td></tr>
</tbody></table>

</details>

___

<!-- pi-reviewer:end -->
