### PR TITLE
fix(dashboard): migrate deployments and overview spinners

### DIFF
--- a/dashboard/src/features/orgs/projects/deployments/components/AppDeployments/AppDeployments.tsx
+++ b/dashboard/src/features/orgs/projects/deployments/components/AppDeployments/AppDeployments.tsx
@@ -2,10 +2,10 @@ import { ChevronLeftIcon, ChevronRightIcon } from 'lucide-react';
 import NextLink from 'next/link';
 import { useRouter } from 'next/router';
 import { Fragment } from 'react';
-import { ActivityIndicator } from '@/components/ui/v2/ActivityIndicator';
 import { Divider } from '@/components/ui/v2/Divider';
 import { List } from '@/components/ui/v2/List';
 import { Text } from '@/components/ui/v2/Text';
+import { Spinner } from '@/components/ui/v3/spinner';
 import { DeploymentListItem } from '@/features/orgs/projects/deployments/components/DeploymentListItem';
 import {
   useGetUnifiedDeploymentsSubSubscription,
@@ -85,11 +85,11 @@ export default function AppDeployments(props: AppDeploymentsProps) {
 
   if (loading || latestLiveLoading || pendingOrRunningLoading) {
     return (
-      <ActivityIndicator
-        delay={500}
-        className="mt-12"
-        label="Loading deployments..."
-      />
+      <Spinner size="xs" wrapperClassName="mt-12 flex-row gap-1.5">
+        <span className="text-muted-foreground text-xs">
+          Loading deployments...
+        </span>
+      </Spinner>
     );
   }
 

--- a/dashboard/src/features/orgs/projects/deployments/components/DeploymentDetails/DeploymentDetails.tsx
+++ b/dashboard/src/features/orgs/projects/deployments/components/DeploymentDetails/DeploymentDetails.tsx
@@ -3,7 +3,6 @@ import { useEffect, useMemo, useRef, useState } from 'react';
 import { Container } from '@/components/layout/Container';
 import type { DeploymentStatus } from '@/components/presentational/StatusCircle';
 import { StatusCircle } from '@/components/presentational/StatusCircle';
-import { ActivityIndicator } from '@/components/ui/v2/ActivityIndicator';
 import { Avatar } from '@/components/ui/v2/Avatar';
 import { Box } from '@/components/ui/v2/Box';
 import { Text } from '@/components/ui/v2/Text';
@@ -13,6 +12,7 @@ import {
   AccordionItem,
   AccordionTrigger,
 } from '@/components/ui/v3/accordion';
+import { Spinner } from '@/components/ui/v3/spinner';
 import { TextLink } from '@/components/ui/v3/text-link';
 import {
   Tooltip,
@@ -466,7 +466,11 @@ function DeploymentDetails() {
   if (loading || legacyLoading) {
     return (
       <Container>
-        <ActivityIndicator delay={500} label="Loading deployment..." />
+        <Spinner size="xs" wrapperClassName="flex-row gap-1.5">
+          <span className="text-muted-foreground text-xs">
+            Loading deployment...
+          </span>
+        </Spinner>
       </Container>
     );
   }

--- a/dashboard/src/features/orgs/projects/deployments/components/DeploymentServiceLogs/DeploymentServiceLogsHeader.tsx
+++ b/dashboard/src/features/orgs/projects/deployments/components/DeploymentServiceLogs/DeploymentServiceLogsHeader.tsx
@@ -1,10 +1,9 @@
 import { yupResolver } from '@hookform/resolvers/yup';
-import { SearchIcon } from 'lucide-react';
+import { Loader2, SearchIcon } from 'lucide-react';
 import { memo, useEffect } from 'react';
 import { FormProvider, useForm } from 'react-hook-form';
 import * as Yup from 'yup';
 import { Form } from '@/components/form/Form';
-import { ActivityIndicator } from '@/components/ui/v2/ActivityIndicator';
 import { Box } from '@/components/ui/v2/Box';
 import { Button } from '@/components/ui/v2/Button';
 import { LogsRegexFilter } from '@/features/orgs/projects/common/components/LogsRegexFilter';
@@ -64,7 +63,7 @@ function DeploymentLogsHeader({ onSubmit, loading, from, to }: Props) {
             startIcon={
               <div className="flex h-5 w-5 items-center justify-center">
                 {loading ? (
-                  <ActivityIndicator className="h-5 w-5" />
+                  <Loader2 className="h-5 w-5 animate-spin" />
                 ) : (
                   <SearchIcon className="h-5 w-5" />
                 )}

--- a/dashboard/src/features/orgs/projects/overview/components/OverviewDeployments/OverviewDeployments.tsx
+++ b/dashboard/src/features/orgs/projects/overview/components/OverviewDeployments/OverviewDeployments.tsx
@@ -2,12 +2,12 @@ import { SiGithub as GitHubIcon } from '@icons-pack/react-simple-icons';
 import { ChevronRightIcon, RocketIcon } from 'lucide-react';
 import { Fragment } from 'react';
 import { NavLink } from '@/components/common/NavLink';
-import { ActivityIndicator } from '@/components/ui/v2/ActivityIndicator';
 import { Box } from '@/components/ui/v2/Box';
 import { Button } from '@/components/ui/v2/Button';
 import { Divider } from '@/components/ui/v2/Divider';
 import { List } from '@/components/ui/v2/List';
 import { Text } from '@/components/ui/v2/Text';
+import { Spinner } from '@/components/ui/v3/spinner';
 import { DeploymentListItem } from '@/features/orgs/projects/deployments/components/DeploymentListItem';
 import { useGitHubModal } from '@/features/orgs/projects/git/common/hooks/useGitHubModal';
 import { useCurrentOrg } from '@/features/orgs/projects/hooks/useCurrentOrg';
@@ -69,7 +69,11 @@ function OverviewDeploymentList() {
   if (loading || latestLiveLoading || pendingOrRunningLoading) {
     return (
       <Box className="h-[323px] rounded-lg border-1 p-2">
-        <ActivityIndicator label="Loading deployments..." />
+        <Spinner size="xs" wrapperClassName="flex-row gap-1.5">
+          <span className="text-muted-foreground text-xs">
+            Loading deployments...
+          </span>
+        </Spinner>
       </Box>
     );
   }
@@ -145,7 +149,13 @@ export default function OverviewDeployments() {
   const isGitHubConnected = !!project?.githubRepository;
 
   if (loading) {
-    return <ActivityIndicator label="Loading project info..." delay={1000} />;
+    return (
+      <Spinner size="xs" wrapperClassName="flex-row gap-1.5">
+        <span className="text-muted-foreground text-xs">
+          Loading project info...
+        </span>
+      </Spinner>
+    );
   }
 
   // GitHub repo connected. Show deployments


### PR DESCRIPTION
<!-- pi-reviewer:start -->
### **What this change solves**
Migrates deployment and overview loading indicators from the legacy ActivityIndicator to newer spinner patterns while preserving existing loading labels and button feedback.

___

### **Change Type**
Refactoring

___

### **Description**
- Replaces deployment list and detail loading states with the v3 Spinner component.
- Updates deployment log search button loading feedback to use an animated Loader2 icon.
- Migrates project overview deployment loading states to Spinner with the existing user-facing copy.

___

<details> <summary><h3> File Walkthrough</h3></summary>

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody>
<tr><td><strong>Deployments</strong></td><td><details><summary>3 files</summary><table>
<tr><td><strong>dashboard/src/features/orgs/projects/deployments/components/AppDeployments/AppDeployments.tsx</strong><dd><code>Uses v3 Spinner for deployments list loading.</code></dd></td><td>+6/-6</td></tr>
<tr><td><strong>dashboard/src/features/orgs/projects/deployments/components/DeploymentDetails/DeploymentDetails.tsx</strong><dd><code>Uses v3 Spinner for deployment details loading.</code></dd></td><td>+6/-2</td></tr>
<tr><td><strong>dashboard/src/features/orgs/projects/deployments/components/DeploymentServiceLogs/DeploymentServiceLogsHeader.tsx</strong><dd><code>Uses animated Loader2 for log search loading state.</code></dd></td><td>+2/-3</td></tr>
</table></details></td></tr>
<tr><td><strong>Overview</strong></td><td><details><summary>1 file</summary><table>
<tr><td><strong>dashboard/src/features/orgs/projects/overview/components/OverviewDeployments/OverviewDeployments.tsx</strong><dd><code>Uses v3 Spinner for overview deployment and project info loading states.</code></dd></td><td>+13/-3</td></tr>
</table></details></td></tr>
</tbody></table>

</details>

___

<!-- pi-reviewer:end -->
