### PR TITLE
fix(dashboard): migrate org, billing, and dialog spinners

### DIFF
--- a/dashboard/src/components/common/SelectOrg/SelectOrg.tsx
+++ b/dashboard/src/components/common/SelectOrg/SelectOrg.tsx
@@ -5,13 +5,13 @@ import { useRouter } from 'next/router';
 import type { ChangeEvent } from 'react';
 import { Fragment, useEffect, useMemo, useState } from 'react';
 import { RetryableErrorBoundary } from '@/components/presentational/RetryableErrorBoundary';
-import { ActivityIndicator } from '@/components/ui/v2/ActivityIndicator';
 import { Box } from '@/components/ui/v2/Box';
 import { Button } from '@/components/ui/v2/Button';
 import { Input } from '@/components/ui/v2/Input';
 import { List } from '@/components/ui/v2/List';
 import { ListItem } from '@/components/ui/v2/ListItem';
 import { Text } from '@/components/ui/v2/Text';
+import { Spinner } from '@/components/ui/v3/spinner';
 import { useOrgs } from '@/features/orgs/projects/hooks/useOrgs';
 
 export default function SelectOrganizationAndProject() {
@@ -56,7 +56,11 @@ export default function SelectOrganizationAndProject() {
   if (loading) {
     return (
       <div className="flex w-full justify-center">
-        <ActivityIndicator delay={500} label="Loading organizations..." />
+        <Spinner size="xs" wrapperClassName="flex-row gap-1.5">
+          <span className="text-muted-foreground text-xs">
+            Loading organizations...
+          </span>
+        </Spinner>
       </div>
     );
   }

--- a/dashboard/src/components/common/SelectOrgAndProject/SelectOrgAndProject.tsx
+++ b/dashboard/src/components/common/SelectOrgAndProject/SelectOrgAndProject.tsx
@@ -5,13 +5,13 @@ import { useRouter } from 'next/router';
 import type { ChangeEvent } from 'react';
 import { Fragment, useEffect, useMemo, useState } from 'react';
 import { RetryableErrorBoundary } from '@/components/presentational/RetryableErrorBoundary';
-import { ActivityIndicator } from '@/components/ui/v2/ActivityIndicator';
 import { Box } from '@/components/ui/v2/Box';
 import { Button } from '@/components/ui/v2/Button';
 import { Input } from '@/components/ui/v2/Input';
 import { List } from '@/components/ui/v2/List';
 import { ListItem } from '@/components/ui/v2/ListItem';
 import { Text } from '@/components/ui/v2/Text';
+import { Spinner } from '@/components/ui/v3/spinner';
 import { useOrgs } from '@/features/orgs/projects/hooks/useOrgs';
 
 export default function SelectOrganizationAndProject() {
@@ -63,10 +63,11 @@ export default function SelectOrganizationAndProject() {
   if (loading) {
     return (
       <div className="flex w-full justify-center">
-        <ActivityIndicator
-          delay={500}
-          label="Loading organizations and projects..."
-        />
+        <Spinner size="xs" wrapperClassName="flex-row gap-1.5">
+          <span className="text-muted-foreground text-xs">
+            Loading organizations and projects...
+          </span>
+        </Spinner>
       </div>
     );
   }

--- a/dashboard/src/features/orgs/components/CreateOrgFormDialog/CreateOrgFormDialog.tsx
+++ b/dashboard/src/features/orgs/components/CreateOrgFormDialog/CreateOrgFormDialog.tsx
@@ -5,7 +5,6 @@ import { useRouter } from 'next/router';
 import { useState } from 'react';
 import { useForm } from 'react-hook-form';
 import { z } from 'zod';
-import { ActivityIndicator } from '@/components/ui/v2/ActivityIndicator';
 import { Button, ButtonWithLoading } from '@/components/ui/v3/button';
 import {
   Dialog,
@@ -32,6 +31,7 @@ import {
   SelectTrigger,
   SelectValue,
 } from '@/components/ui/v3/select';
+import { Spinner } from '@/components/ui/v3/spinner';
 import { TextLink } from '@/components/ui/v3/text-link';
 import {
   Tooltip,
@@ -396,11 +396,7 @@ export default function CreateOrgDialog({
 
         {loading && (
           <div className="flex h-52 items-center justify-center">
-            <ActivityIndicator
-              circularProgressProps={{
-                className: 'w-5 h-5',
-              }}
-            />
+            <Spinner className="h-5 w-5" />
           </div>
         )}
         {data && !loading && !stripeClientSecret && (

--- a/dashboard/src/features/orgs/components/billing/BillingEstimate/components/BillingDetails/BillingDetails.tsx
+++ b/dashboard/src/features/orgs/components/billing/BillingEstimate/components/BillingDetails/BillingDetails.tsx
@@ -1,4 +1,3 @@
-import { ActivityIndicator } from '@/components/ui/v2/ActivityIndicator';
 import {
   Accordion,
   AccordionContent,
@@ -6,6 +5,7 @@ import {
   AccordionTrigger,
 } from '@/components/ui/v3/accordion';
 import { Alert, AlertDescription, AlertTitle } from '@/components/ui/v3/alert';
+import { Spinner } from '@/components/ui/v3/spinner';
 import {
   Table,
   TableBody,
@@ -36,10 +36,14 @@ export default function BillingDetails() {
       <div className="flex flex-col">
         <div className="flex flex-col gap-4 p-4">
           <div className="flex h-32 place-content-center">
-            <ActivityIndicator
-              label="Loading billing details..."
-              className="justify-center text-sm"
-            />
+            <Spinner
+              size="xs"
+              wrapperClassName="flex-row justify-center gap-1.5"
+            >
+              <span className="text-muted-foreground text-xs">
+                Loading billing details...
+              </span>
+            </Spinner>
           </div>
         </div>
       </div>

--- a/dashboard/src/features/orgs/components/billing/BillingEstimate/components/SpendingNotifications/SpendingNotifications.tsx
+++ b/dashboard/src/features/orgs/components/billing/BillingEstimate/components/SpendingNotifications/SpendingNotifications.tsx
@@ -2,7 +2,6 @@ import { yupResolver } from '@hookform/resolvers/yup';
 import { type ChangeEvent, useEffect, useMemo } from 'react';
 import { useForm } from 'react-hook-form';
 import * as Yup from 'yup';
-import { ActivityIndicator } from '@/components/ui/v2/ActivityIndicator';
 import { Switch } from '@/components/ui/v2/Switch';
 import { ButtonWithLoading } from '@/components/ui/v3/button';
 import {
@@ -15,6 +14,7 @@ import {
 } from '@/components/ui/v3/form';
 import { Input } from '@/components/ui/v3/input';
 import { Progress } from '@/components/ui/v3/progress';
+import { Spinner } from '@/components/ui/v3/spinner';
 import {
   Tooltip,
   TooltipContent,
@@ -174,10 +174,14 @@ export default function SpendingNotifications() {
       <div className="flex flex-col">
         <div className="flex flex-col gap-4 p-4">
           <div className="flex h-32 place-content-center">
-            <ActivityIndicator
-              label="Loading spending notifications..."
-              className="justify-center text-sm"
-            />
+            <Spinner
+              size="xs"
+              wrapperClassName="flex-row justify-center gap-1.5"
+            >
+              <span className="text-muted-foreground text-xs">
+                Loading spending notifications...
+              </span>
+            </Spinner>
           </div>
         </div>
       </div>

--- a/dashboard/src/features/orgs/components/common/FinishOrganizationProcess/FinishOrganizationProcess.tsx
+++ b/dashboard/src/features/orgs/components/common/FinishOrganizationProcess/FinishOrganizationProcess.tsx
@@ -1,6 +1,6 @@
 import { memo } from 'react';
-import { ActivityIndicator } from '@/components/ui/v2/ActivityIndicator';
 import { DialogDescription } from '@/components/ui/v3/dialog';
+import { Spinner } from '@/components/ui/v3/spinner';
 import { useFinishOrganizationProcess } from '@/features/orgs/hooks/useFinishOrganizationProcess';
 import type { FinishOrgCreationOnCompletedCb } from '@/features/orgs/hooks/useFinishOrganizationProcess/useFinishOrganizationProcess';
 import { CheckoutStatus } from '@/utils/__generated__/graphql';
@@ -57,7 +57,7 @@ function FinishOrgCreationProcess({
     <div className="relative flex flex-auto overflow-x-hidden">
       <div className="flex h-full w-full flex-col items-center justify-center space-y-2">
         {(loading || status === CheckoutStatus.Completed) && (
-          <ActivityIndicator circularProgressProps={{ className: 'w-6 h-6' }} />
+          <Spinner size="small" />
         )}
         <Component data-testid="message">{message}</Component>
       </div>

--- a/dashboard/src/features/orgs/components/general/components/DeleteOrg/DeleteOrg.tsx
+++ b/dashboard/src/features/orgs/components/general/components/DeleteOrg/DeleteOrg.tsx
@@ -1,6 +1,6 @@
+import { Loader2 } from 'lucide-react';
 import { useRouter } from 'next/router';
 import { useState } from 'react';
-import { ActivityIndicator } from '@/components/ui/v2/ActivityIndicator';
 import {
   AlertDialog,
   AlertDialogAction,
@@ -127,7 +127,11 @@ export default function DeleteOrg() {
                 className={buttonVariants({ variant: 'destructive' })}
                 disabled={deleting || !(deleteCheck1 && deleteCheck2)}
               >
-                {deleting ? <ActivityIndicator /> : 'Delete'}
+                {deleting ? (
+                  <Loader2 className="h-4 w-4 animate-spin" />
+                ) : (
+                  'Delete'
+                )}
               </AlertDialogAction>
             </AlertDialogFooter>
           </AlertDialogContent>

--- a/dashboard/src/features/orgs/components/members/components/OrgInvite/OrgInvite.tsx
+++ b/dashboard/src/features/orgs/components/members/components/OrgInvite/OrgInvite.tsx
@@ -1,9 +1,8 @@
 import { zodResolver } from '@hookform/resolvers/zod';
-import { Ellipsis } from 'lucide-react';
+import { Ellipsis, Loader2 } from 'lucide-react';
 import { useState } from 'react';
 import { useForm } from 'react-hook-form';
 import { z } from 'zod';
-import { ActivityIndicator } from '@/components/ui/v2/ActivityIndicator';
 import {
   AlertDialog,
   AlertDialogAction,
@@ -200,7 +199,11 @@ export default function OrgInvite({ invite, isAdmin }: InviteProps) {
               className={buttonVariants({ variant: 'destructive' })}
               disabled={deleting}
             >
-              {deleting ? <ActivityIndicator /> : 'Delete'}
+              {deleting ? (
+                <Loader2 className="h-4 w-4 animate-spin" />
+              ) : (
+                'Delete'
+              )}
             </AlertDialogAction>
           </AlertDialogFooter>
         </AlertDialogContent>

--- a/dashboard/src/features/orgs/components/members/components/PendingInvites/PendingInvites.tsx
+++ b/dashboard/src/features/orgs/components/members/components/PendingInvites/PendingInvites.tsx
@@ -3,7 +3,6 @@ import { Inbox, TriangleAlert } from 'lucide-react';
 import { useState } from 'react';
 import { useForm } from 'react-hook-form';
 import { z } from 'zod';
-import { ActivityIndicator } from '@/components/ui/v2/ActivityIndicator';
 import { Alert } from '@/components/ui/v2/Alert';
 import { Button } from '@/components/ui/v3/button';
 import {
@@ -31,6 +30,7 @@ import {
   SelectTrigger,
   SelectValue,
 } from '@/components/ui/v3/select';
+import { Spinner } from '@/components/ui/v3/spinner';
 import { OrgInvite } from '@/features/orgs/components/members/components/OrgInvite';
 import { useIsOrgAdmin } from '@/features/orgs/hooks/useIsOrgAdmin';
 import { useCurrentOrg } from '@/features/orgs/projects/hooks/useCurrentOrg';
@@ -248,11 +248,11 @@ export default function PendingInvites() {
       {/* Todo add an empty state here */}
       <div className="flex w-full flex-col items-center gap-4 p-4">
         {loading && (
-          <ActivityIndicator
-            delay={1000}
-            label="Loading pending invites..."
-            className="justify-center text-sm"
-          />
+          <Spinner size="xs" wrapperClassName="flex-row justify-center gap-1.5">
+            <span className="text-muted-foreground text-xs">
+              Loading pending invites...
+            </span>
+          </Spinner>
         )}
 
         {!loading &&

--- a/dashboard/src/features/orgs/projects/git/common/components/ConnectGitHubModal/ConnectGitHubModal.tsx
+++ b/dashboard/src/features/orgs/projects/git/common/components/ConnectGitHubModal/ConnectGitHubModal.tsx
@@ -11,7 +11,6 @@ import { Fragment, useEffect, useMemo, useState } from 'react';
 import toast from 'react-hot-toast';
 import { ErrorMessage } from '@/components/presentational/ErrorMessage';
 import { RetryableErrorBoundary } from '@/components/presentational/RetryableErrorBoundary';
-import { ActivityIndicator } from '@/components/ui/v2/ActivityIndicator';
 import { Avatar } from '@/components/ui/v2/Avatar';
 import { Box } from '@/components/ui/v2/Box';
 import { Button } from '@/components/ui/v2/Button';
@@ -19,6 +18,7 @@ import { Input } from '@/components/ui/v2/Input';
 import { List } from '@/components/ui/v2/List';
 import { ListItem } from '@/components/ui/v2/ListItem';
 import { Text } from '@/components/ui/v2/Text';
+import { Spinner } from '@/components/ui/v3/spinner';
 import { GithubAuthButton } from '@/features/auth/AuthProviders/Github/GithubAuthButton';
 import { useHostName } from '@/features/orgs/projects/common/hooks/useHostName';
 import { EditRepositorySettings } from '@/features/orgs/projects/git/common/components/EditRepositorySettings';
@@ -261,7 +261,7 @@ export default function ConnectGitHubModal({ close }: ConnectGitHubModalProps) {
               </div>
             </div>
             <div className="flex h-import items-center justify-center border-y">
-              <ActivityIndicator delay={0} label="" />
+              <Spinner size="xs" />
             </div>
           </div>
         </div>

--- a/dashboard/src/utils/toast/showLoadingToast.tsx
+++ b/dashboard/src/utils/toast/showLoadingToast.tsx
@@ -1,8 +1,8 @@
 import { ThemeProvider } from '@mui/material';
 import clsx from 'clsx';
+import { Loader2 } from 'lucide-react';
 import type { ToastOptions } from 'react-hot-toast';
 import { toast } from 'react-hot-toast';
-import { ActivityIndicator } from '@/components/ui/v2/ActivityIndicator';
 import { Box } from '@/components/ui/v2/Box';
 import { createTheme } from '@/components/ui/v2/createTheme';
 import getColor from './getColor';
@@ -25,7 +25,10 @@ export default function showLoadingToast(message: string, opts?: ToastOptions) {
           }}
         >
           <ThemeProvider theme={createTheme('dark')}>
-            <ActivityIndicator label={message} />
+            <span className="flex flex-row items-center gap-1.5">
+              <Loader2 className="h-3 w-3 animate-spin" />
+              <span className="text-xs">{message}</span>
+            </span>
           </ThemeProvider>
         </Box>
       </ThemeProvider>


### PR DESCRIPTION
<!-- pi-reviewer:start -->
### **What this change solves**
Migrates organization-level and shared dashboard loading indicators away from the legacy ActivityIndicator toward v3 Spinner or lucide Loader2 patterns.

___

### **Change Type**
Refactoring

___

### **Description**
- Replaces organization/project selection and billing loading states with v3 Spinner.
- Updates organization dialog, invite deletion, GitHub connection, and toast loading feedback to newer spinner icons.
- Preserves existing loading text while moving the affected UI surfaces off the legacy ActivityIndicator component.

___

<details> <summary><h3> File Walkthrough</h3></summary>

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody>
<tr><td><strong>Shared selectors and org flows</strong></td><td><details><summary>4 files</summary><table>
<tr><td><strong>dashboard/src/components/common/SelectOrg/SelectOrg.tsx</strong><dd><code>Uses v3 Spinner for organization loading.</code></dd></td><td>+6/-2</td></tr>
<tr><td><strong>dashboard/src/components/common/SelectOrgAndProject/SelectOrgAndProject.tsx</strong><dd><code>Uses v3 Spinner for organization/project loading.</code></dd></td><td>+6/-5</td></tr>
<tr><td><strong>dashboard/src/features/orgs/components/CreateOrgFormDialog/CreateOrgFormDialog.tsx</strong><dd><code>Uses v3 Spinner in organization creation loading UI.</code></dd></td><td>+2/-6</td></tr>
<tr><td><strong>dashboard/src/features/orgs/components/common/FinishOrganizationProcess/FinishOrganizationProcess.tsx</strong><dd><code>Uses Loader2 for finishing-organization spinner feedback.</code></dd></td><td>+2/-2</td></tr>
</table></details></td></tr>
<tr><td><strong>Billing and members</strong></td><td><details><summary>5 files</summary><table>
<tr><td><strong>dashboard/src/features/orgs/components/billing/BillingEstimate/components/BillingDetails/BillingDetails.tsx</strong><dd><code>Uses v3 Spinner for billing details loading.</code></dd></td><td>+6/-5</td></tr>
<tr><td><strong>dashboard/src/features/orgs/components/billing/BillingEstimate/components/SpendingNotifications/SpendingNotifications.tsx</strong><dd><code>Uses v3 Spinner for spending notification loading.</code></dd></td><td>+6/-5</td></tr>
<tr><td><strong>dashboard/src/features/orgs/components/general/components/DeleteOrg/DeleteOrg.tsx</strong><dd><code>Uses Loader2 for delete organization button progress.</code></dd></td><td>+6/-2</td></tr>
<tr><td><strong>dashboard/src/features/orgs/components/members/components/OrgInvite/OrgInvite.tsx</strong><dd><code>Uses Loader2 for invite deletion progress.</code></dd></td><td>+6/-3</td></tr>
<tr><td><strong>dashboard/src/features/orgs/components/members/components/PendingInvites/PendingInvites.tsx</strong><dd><code>Uses v3 Spinner for pending invite loading.</code></dd></td><td>+6/-6</td></tr>
</table></details></td></tr>
<tr><td><strong>GitHub and toast feedback</strong></td><td><details><summary>2 files</summary><table>
<tr><td><strong>dashboard/src/features/orgs/projects/git/common/components/ConnectGitHubModal/ConnectGitHubModal.tsx</strong><dd><code>Uses v3 Spinner while GitHub data loads.</code></dd></td><td>+2/-2</td></tr>
<tr><td><strong>dashboard/src/utils/toast/showLoadingToast.tsx</strong><dd><code>Uses Loader2 and inline text for loading toasts.</code></dd></td><td>+5/-2</td></tr>
</table></details></td></tr>
</tbody></table>

</details>

___

<!-- pi-reviewer:end -->
