### PR TITLE
fix(dashboard): migrate remaining page spinners

### DIFF
--- a/dashboard/src/pages/orgs/[orgSlug]/projects/[appSubdomain]/ai/assistants/index.tsx
+++ b/dashboard/src/pages/orgs/[orgSlug]/projects/[appSubdomain]/ai/assistants/index.tsx
@@ -5,11 +5,11 @@ import { useDialog } from '@/components/common/DialogProvider';
 import { UpgradeToProBanner } from '@/components/common/UpgradeToProBanner';
 import { Container } from '@/components/layout/Container';
 import { RetryableErrorBoundary } from '@/components/presentational/RetryableErrorBoundary';
-import { ActivityIndicator } from '@/components/ui/v2/ActivityIndicator';
 import { Alert } from '@/components/ui/v2/Alert';
 import { Box } from '@/components/ui/v2/Box';
 import { Button } from '@/components/ui/v2/Button';
 import { Text } from '@/components/ui/v2/Text';
+import { Spinner } from '@/components/ui/v3/spinner';
 import { useRemoteApplicationGQLClient } from '@/features/orgs/hooks/useRemoteApplicationGQLClient';
 import { AISidebar } from '@/features/orgs/layout/AISidebar';
 import { OrgLayout } from '@/features/orgs/layout/OrgLayout';
@@ -86,11 +86,9 @@ export default function AssistantsPage() {
   if (loadingOrg || loadingProject || loadingGraphite || assistantsLoading) {
     return (
       <Box className="flex h-full w-full items-center justify-center">
-        <ActivityIndicator
-          delay={1000}
-          label="Loading Assistants..."
-          className="justify-center"
-        />
+        <Spinner size="medium" wrapperClassName="gap-2">
+          Loading Assistants...
+        </Spinner>
       </Box>
     );
   }

--- a/dashboard/src/pages/orgs/[orgSlug]/projects/[appSubdomain]/ai/file-stores/index.tsx
+++ b/dashboard/src/pages/orgs/[orgSlug]/projects/[appSubdomain]/ai/file-stores/index.tsx
@@ -4,12 +4,12 @@ import { type ReactElement, useMemo } from 'react';
 import { useDialog } from '@/components/common/DialogProvider';
 import { UpgradeToProBanner } from '@/components/common/UpgradeToProBanner';
 import { RetryableErrorBoundary } from '@/components/presentational/RetryableErrorBoundary';
-import { ActivityIndicator } from '@/components/ui/v2/ActivityIndicator';
 import { Alert } from '@/components/ui/v2/Alert';
 import { Box } from '@/components/ui/v2/Box';
 import { Button } from '@/components/ui/v2/Button';
 import { Text } from '@/components/ui/v2/Text';
 import { FileStoresIcon } from '@/components/ui/v3/icons/FileStoresIcon';
+import { Spinner } from '@/components/ui/v3/spinner';
 import { useRemoteApplicationGQLClient } from '@/features/orgs/hooks/useRemoteApplicationGQLClient';
 import { AISidebar } from '@/features/orgs/layout/AISidebar';
 import { OrgLayout } from '@/features/orgs/layout/OrgLayout';
@@ -57,11 +57,9 @@ export default function FileStoresPage() {
   if (loadingOrg || loadingProject || loading) {
     return (
       <Box className="flex h-full w-full items-center justify-center">
-        <ActivityIndicator
-          delay={1000}
-          label="Loading File Stores..."
-          className="justify-center"
-        />
+        <Spinner size="medium" wrapperClassName="gap-2">
+          Loading File Stores...
+        </Spinner>
       </Box>
     );
   }

--- a/dashboard/src/pages/orgs/[orgSlug]/projects/[appSubdomain]/auth/oauth2-clients.tsx
+++ b/dashboard/src/pages/orgs/[orgSlug]/projects/[appSubdomain]/auth/oauth2-clients.tsx
@@ -7,11 +7,11 @@ import { useDialog } from '@/components/common/DialogProvider';
 import { Pagination } from '@/components/common/Pagination';
 import { Container } from '@/components/layout/Container';
 import { RetryableErrorBoundary } from '@/components/presentational/RetryableErrorBoundary';
-import { ActivityIndicator } from '@/components/ui/v2/ActivityIndicator';
 import { Box } from '@/components/ui/v2/Box';
 import { Button } from '@/components/ui/v2/Button';
 import { Input } from '@/components/ui/v2/Input';
 import { Text } from '@/components/ui/v2/Text';
+import { Spinner } from '@/components/ui/v3/spinner';
 import { useRemoteApplicationGQLClient } from '@/features/orgs/hooks/useRemoteApplicationGQLClient';
 import { OrgLayout } from '@/features/orgs/layout/OrgLayout';
 import { MIN_AUTH_VERSION_OAUTH2 } from '@/features/orgs/projects/authentication/oauth2/constants';
@@ -152,7 +152,9 @@ function OAuth2ClientsPageContent() {
         rootClassName="h-full"
       >
         <div className="flex flex-auto items-center justify-center overflow-hidden">
-          <ActivityIndicator label="Loading..." />
+          <Spinner size="medium" wrapperClassName="gap-2">
+            Loading...
+          </Spinner>
         </div>
       </Container>
     );
@@ -197,7 +199,9 @@ function OAuth2ClientsPageContent() {
         rootClassName="h-full"
       >
         <div className="flex flex-auto items-center justify-center overflow-hidden">
-          <ActivityIndicator label="Loading OAuth2 settings..." />
+          <Spinner size="medium" wrapperClassName="gap-2">
+            Loading OAuth2 settings...
+          </Spinner>
         </div>
       </Container>
     );
@@ -259,7 +263,9 @@ function OAuth2ClientsPageContent() {
           </Button>
         </div>
         <div className="flex flex-auto items-center justify-center overflow-hidden">
-          <ActivityIndicator label="Loading OAuth2 clients..." />
+          <Spinner size="medium" wrapperClassName="gap-2">
+            Loading OAuth2 clients...
+          </Spinner>
         </div>
       </Container>
     );

--- a/dashboard/src/pages/orgs/[orgSlug]/projects/[appSubdomain]/auth/users.tsx
+++ b/dashboard/src/pages/orgs/[orgSlug]/projects/[appSubdomain]/auth/users.tsx
@@ -7,11 +7,11 @@ import { useDialog } from '@/components/common/DialogProvider';
 import { Pagination } from '@/components/common/Pagination';
 import { Container } from '@/components/layout/Container';
 import { RetryableErrorBoundary } from '@/components/presentational/RetryableErrorBoundary';
-import { ActivityIndicator } from '@/components/ui/v2/ActivityIndicator';
 import { Box } from '@/components/ui/v2/Box';
 import { Button } from '@/components/ui/v2/Button';
 import { Input } from '@/components/ui/v2/Input';
 import { Text } from '@/components/ui/v2/Text';
+import { Spinner } from '@/components/ui/v3/spinner';
 import { useRemoteApplicationGQLClient } from '@/features/orgs/hooks/useRemoteApplicationGQLClient';
 import { OrgLayout } from '@/features/orgs/layout/OrgLayout';
 import { CreateUserForm } from '@/features/orgs/projects/authentication/users/components/CreateUserForm';
@@ -239,7 +239,9 @@ function UsersPageContent() {
         </div>
 
         <div className="flex flex-auto items-center justify-center overflow-hidden">
-          <ActivityIndicator label="Loading users..." />
+          <Spinner size="medium" wrapperClassName="gap-2">
+            Loading users...
+          </Spinner>
         </div>
       </Container>
     );

--- a/dashboard/src/pages/orgs/[orgSlug]/projects/[appSubdomain]/graphql/remote-schemas/index.tsx
+++ b/dashboard/src/pages/orgs/[orgSlug]/projects/[appSubdomain]/graphql/remote-schemas/index.tsx
@@ -1,6 +1,6 @@
 import type { ReactElement } from 'react';
-import { ActivityIndicator } from '@/components/ui/v2/ActivityIndicator';
 import { Box } from '@/components/ui/v2/Box';
+import { Spinner } from '@/components/ui/v3/spinner';
 import { OrgLayout } from '@/features/orgs/layout/OrgLayout';
 import { RemoteSchemaBrowserSidebar } from '@/features/orgs/projects/remote-schemas/components/RemoteSchemaBrowserSidebar';
 import { RemoteSchemaEmptyState } from '@/features/orgs/projects/remote-schemas/components/RemoteSchemaEmptyState';
@@ -11,11 +11,9 @@ export default function RemoteSchemasPage() {
 
   if (isLoading) {
     return (
-      <ActivityIndicator
-        delay={1000}
-        label="Loading remote schemas..."
-        className="justify-center"
-      />
+      <Spinner size="medium" wrapperClassName="gap-2">
+        Loading remote schemas...
+      </Spinner>
     );
   }
 

--- a/dashboard/src/pages/orgs/[orgSlug]/projects/[appSubdomain]/metrics.tsx
+++ b/dashboard/src/pages/orgs/[orgSlug]/projects/[appSubdomain]/metrics.tsx
@@ -4,12 +4,12 @@ import type { ReactElement } from 'react';
 import { UpgradeToProBanner } from '@/components/common/UpgradeToProBanner';
 import { Container } from '@/components/layout/Container';
 import { RetryableErrorBoundary } from '@/components/presentational/RetryableErrorBoundary';
-import { ActivityIndicator } from '@/components/ui/v2/ActivityIndicator';
 import { Box } from '@/components/ui/v2/Box';
 import { Button } from '@/components/ui/v2/Button';
 import { Divider } from '@/components/ui/v2/Divider';
 import { IconButton } from '@/components/ui/v2/IconButton';
 import { Text } from '@/components/ui/v2/Text';
+import { Spinner } from '@/components/ui/v3/spinner';
 import { OrgLayout } from '@/features/orgs/layout/OrgLayout';
 import { generateAppServiceUrl } from '@/features/orgs/projects/common/utils/generateAppServiceUrl';
 import { useCurrentOrg } from '@/features/orgs/projects/hooks/useCurrentOrg';
@@ -37,7 +37,9 @@ function MetricsPageContent() {
   if (loadingOrg || loadingProject) {
     return (
       <Container>
-        <ActivityIndicator label="Loading project..." delay={1000} />
+        <Spinner size="medium" wrapperClassName="gap-2">
+          Loading project...
+        </Spinner>
       </Container>
     );
   }

--- a/dashboard/src/pages/orgs/[orgSlug]/projects/[appSubdomain]/run.tsx
+++ b/dashboard/src/pages/orgs/[orgSlug]/projects/[appSubdomain]/run.tsx
@@ -6,10 +6,10 @@ import { useDialog } from '@/components/common/DialogProvider';
 import { Pagination } from '@/components/common/Pagination';
 import { UpgradeToProBanner } from '@/components/common/UpgradeToProBanner';
 import { Container } from '@/components/layout/Container';
-import { ActivityIndicator } from '@/components/ui/v2/ActivityIndicator';
 import { Box } from '@/components/ui/v2/Box';
 import { Button } from '@/components/ui/v2/Button';
 import { Text } from '@/components/ui/v2/Text';
+import { Spinner } from '@/components/ui/v3/spinner';
 import { OrgLayout } from '@/features/orgs/layout/OrgLayout';
 import { useIsPlatform } from '@/features/orgs/projects/common/hooks/useIsPlatform';
 import { useRunServices } from '@/features/orgs/projects/common/hooks/useRunServices';
@@ -111,7 +111,7 @@ export default function RunPage() {
   if (loading && loadingProject) {
     return (
       <Container>
-        <ActivityIndicator />
+        <Spinner size="medium" />
       </Container>
     );
   }

--- a/dashboard/src/pages/orgs/[orgSlug]/projects/index.tsx
+++ b/dashboard/src/pages/orgs/[orgSlug]/projects/index.tsx
@@ -1,8 +1,8 @@
 import { Plus } from 'lucide-react';
 import Link from 'next/link';
 import type { ReactElement } from 'react';
-import { ActivityIndicator } from '@/components/ui/v2/ActivityIndicator';
 import { Button } from '@/components/ui/v3/button';
+import { Spinner } from '@/components/ui/v3/spinner';
 import { ProjectsGrid } from '@/features/orgs/components/projects/projects-grid';
 import { OrgLayout } from '@/features/orgs/layout/OrgLayout';
 import { useCurrentOrg } from '@/features/orgs/projects/hooks/useCurrentOrg';
@@ -28,7 +28,7 @@ export default function OrgProjects() {
   if (loading || currentOrgLoading) {
     return (
       <div className="flex h-full w-full items-center justify-center">
-        <ActivityIndicator circularProgressProps={{ className: 'w-6 h-6' }} />
+        <Spinner size="medium" />
       </div>
     );
   }

--- a/dashboard/src/pages/orgs/[orgSlug]/projects/new.tsx
+++ b/dashboard/src/pages/orgs/[orgSlug]/projects/new.tsx
@@ -4,7 +4,6 @@ import type { FormEvent, ReactElement } from 'react';
 import { useState } from 'react';
 import slugify from 'slugify';
 import { Container } from '@/components/layout/Container';
-import { ActivityIndicator } from '@/components/ui/v2/ActivityIndicator';
 import { Alert } from '@/components/ui/v2/Alert';
 import { Box } from '@/components/ui/v2/Box';
 import { Button } from '@/components/ui/v2/Button';
@@ -17,6 +16,7 @@ import {
   SelectTrigger,
   SelectValue,
 } from '@/components/ui/v3/select';
+import { Spinner } from '@/components/ui/v3/spinner';
 import { OrgLayout } from '@/features/orgs/layout/OrgLayout';
 import { useOrgs } from '@/features/orgs/projects/hooks/useOrgs';
 import { execPromiseWithErrorToast } from '@/features/orgs/utils/execPromiseWithErrorToast';
@@ -404,7 +404,11 @@ export default function NewProjectPage() {
   }
 
   if (loadingOrgs || loadingPlans || !data) {
-    return <ActivityIndicator delay={500} label="Loading regions..." />;
+    return (
+      <Spinner size="medium" wrapperClassName="gap-2">
+        Loading regions...
+      </Spinner>
+    );
   }
 
   const { regions } = data;

--- a/dashboard/src/pages/run-one-click-install.tsx
+++ b/dashboard/src/pages/run-one-click-install.tsx
@@ -7,7 +7,6 @@ import { Fragment, useCallback, useEffect, useMemo, useState } from 'react';
 import { useDialog } from '@/components/common/DialogProvider';
 import { AuthenticatedLayout } from '@/components/layout/AuthenticatedLayout';
 import { RetryableErrorBoundary } from '@/components/presentational/RetryableErrorBoundary';
-import { ActivityIndicator } from '@/components/ui/v2/ActivityIndicator';
 import { Box } from '@/components/ui/v2/Box';
 import { Button } from '@/components/ui/v2/Button';
 import { Input } from '@/components/ui/v2/Input';
@@ -15,6 +14,7 @@ import { List } from '@/components/ui/v2/List';
 import { ListItem } from '@/components/ui/v2/ListItem';
 import { Text } from '@/components/ui/v2/Text';
 import { Badge } from '@/components/ui/v3/badge';
+import { Spinner } from '@/components/ui/v3/spinner';
 import { useOrgs } from '@/features/orgs/projects/hooks/useOrgs';
 import { InfoCard } from '@/features/orgs/projects/overview/components/InfoCard';
 import { cn } from '@/lib/utils';
@@ -126,7 +126,9 @@ export default function SelectOrganizationAndProject() {
   if (loadingOrgs) {
     return (
       <div className="flex w-full justify-center">
-        <ActivityIndicator delay={500} label="Loading projects..." />
+        <Spinner size="medium" wrapperClassName="gap-2">
+          Loading projects...
+        </Spinner>
       </div>
     );
   }


### PR DESCRIPTION
<!-- pi-reviewer:start -->
### **What this change solves**
Migrates remaining dashboard page-level loading indicators from the legacy ActivityIndicator to the v3 Spinner component.

___

### **Change Type**
Refactoring

___

### **Description**
- Replaces ActivityIndicator usage on AI, auth, GraphQL, metrics, run, project list, project creation, and one-click install pages.
- Preserves existing loading messages where present while adopting Spinner sizing and wrapper classes.
- Removes the legacy ActivityIndicator import from the affected page components.

___

<details> <summary><h3> File Walkthrough</h3></summary>

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody>
<tr><td><strong>App pages</strong></td><td><details><summary>7 files</summary><table>
<tr><td><strong>dashboard/src/pages/orgs/[orgSlug]/projects/[appSubdomain]/ai/assistants/index.tsx</strong><dd><code>Uses v3 Spinner for assistants loading.</code></dd></td><td>+4/-6</td></tr>
<tr><td><strong>dashboard/src/pages/orgs/[orgSlug]/projects/[appSubdomain]/ai/file-stores/index.tsx</strong><dd><code>Uses v3 Spinner for file stores loading.</code></dd></td><td>+4/-6</td></tr>
<tr><td><strong>dashboard/src/pages/orgs/[orgSlug]/projects/[appSubdomain]/auth/oauth2-clients.tsx</strong><dd><code>Uses v3 Spinner for OAuth2 loading states.</code></dd></td><td>+10/-4</td></tr>
<tr><td><strong>dashboard/src/pages/orgs/[orgSlug]/projects/[appSubdomain]/auth/users.tsx</strong><dd><code>Uses v3 Spinner for users loading.</code></dd></td><td>+4/-2</td></tr>
<tr><td><strong>dashboard/src/pages/orgs/[orgSlug]/projects/[appSubdomain]/graphql/remote-schemas/index.tsx</strong><dd><code>Uses v3 Spinner for remote schema page loading.</code></dd></td><td>+4/-6</td></tr>
<tr><td><strong>dashboard/src/pages/orgs/[orgSlug]/projects/[appSubdomain]/metrics.tsx</strong><dd><code>Uses v3 Spinner for metrics project loading.</code></dd></td><td>+4/-2</td></tr>
<tr><td><strong>dashboard/src/pages/orgs/[orgSlug]/projects/[appSubdomain]/run.tsx</strong><dd><code>Uses v3 Spinner for run page loading.</code></dd></td><td>+2/-2</td></tr>
</table></details></td></tr>
<tr><td><strong>Project selection and creation</strong></td><td><details><summary>3 files</summary><table>
<tr><td><strong>dashboard/src/pages/orgs/[orgSlug]/projects/index.tsx</strong><dd><code>Uses v3 Spinner for projects list loading.</code></dd></td><td>+2/-2</td></tr>
<tr><td><strong>dashboard/src/pages/orgs/[orgSlug]/projects/new.tsx</strong><dd><code>Uses v3 Spinner for project creation prerequisite loading.</code></dd></td><td>+6/-2</td></tr>
<tr><td><strong>dashboard/src/pages/run-one-click-install.tsx</strong><dd><code>Uses v3 Spinner for one-click install project loading.</code></dd></td><td>+4/-2</td></tr>
</table></details></td></tr>
</tbody></table>

</details>

___

<!-- pi-reviewer:end -->
