### PR TITLE
fix(dashboard): migrate layout, guard, and shared component spinners

### DIFF
--- a/dashboard/src/components/layout/AuthenticatedLayout/AuthenticatedLayout.tsx
+++ b/dashboard/src/components/layout/AuthenticatedLayout/AuthenticatedLayout.tsx
@@ -12,8 +12,8 @@ import PinnedMainNav from '@/components/layout/MainNav/PinnedMainNav';
 import { useTreeNavState } from '@/components/layout/MainNav/TreeNavStateContext';
 import { HighlightedText } from '@/components/presentational/HighlightedText';
 import { RetryableErrorBoundary } from '@/components/presentational/RetryableErrorBoundary';
-import { ActivityIndicator } from '@/components/ui/v2/ActivityIndicator';
 import { Text } from '@/components/ui/v2/Text';
+import { Spinner } from '@/components/ui/v3/spinner';
 import { TextLink } from '@/components/ui/v3/text-link';
 import { OrgStatus } from '@/features/orgs/components/OrgStatus';
 import { useIsHealthy } from '@/features/orgs/projects/common/hooks/useIsHealthy';
@@ -111,7 +111,9 @@ export default function AuthenticatedLayout({
             if you are having trouble starting your project.
           </Text>
 
-          <ActivityIndicator label="Checking status..." className="mx-auto" />
+          <Spinner size="medium" wrapperClassName="gap-2">
+            Checking status...
+          </Spinner>
         </Container>
       </BaseLayout>
     );

--- a/dashboard/src/components/presentational/LoadingScreen/LoadingScreen.tsx
+++ b/dashboard/src/components/presentational/LoadingScreen/LoadingScreen.tsx
@@ -1,8 +1,7 @@
 import { twMerge } from 'tailwind-merge';
-import type { ActivityIndicatorProps } from '@/components/ui/v2/ActivityIndicator';
-import { ActivityIndicator } from '@/components/ui/v2/ActivityIndicator';
 import type { BoxProps } from '@/components/ui/v2/Box';
 import { Box } from '@/components/ui/v2/Box';
+import { Spinner } from '@/components/ui/v3/spinner';
 
 export interface LoadingScreenProps extends BoxProps {
   /**
@@ -13,16 +12,12 @@ export interface LoadingScreenProps extends BoxProps {
      * Props passed to the `<Box />` component.
      */
     root?: BoxProps;
-    /**
-     * Props passed to the `<ActivityIndicator />` component.
-     */
-    activityIndicator?: ActivityIndicatorProps;
   };
 }
 
 export default function LoadingScreen({
   className,
-  slotProps = { root: {}, activityIndicator: {} },
+  slotProps = { root: {} },
   ...props
 }: LoadingScreenProps) {
   return (
@@ -35,16 +30,7 @@ export default function LoadingScreen({
       {...slotProps?.root}
       {...props}
     >
-      <ActivityIndicator
-        {...slotProps?.activityIndicator}
-        circularProgressProps={{
-          ...slotProps?.activityIndicator?.circularProgressProps,
-          className: twMerge(
-            'w-5 h-5',
-            slotProps?.activityIndicator?.circularProgressProps?.className,
-          ),
-        }}
-      />
+      <Spinner className="h-5 w-5" />
     </Box>
   );
 }

--- a/dashboard/src/components/ui/v2/Button/Button.tsx
+++ b/dashboard/src/components/ui/v2/Button/Button.tsx
@@ -5,9 +5,9 @@ import type {
   ButtonProps as MaterialButtonProps,
 } from '@mui/material/Button';
 import MaterialButton, { buttonClasses } from '@mui/material/Button';
+import { Loader2 } from 'lucide-react';
 import type { ForwardedRef } from 'react';
 import { forwardRef } from 'react';
-import { ActivityIndicator } from '@/components/ui/v2/ActivityIndicator';
 
 export type ButtonProps<
   D extends React.ElementType = ButtonTypeMap['defaultComponent'],
@@ -366,7 +366,11 @@ function Button(
     ref,
     color,
     disabled: disabled || loading,
-    startIcon: loading ? <ActivityIndicator /> : props.startIcon,
+    startIcon: loading ? (
+      <Loader2 className="h-3 w-3 animate-spin" />
+    ) : (
+      props.startIcon
+    ),
   };
 
   if (variant === 'borderless') {

--- a/dashboard/src/features/orgs/layout/OrgLayout/ProjectStateGuard.tsx
+++ b/dashboard/src/features/orgs/layout/OrgLayout/ProjectStateGuard.tsx
@@ -3,9 +3,9 @@ import Image from 'next/image';
 import { useRouter } from 'next/router';
 import type { PropsWithChildren } from 'react';
 import { useCallback } from 'react';
-import { ActivityIndicator } from '@/components/ui/v2/ActivityIndicator';
-import { Button } from '@/components/ui/v3/button';
+import { ButtonWithLoading } from '@/components/ui/v3/button';
 import { Dialog, DialogTitle } from '@/components/ui/v3/dialog';
+import { Spinner } from '@/components/ui/v3/spinner';
 import { useAppPausedReason } from '@/features/orgs/projects/common/hooks/useAppPausedReason';
 import { useAppState } from '@/features/orgs/projects/common/hooks/useAppState';
 import { useProject } from '@/features/orgs/projects/hooks/useProject';
@@ -145,25 +145,21 @@ export default function ProjectStateGuard({
                   </p>
                 )}
                 {state === ApplicationStatus.Paused && (
-                  <Button
+                  <ButtonWithLoading
                     variant="outline"
                     className="w-full"
-                    disabled={changingApplicationStateLoading}
+                    loading={changingApplicationStateLoading}
                     onClick={handleTriggerUnpausing}
                   >
-                    {changingApplicationStateLoading ? (
-                      <ActivityIndicator />
-                    ) : (
-                      'Wake up'
-                    )}
-                  </Button>
+                    Wake up
+                  </ButtonWithLoading>
                 )}
               </>
             )}
 
             {variant === 'pausing' && (
               <p className="flex items-center gap-2 text-center">
-                <ActivityIndicator />
+                <Spinner size="xs" />
                 Project is pausing...
               </p>
             )}
@@ -171,7 +167,7 @@ export default function ProjectStateGuard({
             {variant === 'unpausing' && (
               <>
                 <p className="flex items-center gap-2 text-center">
-                  <ActivityIndicator />
+                  <Spinner size="xs" />
                   Project is waking up...
                 </p>
                 <p className="text-center text-muted-foreground text-sm">

--- a/dashboard/src/features/orgs/projects/authentication/users/components/UsersBody/UsersBody.tsx
+++ b/dashboard/src/features/orgs/projects/authentication/users/components/UsersBody/UsersBody.tsx
@@ -11,7 +11,6 @@ import Image from 'next/image';
 import { Fragment } from 'react';
 import { useDialog } from '@/components/common/DialogProvider';
 import { FormActivityIndicator } from '@/components/form/FormActivityIndicator';
-import { ActivityIndicator } from '@/components/ui/v2/ActivityIndicator';
 import { Avatar } from '@/components/ui/v2/Avatar';
 import { Chip } from '@/components/ui/v2/Chip';
 import { Divider } from '@/components/ui/v2/Divider';
@@ -54,7 +53,7 @@ export interface UsersBodyProps {
    * The users fetched from entering the users page given a limit and offset.
    * @remark users will be an empty array if there are no users.
    */
-  users?: RemoteAppUser[];
+  users: RemoteAppUser[];
   /**
    * Function to be called after a successful action.
    */
@@ -217,21 +216,6 @@ export default function UsersBody({
         />
       ),
     });
-  }
-
-  if (!users) {
-    return (
-      <div className="h-screen w-screen overflow-hidden">
-        <div className="absolute top-0 left-0 z-50 block h-full w-full">
-          <span className="top50percent relative top-1/2 mx-auto my-0 block">
-            <ActivityIndicator
-              label="Loading users..."
-              className="my-auto flex items-center justify-center"
-            />
-          </span>
-        </div>
-      </div>
-    );
   }
 
   return (

--- a/dashboard/src/features/orgs/projects/common/components/AppLoader/AppLoader.tsx
+++ b/dashboard/src/features/orgs/projects/common/components/AppLoader/AppLoader.tsx
@@ -1,8 +1,8 @@
 import Link from 'next/link';
 import { useEffect, useState } from 'react';
 import { LoadingScreen } from '@/components/presentational/LoadingScreen';
-import { ActivityIndicator } from '@/components/ui/v2/ActivityIndicator';
 import { Text } from '@/components/ui/v2/Text';
+import { Spinner } from '@/components/ui/v3/spinner';
 import { useProject } from '@/features/orgs/projects/hooks/useProject';
 import { useInterval } from '@/hooks/useInterval';
 import { getRelativeDateByApplicationState } from '@/utils/helpers';
@@ -92,7 +92,7 @@ export default function AppLoader({
         <Text color="disabled">Setting up Hasura</Text>
       )}
       {timeElapsed > 20 && <Text color="disabled">Doing final cleanup</Text>}
-      <ActivityIndicator className="mx-auto" />
+      <Spinner size="xs" />
 
       {timeElapsed > 180 && (
         <Link

--- a/dashboard/src/features/orgs/projects/common/components/ApplicationProvisioning/ApplicationProvisioning.tsx
+++ b/dashboard/src/features/orgs/projects/common/components/ApplicationProvisioning/ApplicationProvisioning.tsx
@@ -1,7 +1,7 @@
 import Image from 'next/image';
 import { Container } from '@/components/layout/Container';
-import { ActivityIndicator } from '@/components/ui/v2/ActivityIndicator';
 import { Text } from '@/components/ui/v2/Text';
+import { Spinner } from '@/components/ui/v3/spinner';
 import { AppLoader } from '@/features/orgs/projects/common/components/AppLoader';
 import { ApplicationInfo } from '@/features/orgs/projects/common/components/ApplicationInfo';
 import { StagingMetadata } from '@/features/orgs/projects/common/components/StagingMetadata';
@@ -30,7 +30,7 @@ export default function ApplicationProvisioning() {
             Setting Up {project?.name}
           </Text>
           <Text>This normally takes around 2 minutes</Text>
-          <ActivityIndicator className="mx-auto" />
+          <Spinner size="xs" />
         </div>
       ) : (
         <AppLoader startLoader date={currentProjectState.createdAt} />


### PR DESCRIPTION
<!-- pi-reviewer:start -->
### **What this change solves**
Migrates layout, guard, provisioning, and shared button loading indicators away from the legacy ActivityIndicator toward v3 Spinner or lucide Loader2 patterns.

___

### **Change Type**
Refactoring

___

### **Description**
- Updates authenticated layout and project state guard loading UI to newer spinner components.
- Simplifies LoadingScreen to render v3 Spinner and removes its ActivityIndicator-specific slot props.
- Replaces v2 Button loading icons and provisioning loaders with Loader2 or Spinner.
- Removes a redundant users body loading fallback that depended on ActivityIndicator.

___

<details> <summary><h3> File Walkthrough</h3></summary>

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody>
<tr><td><strong>Layout and reusable components</strong></td><td><details><summary>3 files</summary><table>
<tr><td><strong>dashboard/src/components/layout/AuthenticatedLayout/AuthenticatedLayout.tsx</strong><dd><code>Uses v3 Spinner for health-check loading feedback.</code></dd></td><td>+4/-2</td></tr>
<tr><td><strong>dashboard/src/components/presentational/LoadingScreen/LoadingScreen.tsx</strong><dd><code>Replaces ActivityIndicator with v3 Spinner and removes activityIndicator slot props.</code></dd></td><td>+3/-17</td></tr>
<tr><td><strong>dashboard/src/components/ui/v2/Button/Button.tsx</strong><dd><code>Uses Loader2 for v2 Button loading start icon.</code></dd></td><td>+6/-2</td></tr>
</table></details></td></tr>
<tr><td><strong>Project guards and provisioning</strong></td><td><details><summary>4 files</summary><table>
<tr><td><strong>dashboard/src/features/orgs/layout/OrgLayout/ProjectStateGuard.tsx</strong><dd><code>Uses ButtonWithLoading and v3 Spinner in project pause/unpause states.</code></dd></td><td>+8/-12</td></tr>
<tr><td><strong>dashboard/src/features/orgs/projects/authentication/users/components/UsersBody/UsersBody.tsx</strong><dd><code>Removes the users loading fallback that rendered ActivityIndicator.</code></dd></td><td>+0/-16</td></tr>
<tr><td><strong>dashboard/src/features/orgs/projects/common/components/AppLoader/AppLoader.tsx</strong><dd><code>Uses v3 Spinner in app setup progress UI.</code></dd></td><td>+2/-2</td></tr>
<tr><td><strong>dashboard/src/features/orgs/projects/common/components/ApplicationProvisioning/ApplicationProvisioning.tsx</strong><dd><code>Uses v3 Spinner in application provisioning UI.</code></dd></td><td>+2/-2</td></tr>
</table></details></td></tr>
</tbody></table>

</details>

___

<!-- pi-reviewer:end -->
