### PR TITLE
fix(docs): skip github.com/signup in link-checker

### DIFF
--- a/docs/check_broken_links.sh
+++ b/docs/check_broken_links.sh
@@ -19,6 +19,7 @@ SKIP=(
 
   # Sign-in portals that reject automated requests with 4xx (false positives)
   'portal\.azure\.com'
+  '^https:\/\/github\.com\/signup$'
 
   # Microsoft support behind Akamai/Azure bot detection: returns 301 to real
   # browsers but 403/404 to datacenter IPs / the link checker (false positive)


### PR DESCRIPTION
The docs `tests` job is failing on unrelated PRs (e.g. #4647) because the external link checker reports:

```
https://github.com/signup → 403 BROKEN
parent: dist/client/products/auth/providers/sign-in-github/
```

The link (from `products/auth/providers/sign-in-github.mdx`) has been in the docs unchanged since the Starlight release (#3877). GitHub now returns 403 for `/signup` when requested from the CI runner, while the page loads fine in a real browser.

### Checklist

- [x] No breaking changes
- [x] Tests pass
- [x] New features have new tests
- [x] Documentation is updated (if applicable)
- [x] Title of the PR is in the correct format (see below)

## Solution

Add `^https:\/\/github\.com\/signup$` to the `SKIP` list in `docs/check_broken_links.sh`, under the existing "sign-in portals that reject automated requests" group alongside `portal.azure.com`.

<!-- pi-reviewer:start -->
### **What this change solves**
The docs broken-links check reports `https://github.com/signup` as broken because GitHub rejects automated/datacenter requests to that sign-up page with a 4xx. Skipping it removes a false positive from the CI link check.

___

### **Change Type**
Bug fix

___

### **Description**
- Adds a `linkinator` skip regex for `https://github.com/signup` to the `SKIP` list in the docs broken-links checker.
- Groups the new entry under the existing "Sign-in portals that reject automated requests with 4xx" comment.

___

<details> <summary><h3> File Walkthrough</h3></summary>

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody>
<tr><td><strong>Configuration</strong></td><td><details><summary>1 files</summary><table>
<tr>
  <td><strong>check_broken_links.sh</strong><dd><code>Add github.com/signup to link-checker skip list</code></dd></td>
  <td>+1/-0</td>
</tr>
</table></details></td></tr>
</tbody></table>

</details>

___

<!-- pi-reviewer:end -->
