### PR TITLE
fix(dashboard): Migrate remote schema page to v3

### DIFF
--- a/dashboard/src/components/form/FormInput/FormInput.tsx
+++ b/dashboard/src/components/form/FormInput/FormInput.tsx
@@ -32,7 +32,7 @@ import {
 import { cn, isNotEmptyValue } from '@/lib/utils';
 
 const inputClasses =
-  '!bg-transparent aria-[invalid=true]:border-red-500 aria-[invalid=true]:focus:border-red-500 aria-[invalid=true]:focus:ring-red-500';
+  '!bg-transparent aria-[invalid=true]:border-red-500 aria-[invalid=true]:focus:border-red-500 aria-[invalid=true]:focus:ring-red-500 disabled:!bg-data-cell-bg-disabled disabled:text-disabled disabled:placeholder:text-disabled disabled:opacity-100';
 
 interface FormInputProps<
   TFieldValues extends FieldValues = FieldValues,
@@ -108,7 +108,7 @@ function InnerFormInput<
     <FormField
       control={control}
       name={name}
-      render={({ field }) => {
+      render={({ field, fieldState }) => {
         const baseFieldProps = isNotEmptyValue(transform)
           ? getTransformedFieldProps(field, transform)
           : field;
@@ -166,6 +166,7 @@ function InnerFormInput<
                       autoComplete={autoComplete}
                       data-testid={dataTestId}
                       aria-label={ariaLabel}
+                      aria-invalid={fieldState.invalid}
                       {...restFieldProps}
                       onChange={handleChange}
                       onBlur={handleBlur}

--- a/dashboard/src/components/ui/v3/input-group.tsx
+++ b/dashboard/src/components/ui/v3/input-group.tsx
@@ -25,6 +25,9 @@ function InputGroup({ className, ...props }: React.ComponentProps<'div'>) {
         // Focus state.
         'has-[[data-slot=input-group-control]:focus-visible]:border-ring has-[[data-slot=input-group-control]:focus-visible]:ring-[3px] has-[[data-slot=input-group-control]:focus-visible]:ring-ring/50',
 
+        // Disabled state.
+        'has-[[data-slot=input-group-control]:disabled]:border-border has-[[data-slot=input-group-control]:disabled]:bg-data-cell-bg-disabled has-[[data-slot=input-group-control]:disabled]:shadow-none',
+
         // Error state.
         'has-[[data-slot][aria-invalid=true]]:border-destructive has-[[data-slot][aria-invalid=true]]:ring-destructive/20 dark:has-[[data-slot][aria-invalid=true]]:ring-destructive/40',
 
@@ -36,7 +39,7 @@ function InputGroup({ className, ...props }: React.ComponentProps<'div'>) {
 }
 
 const inputGroupAddonVariants = cva(
-  "flex h-auto cursor-text select-none items-center justify-center gap-2 py-1.5 font-medium text-muted-foreground text-sm group-data-[disabled=true]/input-group:opacity-50 [&>kbd]:rounded-[calc(var(--radius)-5px)] [&>svg:not([class*='size-'])]:size-4",
+  "flex h-auto cursor-text select-none items-center justify-center gap-2 py-1.5 font-medium text-muted-foreground text-sm group-has-[[data-slot=input-group-control]:disabled]/input-group:text-disabled group-data-[disabled=true]/input-group:opacity-50 [&>kbd]:rounded-[calc(var(--radius)-5px)] [&>svg:not([class*='size-'])]:size-4",
   {
     variants: {
       align: {
@@ -131,10 +134,11 @@ function InputGroupText({ className, ...props }: React.ComponentProps<'span'>) {
 const InputGroupInput = React.forwardRef<
   React.ComponentRef<typeof Input>,
   React.ComponentPropsWithoutRef<typeof Input>
->(({ className, ...props }, ref) => {
+>(({ className, wrapperClassName, ...props }, ref) => {
   return (
     <Input
       data-slot="input-group-control"
+      wrapperClassName={cn('min-w-0 flex-1', wrapperClassName)}
       className={cn(
         'flex-1 rounded-none border-0 bg-transparent shadow-none focus-visible:ring-0 dark:bg-transparent',
         className,

--- a/dashboard/src/components/ui/v3/input.tsx
+++ b/dashboard/src/components/ui/v3/input.tsx
@@ -20,7 +20,7 @@ const Input = React.forwardRef<HTMLInputElement, InputProps>(
         <input
           type={type}
           className={cn(
-            'flex h-10 w-full rounded-md border border-input bg-background px-3 py-2 text-sm ring-offset-background file:border-0 file:bg-transparent file:font-medium file:text-sm placeholder:text-muted-foreground focus-visible:outline-none focus-visible:ring-1 focus-visible:ring-ring focus-visible:ring-offset-0 disabled:cursor-not-allowed disabled:opacity-50 dark:bg-accent-background',
+            'flex h-10 w-full rounded-md border border-input bg-background px-3 py-2 text-sm ring-offset-background file:border-0 file:bg-transparent file:font-medium file:text-sm placeholder:text-muted-foreground focus-visible:outline-none focus-visible:ring-1 focus-visible:ring-ring focus-visible:ring-offset-0 disabled:cursor-not-allowed disabled:border-border disabled:bg-data-cell-bg-disabled disabled:text-disabled disabled:opacity-100 disabled:placeholder:text-disabled dark:bg-accent-background',
             { 'pl-6': prefix },
             className,
           )}

--- a/dashboard/src/features/orgs/projects/database/dataGrid/components/DataBrowserSidebar/DatabaseObjectListItem.tsx
+++ b/dashboard/src/features/orgs/projects/database/dataGrid/components/DataBrowserSidebar/DatabaseObjectListItem.tsx
@@ -146,7 +146,7 @@ export default function DatabaseObjectListItem({
                 onOpen={() => setSidebarMenuObject(objectKey)}
                 onClose={() => setSidebarMenuObject(undefined)}
                 className={cn(
-                  'relative z-10 opacity-0 group-hover:opacity-100',
+                  'relative z-10 opacity-0 group-focus-within:opacity-100 group-hover:opacity-100 group-active:opacity-100',
                   {
                     'opacity-100': isSelected || isSidebarMenuOpen,
                   },

--- a/dashboard/src/features/orgs/projects/remote-schemas/components/BaseRemoteSchemaForm/AdditionalHeadersEditor.tsx
+++ b/dashboard/src/features/orgs/projects/remote-schemas/components/BaseRemoteSchemaForm/AdditionalHeadersEditor.tsx
@@ -1,13 +1,8 @@
-import { inputBaseClasses } from '@mui/material';
 import { InfoIcon, PlusIcon, Trash2 as TrashIcon } from 'lucide-react';
 import { useEffect, useState } from 'react';
 import { useFieldArray, useFormContext } from 'react-hook-form';
-import { Box } from '@/components/ui/v2/Box';
-import { HelperText } from '@/components/ui/v2/HelperText';
-import { Input } from '@/components/ui/v2/Input';
-import { Text } from '@/components/ui/v2/Text';
-import { Tooltip } from '@/components/ui/v2/Tooltip';
 import { Button } from '@/components/ui/v3/button';
+import { Input } from '@/components/ui/v3/input';
 import {
   Select,
   SelectContent,
@@ -15,6 +10,12 @@ import {
   SelectTrigger,
   SelectValue,
 } from '@/components/ui/v3/select';
+import {
+  Tooltip,
+  TooltipContent,
+  TooltipTrigger,
+} from '@/components/ui/v3/tooltip';
+import { cn } from '@/lib/utils';
 import type { BaseRemoteSchemaFormValues } from './BaseRemoteSchemaForm';
 
 export default function AdditionalHeadersEditor() {
@@ -86,34 +87,44 @@ export default function AdditionalHeadersEditor() {
   ];
 
   return (
-    <Box className="space-y-4 rounded border-1 p-4">
-      <Box className="flex flex-row items-center justify-between">
-        <Box className="flex flex-row items-center space-x-2">
-          <Text variant="h4" className="font-semibold">
-            Additional headers
-          </Text>
-          <Tooltip title="Custom headers to be sent to the remote GraphQL server">
-            <InfoIcon aria-label="Info" className="h-4 w-4 text-primary" />
+    <div className="box space-y-4 rounded border-1 p-4">
+      <div className="flex flex-row items-center justify-between">
+        <div className="flex flex-row items-center space-x-2">
+          <h4 className="font-semibold">Additional headers</h4>
+          <Tooltip>
+            <TooltipTrigger asChild>
+              <button
+                type="button"
+                aria-label="Info"
+                className="flex items-center"
+              >
+                <InfoIcon className="h-4 w-4 text-primary" />
+              </button>
+            </TooltipTrigger>
+            <TooltipContent className="max-w-xs">
+              Custom headers to be sent to the remote GraphQL server
+            </TooltipContent>
           </Tooltip>
-        </Box>
+        </div>
         <Button
+          aria-label="Add header"
+          type="button"
           variant="ghost"
           size="icon"
-          aria-label="Add header"
           onClick={() => append({ name: '', value: '', value_from_env: '' })}
         >
           <PlusIcon className="h-5 w-5" />
         </Button>
-      </Box>
+      </div>
 
-      <Box className="flex flex-col space-y-4">
+      <div className="flex flex-col space-y-4">
         {fields.length > 0 && (
-          <Box className="grid grid-cols-9 gap-4">
-            <Text className="col-span-3">Key</Text>
+          <div className="grid grid-cols-9 gap-4">
+            <span className="col-span-3">Key</span>
             <div className="col-span-1" />
-            <Text className="col-span-4">Value</Text>
+            <span className="col-span-4">Value</span>
             <div className="col-span-1" />
-          </Box>
+          </div>
         )}
 
         {fields.map((field, index) => {
@@ -125,26 +136,24 @@ export default function AdditionalHeadersEditor() {
           const combinedMessage = nameMessage ?? objectLevelMessage;
 
           return (
-            <Box key={field.id} className="grid grid-cols-9 items-center gap-4">
+            <div key={field.id} className="grid grid-cols-9 items-center gap-4">
               {combinedMessage && (
-                <HelperText className="col-span-9" error>
+                <p className="col-span-9 text-destructive text-sm">
                   {combinedMessage}
-                </HelperText>
+                </p>
               )}
               <Input
                 {...register(`definition.headers.${index}.name`)}
                 id={`${field.id}-name`}
                 placeholder="Header name"
-                className="col-span-3"
-                hideEmptyHelperText
-                error={Boolean(combinedMessage)}
-                fullWidth
+                className={cn({ 'border-destructive': combinedMessage })}
+                wrapperClassName="col-span-3"
                 autoComplete="off"
               />
 
-              <Text className="col-span-1 text-center">:</Text>
+              <span className="col-span-1 text-center">:</span>
 
-              <Box className="col-span-4 flex flex-col gap-1 md:flex-row md:gap-0">
+              <div className="col-span-4 flex flex-col gap-1 md:flex-row md:gap-0">
                 <Select
                   value={currentValueType}
                   onValueChange={(value) =>
@@ -171,27 +180,18 @@ export default function AdditionalHeadersEditor() {
                     `definition.headers.${index}.${currentValueType}`,
                   )}
                   id={`${field.id}-${currentValueType}`}
-                  className="pl-0"
-                  sx={{
-                    [`& .${inputBaseClasses.input}`]: {
-                      paddingLeft: '8px',
-                    },
-                    borderLeft: 'none',
-                    borderTopLeftRadius: 0,
-                    borderBottomLeftRadius: 0,
-                  }}
                   placeholder={
                     currentValueType === 'value'
                       ? 'Header value'
                       : 'Env var name'
                   }
-                  hideEmptyHelperText
-                  error={Boolean(combinedMessage)}
-                  helperText=""
-                  fullWidth
+                  className={cn('md:rounded-l-none md:border-l-0', {
+                    'border-destructive': combinedMessage,
+                  })}
+                  wrapperClassName="w-full"
                   autoComplete="off"
                 />
-              </Box>
+              </div>
 
               <Button
                 variant="ghost"
@@ -202,10 +202,10 @@ export default function AdditionalHeadersEditor() {
               >
                 <TrashIcon className="h-4 w-4" />
               </Button>
-            </Box>
+            </div>
           );
         })}
-      </Box>
-    </Box>
+      </div>
+    </div>
   );
 }

--- a/dashboard/src/features/orgs/projects/remote-schemas/components/BaseRemoteSchemaForm/BaseRemoteSchemaForm.tsx
+++ b/dashboard/src/features/orgs/projects/remote-schemas/components/BaseRemoteSchemaForm/BaseRemoteSchemaForm.tsx
@@ -1,10 +1,7 @@
-import { useEffect } from 'react';
-import { useFormState } from 'react-hook-form';
-import * as Yup from 'yup';
+import { type KeyboardEvent, useEffect, useRef } from 'react';
+import { useFormContext, useFormState } from 'react-hook-form';
+import { z } from 'zod';
 import { useDialog } from '@/components/common/DialogProvider';
-import { Form } from '@/components/form/Form';
-import { Box } from '@/components/ui/v2/Box';
-import { Text } from '@/components/ui/v2/Text';
 import { Button, ButtonWithLoading } from '@/components/ui/v3/button';
 import type { DialogFormProps } from '@/types/common';
 import AdditionalHeadersEditor from './AdditionalHeadersEditor';
@@ -15,16 +12,75 @@ import GraphQLServiceURLInput from './GraphQLServiceURLInput';
 import RemoteSchemaCommentInput from './RemoteSchemaCommentInput';
 import RemoteSchemaNameInput from './RemoteSchemaNameInput';
 
-type RequireFields<T, K extends keyof T> = T & Required<Pick<T, K>>;
+const rootCustomizationSchema = z.object({
+  parent_type: z.string().optional(),
+  prefix: z.string().optional(),
+  suffix: z.string().optional(),
+});
 
-type YupInferred = Yup.InferType<typeof baseRemoteSchemaValidationSchema>;
+export const baseRemoteSchemaValidationSchema = z.object({
+  name: z.string().min(1, 'Name is required.'),
+  comment: z.string().optional(),
+  definition: z.object({
+    url: z
+      .string()
+      .min(1, 'Service URL is required.')
+      .url('Invalid service URL.'),
+    forward_client_headers: z.boolean(),
+    headers: z
+      .array(
+        z
+          .object({
+            name: z.string().min(1, 'Header name is required.'),
+            value: z.string().optional(),
+            value_from_env: z.string().optional(),
+          })
+          .refine(
+            (header) =>
+              (header.value ?? '').trim() !== '' ||
+              (header.value_from_env ?? '').trim() !== '',
+            {
+              message:
+                'Either value or value from environment variable must be provided.',
+            },
+          ),
+      )
+      .optional(),
+    timeout_seconds: z.coerce
+      .number({ invalid_type_error: 'Timeout must be a number.' })
+      .positive('Timeout must be a positive number.'),
+    customization: z
+      .object({
+        root_fields_namespace: z.string().optional(),
+        type_prefix: z.string().optional(),
+        type_suffix: z.string().optional(),
+        query_root: rootCustomizationSchema.optional(),
+        mutation_root: rootCustomizationSchema.optional(),
+        type_names: z
+          .object({
+            prefix: z.string().optional(),
+            suffix: z.string().optional(),
+            mapping: z.record(z.string()).optional(),
+          })
+          .optional(),
+        field_names: z
+          .array(
+            z.object({
+              parent_type: z.string().optional(),
+              prefix: z.string().optional(),
+              suffix: z.string().optional(),
+              mapping: z.record(z.string()).optional(),
+            }),
+          )
+          .optional(),
+      })
+      .optional(),
+  }),
+});
 
-export type BaseRemoteSchemaFormValues = YupInferred & {
-  definition: RequireFields<
-    YupInferred['definition'],
-    'url' | 'forward_client_headers' | 'timeout_seconds'
-  >;
-};
+export type BaseRemoteSchemaFormValues = z.infer<
+  typeof baseRemoteSchemaValidationSchema
+>;
 
 export interface BaseRemoteSchemaFormProps extends DialogFormProps {
   /**
@@ -51,54 +107,6 @@ export interface BaseRemoteSchemaFormProps extends DialogFormProps {
   graphQLCustomizationsSlot?: React.ReactNode;
 }
 
-export const baseRemoteSchemaValidationSchema = Yup.object({
-  name: Yup.string().required('Name is required.'),
-  comment: Yup.string(),
-  definition: Yup.object({
-    url: Yup.string()
-      .url('Invalid service URL.')
-      .required('Service URL is required.'),
-    forward_client_headers: Yup.boolean().required(
-      'Forward client headers is required.',
-    ),
-    headers: Yup.array().of(
-      Yup.object({
-        name: Yup.string().required('Header name is required.'),
-        value: Yup.string(),
-        value_from_env: Yup.string(),
-      }).test(
-        'has-value-or-env',
-        'Either value or value from environment variable must be provided.',
-        (obj) => {
-          const { value, value_from_env } = obj || {};
-          const hasValue = (value ?? '').trim() !== '';
-          const hasEnvValue = (value_from_env ?? '').trim() !== '';
-          return hasValue || hasEnvValue;
-        },
-      ),
-    ),
-    timeout_seconds: Yup.number()
-      .required('Timeout is required.')
-      .positive('Timeout must be a positive number.')
-      .typeError('Timeout must be a number.'),
-    customization: Yup.object({
-      root_fields_namespace: Yup.string(),
-      type_prefix: Yup.string(),
-      type_suffix: Yup.string(),
-      query_root: Yup.object({
-        parent_type: Yup.string(),
-        prefix: Yup.string(),
-        suffix: Yup.string(),
-      }),
-      mutation_root: Yup.object({
-        parent_type: Yup.string(),
-        prefix: Yup.string(),
-        suffix: Yup.string(),
-      }),
-    }),
-  }).required('Definition is required.'),
-});
-
 function FormFooter({
   onCancel,
   submitButtonText,
@@ -117,8 +125,13 @@ function FormFooter({
   }, [isDirty, location, onDirtyStateChange]);
 
   return (
-    <Box className="grid flex-shrink-0 grid-flow-col justify-between gap-3 border-t-1 p-2">
-      <Button variant="ghost" onClick={onCancel} tabIndex={isDirty ? -1 : 0}>
+    <div className="box grid flex-shrink-0 grid-flow-col justify-between gap-3 border-t-1 p-2">
+      <Button
+        variant="ghost"
+        onClick={onCancel}
+        tabIndex={isDirty ? -1 : 0}
+        type="button"
+      >
         Cancel
       </Button>
 
@@ -130,7 +143,7 @@ function FormFooter({
       >
         {submitButtonText}
       </ButtonWithLoading>
-    </Box>
+    </div>
   );
 }
 
@@ -142,49 +155,69 @@ export default function BaseRemoteSchemaForm({
   nameInputDisabled = false,
   graphQLCustomizationsSlot,
 }: BaseRemoteSchemaFormProps) {
+  const formRef = useRef<HTMLFormElement | null>(null);
+  const {
+    handleSubmit,
+    formState: { isSubmitting },
+  } = useFormContext<BaseRemoteSchemaFormValues>();
+
+  // Support form submission using `Ctrl + Enter` and `Cmd + Enter`.
+  function handleKeyDown(event: KeyboardEvent) {
+    const isModifierEnter =
+      event.key === 'Enter' && (event.ctrlKey || event.metaKey);
+
+    if (!isModifierEnter || isSubmitting) {
+      return;
+    }
+
+    const submitButton = Array.from(
+      formRef.current!.getElementsByTagName('button'),
+    ).find((item) => item.type === 'submit');
+
+    if (submitButton?.disabled) {
+      return;
+    }
+
+    event.preventDefault();
+    handleSubmit(handleExternalSubmit)(event);
+  }
+
   return (
-    <Form
-      onSubmit={handleExternalSubmit}
+    <form
+      ref={formRef}
+      onSubmit={handleSubmit(handleExternalSubmit)}
+      onKeyDown={handleKeyDown}
       className="flex flex-auto flex-col content-between overflow-hidden border-t-1"
     >
       <div className="flex-auto overflow-y-auto pb-4">
-        <Box
-          component="section"
-          className="flex flex-col gap-3 px-6 py-6 md:grid md:grid-cols-8"
-        >
+        <section className="flex flex-col gap-3 px-6 py-6 md:grid md:grid-cols-8">
           <div className="col-span-6">
             <RemoteSchemaNameInput disabled={nameInputDisabled} />
           </div>
           <div className="col-span-6">
             <RemoteSchemaCommentInput />
           </div>
-        </Box>
+        </section>
 
-        <Box
-          component="section"
-          className="flex flex-col gap-3 border-t-1 px-6 py-6 md:grid md:grid-cols-8"
-        >
+        <section className="flex flex-col gap-3 border-t-1 px-6 py-6 md:grid md:grid-cols-8">
           <div className="col-span-6">
             <GraphQLServiceURLInput />
           </div>
           <div className="col-span-6">
             <GraphQLServerTimeoutInput />
           </div>
-        </Box>
+        </section>
 
-        <Box
-          component="section"
-          className="flex flex-col gap-3 border-t-1 px-6 py-6"
-        >
-          <Text variant="h4" className="font-semibold text-lg">
+        <section className="flex flex-col gap-3 border-t-1 px-6 py-6">
+          <h4 className="font-semibold text-lg">
             Headers for remote GraphQL server
-          </Text>
+          </h4>
           <ForwardClientHeadersToggle />
           <AdditionalHeadersEditor />
-        </Box>
-        <Box className="border-t-1 px-6 py-6">
+        </section>
+        <div className="box border-t-1 px-6 py-6">
           {graphQLCustomizationsSlot ?? <GraphQLCustomizations />}
-        </Box>
+        </div>
       </div>
 
       <FormFooter
@@ -192,6 +225,6 @@ export default function BaseRemoteSchemaForm({
         submitButtonText={submitButtonText}
         location={location}
       />
-    </Form>
+    </form>
   );
 }

--- a/dashboard/src/features/orgs/projects/remote-schemas/components/BaseRemoteSchemaForm/ForwardClientHeadersToggle.tsx
+++ b/dashboard/src/features/orgs/projects/remote-schemas/components/BaseRemoteSchemaForm/ForwardClientHeadersToggle.tsx
@@ -1,26 +1,41 @@
 import { InfoIcon } from 'lucide-react';
 import { useFormContext } from 'react-hook-form';
-import { ControlledSwitch } from '@/components/form/ControlledSwitch';
-import { Box } from '@/components/ui/v2/Box';
-import { Text } from '@/components/ui/v2/Text';
-import { Tooltip } from '@/components/ui/v2/Tooltip';
+import { FormSwitch } from '@/components/form/FormSwitch';
+import {
+  Tooltip,
+  TooltipContent,
+  TooltipTrigger,
+} from '@/components/ui/v3/tooltip';
 import type { BaseRemoteSchemaFormValues } from './BaseRemoteSchemaForm';
 
 export default function ForwardClientHeadersToggle() {
-  const { register } = useFormContext<BaseRemoteSchemaFormValues>();
+  const { control } = useFormContext<BaseRemoteSchemaFormValues>();
 
   return (
-    <Box className="flex flex-row justify-between gap-2">
-      <Box className="flex flex-row items-center gap-2">
-        <Text>Forward all headers from client</Text>
-        <Tooltip title="Toggle forwarding headers sent by the client app in the request to your remote GraphQL server">
-          <InfoIcon aria-label="Info" className="h-4 w-4 text-primary" />
-        </Tooltip>
-      </Box>
-      <ControlledSwitch
-        {...register('definition.forward_client_headers')}
-        className="self-center"
-      />
-    </Box>
+    <FormSwitch
+      control={control}
+      name="definition.forward_client_headers"
+      containerClassName="flex flex-row items-center justify-between gap-2 space-y-0"
+      label={
+        <span className="flex flex-row items-center gap-2">
+          Forward all headers from client
+          <Tooltip>
+            <TooltipTrigger asChild>
+              <button
+                type="button"
+                aria-label="Info"
+                className="flex items-center"
+              >
+                <InfoIcon className="h-4 w-4 text-primary" />
+              </button>
+            </TooltipTrigger>
+            <TooltipContent className="max-w-xs">
+              Toggle forwarding headers sent by the client app in the request to
+              your remote GraphQL server
+            </TooltipContent>
+          </Tooltip>
+        </span>
+      }
+    />
   );
 }

--- a/dashboard/src/features/orgs/projects/remote-schemas/components/BaseRemoteSchemaForm/GraphQLCustomizations.tsx
+++ b/dashboard/src/features/orgs/projects/remote-schemas/components/BaseRemoteSchemaForm/GraphQLCustomizations.tsx
@@ -1,16 +1,57 @@
 import { InfoIcon, PlusIcon } from 'lucide-react';
 import { useState } from 'react';
 import { useFormContext } from 'react-hook-form';
-import { Box } from '@/components/ui/v2/Box';
-import { Input } from '@/components/ui/v2/Input';
-import { Text } from '@/components/ui/v2/Text';
-import { Tooltip } from '@/components/ui/v2/Tooltip';
+import { FormInput } from '@/components/form/FormInput';
+import type { Transformer } from '@/components/form/utils/getTransformedFieldProps';
 import { Button } from '@/components/ui/v3/button';
+import {
+  Tooltip,
+  TooltipContent,
+  TooltipTrigger,
+} from '@/components/ui/v3/tooltip';
 import type { BaseRemoteSchemaFormValues } from './BaseRemoteSchemaForm';
+
+const emptyStringToUndefined: Transformer = {
+  in: (value) => value ?? '',
+  out: (event) => {
+    const value = event?.target?.value;
+    return typeof value === 'string' && value.trim() === '' ? undefined : value;
+  },
+};
+
+function CustomizationDescription() {
+  return (
+    <p className="text-muted-foreground text-sm">
+      Individual Types and Fields will be editable after saving.{' '}
+      <a
+        href="https://spec.graphql.org/June2018/#example-e2969"
+        target="_blank"
+        rel="noopener noreferrer"
+        className="text-blue-600 underline hover:text-blue-800"
+      >
+        Read more
+      </a>{' '}
+      in the official GraphQL spec.
+    </p>
+  );
+}
+
+function InfoTooltip({ title }: { title: string }) {
+  return (
+    <Tooltip>
+      <TooltipTrigger asChild>
+        <button type="button" aria-label="Info" className="flex items-center">
+          <InfoIcon className="h-4 w-4 text-primary" />
+        </button>
+      </TooltipTrigger>
+      <TooltipContent className="max-w-xs">{title}</TooltipContent>
+    </Tooltip>
+  );
+}
 
 export default function GraphQLCustomizations() {
   const [isOpen, setIsOpen] = useState(false);
-  const { register, getFieldState, formState } =
+  const { control, getFieldState, formState } =
     useFormContext<BaseRemoteSchemaFormValues>();
 
   const queryRootError = getFieldState(
@@ -24,242 +65,152 @@ export default function GraphQLCustomizations() {
 
   if (!isOpen) {
     return (
-      <Box className="space-y-4">
-        <Box className="flex h-8 flex-row items-center justify-between">
-          <Text variant="h4" className="font-semibold text-lg">
-            GraphQL Customizations
-          </Text>
-        </Box>
-        <Text variant="body2" color="secondary" className="text-sm">
-          Individual Types and Fields will be editable after saving.{' '}
-          <a
-            href="https://spec.graphql.org/June2018/#example-e2969"
-            target="_blank"
-            rel="noopener noreferrer"
-            className="text-blue-600 underline hover:text-blue-800"
-          >
-            Read more
-          </a>{' '}
-          in the official GraphQL spec.
-        </Text>
+      <div className="space-y-4">
+        <div className="flex h-8 flex-row items-center justify-between">
+          <h4 className="font-semibold text-lg">GraphQL Customizations</h4>
+        </div>
+        <CustomizationDescription />
         <Button
+          type="button"
           variant="outline"
           size="sm"
           onClick={() => setIsOpen(true)}
-          className="mt-2 px-2"
+          className="mt-2 gap-1 px-2"
         >
-          <PlusIcon className="mr-2 h-4 w-4" />
+          <PlusIcon className="h-4 w-4" />
           Add GraphQL Customization
         </Button>
-      </Box>
+      </div>
     );
   }
 
   return (
-    <Box className="space-y-4">
-      <Box className="flex flex-row items-center justify-between">
-        <Text variant="h4" className="font-semibold text-lg">
-          GraphQL Customizations
-        </Text>
-        <Button variant="outline" size="sm" onClick={() => setIsOpen(false)}>
+    <div className="space-y-4">
+      <div className="flex flex-row items-center justify-between">
+        <h4 className="font-semibold text-lg">GraphQL Customizations</h4>
+        <Button
+          type="button"
+          variant="outline"
+          size="sm"
+          onClick={() => setIsOpen(false)}
+        >
           Close
         </Button>
-      </Box>
+      </div>
 
-      <Text variant="body2" color="secondary" className="text-sm">
-        Individual Types and Fields will be editable after saving.{' '}
-        <a
-          href="https://spec.graphql.org/June2018/#example-e2969"
-          target="_blank"
-          rel="noopener noreferrer"
-          className="text-blue-600 underline hover:text-blue-800"
-        >
-          Read more
-        </a>{' '}
-        in the official GraphQL spec.
-      </Text>
+      <CustomizationDescription />
 
-      <Box className="space-y-4 rounded border p-4">
-        <Box className="space-y-2">
-          <Box className="flex flex-row items-center space-x-2">
-            <Text className="font-medium">Root Field Namespace</Text>
-            <Tooltip title="Root field type names will be under this namespace.">
-              <InfoIcon aria-label="Info" className="h-4 w-4 text-primary" />
-            </Tooltip>
-          </Box>
-          <Input
-            {...register('definition.customization.root_fields_namespace', {
-              setValueAs: (v) =>
-                typeof v === 'string' && v.trim() === '' ? undefined : v,
-            })}
-            id="definition.customization.root_fields_namespace"
-            name="definition.customization.root_fields_namespace"
-            placeholder="namespace_"
-            hideEmptyHelperText
+      <div className="box space-y-4 rounded border p-4">
+        <FormInput
+          control={control}
+          name="definition.customization.root_fields_namespace"
+          transform={emptyStringToUndefined}
+          label={
+            <span className="flex flex-row items-center gap-2">
+              Root Field Namespace
+              <InfoTooltip title="Root field type names will be under this namespace." />
+            </span>
+          }
+          placeholder="namespace_"
+          autoComplete="off"
+        />
+
+        <div className="space-y-3">
+          <div className="flex flex-row items-center space-x-2">
+            <h4 className="font-semibold text-lg">Types</h4>
+            <InfoTooltip title="Add a prefix / suffix to all types of the remote schema" />
+          </div>
+
+          <FormInput
+            control={control}
+            name="definition.customization.type_prefix"
+            label="Prefix"
+            placeholder="prefix_"
             autoComplete="off"
-            variant="inline"
-            fullWidth
           />
-        </Box>
 
-        <Box className="space-y-3">
-          <Box className="flex flex-row items-center space-x-2">
-            <Text variant="h4" className="font-semibold text-lg">
-              Types
-            </Text>
-            <Tooltip title="Add a prefix / suffix to all types of the remote schema">
-              <InfoIcon aria-label="Info" className="h-4 w-4 text-primary" />
-            </Tooltip>
-          </Box>
+          <FormInput
+            control={control}
+            name="definition.customization.type_suffix"
+            label="Suffix"
+            placeholder="_suffix"
+            autoComplete="off"
+          />
+        </div>
 
-          <Box className="space-y-2">
-            <Text className="font-medium">Prefix</Text>
-            <Input
-              {...register('definition.customization.type_prefix')}
-              id="definition.customization.type_prefix"
-              name="definition.customization.type_prefix"
-              placeholder="prefix_"
-              hideEmptyHelperText
-              autoComplete="off"
-              variant="inline"
-              fullWidth
-            />
-          </Box>
+        <div className="space-y-3">
+          <div className="flex flex-row items-center space-x-2">
+            <h4 className="font-semibold text-lg">Fields</h4>
+            <InfoTooltip title="Add a prefix / suffix to the fields of the query / mutation root fields" />
+          </div>
 
-          <Box className="space-y-2">
-            <Text className="font-medium">Suffix</Text>
-            <Input
-              {...register('definition.customization.type_suffix')}
-              id="definition.customization.type_suffix"
-              name="definition.customization.type_suffix"
-              placeholder="_suffix"
-              hideEmptyHelperText
-              autoComplete="off"
-              variant="inline"
-              fullWidth
-            />
-          </Box>
-        </Box>
-
-        <Box className="space-y-3">
-          <Box className="flex flex-row items-center space-x-2">
-            <Text variant="h4" className="font-semibold text-lg">
-              Fields
-            </Text>
-            <Tooltip title="Add a prefix / suffix to the fields of the query / mutation root fields">
-              <InfoIcon aria-label="Info" className="h-4 w-4 text-primary" />
-            </Tooltip>
-          </Box>
-
-          <Box className="space-y-3">
-            <Text variant="h4" className="font-semibold">
-              Query root
-            </Text>
+          <div className="space-y-3">
+            <h4 className="font-semibold">Query root</h4>
             {queryRootError?.message && (
-              <Text color="error" className="text-sm">
+              <p className="text-destructive text-sm">
                 {queryRootError.message}
-              </Text>
+              </p>
             )}
 
-            <Box className="space-y-2">
-              <Text className="font-medium">Type Name</Text>
-              <Input
-                {...register('definition.customization.query_root.parent_type')}
-                id="definition.customization.query_root.parent_type"
-                name="definition.customization.query_root.parent_type"
-                placeholder="Query/query_root"
-                hideEmptyHelperText
-                autoComplete="off"
-                variant="inline"
-                fullWidth
-              />
-            </Box>
+            <FormInput
+              control={control}
+              name="definition.customization.query_root.parent_type"
+              label="Type Name"
+              placeholder="Query/query_root"
+              autoComplete="off"
+            />
 
-            <Box className="space-y-2">
-              <Text className="font-medium">Prefix</Text>
-              <Input
-                {...register('definition.customization.query_root.prefix')}
-                id="definition.customization.query_root.prefix"
-                name="definition.customization.query_root.prefix"
-                placeholder="prefix_"
-                hideEmptyHelperText
-                autoComplete="off"
-                variant="inline"
-                fullWidth
-              />
-            </Box>
+            <FormInput
+              control={control}
+              name="definition.customization.query_root.prefix"
+              label="Prefix"
+              placeholder="prefix_"
+              autoComplete="off"
+            />
 
-            <Box className="space-y-2">
-              <Text className="font-medium">Suffix</Text>
-              <Input
-                {...register('definition.customization.query_root.suffix')}
-                id="definition.customization.query_root.suffix"
-                name="definition.customization.query_root.suffix"
-                placeholder="_suffix"
-                hideEmptyHelperText
-                autoComplete="off"
-                variant="inline"
-                fullWidth
-              />
-            </Box>
-          </Box>
+            <FormInput
+              control={control}
+              name="definition.customization.query_root.suffix"
+              label="Suffix"
+              placeholder="_suffix"
+              autoComplete="off"
+            />
+          </div>
 
-          <Box className="space-y-3">
-            <Text variant="h4" className="font-semibold">
-              Mutation root
-            </Text>
+          <div className="space-y-3">
+            <h4 className="font-semibold">Mutation root</h4>
             {mutationRootError?.message && (
-              <Text color="error" className="text-sm">
+              <p className="text-destructive text-sm">
                 {mutationRootError.message}
-              </Text>
+              </p>
             )}
 
-            <Box className="space-y-2">
-              <Text className="font-medium">Type Name</Text>
-              <Input
-                {...register(
-                  'definition.customization.mutation_root.parent_type',
-                )}
-                id="definition.customization.mutation_root.parent_type"
-                name="definition.customization.mutation_root.parent_type"
-                placeholder="Mutation/mutation_root"
-                hideEmptyHelperText
-                autoComplete="off"
-                variant="inline"
-                fullWidth
-              />
-            </Box>
+            <FormInput
+              control={control}
+              name="definition.customization.mutation_root.parent_type"
+              label="Type Name"
+              placeholder="Mutation/mutation_root"
+              autoComplete="off"
+            />
 
-            <Box className="space-y-2">
-              <Text className="font-medium">Prefix</Text>
-              <Input
-                {...register('definition.customization.mutation_root.prefix')}
-                id="definition.customization.mutation_root.prefix"
-                name="definition.customization.mutation_root.prefix"
-                placeholder="prefix_"
-                hideEmptyHelperText
-                autoComplete="off"
-                variant="inline"
-                fullWidth
-              />
-            </Box>
+            <FormInput
+              control={control}
+              name="definition.customization.mutation_root.prefix"
+              label="Prefix"
+              placeholder="prefix_"
+              autoComplete="off"
+            />
 
-            <Box className="space-y-2">
-              <Text className="font-medium">Suffix</Text>
-              <Input
-                {...register('definition.customization.mutation_root.suffix')}
-                id="definition.customization.mutation_root.suffix"
-                name="definition.customization.mutation_root.suffix"
-                placeholder="_suffix"
-                hideEmptyHelperText
-                autoComplete="off"
-                variant="inline"
-                fullWidth
-              />
-            </Box>
-          </Box>
-        </Box>
-      </Box>
-    </Box>
+            <FormInput
+              control={control}
+              name="definition.customization.mutation_root.suffix"
+              label="Suffix"
+              placeholder="_suffix"
+              autoComplete="off"
+            />
+          </div>
+        </div>
+      </div>
+    </div>
   );
 }

--- a/dashboard/src/features/orgs/projects/remote-schemas/components/BaseRemoteSchemaForm/GraphQLServerTimeoutInput.tsx
+++ b/dashboard/src/features/orgs/projects/remote-schemas/components/BaseRemoteSchemaForm/GraphQLServerTimeoutInput.tsx
@@ -1,43 +1,43 @@
 import { InfoIcon } from 'lucide-react';
 import { useFormContext } from 'react-hook-form';
-import { Box } from '@/components/ui/v2/Box';
-import { Input } from '@/components/ui/v2/Input';
-import { Text } from '@/components/ui/v2/Text';
-import { Tooltip } from '@/components/ui/v2/Tooltip';
+import { FormInput } from '@/components/form/FormInput';
+import {
+  Tooltip,
+  TooltipContent,
+  TooltipTrigger,
+} from '@/components/ui/v3/tooltip';
 import { DEFAULT_REMOTE_SCHEMA_TIMEOUT_SECONDS } from '@/features/orgs/projects/remote-schemas/utils/constants';
 import type { BaseRemoteSchemaFormValues } from './BaseRemoteSchemaForm';
 
 export default function GraphQLServerTimeoutInput() {
-  const {
-    register,
-    formState: { errors },
-  } = useFormContext<BaseRemoteSchemaFormValues>();
+  const { control } = useFormContext<BaseRemoteSchemaFormValues>();
 
   return (
-    <Box className="space-y-2">
-      <Box className="flex flex-row items-center space-x-2">
-        <Text>GraphQL Server Timeout</Text>
-        <Tooltip title="Configure timeout for your remote GraphQL server.">
-          <InfoIcon aria-label="Info" className="h-4 w-4 text-primary" />
-        </Tooltip>
-      </Box>
-      <Input
-        {...register('definition.timeout_seconds')}
-        id="definition.timeout_seconds"
-        name="definition.timeout_seconds"
-        placeholder={DEFAULT_REMOTE_SCHEMA_TIMEOUT_SECONDS.toString()}
-        className=""
-        hideEmptyHelperText
-        error={Boolean(errors?.definition?.timeout_seconds)}
-        autoComplete="off"
-        fullWidth
-        helperText={errors?.definition?.timeout_seconds?.message}
-        endAdornment={
-          <Text sx={{ color: 'grey.500' }} className="pr-2">
-            seconds
-          </Text>
-        }
-      />
-    </Box>
+    <FormInput
+      control={control}
+      name="definition.timeout_seconds"
+      label={
+        <span className="flex flex-row items-center gap-2">
+          GraphQL Server Timeout
+          <Tooltip>
+            <TooltipTrigger asChild>
+              <button
+                type="button"
+                aria-label="Info"
+                className="flex items-center"
+              >
+                <InfoIcon className="h-4 w-4 text-primary" />
+              </button>
+            </TooltipTrigger>
+            <TooltipContent className="max-w-xs">
+              Configure timeout for your remote GraphQL server.
+            </TooltipContent>
+          </Tooltip>
+        </span>
+      }
+      placeholder={DEFAULT_REMOTE_SCHEMA_TIMEOUT_SECONDS.toString()}
+      autoComplete="off"
+      addonEnd={<span className="text-muted-foreground">seconds</span>}
+    />
   );
 }

--- a/dashboard/src/features/orgs/projects/remote-schemas/components/BaseRemoteSchemaForm/GraphQLServiceURLInput.tsx
+++ b/dashboard/src/features/orgs/projects/remote-schemas/components/BaseRemoteSchemaForm/GraphQLServiceURLInput.tsx
@@ -1,37 +1,44 @@
 import { InfoIcon } from 'lucide-react';
 import { useFormContext } from 'react-hook-form';
-import { Box } from '@/components/ui/v2/Box';
-import { Input } from '@/components/ui/v2/Input';
-import { Text } from '@/components/ui/v2/Text';
-import { Tooltip } from '@/components/ui/v2/Tooltip';
+import { FormInput } from '@/components/form/FormInput';
+import {
+  Tooltip,
+  TooltipContent,
+  TooltipTrigger,
+} from '@/components/ui/v3/tooltip';
 import type { BaseRemoteSchemaFormValues } from './BaseRemoteSchemaForm';
 
 export default function GraphQLServiceURLInput() {
-  const {
-    register,
-    formState: { errors },
-  } = useFormContext<BaseRemoteSchemaFormValues>();
+  const { control } = useFormContext<BaseRemoteSchemaFormValues>();
 
   return (
-    <Box className="space-y-2">
-      <Box className="flex flex-row items-center space-x-2">
-        <Text>GraphQL Service URL</Text>
-        <Tooltip title="The URL of the GraphQL service to be used as a remote schema. Environment variables and secrets are available using the {{VARIABLE}} tag. Example: https://{{ENV_VAR}}/endpoint_url.">
-          <InfoIcon aria-label="Info" className="h-4 w-4 text-primary" />
-        </Tooltip>
-      </Box>
-      <Input
-        {...register('definition.url')}
-        id="definition.url"
-        name="definition.url"
-        placeholder="https://graphql-service.example.com or {{ENV_VAR}}/endpoint_url"
-        className=""
-        hideEmptyHelperText
-        error={Boolean(errors?.definition?.url)}
-        autoComplete="off"
-        fullWidth
-        helperText={errors?.definition?.url?.message}
-      />
-    </Box>
+    <FormInput
+      control={control}
+      name="definition.url"
+      label={
+        <span className="flex flex-row items-center gap-2">
+          GraphQL Service URL
+          <Tooltip>
+            <TooltipTrigger asChild>
+              <button
+                type="button"
+                aria-label="Info"
+                className="flex items-center"
+              >
+                <InfoIcon className="h-4 w-4 text-primary" />
+              </button>
+            </TooltipTrigger>
+            <TooltipContent className="max-w-xs">
+              The URL of the GraphQL service to be used as a remote schema.
+              Environment variables and secrets are available using the
+              {' {{VARIABLE}} '}
+              tag. Example: https://{'{{ENV_VAR}}'}/endpoint_url.
+            </TooltipContent>
+          </Tooltip>
+        </span>
+      }
+      placeholder="https://graphql-service.example.com or {{ENV_VAR}}/endpoint_url"
+      autoComplete="off"
+    />
   );
 }

--- a/dashboard/src/features/orgs/projects/remote-schemas/components/BaseRemoteSchemaForm/RemoteSchemaCommentInput.tsx
+++ b/dashboard/src/features/orgs/projects/remote-schemas/components/BaseRemoteSchemaForm/RemoteSchemaCommentInput.tsx
@@ -1,39 +1,41 @@
 import { InfoIcon } from 'lucide-react';
-import { useFormContext, useFormState } from 'react-hook-form';
-import { Box } from '@/components/ui/v2/Box';
-import { Input } from '@/components/ui/v2/Input';
-import { Text } from '@/components/ui/v2/Text';
-import { Tooltip } from '@/components/ui/v2/Tooltip';
+import { useFormContext } from 'react-hook-form';
+import { FormInput } from '@/components/form/FormInput';
+import {
+  Tooltip,
+  TooltipContent,
+  TooltipTrigger,
+} from '@/components/ui/v3/tooltip';
 import type { BaseRemoteSchemaFormValues } from './BaseRemoteSchemaForm';
 
 export default function RemoteSchemaCommentInput() {
-  const { register } = useFormContext<BaseRemoteSchemaFormValues>();
-  const { errors } = useFormState({ name: 'comment' });
+  const { control } = useFormContext<BaseRemoteSchemaFormValues>();
 
   return (
-    <Box className="space-y-2">
-      <Box className="flex flex-row items-center space-x-2">
-        <Text>Comment</Text>
-        <Tooltip title="A statement to help describe the remote schema in brief.">
-          <InfoIcon aria-label="Info" className="h-4 w-4 text-primary" />
-        </Tooltip>
-      </Box>
-      <Input
-        {...register('comment')}
-        id="comment"
-        name="comment"
-        placeholder="Comment, e.g. 'Remote schema for the Graphite API'"
-        className=""
-        hideEmptyHelperText
-        error={Boolean(errors.comment)}
-        autoComplete="off"
-        fullWidth
-        helperText={
-          typeof errors.comment?.message === 'string'
-            ? errors.comment?.message
-            : ''
-        }
-      />
-    </Box>
+    <FormInput
+      control={control}
+      name="comment"
+      label={
+        <span className="flex flex-row items-center gap-2">
+          Comment
+          <Tooltip>
+            <TooltipTrigger asChild>
+              <button
+                type="button"
+                aria-label="Info"
+                className="flex items-center"
+              >
+                <InfoIcon className="h-4 w-4 text-primary" />
+              </button>
+            </TooltipTrigger>
+            <TooltipContent className="max-w-xs">
+              A statement to help describe the remote schema in brief.
+            </TooltipContent>
+          </Tooltip>
+        </span>
+      }
+      placeholder="Comment, e.g. 'Remote schema for the Graphite API'"
+      autoComplete="off"
+    />
   );
 }

--- a/dashboard/src/features/orgs/projects/remote-schemas/components/BaseRemoteSchemaForm/RemoteSchemaNameInput.tsx
+++ b/dashboard/src/features/orgs/projects/remote-schemas/components/BaseRemoteSchemaForm/RemoteSchemaNameInput.tsx
@@ -1,8 +1,5 @@
 import { useFormContext } from 'react-hook-form';
-
-import { Box } from '@/components/ui/v2/Box';
-import { Input } from '@/components/ui/v2/Input';
-import { Text } from '@/components/ui/v2/Text';
+import { FormInput } from '@/components/form/FormInput';
 import type { BaseRemoteSchemaFormValues } from './BaseRemoteSchemaForm';
 
 export interface RemoteSchemaNameInputProps {
@@ -15,29 +12,16 @@ export interface RemoteSchemaNameInputProps {
 export default function RemoteSchemaNameInput({
   disabled,
 }: RemoteSchemaNameInputProps) {
-  const {
-    register,
-    formState: { errors },
-  } = useFormContext<BaseRemoteSchemaFormValues>();
+  const { control } = useFormContext<BaseRemoteSchemaFormValues>();
 
   return (
-    <Box className="space-y-2">
-      <Box className="flex flex-row items-center space-x-2">
-        <Text>Name</Text>
-      </Box>
-      <Input
-        {...register('name')}
-        id="name"
-        name="name"
-        placeholder="Remote Schema Name"
-        disabled={disabled}
-        className=""
-        hideEmptyHelperText
-        error={Boolean(errors?.name)}
-        autoComplete="off"
-        fullWidth
-        helperText={errors?.name?.message}
-      />
-    </Box>
+    <FormInput
+      control={control}
+      name="name"
+      label="Name"
+      placeholder="Remote Schema Name"
+      disabled={disabled}
+      autoComplete="off"
+    />
   );
 }

--- a/dashboard/src/features/orgs/projects/remote-schemas/components/BaseRemoteSchemaRelationshipForm/sections/DatabaseRelationshipForm.tsx
+++ b/dashboard/src/features/orgs/projects/remote-schemas/components/BaseRemoteSchemaRelationshipForm/sections/DatabaseRelationshipForm.tsx
@@ -2,7 +2,6 @@ import { zodResolver } from '@hookform/resolvers/zod';
 import { Anchor, ChevronsUpDown, InfoIcon } from 'lucide-react';
 import { useForm } from 'react-hook-form';
 import { z } from 'zod';
-import { Tooltip } from '@/components/ui/v2/Tooltip';
 import { Button } from '@/components/ui/v3/button';
 import {
   Form,
@@ -22,6 +21,11 @@ import {
   SelectValue,
 } from '@/components/ui/v3/select';
 import { Spinner } from '@/components/ui/v3/spinner';
+import {
+  Tooltip,
+  TooltipContent,
+  TooltipTrigger,
+} from '@/components/ui/v3/tooltip';
 import { useIntrospectRemoteSchemaQuery } from '@/features/orgs/projects/remote-schemas/hooks/useIntrospectRemoteSchemaQuery';
 import getSourceTypes from '@/features/orgs/projects/remote-schemas/utils/getSourceTypes';
 import { cn } from '@/lib/utils';
@@ -125,11 +129,19 @@ export default function DatabaseRelationshipForm({
               <FormItem>
                 <FormLabel className="flex flex-row items-center gap-2">
                   Relationship name
-                  <Tooltip title="This will be used as the field name in the source type.">
-                    <InfoIcon
-                      aria-label="Info"
-                      className="h-4 w-4 text-primary"
-                    />
+                  <Tooltip>
+                    <TooltipTrigger asChild>
+                      <button
+                        type="button"
+                        aria-label="Info"
+                        className="flex items-center"
+                      >
+                        <InfoIcon className="h-4 w-4 text-primary" />
+                      </button>
+                    </TooltipTrigger>
+                    <TooltipContent className="max-w-xs">
+                      This will be used as the field name in the source type.
+                    </TooltipContent>
                   </Tooltip>
                 </FormLabel>
                 <FormControl>

--- a/dashboard/src/features/orgs/projects/remote-schemas/components/BaseRemoteSchemaRelationshipForm/sections/FieldToColumnMapSelector.tsx
+++ b/dashboard/src/features/orgs/projects/remote-schemas/components/BaseRemoteSchemaRelationshipForm/sections/FieldToColumnMapSelector.tsx
@@ -1,8 +1,6 @@
 import { isObjectType } from 'graphql';
 import { PlusIcon, Trash2 as TrashIcon } from 'lucide-react';
 import { useFieldArray, useFormContext } from 'react-hook-form';
-import { Box } from '@/components/ui/v2/Box';
-import { Text } from '@/components/ui/v2/Text';
 import { Button } from '@/components/ui/v3/button';
 import { useTableSchemaQuery } from '@/features/orgs/projects/database/common/hooks/useTableSchemaQuery';
 import { useIntrospectRemoteSchemaQuery } from '@/features/orgs/projects/remote-schemas/hooks/useIntrospectRemoteSchemaQuery';
@@ -76,12 +74,12 @@ export default function FieldToColumnMapSelector({
     });
 
   return (
-    <Box className="mx-2 space-y-4 rounded border-1 p-4">
-      <Box className="flex flex-col space-y-4">
-        <Box className="grid grid-cols-8 items-center gap-4">
-          <Text className="col-span-3">Source Field</Text>
+    <div className="box mx-2 space-y-4 rounded border-1 p-4">
+      <div className="flex flex-col space-y-4">
+        <div className="grid grid-cols-8 items-center gap-4">
+          <span className="col-span-3">Source Field</span>
           <div className="col-span-1" />
-          <Text className="col-span-3">Reference Column</Text>
+          <span className="col-span-3">Reference Column</span>
           <Button
             variant="ghost"
             size="icon"
@@ -91,10 +89,10 @@ export default function FieldToColumnMapSelector({
           >
             <PlusIcon className="h-5 w-5" />
           </Button>
-        </Box>
+        </div>
 
         {fields.map((field, index) => (
-          <Box key={field.id} className="grid grid-cols-8 items-center gap-4">
+          <div key={field.id} className="grid grid-cols-8 items-center gap-4">
             <FieldToColumnMapSelectorItem
               columns={columns}
               sourceFields={sourceFields}
@@ -102,17 +100,17 @@ export default function FieldToColumnMapSelector({
             />
 
             <Button
-              variant="ghost"
-              size="icon"
               className="col-span-1 text-destructive hover:text-destructive"
               aria-label="Remove field mapping"
+              variant="ghost"
+              size="icon"
               onClick={() => remove(index)}
             >
               <TrashIcon className="h-4 w-4" />
             </Button>
-          </Box>
+          </div>
         ))}
-      </Box>
-    </Box>
+      </div>
+    </div>
   );
 }

--- a/dashboard/src/features/orgs/projects/remote-schemas/components/BaseRemoteSchemaRelationshipForm/sections/FieldToColumnMapSelectorItem.tsx
+++ b/dashboard/src/features/orgs/projects/remote-schemas/components/BaseRemoteSchemaRelationshipForm/sections/FieldToColumnMapSelectorItem.tsx
@@ -1,7 +1,6 @@
 import { Check, ChevronsUpDown } from 'lucide-react';
 import { useState } from 'react';
 import { useFormContext } from 'react-hook-form';
-import { Text } from '@/components/ui/v2/Text';
 import { Button } from '@/components/ui/v3/button';
 import {
   Command,
@@ -126,7 +125,7 @@ export default function FieldToColumnMapSelectorItem({
         )}
       />
 
-      <Text className="col-span-1 text-center">:</Text>
+      <span className="col-span-1 text-center">:</span>
 
       <FormField
         control={form.control}

--- a/dashboard/src/features/orgs/projects/remote-schemas/components/BaseRemoteSchemaRelationshipForm/sections/RemoteSchemaRelationshipForm.tsx
+++ b/dashboard/src/features/orgs/projects/remote-schemas/components/BaseRemoteSchemaRelationshipForm/sections/RemoteSchemaRelationshipForm.tsx
@@ -3,7 +3,6 @@ import { Anchor, InfoIcon } from 'lucide-react';
 import { useForm } from 'react-hook-form';
 import { z } from 'zod';
 import { FormCombobox } from '@/components/form/FormCombobox';
-import { Tooltip } from '@/components/ui/v2/Tooltip';
 import { Button } from '@/components/ui/v3/button';
 import {
   Form,
@@ -15,6 +14,11 @@ import {
 } from '@/components/ui/v3/form';
 import { Input } from '@/components/ui/v3/input';
 import { Spinner } from '@/components/ui/v3/spinner';
+import {
+  Tooltip,
+  TooltipContent,
+  TooltipTrigger,
+} from '@/components/ui/v3/tooltip';
 import { useGetRemoteSchemas } from '@/features/orgs/projects/remote-schemas/hooks/useGetRemoteSchemas';
 import { useIntrospectRemoteSchemaQuery } from '@/features/orgs/projects/remote-schemas/hooks/useIntrospectRemoteSchemaQuery';
 import getQueryTypeFields from '@/features/orgs/projects/remote-schemas/utils/getQueryTypeFields';
@@ -137,11 +141,19 @@ export default function RemoteSchemaRelationshipForm({
               <FormItem>
                 <FormLabel className="flex flex-row items-center gap-2">
                   Relationship name
-                  <Tooltip title="This will be used as the field name in the source type.">
-                    <InfoIcon
-                      aria-label="Info"
-                      className="h-4 w-4 text-primary"
-                    />
+                  <Tooltip>
+                    <TooltipTrigger asChild>
+                      <button
+                        type="button"
+                        aria-label="Info"
+                        className="flex items-center"
+                      >
+                        <InfoIcon className="h-4 w-4 text-primary" />
+                      </button>
+                    </TooltipTrigger>
+                    <TooltipContent className="max-w-xs">
+                      This will be used as the field name in the source type.
+                    </TooltipContent>
                   </Tooltip>
                 </FormLabel>
                 <FormControl>

--- a/dashboard/src/features/orgs/projects/remote-schemas/components/BaseRemoteSchemaRelationshipForm/sections/SchemaToArgumentMapSelector.tsx
+++ b/dashboard/src/features/orgs/projects/remote-schemas/components/BaseRemoteSchemaRelationshipForm/sections/SchemaToArgumentMapSelector.tsx
@@ -1,7 +1,5 @@
 import { isObjectType } from 'graphql';
 import { useFieldArray, useFormContext } from 'react-hook-form';
-import { Box } from '@/components/ui/v2/Box';
-import { Text } from '@/components/ui/v2/Text';
 import { Checkbox } from '@/components/ui/v3/checkbox';
 import {
   FormControl,
@@ -141,25 +139,25 @@ export default function SchemaToArgumentMapSelector({
 
   if (!selectedTargetField) {
     return (
-      <Box className="space-y-4 rounded border-1 p-4">
-        <Text className="text-muted-foreground text-sm">
+      <div className="box space-y-4 rounded border-1 p-4">
+        <p className="text-muted-foreground text-sm">
           Select a target field to configure argument mappings.
-        </Text>
-      </Box>
+        </p>
+      </div>
     );
   }
 
   return (
-    <Box className="space-y-4 rounded border-1 p-4">
-      <Box className="flex flex-col space-y-4">
-        <Text className="font-semibold text-lg">
+    <div className="box space-y-4 rounded border-1 p-4">
+      <div className="flex flex-col space-y-4">
+        <h4 className="font-semibold text-lg">
           Configure arguments for {selectedTargetField}
-        </Text>
+        </h4>
 
         {targetArguments.length === 0 ? (
-          <Text className="text-muted-foreground text-sm">
+          <p className="text-muted-foreground text-sm">
             No selectable items available for this type
-          </Text>
+          </p>
         ) : (
           <div className="space-y-3">
             {targetArguments.map((argument) => {
@@ -248,7 +246,7 @@ export default function SchemaToArgumentMapSelector({
             })}
           </div>
         )}
-      </Box>
-    </Box>
+      </div>
+    </div>
   );
 }

--- a/dashboard/src/features/orgs/projects/remote-schemas/components/CreateRemoteSchemaForm/CreateRemoteSchemaForm.tsx
+++ b/dashboard/src/features/orgs/projects/remote-schemas/components/CreateRemoteSchemaForm/CreateRemoteSchemaForm.tsx
@@ -1,7 +1,7 @@
-import { yupResolver } from '@hookform/resolvers/yup';
+import { zodResolver } from '@hookform/resolvers/zod';
 import { useRouter } from 'next/router';
-import { FormProvider, useForm } from 'react-hook-form';
-import type * as Yup from 'yup';
+import { useForm } from 'react-hook-form';
+import { Form } from '@/components/ui/v3/form';
 import BaseRemoteSchemaForm, {
   type BaseRemoteSchemaFormProps,
   type BaseRemoteSchemaFormValues,
@@ -31,10 +31,7 @@ export default function CreateRemoteSchemaForm({
 
   const { mutateAsync: createRemoteSchema } = useCreateRemoteSchemaMutation();
 
-  const form = useForm<
-    | BaseRemoteSchemaFormValues
-    | Yup.InferType<typeof baseRemoteSchemaValidationSchema>
-  >({
+  const form = useForm<BaseRemoteSchemaFormValues>({
     defaultValues: {
       name: '',
       comment: '',
@@ -62,7 +59,7 @@ export default function CreateRemoteSchemaForm({
     },
     shouldUnregister: true,
     reValidateMode: 'onSubmit',
-    resolver: yupResolver(baseRemoteSchemaValidationSchema),
+    resolver: zodResolver(baseRemoteSchemaValidationSchema),
   });
 
   async function handleSubmit(values: BaseRemoteSchemaFormValues) {
@@ -119,12 +116,12 @@ export default function CreateRemoteSchemaForm({
   }
 
   return (
-    <FormProvider {...form}>
+    <Form {...form}>
       <BaseRemoteSchemaForm
         submitButtonText="Create"
         onSubmit={handleSubmit}
         {...props}
       />
-    </FormProvider>
+    </Form>
   );
 }

--- a/dashboard/src/features/orgs/projects/remote-schemas/components/EditRemoteSchemaForm/EditRemoteSchemaForm.tsx
+++ b/dashboard/src/features/orgs/projects/remote-schemas/components/EditRemoteSchemaForm/EditRemoteSchemaForm.tsx
@@ -1,7 +1,7 @@
-import { yupResolver } from '@hookform/resolvers/yup';
+import { zodResolver } from '@hookform/resolvers/zod';
 import { useRouter } from 'next/router';
-import { FormProvider, useForm } from 'react-hook-form';
-import type * as Yup from 'yup';
+import { useForm } from 'react-hook-form';
+import { Form } from '@/components/ui/v3/form';
 import { useGetMetadataResourceVersion } from '@/features/orgs/projects/common/hooks/useGetMetadataResourceVersion';
 import BaseRemoteSchemaForm, {
   type BaseRemoteSchemaFormProps,
@@ -41,10 +41,7 @@ export default function EditRemoteSchemaForm({
 
   const { mutateAsync: updateRemoteSchema } = useUpdateRemoteSchemaMutation();
 
-  const form = useForm<
-    | BaseRemoteSchemaFormValues
-    | Yup.InferType<typeof baseRemoteSchemaValidationSchema>
-  >({
+  const form = useForm<BaseRemoteSchemaFormValues>({
     defaultValues: {
       name: originalSchema.name,
       comment: originalSchema.comment,
@@ -67,7 +64,7 @@ export default function EditRemoteSchemaForm({
     },
     shouldUnregister: true,
     reValidateMode: 'onSubmit',
-    resolver: yupResolver(baseRemoteSchemaValidationSchema),
+    resolver: zodResolver(baseRemoteSchemaValidationSchema),
   });
 
   async function handleSubmit(values: BaseRemoteSchemaFormValues) {
@@ -129,7 +126,7 @@ export default function EditRemoteSchemaForm({
   }
 
   return (
-    <FormProvider {...form}>
+    <Form {...form}>
       <BaseRemoteSchemaForm
         submitButtonText="Save"
         onSubmit={handleSubmit}
@@ -139,6 +136,6 @@ export default function EditRemoteSchemaForm({
         }
         {...props}
       />
-    </FormProvider>
+    </Form>
   );
 }

--- a/dashboard/src/features/orgs/projects/remote-schemas/components/EditRemoteSchemaForm/sections/EditGraphQLCustomizations.tsx
+++ b/dashboard/src/features/orgs/projects/remote-schemas/components/EditRemoteSchemaForm/sections/EditGraphQLCustomizations.tsx
@@ -13,10 +13,6 @@ import {
   useFormContext,
   useWatch,
 } from 'react-hook-form';
-import { Box } from '@/components/ui/v2/Box';
-import { Input } from '@/components/ui/v2/Input';
-import { Text } from '@/components/ui/v2/Text';
-import { Tooltip } from '@/components/ui/v2/Tooltip';
 import { Button } from '@/components/ui/v3/button';
 import {
   Command,
@@ -26,11 +22,17 @@ import {
   CommandItem,
   CommandList,
 } from '@/components/ui/v3/command';
+import { Input } from '@/components/ui/v3/input';
 import {
   Popover,
   PopoverContent,
   PopoverTrigger,
 } from '@/components/ui/v3/popover';
+import {
+  Tooltip,
+  TooltipContent,
+  TooltipTrigger,
+} from '@/components/ui/v3/tooltip';
 import useIntrospectRemoteSchemaQuery from '@/features/orgs/projects/remote-schemas/hooks/useIntrospectRemoteSchemaQuery/useIntrospectRemoteSchemaQuery';
 import isStandardGraphQLScalar from '@/features/orgs/projects/remote-schemas/utils/isStandardGraphQLScalar';
 import { cn } from '@/lib/utils';
@@ -40,6 +42,19 @@ import type {
   RemoteSchemaCustomizationFieldNamesItem,
 } from '@/utils/hasura-api/generated/schemas';
 import TypeNameCustomizationCombobox from './TypeNameCustomizationCombobox';
+
+function InfoTooltip({ title }: { title: string }) {
+  return (
+    <Tooltip>
+      <TooltipTrigger asChild>
+        <button type="button" aria-label="Info" className="flex items-center">
+          <InfoIcon className="h-4 w-4 text-primary" />
+        </button>
+      </TooltipTrigger>
+      <TooltipContent className="max-w-xs">{title}</TooltipContent>
+    </Tooltip>
+  );
+}
 
 export interface EditGraphQLCustomizationsProps {
   remoteSchemaName: string;
@@ -168,68 +183,63 @@ export default function EditGraphQLCustomizations({
 
   if (isLoading) {
     return (
-      <Box className="space-y-2">
-        <Text variant="h4" className="font-semibold text-lg">
-          GraphQL Customizations
-        </Text>
-        <Text variant="body2" color="secondary" className="text-sm">
+      <div className="space-y-2">
+        <h4 className="font-semibold text-lg">GraphQL Customizations</h4>
+        <p className="text-muted-foreground text-sm">
           Introspecting remote schema...
-        </Text>
-      </Box>
+        </p>
+      </div>
     );
   }
 
   if (error) {
     return (
-      <Box className="space-y-2">
-        <Text variant="h4" className="font-semibold text-lg">
-          GraphQL Customizations
-        </Text>
-        <Text variant="body2" color="error" className="text-sm">
+      <div className="space-y-2">
+        <h4 className="font-semibold text-lg">GraphQL Customizations</h4>
+        <p className="text-destructive text-sm">
           Failed to introspect remote schema. Type/field mapping is unavailable.
-        </Text>
-      </Box>
+        </p>
+      </div>
     );
   }
 
   if (!isOpen) {
     return (
-      <Box className="space-y-4">
-        <Text variant="h4" className="font-semibold text-lg">
-          GraphQL Customizations
-        </Text>
+      <div className="space-y-4">
+        <h4 className="font-semibold text-lg">GraphQL Customizations</h4>
         <Button
           variant="outline"
           size="sm"
           onClick={() => setIsOpen(true)}
-          className="mt-2 px-2"
+          className="mt-2 gap-1 border-blue-600 px-2 text-blue-600 hover:bg-blue-50 hover:text-blue-800"
         >
-          <PencilIcon className="mr-2 h-4 w-4" />
+          <PencilIcon className="h-4 w-4" />
           Edit GraphQL Customization
         </Button>
-      </Box>
+      </div>
     );
   }
 
   return (
-    <Box className="space-y-4">
-      <Box className="flex flex-row items-center justify-between">
-        <Text variant="h4" className="font-semibold text-lg">
-          GraphQL Customizations
-        </Text>
-        <Button variant="outline" size="sm" onClick={() => setIsOpen(false)}>
+    <div className="space-y-4">
+      <div className="flex flex-row items-center justify-between">
+        <h4 className="font-semibold text-lg">GraphQL Customizations</h4>
+        <Button
+          type="button"
+          variant="outline"
+          size="sm"
+          onClick={() => setIsOpen(false)}
+        >
           Close
         </Button>
-      </Box>
+      </div>
 
-      <Box className="space-y-4 rounded border-1 p-4">
-        <Box className="space-y-2">
-          <Box className="flex flex-row items-center space-x-2">
-            <Text className="font-medium">Root Field Namespace</Text>
-            <Tooltip title="Root field type names will be prefixed by this name.">
-              <InfoIcon aria-label="Info" className="h-4 w-4 text-primary" />
-            </Tooltip>
-          </Box>
+      <div className="box space-y-4 rounded border-1 p-4">
+        <div className="space-y-2">
+          <div className="flex flex-row items-center space-x-2">
+            <p className="font-medium">Root Field Namespace</p>
+            <InfoTooltip title="Root field type names will be prefixed by this name." />
+          </div>
           <Input
             {...register('definition.customization.root_fields_namespace', {
               setValueAs: (v) =>
@@ -238,25 +248,18 @@ export default function EditGraphQLCustomizations({
             id="definition.customization.root_fields_namespace"
             name="definition.customization.root_fields_namespace"
             placeholder="namespace_"
-            hideEmptyHelperText
             autoComplete="off"
-            variant="inline"
-            fullWidth
           />
-        </Box>
+        </div>
 
-        <Box className="space-y-3">
-          <Box className="flex flex-row items-center space-x-2">
-            <Text variant="h4" className="font-semibold text-lg">
-              Types
-            </Text>
-            <Tooltip title="Add a prefix / suffix to all types of the remote schema">
-              <InfoIcon aria-label="Info" className="h-4 w-4 text-primary" />
-            </Tooltip>
-          </Box>
+        <div className="space-y-3">
+          <div className="flex flex-row items-center space-x-2">
+            <h4 className="font-semibold text-lg">Types</h4>
+            <InfoTooltip title="Add a prefix / suffix to all types of the remote schema" />
+          </div>
 
-          <Box className="space-y-2">
-            <Text className="font-medium">Prefix</Text>
+          <div className="space-y-2">
+            <p className="font-medium">Prefix</p>
             <Input
               {...register('definition.customization.type_names.prefix', {
                 setValueAs: (v) =>
@@ -265,15 +268,12 @@ export default function EditGraphQLCustomizations({
               id="definition.customization.type_names.prefix"
               name="definition.customization.type_names.prefix"
               placeholder="prefix_"
-              hideEmptyHelperText
               autoComplete="off"
-              variant="inline"
-              fullWidth
             />
-          </Box>
+          </div>
 
-          <Box className="space-y-2">
-            <Text className="font-medium">Suffix</Text>
+          <div className="space-y-2">
+            <p className="font-medium">Suffix</p>
             <Input
               {...register('definition.customization.type_names.suffix', {
                 setValueAs: (v) =>
@@ -282,47 +282,41 @@ export default function EditGraphQLCustomizations({
               id="definition.customization.type_names.suffix"
               name="definition.customization.type_names.suffix"
               placeholder="_suffix"
-              hideEmptyHelperText
               autoComplete="off"
-              variant="inline"
-              fullWidth
             />
-          </Box>
-        </Box>
-      </Box>
+          </div>
+        </div>
+      </div>
 
-      <Box className="space-y-4 rounded border-1 p-4">
-        <Box className="flex flex-row items-center justify-between">
-          <Box className="flex flex-row items-center space-x-2">
-            <Text variant="h4" className="font-semibold text-lg">
-              Rename Type Names
-            </Text>
-            <Tooltip title="Type remapping takes precedence to prefixes and suffixes.">
-              <InfoIcon aria-label="Info" className="h-4 w-4 text-primary" />
-            </Tooltip>
-          </Box>
+      <div className="box space-y-4 rounded border-1 p-4">
+        <div className="flex flex-row items-center justify-between">
+          <div className="flex flex-row items-center space-x-2">
+            <h4 className="font-semibold text-lg">Rename Type Names</h4>
+            <InfoTooltip title="Type remapping takes precedence to prefixes and suffixes." />
+          </div>
           <Button
+            aria-label="Add type remap"
+            type="button"
             variant="ghost"
             size="icon"
-            aria-label="Add type remap"
             onClick={addFirstAvailableTypeRemap}
             disabled={!canAddTypeRemap}
           >
             <PlusIcon className="h-5 w-5" />
           </Button>
-        </Box>
+        </div>
 
-        <Box className="space-y-3">
+        <div className="space-y-3">
           {Object.entries(typeNamesMapping).map(([fromType]) => (
-            <Box key={fromType} className="rounded border p-3">
-              <Box className="grid grid-cols-1 gap-3 md:grid-cols-3">
+            <div key={fromType} className="box rounded border p-3">
+              <div className="grid grid-cols-1 gap-3 md:grid-cols-3">
                 <TypeNameCustomizationCombobox
                   fromType={fromType}
                   schemaTypes={schemaTypes}
                   changeTypeKey={changeTypeKey}
                 />
-                <Box>
-                  <Text className="font-medium">New name</Text>
+                <div>
+                  <p className="font-medium">New name</p>
                   <Controller
                     control={control}
                     name={`definition.customization.type_names.mapping.${fromType}`}
@@ -332,53 +326,47 @@ export default function EditGraphQLCustomizations({
                         onChange={(e) => field.onChange(e.target.value)}
                         className="mt-1"
                         placeholder="New type name"
-                        hideEmptyHelperText
                         autoComplete="off"
-                        variant="inline"
-                        fullWidth
                       />
                     )}
                   />
-                </Box>
-                <Box className="flex">
+                </div>
+                <div className="flex">
                   <Button
-                    variant="ghost"
                     className="h-10 self-end text-destructive hover:text-destructive"
                     aria-label="Remove type remap"
+                    variant="ghost"
+                    size="icon"
                     onClick={() => removeTypeRemap(fromType)}
                   >
                     <TrashIcon className="h-4 w-4" />
                   </Button>
-                </Box>
-              </Box>
-            </Box>
+                </div>
+              </div>
+            </div>
           ))}
-        </Box>
-      </Box>
+        </div>
+      </div>
 
-      <Box className="space-y-4 rounded border-1 p-4">
-        <Box className="flex flex-row items-center justify-between">
-          <Box className="flex flex-row items-center space-x-2">
-            <Text variant="h4" className="font-semibold text-lg">
-              Field Names
-            </Text>
-            <Tooltip title="Add mappings for fields of a selected parent type. You can also set a prefix/suffix for those fields.">
-              <InfoIcon aria-label="Info" className="h-4 w-4 text-primary" />
-            </Tooltip>
-          </Box>
+      <div className="box space-y-4 rounded border-1 p-4">
+        <div className="flex flex-row items-center justify-between">
+          <div className="flex flex-row items-center space-x-2">
+            <h4 className="font-semibold text-lg">Field Names</h4>
+            <InfoTooltip title="Add mappings for fields of a selected parent type. You can also set a prefix/suffix for those fields." />
+          </div>
           <Button
+            aria-label="Add field name"
             variant="ghost"
             size="icon"
-            aria-label="Add field name"
             onClick={() =>
               appendFieldName({} as RemoteSchemaCustomizationFieldNamesItem)
             }
           >
             <PlusIcon className="h-5 w-5" />
           </Button>
-        </Box>
+        </div>
 
-        <Box className="space-y-3">
+        <div className="space-y-3">
           {fieldArrayFields?.map((row, index) => {
             const parentTypeValue =
               (Array.isArray(rawFieldNames) &&
@@ -389,10 +377,10 @@ export default function EditGraphQLCustomizations({
               (row as any)?.parent_type;
             const fields = getParentTypeFields(parentTypeValue);
             return (
-              <Box key={row.id ?? index} className="rounded border p-3">
-                <Box className="grid grid-cols-1 gap-3 md:grid-cols-4">
-                  <Box>
-                    <Text className="font-medium">Parent type</Text>
+              <div key={row.id ?? index} className="box rounded border p-3">
+                <div className="grid grid-cols-1 gap-3 md:grid-cols-4">
+                  <div>
+                    <p className="font-medium">Parent type</p>
                     <Controller
                       name={`definition.customization.field_names.${index}.parent_type`}
                       control={control}
@@ -473,9 +461,9 @@ export default function EditGraphQLCustomizations({
                         </Popover>
                       )}
                     />
-                  </Box>
-                  <Box>
-                    <Text className="font-medium">Field Prefix</Text>
+                  </div>
+                  <div>
+                    <p className="font-medium">Field Prefix</p>
                     <Input
                       {...register(
                         `definition.customization.field_names.${index}.prefix`,
@@ -489,13 +477,12 @@ export default function EditGraphQLCustomizations({
                       // biome-ignore lint/suspicious/noExplicitAny: TODO
                       defaultValue={(row as any)?.prefix ?? ''}
                       placeholder="prefix_"
-                      hideEmptyHelperText
                       autoComplete="off"
                       className="mt-1"
                     />
-                  </Box>
-                  <Box>
-                    <Text className="font-medium">Field Suffix</Text>
+                  </div>
+                  <div>
+                    <p className="font-medium">Field Suffix</p>
                     <Input
                       {...register(
                         `definition.customization.field_names.${index}.suffix`,
@@ -509,42 +496,35 @@ export default function EditGraphQLCustomizations({
                       // biome-ignore lint/suspicious/noExplicitAny: TODO
                       defaultValue={(row as any)?.suffix ?? ''}
                       placeholder="_suffix"
-                      hideEmptyHelperText
                       autoComplete="off"
                       className="mt-1"
-                      variant="inline"
-                      fullWidth
                     />
-                  </Box>
-                  <Box className="flex">
+                  </div>
+                  <div className="flex">
                     <Button
-                      variant="ghost"
                       className="h-10 self-end text-destructive hover:text-destructive"
                       aria-label="Remove field name"
+                      variant="ghost"
+                      size="icon"
                       onClick={() => removeFieldName(index)}
                     >
                       <TrashIcon className="h-4 w-4" />
                     </Button>
-                  </Box>
-                </Box>
+                  </div>
+                </div>
 
                 {fields.length > 0 && (
-                  <Box className="mt-3 space-y-2">
-                    <Text className="font-medium">Field remaps</Text>
-                    <Box className="space-y-2">
+                  <div className="mt-3 space-y-2">
+                    <p className="font-medium">Field remaps</p>
+                    <div className="space-y-2">
                       {fields.map((f) => {
                         const key = f.name;
                         return (
-                          <Box
+                          <div
                             key={key}
                             className="grid grid-cols-1 gap-2 md:grid-cols-2"
                           >
-                            <Input
-                              disabled
-                              value={key}
-                              variant="inline"
-                              fullWidth
-                            />
+                            <Input disabled value={key} />
                             <Controller
                               control={control}
                               name={`definition.customization.field_names.${index}.mapping.${key}`}
@@ -555,24 +535,21 @@ export default function EditGraphQLCustomizations({
                                     field.onChange(e.target.value)
                                   }
                                   placeholder="new_field_name"
-                                  hideEmptyHelperText
                                   autoComplete="off"
-                                  variant="inline"
-                                  fullWidth
                                 />
                               )}
                             />
-                          </Box>
+                          </div>
                         );
                       })}
-                    </Box>
-                  </Box>
+                    </div>
+                  </div>
                 )}
-              </Box>
+              </div>
             );
           })}
-        </Box>
-      </Box>
-    </Box>
+        </div>
+      </div>
+    </div>
   );
 }

--- a/dashboard/src/features/orgs/projects/remote-schemas/components/EditRemoteSchemaForm/sections/TypeNameCustomizationCombobox.tsx
+++ b/dashboard/src/features/orgs/projects/remote-schemas/components/EditRemoteSchemaForm/sections/TypeNameCustomizationCombobox.tsx
@@ -1,5 +1,3 @@
-import { Box } from '@/components/ui/v2/Box';
-import { Text } from '@/components/ui/v2/Text';
 import { Combobox } from '@/components/ui/v3/combobox';
 import type { GraphQLTypeForVisualization } from '@/utils/hasura-api/generated/schemas';
 
@@ -20,8 +18,8 @@ export default function TypeNameCustomizationCombobox({
   }));
 
   return (
-    <Box>
-      <Text className="font-medium">Type</Text>
+    <div>
+      <p className="font-medium">Type</p>
       <Combobox
         options={options}
         value={fromType || null}
@@ -31,6 +29,6 @@ export default function TypeNameCustomizationCombobox({
         className="mt-1 w-full justify-between overflow-hidden text-left"
         onChange={(value) => changeTypeKey(fromType, value)}
       />
-    </Box>
+    </div>
   );
 }

--- a/dashboard/src/features/orgs/projects/remote-schemas/components/EditRemoteSchemaPermissionsForm/EditRemoteSchemaPermissionsForm.tsx
+++ b/dashboard/src/features/orgs/projects/remote-schemas/components/EditRemoteSchemaPermissionsForm/EditRemoteSchemaPermissionsForm.tsx
@@ -1,21 +1,21 @@
-import Link from 'next/link';
 import { useState } from 'react';
 import { twMerge } from 'tailwind-merge';
 import { NavLink } from '@/components/common/NavLink';
-import { Alert } from '@/components/ui/v2/Alert';
-import { Box } from '@/components/ui/v2/Box';
-import { Table } from '@/components/ui/v2/Table';
-import { TableBody } from '@/components/ui/v2/TableBody';
-import { TableCell } from '@/components/ui/v2/TableCell';
-import { TableContainer } from '@/components/ui/v2/TableContainer';
-import { TableHead } from '@/components/ui/v2/TableHead';
-import { TableRow } from '@/components/ui/v2/TableRow';
-import { Text } from '@/components/ui/v2/Text';
+import { Alert } from '@/components/ui/v3/alert';
 import { Button } from '@/components/ui/v3/button';
 import { FullPermissionIcon } from '@/components/ui/v3/icons/FullPermissionIcon';
 import { NoPermissionIcon } from '@/components/ui/v3/icons/NoPermissionIcon';
 import { PartialPermissionIcon } from '@/components/ui/v3/icons/PartialPermissionIcon';
 import { Spinner } from '@/components/ui/v3/spinner';
+import {
+  Table,
+  TableBody,
+  TableHead,
+  TableHeader,
+  TableRow,
+} from '@/components/ui/v3/table';
+import { TextLink } from '@/components/ui/v3/text-link';
+import { InfoAlert } from '@/features/orgs/components/InfoAlert';
 import { useRemoteApplicationGQLClient } from '@/features/orgs/hooks/useRemoteApplicationGQLClient';
 import { useIsPlatform } from '@/features/orgs/projects/common/hooks/useIsPlatform';
 import { useCurrentOrg } from '@/features/orgs/projects/hooks/useCurrentOrg';
@@ -113,23 +113,16 @@ export default function EditRemoteSchemaPermissionsForm({
 
   if (!remoteSchemaPermissionsEnabled) {
     return (
-      <Box className="p-4">
-        <Alert className="grid w-full grid-flow-col place-content-between items-center gap-2">
-          <Text className="grid grid-flow-row justify-items-start gap-0.5">
-            <Text component="span">
-              To configure permissions, enable remote schema permissions first
-              in{' '}
-              <Link
-                href={`/orgs/${org?.slug}/projects/${project?.subdomain}/settings/hasura`}
-                className="text-primary hover:underline"
-              >
-                Hasura Settings
-              </Link>
-              .
-            </Text>
-          </Text>
-        </Alert>
-      </Box>
+      <div className="p-4">
+        <InfoAlert>
+          To configure permissions, enable remote schema permissions first in{' '}
+          <TextLink
+            href={`/orgs/${org?.slug}/projects/${project?.subdomain}/settings/hasura`}
+          >
+            Hasura Settings.
+          </TextLink>
+        </InfoAlert>
+      </div>
     );
   }
 
@@ -215,78 +208,62 @@ export default function EditRemoteSchemaPermissionsForm({
   }
 
   return (
-    <Box
-      className="flex flex-auto flex-col content-between overflow-hidden border-t-1"
-      sx={{ backgroundColor: 'background.default' }}
-    >
+    <div className="box flex flex-auto flex-col content-between overflow-hidden border-t-1">
       <div className="flex-auto">
-        <Box className="grid grid-flow-row content-start gap-6 overflow-y-auto border-b-1 p-6">
+        <div className="box grid grid-flow-row content-start gap-6 overflow-y-auto border-b-1 p-6">
           <div className="grid grid-flow-row gap-2">
-            <Text component="h2" className="!font-bold">
-              Remote Schema: {schema}
-            </Text>
+            <h2 className="!font-bold">Remote Schema: {schema}</h2>
 
-            <Text>
+            <p>
               Configure permissions for remote schema access. Rules for each
               role can be set by clicking on the corresponding cell.
-            </Text>
+            </p>
           </div>
 
           <div className="grid grid-flow-col items-center justify-start gap-4">
-            <Text
-              variant="subtitle2"
-              className="grid grid-flow-col items-center gap-1"
-            >
+            <span className="grid grid-flow-col items-center gap-1 text-sm">
               full access <FullPermissionIcon />
-            </Text>
+            </span>
 
-            <Text
-              variant="subtitle2"
-              className="grid grid-flow-col items-center gap-1"
-            >
+            <span className="grid grid-flow-col items-center gap-1 text-sm">
               partial access <PartialPermissionIcon />
-            </Text>
+            </span>
 
-            <Text
-              variant="subtitle2"
-              className="grid grid-flow-col items-center gap-1"
-            >
+            <span className="grid grid-flow-col items-center gap-1 text-sm">
               no access <NoPermissionIcon />
-            </Text>
+            </span>
           </div>
 
-          <TableContainer sx={{ backgroundColor: 'background.paper' }}>
-            <Table>
-              <TableHead className="block">
-                <TableRow className="grid grid-cols-2 items-center">
-                  <TableCell className="border-b-0 p-2">Role</TableCell>
+          <Table containerClassName="bg-card">
+            <TableHeader className="block">
+              <TableRow className="grid grid-cols-2 items-center">
+                <TableHead className="border-b-0 p-2">Role</TableHead>
 
-                  <TableCell className="border-b-0 p-2 text-center">
-                    Permission
-                  </TableCell>
-                </TableRow>
-              </TableHead>
+                <TableHead className="border-b-0 p-2 text-center">
+                  Permission
+                </TableHead>
+              </TableRow>
+            </TableHeader>
 
-              <TableBody className="block rounded-sm+ border-1">
-                <RolePermissionsRow name="admin" disabled accessLevel="full" />
+            <TableBody className="block rounded-sm+ border-1">
+              <RolePermissionsRow name="admin" disabled accessLevel="full" />
 
-                {availableRoles.map((currentRole, index) => (
-                  <RolePermissionsRow
-                    name={currentRole}
-                    key={currentRole}
-                    className={twMerge(
-                      index === availableRoles.length - 1 && 'border-b-0',
-                    )}
-                    onActionSelect={() => {
-                      setSelectedRole(currentRole);
-                      setIsEditing(true);
-                    }}
-                    accessLevel={getPermissionAccessLevel(currentRole)}
-                  />
-                ))}
-              </TableBody>
-            </Table>
-          </TableContainer>
+              {availableRoles.map((currentRole, index) => (
+                <RolePermissionsRow
+                  name={currentRole}
+                  key={currentRole}
+                  className={twMerge(
+                    index === availableRoles.length - 1 && 'border-b-0',
+                  )}
+                  onActionSelect={() => {
+                    setSelectedRole(currentRole);
+                    setIsEditing(true);
+                  }}
+                  accessLevel={getPermissionAccessLevel(currentRole)}
+                />
+              ))}
+            </TableBody>
+          </Table>
 
           <Alert className="text-left">
             Please go to the{' '}
@@ -299,14 +276,14 @@ export default function EditRemoteSchemaPermissionsForm({
             </NavLink>{' '}
             to add and delete roles.
           </Alert>
-        </Box>
+        </div>
       </div>
 
-      <Box className="grid flex-shrink-0 grid-flow-col justify-between gap-3 border-t-1 p-2">
-        <Button variant="ghost" onClick={onCancel}>
+      <div className="box grid flex-shrink-0 grid-flow-col justify-between gap-3 border-t-1 p-2">
+        <Button type="button" variant="ghost" onClick={onCancel}>
           Cancel
         </Button>
-      </Box>
-    </Box>
+      </div>
+    </div>
   );
 }

--- a/dashboard/src/features/orgs/projects/remote-schemas/components/EditRemoteSchemaPermissionsForm/RemoteSchemaRolePermissionsEditorForm.tsx
+++ b/dashboard/src/features/orgs/projects/remote-schemas/components/EditRemoteSchemaPermissionsForm/RemoteSchemaRolePermissionsEditorForm.tsx
@@ -8,15 +8,13 @@ import { useCallback, useEffect, useMemo, useState } from 'react';
 import { useForm } from 'react-hook-form';
 import { z } from 'zod';
 import { useDialog } from '@/components/common/DialogProvider';
-import { Alert } from '@/components/ui/v2/Alert';
-import { Box } from '@/components/ui/v2/Box';
-import { Text } from '@/components/ui/v2/Text';
 import {
   Accordion,
   AccordionContent,
   AccordionItem,
   AccordionTrigger,
 } from '@/components/ui/v3/accordion';
+import { Alert } from '@/components/ui/v3/alert';
 import { Button, ButtonWithLoading } from '@/components/ui/v3/button';
 import { Checkbox } from '@/components/ui/v3/checkbox';
 import { Form } from '@/components/ui/v3/form';
@@ -530,7 +528,7 @@ export default function RemoteSchemaRolePermissionsEditorForm({
   if (schemaError) {
     return (
       <div className="p-6">
-        <Alert severity="error">
+        <Alert variant="destructive">
           Failed to load remote schema:{' '}
           {schemaError instanceof Error ? schemaError.message : 'Unknown error'}
         </Alert>
@@ -540,25 +538,18 @@ export default function RemoteSchemaRolePermissionsEditorForm({
 
   return (
     <Form {...form}>
-      <Box
-        className="flex flex-auto flex-col content-between border-t-1"
-        sx={{
-          backgroundColor: 'background.default',
-          height: '92vh',
-          maxHeight: '92vh',
-        }}
-      >
+      <div className="box flex h-[92vh] max-h-[92vh] flex-auto flex-col content-between border-t-1">
         <div className="flex flex-auto flex-col overflow-hidden">
-          <Box className="flex-1 overflow-y-auto p-6">
+          <div className="flex-1 overflow-y-auto p-6">
             <div className="space-y-6">
               <div className="grid grid-flow-row gap-2">
-                <Text component="h2" className="!font-bold">
+                <h2 className="!font-bold">
                   Edit Permissions: {remoteSchemaName} - {role}
-                </Text>
-                <Text>
+                </h2>
+                <p>
                   Select the fields and operations that should be available for
                   this role. Edit preset values for arguments when needed.
-                </Text>
+                </p>
               </div>
 
               <div className="relative space-y-2">
@@ -576,12 +567,10 @@ export default function RemoteSchemaRolePermissionsEditorForm({
                 )}
               </div>
 
-              <Box className="space-y-6">
+              <div className="space-y-6">
                 {rootTypes.length > 0 && (
                   <div className="space-y-4">
-                    <Text className="font-semibold text-lg">
-                      Root Operations
-                    </Text>
+                    <h3 className="font-semibold text-lg">Root Operations</h3>
                     <div className="space-y-4 rounded border p-4">
                       {rootTypes.map((schemaType) => {
                         const actualSchemaIndex = remoteSchemaFields.findIndex(
@@ -591,9 +580,9 @@ export default function RemoteSchemaRolePermissionsEditorForm({
                           remoteSchemaFields[actualSchemaIndex]?.children;
                         return (
                           <div key={schemaType.name} className="space-y-2">
-                            <Text className="font-semibold text-blue-600">
+                            <p className="font-semibold text-blue-600">
                               {schemaType.name.replace('type ', '')} Operations
-                            </Text>
+                            </p>
                             <div className="pl-4">
                               <Accordion
                                 type="multiple"
@@ -671,9 +660,9 @@ export default function RemoteSchemaRolePermissionsEditorForm({
                                         </div>
                                         <AccordionContent>
                                           <div className="ml-6 space-y-2 border-gray-200 border-l-2 pl-4">
-                                            <Text className="font-medium text-gray-700 text-sm">
+                                            <p className="font-medium text-gray-700 text-sm">
                                               Arguments:
-                                            </Text>
+                                            </p>
                                             {Object.values(field.args).map(
                                               (arg) =>
                                                 renderPresetRow(
@@ -736,7 +725,7 @@ export default function RemoteSchemaRolePermissionsEditorForm({
 
                 {customTypes.length > 0 && (
                   <div className="space-y-4">
-                    <Text className="font-semibold text-lg">Custom Types</Text>
+                    <h3 className="font-semibold text-lg">Custom Types</h3>
                     <div className="space-y-4 rounded border p-4">
                       {customTypes.map((schemaType) => {
                         const actualSchemaIndex = remoteSchemaFields.findIndex(
@@ -746,9 +735,9 @@ export default function RemoteSchemaRolePermissionsEditorForm({
                           remoteSchemaFields[actualSchemaIndex]?.children;
                         return (
                           <div key={schemaType.name} className="space-y-2">
-                            <Text className="font-semibold text-green-600">
+                            <p className="font-semibold text-green-600">
                               {schemaType.name}
-                            </Text>
+                            </p>
                             <div className="space-y-1 pl-4">
                               {(schemaType.children ?? []).map((field) => {
                                 const fieldKey = `${schemaType.name}.${field.name}`;
@@ -805,9 +794,9 @@ export default function RemoteSchemaRolePermissionsEditorForm({
                                       field.args &&
                                       Object.values(field.args).length > 0 && (
                                         <div className="ml-6 space-y-2 border-gray-200 border-l-2 pl-4">
-                                          <Text className="font-medium text-gray-700 text-sm">
+                                          <p className="font-medium text-gray-700 text-sm">
                                             Arguments:
-                                          </Text>
+                                          </p>
                                           {Object.values(field.args).map(
                                             (arg) =>
                                               renderPresetRow(
@@ -837,9 +826,7 @@ export default function RemoteSchemaRolePermissionsEditorForm({
 
                 {filteredFields.length === 0 && (
                   <div className="space-y-4">
-                    <Text className="font-semibold text-lg">
-                      Available Fields
-                    </Text>
+                    <h3 className="font-semibold text-lg">Available Fields</h3>
                     <div className="rounded border p-8 text-center text-gray-500">
                       {searchTerm
                         ? 'No fields match your search'
@@ -847,22 +834,22 @@ export default function RemoteSchemaRolePermissionsEditorForm({
                     </div>
                   </div>
                 )}
-              </Box>
+              </div>
             </div>
-          </Box>
+          </div>
         </div>
 
-        <Box className="grid flex-shrink-0 gap-2 border-t-1 p-2 sm:grid-flow-col sm:justify-between">
-          <Button variant="ghost" onClick={onCancel}>
+        <div className="box grid flex-shrink-0 gap-2 border-t-1 p-2 sm:grid-flow-col sm:justify-between">
+          <Button type="button" variant="ghost" onClick={onCancel}>
             Cancel
           </Button>
 
-          <Box className="grid grid-flow-row gap-2 sm:grid-flow-col">
+          <div className="grid grid-flow-row gap-2 sm:grid-flow-col">
             {permission && (
               <ButtonWithLoading
-                variant="destructive"
+                variant="outline"
+                className="border-destructive text-destructive hover:bg-destructive/10 hover:text-destructive"
                 onClick={handleDeleteClick}
-                disabled={isRemovingPermission}
                 loading={isRemovingPermission}
               >
                 Delete Permissions
@@ -871,16 +858,14 @@ export default function RemoteSchemaRolePermissionsEditorForm({
 
             <ButtonWithLoading
               onClick={handleSavePermission}
-              disabled={
-                !schemaDefinition || isAddingPermission || isUpdatingPermission
-              }
+              disabled={!schemaDefinition}
               loading={isAddingPermission || isUpdatingPermission}
             >
               Save Permissions
             </ButtonWithLoading>
-          </Box>
-        </Box>
-      </Box>
+          </div>
+        </div>
+      </div>
     </Form>
   );
 }

--- a/dashboard/src/features/orgs/projects/remote-schemas/components/EditRemoteSchemaPermissionsForm/RolePermissionsRow.tsx
+++ b/dashboard/src/features/orgs/projects/remote-schemas/components/EditRemoteSchemaPermissionsForm/RolePermissionsRow.tsx
@@ -1,15 +1,13 @@
+import type { ComponentPropsWithoutRef } from 'react';
 import { twMerge } from 'tailwind-merge';
-import { IconButton } from '@/components/ui/v2/IconButton';
-import type { TableCellProps } from '@/components/ui/v2/TableCell';
-import { TableCell } from '@/components/ui/v2/TableCell';
-import type { TableRowProps } from '@/components/ui/v2/TableRow';
-import { TableRow } from '@/components/ui/v2/TableRow';
+import { Button } from '@/components/ui/v3/button';
 import { FullPermissionIcon } from '@/components/ui/v3/icons/FullPermissionIcon';
 import { NoPermissionIcon } from '@/components/ui/v3/icons/NoPermissionIcon';
 import { PartialPermissionIcon } from '@/components/ui/v3/icons/PartialPermissionIcon';
+import { TableCell, TableRow } from '@/components/ui/v3/table';
 import type { RemoteSchemaAccessLevel } from '@/features/orgs/projects/remote-schemas/types';
 
-export interface RolePermissionsProps extends TableRowProps {
+export interface RolePermissionsProps extends ComponentPropsWithoutRef<'tr'> {
   /**
    * Role name.
    */
@@ -34,7 +32,7 @@ export interface RolePermissionsProps extends TableRowProps {
     /**
      * Props passed to every cell in the table row.
      */
-    cell?: Partial<TableCellProps>;
+    cell?: ComponentPropsWithoutRef<'td'>;
   };
 }
 
@@ -90,14 +88,15 @@ export default function RolePermissions({
         {disabled ? (
           <AccessLevelIcon level={accessLevel} />
         ) : (
-          <IconButton
-            variant="borderless"
-            color="secondary"
+          <Button
+            type="button"
+            variant="ghost"
+            size="icon"
             className="h-full w-full rounded-none"
             onClick={onActionSelect}
           >
             <AccessLevelIcon level={accessLevel} />
-          </IconButton>
+          </Button>
         )}
       </TableCell>
     </TableRow>

--- a/dashboard/src/features/orgs/projects/remote-schemas/components/EditRemoteSchemaRelationships/sections/RemoteSchemaRelationshipsInfoTable.tsx
+++ b/dashboard/src/features/orgs/projects/remote-schemas/components/EditRemoteSchemaRelationships/sections/RemoteSchemaRelationshipsInfoTable.tsx
@@ -5,7 +5,6 @@ import {
   Trash2 as TrashIcon,
 } from 'lucide-react';
 import { useDialog } from '@/components/common/DialogProvider';
-import { IconButton } from '@/components/ui/v2/IconButton';
 import { Button } from '@/components/ui/v3/button';
 import {
   DropdownMenu,
@@ -161,9 +160,9 @@ export default function RemoteSchemaRelationshipsInfoTable({
                 <TableCell>
                   <DropdownMenu>
                     <DropdownMenuTrigger asChild>
-                      <IconButton variant="borderless" color="secondary">
+                      <Button type="button" variant="ghost" size="icon">
                         <DotsHorizontalIcon />
-                      </IconButton>
+                      </Button>
                     </DropdownMenuTrigger>
                     <DropdownMenuContent align="end" className="w-52 p-0">
                       <DropdownMenuItem

--- a/dashboard/src/features/orgs/projects/remote-schemas/components/RemoteSchemaBrowserSidebar/RemoteSchemaBrowserSidebar.tsx
+++ b/dashboard/src/features/orgs/projects/remote-schemas/components/RemoteSchemaBrowserSidebar/RemoteSchemaBrowserSidebar.tsx
@@ -8,18 +8,12 @@ import {
   UsersIcon,
 } from 'lucide-react';
 import dynamic from 'next/dynamic';
+import Link from 'next/link';
 import { useRouter } from 'next/router';
 import { useState } from 'react';
 import { useDialog } from '@/components/common/DialogProvider';
-import { ListNavLink } from '@/components/common/NavLink';
 import { FormActivityIndicator } from '@/components/form/FormActivityIndicator';
 import { FeatureSidebar } from '@/components/layout/FeatureSidebar';
-import { InlineCode } from '@/components/presentational/InlineCode';
-import { Box } from '@/components/ui/v2/Box';
-import { IconButton } from '@/components/ui/v2/IconButton';
-import { List } from '@/components/ui/v2/List';
-import { ListItem } from '@/components/ui/v2/ListItem';
-import { Text } from '@/components/ui/v2/Text';
 import { Button } from '@/components/ui/v3/button';
 import {
   DropdownMenu,
@@ -27,6 +21,7 @@ import {
   DropdownMenuItem,
   DropdownMenuTrigger,
 } from '@/components/ui/v3/dropdown-menu';
+import { InlineCode } from '@/components/ui/v3/inline-code';
 import { Spinner } from '@/components/ui/v3/spinner';
 import { useIsPlatform } from '@/features/orgs/projects/common/hooks/useIsPlatform';
 import { useProject } from '@/features/orgs/projects/hooks/useProject';
@@ -78,6 +73,9 @@ const EditRemoteSchemaRelationships = dynamic(
     ssr: false,
   },
 );
+
+const menuItemClassName =
+  'flex h-9 cursor-pointer items-center justify-start gap-2 rounded-none border border-b-1 p-2 font-medium text-sm+ leading-4 hover:bg-data-cell-bg';
 
 export interface RemoteSchemaBrowserSidebarProps {
   className?: string;
@@ -188,148 +186,168 @@ function RemoteSchemaBrowserSidebarContent({
   }
 
   return (
-    <Box className="flex h-full flex-col px-2">
-      <Button
-        variant="ghost"
-        className="mt-1 w-full justify-between px-2"
-        onClick={() => {
-          openDrawer({
-            title: 'Create a New Remote Schema',
-            component: <CreateRemoteSchemaForm onSubmit={refetch} />,
-          });
-          onSidebarItemClick?.();
-        }}
-      >
-        New Remote Schema
-        <PlusIcon className="ml-2" />
-      </Button>
-      {remoteSchemas && remoteSchemas.length === 0 && (
-        <Text className="px-2 py-1.5 text-xs" color="disabled">
-          No remote schemas found.
-        </Text>
-      )}
-      <nav aria-label="Database navigation">
-        {remoteSchemas.length > 0 && (
-          <List className="grid gap-1 pb-6">
-            {remoteSchemas.map((remoteSchema) => {
-              const isSelected = remoteSchemaSlug === remoteSchema.name;
-              const isSidebarMenuOpen =
-                sidebarMenuRemoteSchema === remoteSchema.name;
-              return (
-                <ListItem.Root
-                  className="group"
-                  key={remoteSchema.name}
-                  secondaryAction={
-                    <DropdownMenu
-                      onOpenChange={(open) =>
-                        setSidebarMenuRemoteSchema(
-                          open ? remoteSchema.name : undefined,
-                        )
-                      }
+    <div className="flex h-full flex-col">
+      <div className="flex shrink-0 flex-col gap-4 px-2">
+        <Button
+          variant="link"
+          className="!text-sm+ flex w-full justify-between px-[0.625rem] text-primary hover:bg-accent hover:no-underline disabled:text-disabled"
+          onClick={() => {
+            openDrawer({
+              title: 'Create a New Remote Schema',
+              component: <CreateRemoteSchemaForm onSubmit={refetch} />,
+            });
+            onSidebarItemClick?.();
+          }}
+        >
+          New Remote Schema
+          <PlusIcon className="h-4 w-4" />
+        </Button>
+      </div>
+
+      <div className="min-h-0 flex-1 overflow-y-auto px-2">
+        {remoteSchemas && remoteSchemas.length === 0 && (
+          <p className="px-2 py-1.5 text-disabled text-xs">
+            No remote schemas found.
+          </p>
+        )}
+        <nav className="mt-2" aria-label="Remote schema navigation">
+          {remoteSchemas.length > 0 && (
+            <ul className="w-full max-w-full pb-6">
+              {remoteSchemas.map((remoteSchema) => {
+                const isSelected = remoteSchemaSlug === remoteSchema.name;
+                const isSidebarMenuOpen =
+                  sidebarMenuRemoteSchema === remoteSchema.name;
+                return (
+                  <li className="group pb-1" key={remoteSchema.name}>
+                    <Button
+                      asChild
+                      variant="link"
+                      size="sm"
+                      className={cn(
+                        'flex w-full max-w-full justify-between pl-0 text-sm+ hover:bg-accent hover:no-underline',
+                        {
+                          'bg-table-selected': isSelected,
+                        },
+                      )}
                     >
-                      <DropdownMenuTrigger asChild>
-                        <IconButton
-                          variant="borderless"
-                          color={isSelected ? 'primary' : 'secondary'}
+                      <div>
+                        <Link
+                          href={`/orgs/${orgSlug}/projects/${appSubdomain}/graphql/remote-schemas/${remoteSchema.name}`}
+                          onClick={() => {
+                            onSidebarItemClick?.(remoteSchema.name);
+                          }}
                           className={cn(
-                            !isSelected &&
-                              'opacity-0 group-focus-within:opacity-100 group-hover:opacity-100 group-active:opacity-100',
+                            'flex h-full w-[calc(100%-1.6rem)] items-center p-[0.625rem] pr-0 text-left',
+                            {
+                              'text-primary-main': isSelected,
+                            },
                           )}
                         >
-                          <DotsHorizontalIcon />
-                        </IconButton>
-                      </DropdownMenuTrigger>
-                      <DropdownMenuContent
-                        side="right"
-                        align="start"
-                        className="w-60 p-0"
-                      >
-                        <DropdownMenuItem
-                          key="edit-table"
-                          className="flex h-9 cursor-pointer items-center justify-start gap-2 rounded-none border border-b-1 p-2 font-medium text-sm+ leading-4 hover:bg-data-cell-bg"
-                          onClick={() =>
-                            openDrawer({
-                              title: 'Edit Remote Schema',
-                              component: (
-                                <EditRemoteSchemaForm
-                                  originalSchema={remoteSchema}
-                                  onSubmit={async () => {
-                                    await queryClient.refetchQueries({
-                                      queryKey: [
-                                        `remote_schemas`,
-                                        project?.subdomain,
-                                      ],
-                                    });
-                                    await refetch();
-                                  }}
-                                />
-                              ),
-                            })
+                          <span className="!truncate text-ellipsis">
+                            {remoteSchema.name}
+                          </span>
+                        </Link>
+                        <DropdownMenu
+                          onOpenChange={(open) =>
+                            setSidebarMenuRemoteSchema(
+                              open ? remoteSchema.name : undefined,
+                            )
                           }
                         >
-                          <PencilIcon className="h-4 w-4 text-muted-foreground" />
-                          <span>Edit Remote Schema</span>
-                        </DropdownMenuItem>
-                        <DropdownMenuItem
-                          key="edit-permissions"
-                          className="flex h-9 cursor-pointer items-center justify-start gap-2 rounded-none border border-b-1 p-2 font-medium text-sm+ leading-4 hover:bg-data-cell-bg"
-                          onClick={() =>
-                            handleEditPermissionClick(remoteSchema.name)
-                          }
-                        >
-                          <UsersIcon className="h-4 w-4 text-muted-foreground" />
-                          <span>Edit Permissions</span>
-                        </DropdownMenuItem>
-                        <DropdownMenuItem
-                          key="edit-relationships"
-                          className="flex h-9 cursor-pointer items-center justify-start gap-2 rounded-none border border-b-1 p-2 font-medium text-sm+ leading-4 hover:bg-data-cell-bg"
-                          onClick={() =>
-                            handleEditRelationshipsClick(remoteSchema.name)
-                          }
-                        >
-                          <LinkIcon className="h-4 w-4 text-muted-foreground" />
-                          <span>Edit Relationships</span>
-                        </DropdownMenuItem>
-                        <DropdownMenuItem
-                          key="delete-remote-schema"
-                          className="!text-destructive flex h-9 cursor-pointer items-center justify-start gap-2 rounded-none border border-b-1 p-2 font-medium text-sm+ leading-4 hover:bg-data-cell-bg"
-                          onClick={() =>
-                            handleDeleteRemoteSchemaClick(remoteSchema)
-                          }
-                        >
-                          <TrashIcon className="h-4 w-4" />
-                          <span>Delete Remote Schema</span>
-                        </DropdownMenuItem>
-                      </DropdownMenuContent>
-                    </DropdownMenu>
-                  }
-                >
-                  <ListItem.Button
-                    dense
-                    selected={isSelected}
-                    className="group-focus-within:pr-9 group-hover:pr-9 group-active:pr-9"
-                    sx={{
-                      paddingRight:
-                        (isSelected || isSidebarMenuOpen) &&
-                        '2.25rem !important',
-                    }}
-                    component={ListNavLink}
-                    href={`/orgs/${orgSlug}/projects/${appSubdomain}/graphql/remote-schemas/${remoteSchema.name}`}
-                    onClick={() => {
-                      if (onSidebarItemClick) {
-                        onSidebarItemClick(`${remoteSchema.name}`);
-                      }
-                    }}
-                  >
-                    <ListItem.Text>{remoteSchema.name}</ListItem.Text>
-                  </ListItem.Button>
-                </ListItem.Root>
-              );
-            })}
-          </List>
-        )}
-      </nav>
-    </Box>
+                          <DropdownMenuTrigger
+                            asChild
+                            className={cn(
+                              'relative z-10 opacity-0 transition-opacity group-focus-within:opacity-100 group-hover:opacity-100 group-active:opacity-100',
+                              {
+                                'opacity-100': isSelected || isSidebarMenuOpen,
+                              },
+                            )}
+                          >
+                            <Button
+                              variant="outline"
+                              size="icon"
+                              aria-label="Remote schema options"
+                              className="h-6 w-6 border-none bg-transparent px-0 hover:bg-transparent focus-visible:bg-transparent"
+                            >
+                              <DotsHorizontalIcon />
+                            </Button>
+                          </DropdownMenuTrigger>
+                          <DropdownMenuContent
+                            side="bottom"
+                            align="start"
+                            className="w-60 p-0"
+                          >
+                            <DropdownMenuItem
+                              key="edit-table"
+                              className={menuItemClassName}
+                              onClick={() =>
+                                openDrawer({
+                                  title: 'Edit Remote Schema',
+                                  component: (
+                                    <EditRemoteSchemaForm
+                                      originalSchema={remoteSchema}
+                                      onSubmit={async () => {
+                                        await queryClient.refetchQueries({
+                                          queryKey: [
+                                            `remote_schemas`,
+                                            project?.subdomain,
+                                          ],
+                                        });
+                                        await refetch();
+                                      }}
+                                    />
+                                  ),
+                                })
+                              }
+                            >
+                              <PencilIcon className="h-4 w-4" />
+                              <span>Edit Remote Schema</span>
+                            </DropdownMenuItem>
+                            <DropdownMenuItem
+                              key="edit-permissions"
+                              className={menuItemClassName}
+                              onClick={() =>
+                                handleEditPermissionClick(remoteSchema.name)
+                              }
+                            >
+                              <UsersIcon className="h-4 w-4" />
+                              <span>Edit Permissions</span>
+                            </DropdownMenuItem>
+                            <DropdownMenuItem
+                              key="edit-relationships"
+                              className={menuItemClassName}
+                              onClick={() =>
+                                handleEditRelationshipsClick(remoteSchema.name)
+                              }
+                            >
+                              <LinkIcon className="h-4 w-4" />
+                              <span>Edit Relationships</span>
+                            </DropdownMenuItem>
+                            <DropdownMenuItem
+                              key="delete-remote-schema"
+                              className={cn(
+                                menuItemClassName,
+                                '!text-destructive',
+                              )}
+                              onClick={() =>
+                                handleDeleteRemoteSchemaClick(remoteSchema)
+                              }
+                            >
+                              <TrashIcon className="h-4 w-4" />
+                              <span>Delete Remote Schema</span>
+                            </DropdownMenuItem>
+                          </DropdownMenuContent>
+                        </DropdownMenu>
+                      </div>
+                    </Button>
+                  </li>
+                );
+              })}
+            </ul>
+          )}
+        </nav>
+      </div>
+    </div>
   );
 }
 
@@ -345,7 +363,7 @@ export default function RemoteSchemaBrowserSidebar({
   }
 
   return (
-    <FeatureSidebar toggleOffset="left-8" className={className}>
+    <FeatureSidebar toggleOffset="left-8" className={cn('box', className)}>
       {(collapse) => (
         <RemoteSchemaBrowserSidebarContent
           onSidebarItemClick={(remoteSchemaName) => {

--- a/dashboard/src/features/orgs/projects/remote-schemas/components/RemoteSchemaDetails/RemoteSchemaDetails.tsx
+++ b/dashboard/src/features/orgs/projects/remote-schemas/components/RemoteSchemaDetails/RemoteSchemaDetails.tsx
@@ -1,11 +1,13 @@
 import { InfoIcon, RefreshCw } from 'lucide-react';
 import { useRouter } from 'next/router';
-import { InlineCode } from '@/components/presentational/InlineCode';
-import { Box } from '@/components/ui/v2/Box';
-import { Input } from '@/components/ui/v2/Input';
-import { Text } from '@/components/ui/v2/Text';
-import { Tooltip } from '@/components/ui/v2/Tooltip';
 import { ButtonWithLoading as Button } from '@/components/ui/v3/button';
+import { InlineCode } from '@/components/ui/v3/inline-code';
+import { Input } from '@/components/ui/v3/input';
+import {
+  Tooltip,
+  TooltipContent,
+  TooltipTrigger,
+} from '@/components/ui/v3/tooltip';
 import { RemoteSchemaEmptyState } from '@/features/orgs/projects/remote-schemas/components/RemoteSchemaEmptyState';
 import { RemoteSchemaHeadersTable } from '@/features/orgs/projects/remote-schemas/components/RemoteSchemaHeadersTable';
 import { RemoteSchemaPreview } from '@/features/orgs/projects/remote-schemas/components/RemoteSchemaPreview';
@@ -66,32 +68,41 @@ export default function RemoteSchemaDetails() {
 
   return (
     <div className="space-y-6 p-4">
-      <Box className="grid grid-flow-row gap-4 overflow-hidden rounded-lg border-1 px-4 py-4">
+      <div className="box grid grid-flow-row gap-4 overflow-hidden rounded-lg border-1 px-4 py-4">
         <div>
-          <Text variant="h3" className="pb-2">
-            Remote Schema
-          </Text>
-          <Text className="font-semibold">{remoteSchema.name}</Text>
+          <h3 className="pb-2 font-medium text-lg">Remote Schema</h3>
+          <p className="font-semibold text-sm+">{remoteSchema.name}</p>
         </div>
         {showComment && (
           <div>
-            <Text variant="h3" className="pb-2">
-              Comment
-            </Text>
-            <Text color="secondary">{remoteSchema.comment}</Text>
+            <h3 className="pb-2 font-medium text-lg">Comment</h3>
+            <p className="text-muted-foreground text-sm+">
+              {remoteSchema.comment}
+            </p>
           </div>
         )}
-        <Box className="space-y-2">
-          <Box className="flex flex-row items-center space-x-2">
-            <Text>
+        <div className="space-y-2">
+          <div className="flex flex-row items-center space-x-2">
+            <p className="text-sm+">
               {'url' in remoteSchema.definition
                 ? 'GraphQL Service URL'
                 : 'GraphQL Service URL (from environment)'}
-            </Text>
-            <Tooltip title="The URL of the GraphQL service to be used as a remote schema.">
-              <InfoIcon aria-label="Info" className="h-4 w-4 text-primary" />
+            </p>
+            <Tooltip>
+              <TooltipTrigger asChild>
+                <button
+                  type="button"
+                  aria-label="Info"
+                  className="flex items-center"
+                >
+                  <InfoIcon className="h-4 w-4 text-primary" />
+                </button>
+              </TooltipTrigger>
+              <TooltipContent>
+                The URL of the GraphQL service to be used as a remote schema.
+              </TooltipContent>
             </Tooltip>
-          </Box>
+          </div>
           <div className="flex flex-row items-center gap-3">
             <Input
               value={
@@ -104,9 +115,10 @@ export default function RemoteSchemaDetails() {
                   ? 'https://graphql-service.example.com or {{ENV_VAR}}/endpoint_url'
                   : 'GRAPHQL_ENDPOINT_URL'
               }
+              readOnly
               disabled
-              fullWidth
               className="w-full"
+              wrapperClassName="w-full"
             />
             <Button
               className="flex gap-1"
@@ -118,7 +130,7 @@ export default function RemoteSchemaDetails() {
               Reload
             </Button>
           </div>
-        </Box>
+        </div>
         {remoteSchema.definition.headers &&
           remoteSchema.definition.headers.length > 0 && (
             <RemoteSchemaHeadersTable
@@ -126,26 +138,50 @@ export default function RemoteSchemaDetails() {
             />
           )}
         <div className="flex flex-row items-center space-x-2">
-          <Text>Forward all headers from client:</Text>
-          <Text color="secondary" className="font-semibold">
+          <p className="text-sm+">Forward all headers from client:</p>
+          <p className="font-semibold text-muted-foreground text-sm+">
             {remoteSchema.definition.forward_client_headers
               ? 'Enabled'
               : 'Disabled'}
-          </Text>
-          <Tooltip title="Toggle forwarding headers sent by the client app in the request to your remote GraphQL server">
-            <InfoIcon aria-label="Info" className="h-4 w-4 text-primary" />
+          </p>
+          <Tooltip>
+            <TooltipTrigger asChild>
+              <button
+                type="button"
+                aria-label="Info"
+                className="flex items-center"
+              >
+                <InfoIcon className="h-4 w-4 text-primary" />
+              </button>
+            </TooltipTrigger>
+            <TooltipContent>
+              Toggle forwarding headers sent by the client app in the request to
+              your remote GraphQL server
+            </TooltipContent>
           </Tooltip>
         </div>
         <div className="flex flex-row items-center space-x-2">
-          <Text>GraphQL Server Timeout:</Text>
-          <Text color="secondary" className="font-semibold">
+          <p className="text-sm+">GraphQL Server Timeout:</p>
+          <p className="font-semibold text-muted-foreground text-sm+">
             {remoteSchema.definition.timeout_seconds} seconds
-          </Text>
-          <Tooltip title="Configure timeout for your remote GraphQL server. Defaults to 60 seconds.">
-            <InfoIcon aria-label="Info" className="h-4 w-4 text-primary" />
+          </p>
+          <Tooltip>
+            <TooltipTrigger asChild>
+              <button
+                type="button"
+                aria-label="Info"
+                className="flex items-center"
+              >
+                <InfoIcon className="h-4 w-4 text-primary" />
+              </button>
+            </TooltipTrigger>
+            <TooltipContent>
+              Configure timeout for your remote GraphQL server. Defaults to 60
+              seconds.
+            </TooltipContent>
           </Tooltip>
         </div>
-      </Box>
+      </div>
       <RemoteSchemaPreview name={remoteSchema.name} />
     </div>
   );

--- a/dashboard/src/features/orgs/projects/remote-schemas/components/RemoteSchemaEmptyState/RemoteSchemaEmptyState.tsx
+++ b/dashboard/src/features/orgs/projects/remote-schemas/components/RemoteSchemaEmptyState/RemoteSchemaEmptyState.tsx
@@ -1,7 +1,6 @@
 import { Anchor } from 'lucide-react';
 import type { DetailedHTMLProps, HTMLProps, ReactNode } from 'react';
 import { twMerge } from 'tailwind-merge';
-import { Text } from '@/components/ui/v2/Text';
 
 export interface RemoteSchemaEmptyStateProps
   extends Omit<
@@ -36,11 +35,9 @@ export default function RemoteSchemaEmptyState({
         <Anchor className="h-12 w-12" />
       </div>
 
-      <Text variant="h3" component="h1">
-        {title}
-      </Text>
+      <h1 className="font-medium text-lg">{title}</h1>
 
-      <Text>{description}</Text>
+      <p className="text-sm+">{description}</p>
     </div>
   );
 }

--- a/dashboard/src/features/orgs/projects/remote-schemas/components/RemoteSchemaHeadersTable/RemoteSchemaHeadersTable.tsx
+++ b/dashboard/src/features/orgs/projects/remote-schemas/components/RemoteSchemaHeadersTable/RemoteSchemaHeadersTable.tsx
@@ -1,4 +1,3 @@
-import { Text } from '@/components/ui/v2/Text';
 import {
   Table,
   TableBody,
@@ -19,9 +18,7 @@ export default function RemoteSchemaHeadersTable({
 }: RemoteSchemaHeadersTableProps) {
   return (
     <div>
-      <Text variant="h3" className="pb-2">
-        Headers
-      </Text>
+      <h3 className="pb-2 font-medium text-lg">Headers</h3>
       <Table>
         <TableHeader>
           <TableRow>

--- a/dashboard/src/features/orgs/projects/remote-schemas/components/RemoteSchemaPreview/RemoteSchemaPreview.tsx
+++ b/dashboard/src/features/orgs/projects/remote-schemas/components/RemoteSchemaPreview/RemoteSchemaPreview.tsx
@@ -166,7 +166,10 @@ export default function RemoteSchemaPreview({
           </div>
         </div>
 
-        <form onSubmit={handleSearch} className="flex w-full gap-2">
+        <form
+          onSubmit={handleSearch}
+          className="flex w-full items-center gap-2"
+        >
           <div className="relative max-w-xs flex-1 text-foreground">
             <div className="pointer-events-none absolute inset-y-0 left-0 flex items-center justify-center pl-3 text-muted-foreground peer-disabled:opacity-50">
               <SearchIcon className="z-10 h-4 w-4" />

--- a/dashboard/src/pages/orgs/[orgSlug]/projects/[appSubdomain]/graphql/remote-schemas/[remoteSchemaSlug].tsx
+++ b/dashboard/src/pages/orgs/[orgSlug]/projects/[appSubdomain]/graphql/remote-schemas/[remoteSchemaSlug].tsx
@@ -1,7 +1,6 @@
 import type { ReactElement } from 'react';
-import { LoadingScreen } from '@/components/presentational/LoadingScreen';
 import { RetryableErrorBoundary } from '@/components/presentational/RetryableErrorBoundary';
-import { Box } from '@/components/ui/v2/Box';
+import { Spinner } from '@/components/ui/v3/spinner';
 import { OrgLayout } from '@/features/orgs/layout/OrgLayout';
 import { useIsPlatform } from '@/features/orgs/projects/common/hooks/useIsPlatform';
 import { useProject } from '@/features/orgs/projects/hooks/useProject';
@@ -13,7 +12,11 @@ export default function RemoteSchemaDetailsPage() {
   const isPlatform = useIsPlatform();
 
   if (isPlatform && !project?.config?.hasura.adminSecret) {
-    return <LoadingScreen />;
+    return (
+      <div className="absolute inset-0 z-50 flex h-full w-full items-center justify-center">
+        <Spinner className="h-5 w-5" />
+      </div>
+    );
   }
 
   return (
@@ -32,12 +35,9 @@ RemoteSchemaDetailsPage.getLayout = function getLayout(page: ReactElement) {
     >
       <RemoteSchemaBrowserSidebar />
 
-      <Box
-        className="flex w-full flex-auto flex-col overflow-x-hidden"
-        sx={{ backgroundColor: 'background.default' }}
-      >
+      <div className="flex w-full flex-auto flex-col overflow-x-hidden bg-background-default">
         {page}
-      </Box>
+      </div>
     </OrgLayout>
   );
 };

--- a/dashboard/src/pages/orgs/[orgSlug]/projects/[appSubdomain]/graphql/remote-schemas/index.tsx
+++ b/dashboard/src/pages/orgs/[orgSlug]/projects/[appSubdomain]/graphql/remote-schemas/index.tsx
@@ -1,5 +1,4 @@
 import type { ReactElement } from 'react';
-import { Box } from '@/components/ui/v2/Box';
 import { Spinner } from '@/components/ui/v3/spinner';
 import { OrgLayout } from '@/features/orgs/layout/OrgLayout';
 import { RemoteSchemaBrowserSidebar } from '@/features/orgs/projects/remote-schemas/components/RemoteSchemaBrowserSidebar';
@@ -45,12 +44,9 @@ RemoteSchemasPage.getLayout = function getLayout(page: ReactElement) {
     >
       <RemoteSchemaBrowserSidebar />
 
-      <Box
-        className="flex w-full flex-auto flex-col overflow-x-hidden"
-        sx={{ backgroundColor: 'background.default' }}
-      >
+      <div className="flex w-full flex-auto flex-col overflow-x-hidden bg-background-default">
         {page}
-      </Box>
+      </div>
     </OrgLayout>
   );
 };


### PR DESCRIPTION
### Checklist

- [ ] No breaking changes
- [ ] Tests pass
- [ ] New features have new tests
- [ ] Documentation is updated (if applicable)
- [ ] Title of the PR is in the correct format (see below)

<!-- pi-reviewer:start -->
### **What this change solves**
This change migrates the dashboard remote schema management UI from older v2/MUI-style building blocks to the v3 component system. It keeps the existing remote schema create, edit, permissions, relationships, browser, and detail flows while standardizing their layout, form controls, tables, alerts, and loading states.

___

### **Change Type**
Refactoring

___

### **Description**
- Migrate shared form primitives and remote schema form fields to v3 input, select, switch, alert, table, and layout components.
- Refactor remote schema create/edit, GraphQL customization, header, relationship, and permission UIs around the updated component system.
- Refresh remote schema browser, details, empty-state, preview, and page-level loading/layout wrappers for consistency with the v3 dashboard UI.

___

<details> <summary><h3> File Walkthrough</h3></summary>

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody>
<tr><td><strong>Shared form primitives</strong></td><td><details><summary>3 files</summary><table>
<tr>
  <td><strong>dashboard/src/components/form/FormInput/FormInput.tsx</strong><dd><code>Updates form input styling/integration for the v3 input migration.</code></dd></td>
  <td>+1/-1</td>
</tr>
<tr>
  <td><strong>dashboard/src/components/ui/v3/input-group.tsx</strong><dd><code>Adjusts the v3 input group component API/styles used by migrated remote-schema forms.</code></dd></td>
  <td>+6/-2</td>
</tr>
<tr>
  <td><strong>dashboard/src/components/ui/v3/input.tsx</strong><dd><code>Updates the v3 input component styling used by migrated forms.</code></dd></td>
  <td>+1/-1</td>
</tr>
</table></details></td></tr>
<tr><td><strong>Remote schema base form</strong></td><td><details><summary>8 files</summary><table>
<tr>
  <td><strong>dashboard/src/features/orgs/projects/remote-schemas/components/BaseRemoteSchemaForm/AdditionalHeadersEditor.tsx</strong><dd><code>Migrates additional-header editing UI to v3 form/table controls.</code></dd></td>
  <td>+48/-48</td>
</tr>
<tr>
  <td><strong>dashboard/src/features/orgs/projects/remote-schemas/components/BaseRemoteSchemaForm/BaseRemoteSchemaForm.tsx</strong><dd><code>Refactors the remote schema base form around v3 components and updated layout.</code></dd></td>
  <td>+120/-87</td>
</tr>
<tr>
  <td><strong>dashboard/src/features/orgs/projects/remote-schemas/components/BaseRemoteSchemaForm/ForwardClientHeadersToggle.tsx</strong><dd><code>Migrates the forward-client-headers toggle UI to v3 components.</code></dd></td>
  <td>+32/-17</td>
</tr>
<tr>
  <td><strong>dashboard/src/features/orgs/projects/remote-schemas/components/BaseRemoteSchemaForm/GraphQLCustomizations.tsx</strong><dd><code>Migrates GraphQL customization controls to v3 form primitives and layout.</code></dd></td>
  <td>+161/-210</td>
</tr>
<tr>
  <td><strong>dashboard/src/features/orgs/projects/remote-schemas/components/BaseRemoteSchemaForm/GraphQLServerTimeoutInput.tsx</strong><dd><code>Migrates the GraphQL timeout input to v3 field components.</code></dd></td>
  <td>+33/-33</td>
</tr>
<tr>
  <td><strong>dashboard/src/features/orgs/projects/remote-schemas/components/BaseRemoteSchemaForm/GraphQLServiceURLInput.tsx</strong><dd><code>Migrates the GraphQL service URL input to v3 field components.</code></dd></td>
  <td>+35/-28</td>
</tr>
<tr>
  <td><strong>dashboard/src/features/orgs/projects/remote-schemas/components/BaseRemoteSchemaForm/RemoteSchemaCommentInput.tsx</strong><dd><code>Migrates the remote schema comment input to v3 field components.</code></dd></td>
  <td>+33/-31</td>
</tr>
<tr>
  <td><strong>dashboard/src/features/orgs/projects/remote-schemas/components/BaseRemoteSchemaForm/RemoteSchemaNameInput.tsx</strong><dd><code>Migrates and simplifies the remote schema name input.</code></dd></td>
  <td>+10/-26</td>
</tr>
</table></details></td></tr>
<tr><td><strong>Relationships</strong></td><td><details><summary>5 files</summary><table>
<tr>
  <td><strong>dashboard/src/features/orgs/projects/remote-schemas/components/BaseRemoteSchemaRelationshipForm/sections/DatabaseRelationshipForm.tsx</strong><dd><code>Updates database relationship form section layout for the v3 migration.</code></dd></td>
  <td>+18/-6</td>
</tr>
<tr>
  <td><strong>dashboard/src/features/orgs/projects/remote-schemas/components/BaseRemoteSchemaRelationshipForm/sections/FieldToColumnMapSelector.tsx</strong><dd><code>Migrates field-to-column mapping selector controls.</code></dd></td>
  <td>+12/-14</td>
</tr>
<tr>
  <td><strong>dashboard/src/features/orgs/projects/remote-schemas/components/BaseRemoteSchemaRelationshipForm/sections/FieldToColumnMapSelectorItem.tsx</strong><dd><code>Updates individual field-to-column mapping item styling.</code></dd></td>
  <td>+1/-2</td>
</tr>
<tr>
  <td><strong>dashboard/src/features/orgs/projects/remote-schemas/components/BaseRemoteSchemaRelationshipForm/sections/RemoteSchemaRelationshipForm.tsx</strong><dd><code>Updates remote schema relationship form section layout for the v3 migration.</code></dd></td>
  <td>+18/-6</td>
</tr>
<tr>
  <td><strong>dashboard/src/features/orgs/projects/remote-schemas/components/BaseRemoteSchemaRelationshipForm/sections/SchemaToArgumentMapSelector.tsx</strong><dd><code>Migrates schema-to-argument mapping selector controls.</code></dd></td>
  <td>+12/-14</td>
</tr>
</table></details></td></tr>
<tr><td><strong>Create/edit forms</strong></td><td><details><summary>4 files</summary><table>
<tr>
  <td><strong>dashboard/src/features/orgs/projects/remote-schemas/components/CreateRemoteSchemaForm/CreateRemoteSchemaForm.tsx</strong><dd><code>Updates create form composition around migrated v3 form components.</code></dd></td>
  <td>+7/-10</td>
</tr>
<tr>
  <td><strong>dashboard/src/features/orgs/projects/remote-schemas/components/EditRemoteSchemaForm/EditRemoteSchemaForm.tsx</strong><dd><code>Updates edit form composition around migrated v3 form components.</code></dd></td>
  <td>+7/-10</td>
</tr>
<tr>
  <td><strong>dashboard/src/features/orgs/projects/remote-schemas/components/EditRemoteSchemaForm/sections/EditGraphQLCustomizations.tsx</strong><dd><code>Migrates edit-mode GraphQL customization controls to v3 components.</code></dd></td>
  <td>+124/-147</td>
</tr>
<tr>
  <td><strong>dashboard/src/features/orgs/projects/remote-schemas/components/EditRemoteSchemaForm/sections/TypeNameCustomizationCombobox.tsx</strong><dd><code>Updates type-name customization combobox styling/behavior for v3 controls.</code></dd></td>
  <td>+3/-5</td>
</tr>
</table></details></td></tr>
<tr><td><strong>Permissions</strong></td><td><details><summary>3 files</summary><table>
<tr>
  <td><strong>dashboard/src/features/orgs/projects/remote-schemas/components/EditRemoteSchemaPermissionsForm/EditRemoteSchemaPermissionsForm.tsx</strong><dd><code>Migrates remote schema permissions overview to v3 layout, alert, and table controls.</code></dd></td>
  <td>+63/-86</td>
</tr>
<tr>
  <td><strong>dashboard/src/features/orgs/projects/remote-schemas/components/EditRemoteSchemaPermissionsForm/RemoteSchemaRolePermissionsEditorForm.tsx</strong><dd><code>Migrates the role permissions editor form to v3 components and semantic elements.</code></dd></td>
  <td>+31/-46</td>
</tr>
<tr>
  <td><strong>dashboard/src/features/orgs/projects/remote-schemas/components/EditRemoteSchemaPermissionsForm/RolePermissionsRow.tsx</strong><dd><code>Updates permission row styling/action controls for the v3 migration.</code></dd></td>
  <td>+11/-11</td>
</tr>
</table></details></td></tr>
<tr><td><strong>Browse/detail pages</strong></td><td><details><summary>6 files</summary><table>
<tr>
  <td><strong>dashboard/src/features/orgs/projects/remote-schemas/components/EditRemoteSchemaRelationships/sections/RemoteSchemaRelationshipsInfoTable.tsx</strong><dd><code>Updates remote schema relationships info table styling.</code></dd></td>
  <td>+2/-3</td>
</tr>
<tr>
  <td><strong>dashboard/src/features/orgs/projects/remote-schemas/components/RemoteSchemaBrowserSidebar/RemoteSchemaBrowserSidebar.tsx</strong><dd><code>Migrates the remote schema browser sidebar to v3 controls and layout.</code></dd></td>
  <td>+162/-144</td>
</tr>
<tr>
  <td><strong>dashboard/src/features/orgs/projects/remote-schemas/components/RemoteSchemaDetails/RemoteSchemaDetails.tsx</strong><dd><code>Migrates remote schema details presentation to v3 components.</code></dd></td>
  <td>+70/-34</td>
</tr>
<tr>
  <td><strong>dashboard/src/features/orgs/projects/remote-schemas/components/RemoteSchemaEmptyState/RemoteSchemaEmptyState.tsx</strong><dd><code>Updates the remote schema empty state styling.</code></dd></td>
  <td>+2/-5</td>
</tr>
<tr>
  <td><strong>dashboard/src/features/orgs/projects/remote-schemas/components/RemoteSchemaHeadersTable/RemoteSchemaHeadersTable.tsx</strong><dd><code>Updates remote schema headers table styling.</code></dd></td>
  <td>+1/-4</td>
</tr>
<tr>
  <td><strong>dashboard/src/features/orgs/projects/remote-schemas/components/RemoteSchemaPreview/RemoteSchemaPreview.tsx</strong><dd><code>Updates remote schema preview container styling.</code></dd></td>
  <td>+4/-1</td>
</tr>
</table></details></td></tr>
<tr><td><strong>Pages</strong></td><td><details><summary>2 files</summary><table>
<tr>
  <td><strong>dashboard/src/pages/orgs/[orgSlug]/projects/[appSubdomain]/graphql/remote-schemas/[remoteSchemaSlug].tsx</strong><dd><code>Updates remote schema details page loading/layout wrappers for migrated components.</code></dd></td>
  <td>+8/-8</td>
</tr>
<tr>
  <td><strong>dashboard/src/pages/orgs/[orgSlug]/projects/[appSubdomain]/graphql/remote-schemas/index.tsx</strong><dd><code>Updates remote schemas index page loading/layout wrappers for migrated components.</code></dd></td>
  <td>+2/-6</td>
</tr>
</table></details></td></tr>
</tbody></table>

</details>

___

<!-- pi-reviewer:end -->
