### PR TITLE
fix(postgres): escape dollar-quotes in update-extensions script

### DIFF
--- a/services/postgres/postgres/nhost.d/XXXX-update-extensions.sql
+++ b/services/postgres/postgres/nhost.d/XXXX-update-extensions.sql
@@ -1,4 +1,4 @@
-DO $$
+DO $$$$
 DECLARE
     ext record;
 BEGIN
@@ -16,4 +16,4 @@ BEGIN
         END;
     END LOOP;
 END;
-$$;
+$$$$;


### PR DESCRIPTION
Seems like this has been happening for a while but it was just silently happening.

### Checklist

- [x] No breaking changes
- [x] Tests pass
- [x] New features have new tests
- [x] Documentation is updated (if applicable)
- [x] Title of the PR is in the correct format (see below)

```
postgres-1   | Initializing database
postgres-1   | The files belonging to this database system will be owned by user "postgres".
postgres-1   | This user must also own the server process.
postgres-1   | 
postgres-1   | The database cluster will be initialized with locale "en_US.UTF-8".
postgres-1   | The default database encoding has accordingly been set to "UTF8".
postgres-1   | The default text search configuration will be set to "english".
postgres-1   | 
postgres-1   | Data page checksums are enabled.
postgres-1   | 
postgres-1   | fixing permissions on existing directory /var/lib/postgresql/data/pgdata ... ok
postgres-1   | creating subdirectories ... ok
postgres-1   | selecting dynamic shared memory implementation ... posix
postgres-1   | selecting default "max_connections" ... 100
postgres-1   | selecting default "shared_buffers" ... 128MB
postgres-1   | selecting default time zone ... UTC
postgres-1   | creating configuration files ... ok
postgres-1   | running bootstrap script ... ok
postgres-1   | performing post-bootstrap initialization ... ok
postgres-1   | syncing data to disk ... ok
postgres-1   | 
postgres-1   | 
postgres-1   | Success. You can now start the database server using:
postgres-1   | 
postgres-1   |     pg_ctl -D /var/lib/postgresql/data/pgdata -l logfile start
postgres-1   | 
postgres-1   | initdb: warning: enabling "trust" authentication for local connections
postgres-1   | initdb: hint: You can change this by editing pg_hba.conf or using the option -A, or --auth-local and --auth-host, the next time you run initdb.
postgres-1   | Resolving pg_hba.conf and postgresql.conf
postgres-1   | PostgreSQL started with PID: 41
postgres-1   | Waiting for postgres to start
postgres-1   | Starting postgres
postgres-1   | 2026-07-20 13:46:24.743 GMT [44] LOG:  registered custom resource manager "pg_search" with ID 137
postgres-1   | 2026-07-20 13:46:24.752 GMT [44] LOG:  starting PostgreSQL 18.4 on x86_64-pc-linux-gnu, compiled by clang version 21.1.8, 64-bit
postgres-1   | 2026-07-20 13:46:24.752 GMT [44] LOG:  listening on IPv4 address "0.0.0.0", port 5432
postgres-1   | 2026-07-20 13:46:24.762 GMT [44] LOG:  listening on Unix socket "/run/postgresql/.s.PGSQL.5432"
postgres-1   | 2026-07-20 13:46:24.774 GMT [51] LOG:  database system was shut down at 2026-07-20 13:46:19 GMT
postgres-1   | 2026-07-20 13:46:24.780 GMT [44] LOG:  database system is ready to accept connections
postgres-1   | 2026-07-20 13:46:24.786 GMT [55] FATAL:  database "local" does not exist
postgres-1   | 2026-07-20 13:46:24.786 GMT [54] LOG:  TimescaleDB background worker launcher connected to shared catalogs
postgres-1   | 2026-07-20 13:46:24.787 GMT [44] LOG:  background worker "pg_cron launcher" (PID 55) exited with exit code 1
postgres-1   | Running init scripts
postgres-1   | CREATE DATABASE
postgres-1   | Running nhost's scripts
postgres-1   | psql:/tmp/postgresql/nhost.d/XXXX-nhost.sql:1: NOTICE:  role "nhost_hasura" has already been granted membership in role "postgres" by role "postgres"
postgres-1   | psql:/tmp/postgresql/nhost.d/XXXX-refresh-collation.sql:1: NOTICE:  version has not changed
postgres-1   | 2026-07-20 13:46:25.533 GMT [98] ERROR:  syntax error at or near "$" at character 4
postgres-1   | 2026-07-20 13:46:25.533 GMT [98] STATEMENT:  DO $
postgres-1   | 	DECLARE
postgres-1   | 	   ext record;
postgres-1   | psql:/tmp/postgresql/nhost.d/XXXX-update-extensions.sql:3: ERROR:  syntax error at or near "$"
postgres-1   | LINE 1: DO $
postgres-1   |            ^
postgres-1   | psql:/tmp/postgresql/nhost.d/XXXX-update-extensions.sql:3: STATEMENT:  DO $
postgres-1   | DECLARE
postgres-1   |     ext record;
postgres-1   | 2026-07-20 13:46:25.533 GMT [98] ERROR:  syntax error at or near "FOR" at character 11
postgres-1   | 2026-07-20 13:46:25.533 GMT [98] STATEMENT:  BEGIN
postgres-1   | 	   FOR ext IN
postgres-1   | 	       SELECT e.extname
postgres-1   | 	       FROM pg_extension e
postgres-1   | 	       JOIN pg_available_extensions ae ON e.extname = ae.name
postgres-1   | 	       WHERE e.extversion <> ae.default_version
postgres-1   | 	   LOOP
postgres-1   | 	       BEGIN
postgres-1   | 	           RAISE NOTICE 'Updating extension %', ext.extname;
postgres-1   | psql:/tmp/postgresql/nhost.d/XXXX-update-extensions.sql:12: ERROR:  syntax error at or near "FOR"
postgres-1   | LINE 2:     FOR ext IN
postgres-1   |             ^
postgres-1   | psql:/tmp/postgresql/nhost.d/XXXX-update-extensions.sql:12: STATEMENT:  BEGIN
postgres-1   |     FOR ext IN
postgres-1   |         SELECT e.extname
postgres-1   |         FROM pg_extension e
postgres-1   |         JOIN pg_available_extensions ae ON e.extname = ae.name
postgres-1   |         WHERE e.extversion <> ae.default_version
postgres-1   |     LOOP
postgres-1   |         BEGIN
postgres-1   |             RAISE NOTICE 'Updating extension %', ext.extname;
postgres-1   | 2026-07-20 13:46:25.533 GMT [98] ERROR:  prepared statement "format" does not exist
postgres-1   | 2026-07-20 13:46:25.533 GMT [98] STATEMENT:  EXECUTE format('ALTER EXTENSION %I UPDATE', ext.extname);
postgres-1   | psql:/tmp/postgresql/nhost.d/XXXX-update-extensions.sql:13: ERROR:  prepared statement "format" does not exist
postgres-1   | psql:/tmp/postgresql/nhost.d/XXXX-update-extensions.sql:13: STATEMENT:  EXECUTE format('ALTER EXTENSION %I UPDATE', ext.extname);
postgres-1   | 2026-07-20 13:46:25.533 GMT [98] ERROR:  syntax error at or near "EXCEPTION" at character 1
postgres-1   | 2026-07-20 13:46:25.533 GMT [98] STATEMENT:  EXCEPTION WHEN OTHERS THEN
postgres-1   | 	           RAISE WARNING 'Failed to update extension %: %', ext.extname, SQLERRM;
postgres-1   | psql:/tmp/postgresql/nhost.d/XXXX-update-extensions.sql:15: ERROR:  syntax error at or near "EXCEPTION"
postgres-1   | LINE 1: EXCEPTION WHEN OTHERS THEN
postgres-1   |         ^
postgres-1   | psql:/tmp/postgresql/nhost.d/XXXX-update-extensions.sql:15: STATEMENT:  EXCEPTION WHEN OTHERS THEN
postgres-1   |             RAISE WARNING 'Failed to update extension %: %', ext.extname, SQLERRM;
postgres-1   | 2026-07-20 13:46:25.533 GMT [98] WARNING:  there is no transaction in progress
postgres-1   | psql:/tmp/postgresql/nhost.d/XXXX-update-extensions.sql:16: WARNING:  there is no transaction in progress
postgres-1   | 2026-07-20 13:46:25.533 GMT [98] ERROR:  syntax error at or near "LOOP" at character 5
postgres-1   | 2026-07-20 13:46:25.533 GMT [98] STATEMENT:  END LOOP;
postgres-1   | psql:/tmp/postgresql/nhost.d/XXXX-update-extensions.sql:17: ERROR:  syntax error at or near "LOOP"
postgres-1   | LINE 1: END LOOP;
postgres-1   |             ^
postgres-1   | psql:/tmp/postgresql/nhost.d/XXXX-update-extensions.sql:17: STATEMENT:  END LOOP;
postgres-1   | 2026-07-20 13:46:25.533 GMT [98] WARNING:  there is no transaction in progress
postgres-1   | psql:/tmp/postgresql/nhost.d/XXXX-update-extensions.sql:18: WARNING:  there is no transaction in progress
postgres-1   | 2026-07-20 13:46:25.533 GMT [98] ERROR:  syntax error at or near "$" at character 1
postgres-1   | 2026-07-20 13:46:25.533 GMT [98] STATEMENT:  $;
postgres-1   | psql:/tmp/postgresql/nhost.d/XXXX-update-extensions.sql:19: ERROR:  syntax error at or near "$"
postgres-1   | LINE 1: $;
postgres-1   |         ^
postgres-1   | psql:/tmp/postgresql/nhost.d/XXXX-update-extensions.sql:19: STATEMENT:  $;
postgres-1   | 2026-07-20 13:46:25.789 GMT [102] LOG:  pg_cron scheduler started
```