### PR TITLE
fix(dashboard): Migrate deployment page

### DIFF
--- a/dashboard/package.json
+++ b/dashboard/package.json
@@ -53,6 +53,7 @@
     "@nhost/nhost-js": "workspace:^",
     "@radix-ui/react-accordion": "^1.2.2",
     "@radix-ui/react-alert-dialog": "^1.1.3",
+    "@radix-ui/react-avatar": "^1.1.3",
     "@radix-ui/react-checkbox": "^1.1.3",
     "@radix-ui/react-collapsible": "^1.1.12",
     "@radix-ui/react-dialog": "^1.1.15",

--- a/dashboard/pnpm-lock.yaml
+++ b/dashboard/pnpm-lock.yaml
@@ -157,6 +157,9 @@ importers:
       '@radix-ui/react-alert-dialog':
         specifier: ^1.1.3
         version: 1.1.3(@types/react-dom@19.2.3(@types/react@19.2.8))(@types/react@19.2.8)(react-dom@19.2.3(react@19.2.3))(react@19.2.3)
+      '@radix-ui/react-avatar':
+        specifier: ^1.1.3
+        version: 1.2.0(@types/react-dom@19.2.3(@types/react@19.2.8))(@types/react@19.2.8)(react-dom@19.2.3(react@19.2.3))(react@19.2.3)
       '@radix-ui/react-checkbox':
         specifier: ^1.1.3
         version: 1.1.3(@types/react-dom@19.2.3(@types/react@19.2.8))(@types/react@19.2.8)(react-dom@19.2.3(react@19.2.3))(react@19.2.3)
@@ -2243,6 +2246,19 @@ packages:
       '@types/react-dom':
         optional: true
 
+  '@radix-ui/react-avatar@1.2.0':
+    resolution: {integrity: sha512-am/CwltXtmtdtP+5FbYblYDnMa/zuKcMJP1i3/SJMDXXfj2mG+BTqLH2wucqeyyiQMursUtg/5cK+Nh2pCaSOA==}
+    peerDependencies:
+      '@types/react': '*'
+      '@types/react-dom': '*'
+      react: ^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc
+      react-dom: ^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc
+    peerDependenciesMeta:
+      '@types/react':
+        optional: true
+      '@types/react-dom':
+        optional: true
+
   '@radix-ui/react-checkbox@1.1.3':
     resolution: {integrity: sha512-HD7/ocp8f1B3e6OHygH0n7ZKjONkhciy1Nh0yuBgObqThc3oyx+vuMfFHKAknXRHHWVE9XvXStxJFyjUmB8PIw==}
     peerDependencies:
@@ -2361,6 +2377,15 @@ packages:
       '@types/react':
         optional: true
 
+  '@radix-ui/react-compose-refs@1.1.3':
+    resolution: {integrity: sha512-rYOP8OMnuuPMQF1uhPVlGNcCDlkokKqGFE3JcxFViIkAXP7EvFWUliJAstrapypaBLJNHbZL6jGhbVDGTwmVhA==}
+    peerDependencies:
+      '@types/react': '*'
+      react: ^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc
+    peerDependenciesMeta:
+      '@types/react':
+        optional: true
+
   '@radix-ui/react-context@1.1.0':
     resolution: {integrity: sha512-OKrckBy+sMEgYM/sMmqmErVn0kZqrHPJze+Ql3DzYsDDp0hl0L62nx/2122/Bvps1qz645jlcu2tD9lrRSdf8A==}
     peerDependencies:
@@ -2381,6 +2406,15 @@ packages:
 
   '@radix-ui/react-context@1.1.2':
     resolution: {integrity: sha512-jCi/QKUM2r1Ju5a3J64TH2A5SpKAgh0LpknyqdQ4m6DCV0xJ2HG1xARRwNGPQfi1SLdLWZ1OJz6F4OMBBNiGJA==}
+    peerDependencies:
+      '@types/react': '*'
+      react: ^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc
+    peerDependenciesMeta:
+      '@types/react':
+        optional: true
+
+  '@radix-ui/react-context@1.1.4':
+    resolution: {integrity: sha512-QwH4PO5urrbO+FaGd5Aglg+YJgWTyyuZ3g/6mKvsqraLkglDdckw9JafgL5McL5VEJ6EPNduPaT3ZE9BttDAqg==}
     peerDependencies:
       '@types/react': '*'
       react: ^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc
@@ -2802,6 +2836,19 @@ packages:
       '@types/react-dom':
         optional: true
 
+  '@radix-ui/react-primitive@2.1.6':
+    resolution: {integrity: sha512-wetd0QI77DbvrPpTAvH1SqOxsYF2wZe5TNxqwOd5Ty4XDpV3dpV0s8K/1MGMJBeY5o7lg8ub5VIt1Ub+yVen6g==}
+    peerDependencies:
+      '@types/react': '*'
+      '@types/react-dom': '*'
+      react: ^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc
+      react-dom: ^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc
+    peerDependenciesMeta:
+      '@types/react':
+        optional: true
+      '@types/react-dom':
+        optional: true
+
   '@radix-ui/react-progress@1.1.0':
     resolution: {integrity: sha512-aSzvnYpP725CROcxAOEBVZZSIQVQdHgBr2QQFKySsaD14u8dNT0batuXI+AAGDdAHfXH8rbnHmjYFqVJ21KkRg==}
     peerDependencies:
@@ -2938,6 +2985,15 @@ packages:
       '@types/react':
         optional: true
 
+  '@radix-ui/react-slot@1.3.0':
+    resolution: {integrity: sha512-MojKku4U/miO8Av4Dkb+ctMAQx7JmY96LmtDQlAarCRtd7rN52QCSzBF+XAvr5S6coSVj9HEPBgHAHKEJVk/WA==}
+    peerDependencies:
+      '@types/react': '*'
+      react: ^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc
+    peerDependenciesMeta:
+      '@types/react':
+        optional: true
+
   '@radix-ui/react-switch@1.2.6':
     resolution: {integrity: sha512-bByzr1+ep1zk4VubeEVViV592vu2lHE2BZY5OnzehZqOOgogN80+mNtCqPkhn2gklJqOpxWgPoYTSnhBCqpOXQ==}
     peerDependencies:
@@ -2995,6 +3051,15 @@ packages:
       '@types/react':
         optional: true
 
+  '@radix-ui/react-use-callback-ref@1.1.2':
+    resolution: {integrity: sha512-xCso9j1/u8sEgP1RNHjFrXJLApL8LiqOkI1R4ywuN00rxWdYg4oQXuwKLS3i0j5NWLromUD27/4nlxj2UFVvIw==}
+    peerDependencies:
+      '@types/react': '*'
+      react: ^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc
+    peerDependenciesMeta:
+      '@types/react':
+        optional: true
+
   '@radix-ui/react-use-controllable-state@1.1.0':
     resolution: {integrity: sha512-MtfMVJiSr2NjzS0Aa90NPTnvTSg6C/JLCV7ma0W6+OMV78vd8OyRpID+Ng9LxzsPbLeuBnWBA1Nq30AtBIDChw==}
     peerDependencies:
@@ -3040,6 +3105,15 @@ packages:
       '@types/react':
         optional: true
 
+  '@radix-ui/react-use-is-hydrated@0.1.1':
+    resolution: {integrity: sha512-qwOiz4Tjo8CNnrOLAYUMXeZwDzXgXpvK4TKQPmWLECM9XoWvA6+0Z2/7Ag3A4ivjS4ovbLJPbskkxioFyBhr8A==}
+    peerDependencies:
+      '@types/react': '*'
+      react: ^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc
+    peerDependenciesMeta:
+      '@types/react':
+        optional: true
+
   '@radix-ui/react-use-layout-effect@1.1.0':
     resolution: {integrity: sha512-+FPE0rOdziWSrH9athwI1R0HDVbWlEhd+FR+aSDk4uWGmSJ9Z54sdZVDQPZAinJhJXwfT+qnj969mCsT2gfm5w==}
     peerDependencies:
@@ -3051,6 +3125,15 @@ packages:
 
   '@radix-ui/react-use-layout-effect@1.1.1':
     resolution: {integrity: sha512-RbJRS4UWQFkzHTTwVymMTUv8EqYhOp8dOOviLj2ugtTiXRaRQS7GLGxZTLL1jWhMeoSCf5zmcZkqTl9IiYfXcQ==}
+    peerDependencies:
+      '@types/react': '*'
+      react: ^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc
+    peerDependenciesMeta:
+      '@types/react':
+        optional: true
+
+  '@radix-ui/react-use-layout-effect@1.1.2':
+    resolution: {integrity: sha512-jrBWOxZITuGcnjRCM2t2U5ZPkCLxD+Ym6DjfssS5haTj2iiak/DOb64JeN6OdLfLgptb6/e2kKR+ZuTrGoZTPA==}
     peerDependencies:
       '@types/react': '*'
       react: ^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc
@@ -8724,6 +8807,19 @@ snapshots:
       '@types/react': 19.2.8
       '@types/react-dom': 19.2.3(@types/react@19.2.8)
 
+  '@radix-ui/react-avatar@1.2.0(@types/react-dom@19.2.3(@types/react@19.2.8))(@types/react@19.2.8)(react-dom@19.2.3(react@19.2.3))(react@19.2.3)':
+    dependencies:
+      '@radix-ui/react-context': 1.1.4(@types/react@19.2.8)(react@19.2.3)
+      '@radix-ui/react-primitive': 2.1.6(@types/react-dom@19.2.3(@types/react@19.2.8))(@types/react@19.2.8)(react-dom@19.2.3(react@19.2.3))(react@19.2.3)
+      '@radix-ui/react-use-callback-ref': 1.1.2(@types/react@19.2.8)(react@19.2.3)
+      '@radix-ui/react-use-is-hydrated': 0.1.1(@types/react@19.2.8)(react@19.2.3)
+      '@radix-ui/react-use-layout-effect': 1.1.2(@types/react@19.2.8)(react@19.2.3)
+      react: 19.2.3
+      react-dom: 19.2.3(react@19.2.3)
+    optionalDependencies:
+      '@types/react': 19.2.8
+      '@types/react-dom': 19.2.3(@types/react@19.2.8)
+
   '@radix-ui/react-checkbox@1.1.3(@types/react-dom@19.2.3(@types/react@19.2.8))(@types/react@19.2.8)(react-dom@19.2.3(react@19.2.3))(react@19.2.3)':
     dependencies:
       '@radix-ui/primitive': 1.1.1
@@ -8838,6 +8934,12 @@ snapshots:
     optionalDependencies:
       '@types/react': 19.2.8
 
+  '@radix-ui/react-compose-refs@1.1.3(@types/react@19.2.8)(react@19.2.3)':
+    dependencies:
+      react: 19.2.3
+    optionalDependencies:
+      '@types/react': 19.2.8
+
   '@radix-ui/react-context@1.1.0(@types/react@19.2.8)(react@19.2.3)':
     dependencies:
       react: 19.2.3
@@ -8851,6 +8953,12 @@ snapshots:
       '@types/react': 19.2.8
 
   '@radix-ui/react-context@1.1.2(@types/react@19.2.8)(react@19.2.3)':
+    dependencies:
+      react: 19.2.3
+    optionalDependencies:
+      '@types/react': 19.2.8
+
+  '@radix-ui/react-context@1.1.4(@types/react@19.2.8)(react@19.2.3)':
     dependencies:
       react: 19.2.3
     optionalDependencies:
@@ -9265,6 +9373,15 @@ snapshots:
       '@types/react': 19.2.8
       '@types/react-dom': 19.2.3(@types/react@19.2.8)
 
+  '@radix-ui/react-primitive@2.1.6(@types/react-dom@19.2.3(@types/react@19.2.8))(@types/react@19.2.8)(react-dom@19.2.3(react@19.2.3))(react@19.2.3)':
+    dependencies:
+      '@radix-ui/react-slot': 1.3.0(@types/react@19.2.8)(react@19.2.3)
+      react: 19.2.3
+      react-dom: 19.2.3(react@19.2.3)
+    optionalDependencies:
+      '@types/react': 19.2.8
+      '@types/react-dom': 19.2.3(@types/react@19.2.8)
+
   '@radix-ui/react-progress@1.1.0(@types/react-dom@19.2.3(@types/react@19.2.8))(@types/react@19.2.8)(react-dom@19.2.3(react@19.2.3))(react@19.2.3)':
     dependencies:
       '@radix-ui/react-context': 1.1.0(@types/react@19.2.8)(react@19.2.3)
@@ -9417,6 +9534,13 @@ snapshots:
     optionalDependencies:
       '@types/react': 19.2.8
 
+  '@radix-ui/react-slot@1.3.0(@types/react@19.2.8)(react@19.2.3)':
+    dependencies:
+      '@radix-ui/react-compose-refs': 1.1.3(@types/react@19.2.8)(react@19.2.3)
+      react: 19.2.3
+    optionalDependencies:
+      '@types/react': 19.2.8
+
   '@radix-ui/react-switch@1.2.6(@types/react-dom@19.2.3(@types/react@19.2.8))(@types/react@19.2.8)(react-dom@19.2.3(react@19.2.3))(react@19.2.3)':
     dependencies:
       '@radix-ui/primitive': 1.1.3
@@ -9480,6 +9604,12 @@ snapshots:
     optionalDependencies:
       '@types/react': 19.2.8
 
+  '@radix-ui/react-use-callback-ref@1.1.2(@types/react@19.2.8)(react@19.2.3)':
+    dependencies:
+      react: 19.2.3
+    optionalDependencies:
+      '@types/react': 19.2.8
+
   '@radix-ui/react-use-controllable-state@1.1.0(@types/react@19.2.8)(react@19.2.3)':
     dependencies:
       '@radix-ui/react-use-callback-ref': 1.1.0(@types/react@19.2.8)(react@19.2.3)
@@ -9516,6 +9646,12 @@ snapshots:
     optionalDependencies:
       '@types/react': 19.2.8
 
+  '@radix-ui/react-use-is-hydrated@0.1.1(@types/react@19.2.8)(react@19.2.3)':
+    dependencies:
+      react: 19.2.3
+    optionalDependencies:
+      '@types/react': 19.2.8
+
   '@radix-ui/react-use-layout-effect@1.1.0(@types/react@19.2.8)(react@19.2.3)':
     dependencies:
       react: 19.2.3
@@ -9523,6 +9659,12 @@ snapshots:
       '@types/react': 19.2.8
 
   '@radix-ui/react-use-layout-effect@1.1.1(@types/react@19.2.8)(react@19.2.3)':
+    dependencies:
+      react: 19.2.3
+    optionalDependencies:
+      '@types/react': 19.2.8
+
+  '@radix-ui/react-use-layout-effect@1.1.2(@types/react@19.2.8)(react@19.2.3)':
     dependencies:
       react: 19.2.3
     optionalDependencies:

--- a/dashboard/src/components/common/DragAndDropList/DraggableItem.tsx
+++ b/dashboard/src/components/common/DragAndDropList/DraggableItem.tsx
@@ -1,5 +1,5 @@
 import { Draggable, type DraggableProps } from '@hello-pangea/dnd';
-import type { PropsWithChildren } from 'react';
+import type { CSSProperties, PropsWithChildren } from 'react';
 import { cn } from '@/lib/utils';
 
 export type DraggableItemProps = PropsWithChildren<
@@ -19,6 +19,7 @@ function DraggableItem({
           {...provided.draggableProps}
           {...provided.dragHandleProps}
           className={cn(className)}
+          style={provided.draggableProps.style as CSSProperties}
         >
           {children}
         </div>

--- a/dashboard/src/components/ui/v3/avatar.test.tsx
+++ b/dashboard/src/components/ui/v3/avatar.test.tsx
@@ -1,0 +1,28 @@
+import { Avatar } from '@/components/ui/v3/avatar';
+import { render, screen } from '@/tests/testUtils';
+
+describe('Avatar', () => {
+  it('uses the first grapheme from the name as fallback text', () => {
+    render(<Avatar name="Jane Doe" />);
+
+    expect(screen.getByText('J')).toBeInTheDocument();
+  });
+
+  it('supports non-western names', () => {
+    render(<Avatar name="山田 太郎" />);
+
+    expect(screen.getByText('山')).toBeInTheDocument();
+  });
+
+  it('keeps emoji graphemes intact', () => {
+    render(<Avatar name="👩🏽‍💻 Developer" />);
+
+    expect(screen.getByText('👩🏽‍💻')).toBeInTheDocument();
+  });
+
+  it('prefers explicit fallback content', () => {
+    render(<Avatar name="Jane Doe" fallback="JD" />);
+
+    expect(screen.getByText('JD')).toBeInTheDocument();
+  });
+});

--- a/dashboard/src/components/ui/v3/avatar.tsx
+++ b/dashboard/src/components/ui/v3/avatar.tsx
@@ -1,0 +1,105 @@
+import * as AvatarPrimitive from '@radix-ui/react-avatar';
+import type { ComponentProps, ReactNode } from 'react';
+import { cn } from '@/lib/utils';
+
+function AvatarRoot({
+  className,
+  ...props
+}: ComponentProps<typeof AvatarPrimitive.Root>) {
+  return (
+    <AvatarPrimitive.Root
+      data-slot="avatar"
+      className={cn(
+        'relative flex h-10 w-10 shrink-0 overflow-hidden rounded-full',
+        className,
+      )}
+      {...props}
+    />
+  );
+}
+
+function AvatarImage({
+  className,
+  ...props
+}: ComponentProps<typeof AvatarPrimitive.Image>) {
+  return (
+    <AvatarPrimitive.Image
+      data-slot="avatar-image"
+      className={cn('aspect-square h-full w-full', className)}
+      {...props}
+    />
+  );
+}
+
+function AvatarFallback({
+  className,
+  ...props
+}: ComponentProps<typeof AvatarPrimitive.Fallback>) {
+  return (
+    <AvatarPrimitive.Fallback
+      data-slot="avatar-fallback"
+      className={cn(
+        'flex h-full w-full items-center justify-center rounded-full bg-muted',
+        className,
+      )}
+      {...props}
+    />
+  );
+}
+
+const avatarFallbackSegmenter =
+  typeof Intl.Segmenter === 'function'
+    ? new Intl.Segmenter(undefined, { granularity: 'grapheme' })
+    : null;
+
+function getFirstGrapheme(value: string): string {
+  if (avatarFallbackSegmenter) {
+    return Array.from(avatarFallbackSegmenter.segment(value))[0]?.segment ?? '';
+  }
+
+  return Array.from(value)[0] ?? '';
+}
+
+function getAvatarFallback(name?: string): string {
+  const trimmedName = name?.trim();
+
+  if (!trimmedName) {
+    return '';
+  }
+
+  return getFirstGrapheme(trimmedName).toLocaleUpperCase();
+}
+
+export interface AvatarProps {
+  src?: string | null;
+  alt?: string;
+  name?: string;
+  fallback?: ReactNode;
+  className?: string;
+  imageClassName?: string;
+  fallbackClassName?: string;
+}
+
+function Avatar({
+  src,
+  alt,
+  name,
+  fallback,
+  className,
+  imageClassName,
+  fallbackClassName,
+}: AvatarProps) {
+  return (
+    <AvatarRoot className={className}>
+      {src ? (
+        <AvatarImage src={src} alt={alt} className={imageClassName} />
+      ) : null}
+
+      <AvatarFallback className={fallbackClassName}>
+        {fallback ?? getAvatarFallback(name)}
+      </AvatarFallback>
+    </AvatarRoot>
+  );
+}
+
+export { Avatar, AvatarFallback, AvatarImage, AvatarRoot };

--- a/dashboard/src/features/orgs/projects/deployments/components/AppDeployments/AppDeployments.tsx
+++ b/dashboard/src/features/orgs/projects/deployments/components/AppDeployments/AppDeployments.tsx
@@ -2,9 +2,7 @@ import { ChevronLeftIcon, ChevronRightIcon } from 'lucide-react';
 import NextLink from 'next/link';
 import { useRouter } from 'next/router';
 import { Fragment } from 'react';
-import { Divider } from '@/components/ui/v2/Divider';
-import { List } from '@/components/ui/v2/List';
-import { Text } from '@/components/ui/v2/Text';
+import { Separator } from '@/components/ui/v3/separator';
 import { Spinner } from '@/components/ui/v3/spinner';
 import { DeploymentListItem } from '@/features/orgs/projects/deployments/components/DeploymentListItem';
 import {
@@ -108,10 +106,10 @@ export default function AppDeployments(props: AppDeploymentsProps) {
   return (
     <div className="mt-6">
       {nrOfItems === 0 ? (
-        <Text variant="subtitle2">No deployments yet.</Text>
+        <p className="font-medium text-sm">No deployments yet.</p>
       ) : (
         <div>
-          <List className="mt-3 border-y" sx={{ borderColor: 'grey.300' }}>
+          <ul className="mt-3 border-border border-y">
             {deployments.map((item, index) => (
               <Fragment key={item.id}>
                 <DeploymentListItem
@@ -121,10 +119,14 @@ export default function AppDeployments(props: AppDeploymentsProps) {
                   disableRedeploy={pendingOrRunning.length > 0}
                 />
 
-                {index !== deployments.length - 1 && <Divider component="li" />}
+                {index !== deployments.length - 1 && (
+                  <li className="list-none">
+                    <Separator />
+                  </li>
+                )}
               </Fragment>
             ))}
-          </List>
+          </ul>
           <div className="mt-8 flex w-full justify-center">
             <div className="grid grid-flow-col items-center gap-2">
               <NextPrevPageLink
@@ -132,7 +134,7 @@ export default function AppDeployments(props: AppDeploymentsProps) {
                 allowed={page !== 1}
                 targetPage={page - 1}
               />
-              <Text>{page}</Text>
+              <span>{page}</span>
               <NextPrevPageLink
                 direction="next"
                 allowed={nextAllowed}

--- a/dashboard/src/features/orgs/projects/deployments/components/DeploymentDetails/DeploymentDetails.tsx
+++ b/dashboard/src/features/orgs/projects/deployments/components/DeploymentDetails/DeploymentDetails.tsx
@@ -3,15 +3,13 @@ import { useEffect, useMemo, useRef, useState } from 'react';
 import { Container } from '@/components/layout/Container';
 import type { DeploymentStatus } from '@/components/presentational/StatusCircle';
 import { StatusCircle } from '@/components/presentational/StatusCircle';
-import { Avatar } from '@/components/ui/v2/Avatar';
-import { Box } from '@/components/ui/v2/Box';
-import { Text } from '@/components/ui/v2/Text';
 import {
   Accordion,
   AccordionContent,
   AccordionItem,
   AccordionTrigger,
 } from '@/components/ui/v3/accordion';
+import { Avatar } from '@/components/ui/v3/avatar';
 import { Spinner } from '@/components/ui/v3/spinner';
 import { TextLink } from '@/components/ui/v3/text-link';
 import {
@@ -40,7 +38,7 @@ import type {
   DeploymentFragment,
   PipelineRunFragment,
 } from '@/generated/graphql';
-import { cn, ifNullconvertToUndefined } from '@/lib/utils';
+import { cn } from '@/lib/utils';
 
 // --- Pipeline Run Detail Types ---
 
@@ -190,17 +188,13 @@ function PipelineRunDetails({
     <Container>
       <div className="flex justify-between">
         <div>
-          <Text variant="h2" component="h1">
-            Deployment Details
-          </Text>
+          <h1 className="font-medium text-2xl">Deployment Details</h1>
         </div>
       </div>
 
       <div className="my-8 grid grid-cols-3 gap-x-6 gap-y-4 sm:grid-cols-6">
         <div>
-          <Text className="text-xs" color="secondary">
-            Status
-          </Text>
+          <p className="text-muted-foreground text-xs">Status</p>
           <div className="mt-1">
             <StatusBadge
               status={pipelineRun.status as PipelineRunStatusValue}
@@ -208,9 +202,7 @@ function PipelineRunDetails({
           </div>
         </div>
         <div>
-          <Text className="text-xs" color="secondary">
-            Commit
-          </Text>
+          <p className="text-muted-foreground text-xs">Commit</p>
           <div className="mt-0.5">
             <TextLink
               className="font-medium font-mono text-sm"
@@ -222,12 +214,9 @@ function PipelineRunDetails({
             </TextLink>
             <Tooltip>
               <TooltipTrigger asChild>
-                <Text
-                  className="line-clamp-1 cursor-default text-sm"
-                  color="secondary"
-                >
+                <p className="line-clamp-1 cursor-default text-muted-foreground text-sm">
                   {input?.commit_message}
-                </Text>
+                </p>
               </TooltipTrigger>
               <TooltipContent side="bottom" className="max-w-sm">
                 {input?.commit_message}
@@ -236,62 +225,46 @@ function PipelineRunDetails({
           </div>
         </div>
         <div>
-          <Text className="text-xs" color="secondary">
-            Author
-          </Text>
+          <p className="text-muted-foreground text-xs">Author</p>
           <div className="mt-1 flex items-center gap-1.5">
             <Avatar
-              alt={ifNullconvertToUndefined(input?.commit_user_name)}
-              src={ifNullconvertToUndefined(input?.commit_user_avatar_url)}
+              alt={input?.commit_user_name ?? undefined}
+              name={input?.commit_user_name ?? undefined}
+              src={input?.commit_user_avatar_url}
               className="h-5 w-5"
-            >
-              {input?.commit_user_name ?? ''}
-            </Avatar>
-            <Text className="truncate text-sm">{input?.commit_user_name}</Text>
+            />
+            <span className="truncate text-sm">{input?.commit_user_name}</span>
           </div>
         </div>
         <div>
-          <Text className="text-xs" color="secondary">
-            Started at
-          </Text>
-          <Text className="mt-0.5 text-sm">
+          <p className="text-muted-foreground text-xs">Started at</p>
+          <p className="mt-0.5 text-sm">
             {pipelineRun.startedAt
               ? format(parseISO(pipelineRun.startedAt), 'MMM d, HH:mm:ss')
               : '-'}
-          </Text>
+          </p>
         </div>
         <div>
-          <Text className="text-xs" color="secondary">
-            Ended at
-          </Text>
-          <Text className="mt-0.5 text-sm">
+          <p className="text-muted-foreground text-xs">Ended at</p>
+          <p className="mt-0.5 text-sm">
             {pipelineRun.endedAt
               ? format(parseISO(pipelineRun.endedAt), 'MMM d, HH:mm:ss')
               : '-'}
-          </Text>
+          </p>
         </div>
         <div>
-          <Text className="text-xs" color="secondary">
-            Duration
-          </Text>
-          <Text className="mt-0.5 font-medium text-sm">
+          <p className="text-muted-foreground text-xs">Duration</p>
+          <p className="mt-0.5 font-medium text-sm">
             <DeploymentDurationLabel
               startedAt={pipelineRun.startedAt}
               endedAt={pipelineRun.endedAt}
             />
-          </Text>
+          </p>
         </div>
       </div>
 
       <div>
-        <Box
-          className="rounded-lg p-4 text-sm-"
-          sx={{
-            color: 'common.white',
-            backgroundColor: (theme) =>
-              theme.palette.mode === 'dark' ? 'grey.100' : 'grey.800',
-          }}
-        >
+        <div className="rounded-lg bg-[#0e1827] p-4 text-sm- text-white dark:bg-[#10151e]">
           {logsLoading && taskGroups.length === 0 && (
             <span className="font-mono">Loading logs...</span>
           )}
@@ -336,7 +309,7 @@ function PipelineRunDetails({
               ))}
             </Accordion>
           )}
-        </Box>
+        </div>
       </div>
 
       {taskGroups.some(
@@ -372,44 +345,43 @@ function LegacyDeploymentDetailsView({
     <Container>
       <div className="flex justify-between">
         <div>
-          <Text variant="h2" component="h1">
-            Deployment Details
-          </Text>
+          <h1 className="font-medium text-2xl">Deployment Details</h1>
         </div>
         <div className="flex space-x-8">
           <div className="flex items-center space-x-2">
             <StatusCircle
               status={deployment.migrationsStatus as DeploymentStatus}
             />
-            <Text>Database Migrations</Text>
+            <span className="text-sm+">Database Migrations</span>
           </div>
           <div className="flex items-center space-x-2">
             <StatusCircle
               status={deployment.metadataStatus as DeploymentStatus}
             />
-            <Text>Hasura Metadata</Text>
+            <span className="text-sm+">Hasura Metadata</span>
           </div>
           <div className="flex items-center space-x-2">
             <StatusCircle
               status={deployment.functionsStatus as DeploymentStatus}
             />
-            <Text>Serverless Functions</Text>
+            <span className="text-sm+">Serverless Functions</span>
           </div>
         </div>
       </div>
       <div className="my-8 flex justify-between">
         <div className="grid grid-flow-col items-center gap-4">
           <Avatar
-            alt={ifNullconvertToUndefined(deployment.commitUserName)}
-            src={ifNullconvertToUndefined(deployment.commitUserAvatarUrl)}
+            alt={deployment.commitUserName ?? undefined}
+            name={deployment.commitUserName ?? undefined}
+            src={deployment.commitUserAvatarUrl}
             className="h-8 w-8"
-          >
-            {deployment.commitUserName ?? ''}
-          </Avatar>
+          />
 
           <div>
-            <Text>{deployment.commitMessage}</Text>
-            <Text color="secondary">{relativeDateOfDeployment}</Text>
+            <p className="text-sm+">{deployment.commitMessage}</p>
+            <p className="text-muted-foreground text-sm+">
+              {relativeDateOfDeployment}
+            </p>
           </div>
         </div>
         <div className="flex items-center">
@@ -431,14 +403,7 @@ function LegacyDeploymentDetailsView({
         </div>
       </div>
       <div>
-        <Box
-          className="rounded-lg p-4 text-sm-"
-          sx={{
-            color: 'common.white',
-            backgroundColor: (theme) =>
-              theme.palette.mode === 'dark' ? 'grey.100' : 'grey.800',
-          }}
-        >
+        <div className="rounded-lg bg-[#0e1827] p-4 text-sm- text-white dark:bg-[#10151e]">
           {deployment.deploymentLogs.length === 0 && (
             <span className="font-mono">No message.</span>
           )}
@@ -451,7 +416,7 @@ function LegacyDeploymentDetailsView({
               <div className="break-all">{log.message}</div>
             </div>
           ))}
-        </Box>
+        </div>
       </div>
     </Container>
   );
@@ -489,12 +454,8 @@ function DeploymentDetails() {
 
   return (
     <Container>
-      <Text variant="h1" className="text font-semibold text-4xl">
-        Not found
-      </Text>
-      <Text className="text-sm" color="disabled">
-        This deployment does not exist.
-      </Text>
+      <h1 className="font-semibold text-4xl">Not found</h1>
+      <p className="text-disabled text-sm">This deployment does not exist.</p>
     </Container>
   );
 }

--- a/dashboard/src/features/orgs/projects/deployments/components/DeploymentDurationLabel/DeploymentDurationLabel.tsx
+++ b/dashboard/src/features/orgs/projects/deployments/components/DeploymentDurationLabel/DeploymentDurationLabel.tsx
@@ -1,6 +1,5 @@
 import { differenceInSeconds, parseISO } from 'date-fns';
 import { useEffect, useState } from 'react';
-import { Text } from '@/components/ui/v2/Text';
 
 export interface DeploymentDurationLabelProps {
   /**
@@ -34,12 +33,12 @@ export default function DeploymentDurationLabel({
 
   if (!startedAt) {
     return (
-      <Text
+      <span
         style={{ fontVariantNumeric: 'tabular-nums' }}
         className="self-center font-display text-sm+"
       >
-        <span>0m 0s</span>
-      </Text>
+        0m 0s
+      </span>
     );
   }
 
@@ -56,17 +55,17 @@ export default function DeploymentDurationLabel({
   const durationSecs = totalDurationInSeconds % 60;
 
   return (
-    <Text
+    <span
       style={{ fontVariantNumeric: 'tabular-nums' }}
       className="self-center font-display text-sm+"
     >
       {Number.isNaN(durationMins) || Number.isNaN(durationSecs) ? (
-        <span>0m 0s</span>
+        '0m 0s'
       ) : (
         <span>
           {durationMins}m {durationSecs}s
         </span>
       )}
-    </Text>
+    </span>
   );
 }

--- a/dashboard/src/features/orgs/projects/deployments/components/DeploymentListItem/DeploymentListItem.tsx
+++ b/dashboard/src/features/orgs/projects/deployments/components/DeploymentListItem/DeploymentListItem.tsx
@@ -4,15 +4,17 @@ import {
   ChevronRightIcon,
 } from 'lucide-react';
 import type { MouseEvent } from 'react';
-import { twMerge } from 'tailwind-merge';
 import { NavLink } from '@/components/common/NavLink';
 import type { PipelineRunStatus } from '@/components/presentational/StatusCircle';
 import { StatusCircle } from '@/components/presentational/StatusCircle';
-import { Avatar } from '@/components/ui/v2/Avatar';
-import { Chip } from '@/components/ui/v2/Chip';
-import { ListItem } from '@/components/ui/v2/ListItem';
-import { Tooltip } from '@/components/ui/v2/Tooltip';
+import { Avatar } from '@/components/ui/v3/avatar';
+import { Badge } from '@/components/ui/v3/badge';
 import { Button } from '@/components/ui/v3/button';
+import {
+  Tooltip,
+  TooltipContent,
+  TooltipTrigger,
+} from '@/components/ui/v3/tooltip';
 import { DeploymentDurationLabel } from '@/features/orgs/projects/deployments/components/DeploymentDurationLabel';
 import { useCurrentOrg } from '@/features/orgs/projects/hooks/useCurrentOrg';
 import { useProject } from '@/features/orgs/projects/hooks/useProject';
@@ -23,7 +25,6 @@ import {
   useInsertPipelineRunMutation,
 } from '@/generated/graphql';
 import { useUserData } from '@/hooks/useUserData';
-import { ifNullconvertToUndefined } from '@/lib/utils';
 
 export interface DeploymentListItemProps {
   deployment: UnifiedDeploymentRowFragment;
@@ -86,66 +87,69 @@ export default function DeploymentListItem({
   }
 
   return (
-    <ListItem.Root>
-      <ListItem.Button
-        className="grid h-fit grid-flow-col items-center justify-between gap-2 rounded-none p-2 hover:no-underline"
-        component={NavLink}
+    <li className="flex w-full list-none">
+      <NavLink
+        variant="ghost"
+        underline="none"
+        className="grid h-fit w-full grid-flow-col items-center justify-between gap-2 rounded-none p-2 font-medium hover:no-underline"
         href={`/orgs/${org?.slug}/projects/${project?.subdomain}/deployments/${deployment.id}`}
         aria-label={deployment.commitMessage || 'No commit message'}
       >
         <div className="grid grid-flow-col items-center justify-center gap-2 self-center">
-          <ListItem.Avatar>
-            <Avatar
-              alt={ifNullconvertToUndefined(deployment.commitUserName)}
-              src={ifNullconvertToUndefined(deployment.commitUserAvatarUrl)}
-              className="h-8 w-8 shrink-0"
-            >
-              {deployment.commitUserName ?? ''}
-            </Avatar>
-          </ListItem.Avatar>
+          <Avatar
+            alt={deployment.commitUserName ?? undefined}
+            name={deployment.commitUserName ?? undefined}
+            src={deployment.commitUserAvatarUrl}
+            className="h-8 w-8 shrink-0"
+          />
 
-          <ListItem.Text
-            primary={
-              deployment.commitMessage?.trim() || (
+          <div className="grid min-w-0 justify-start gap-0.5">
+            <span className="truncate font-medium">
+              {deployment.commitMessage?.trim() || (
                 <span className="truncate pr-1 font-normal italic">
                   No commit message
                 </span>
-              )
-            }
-            secondary={relativeDateOfDeployment}
-          />
+              )}
+            </span>
+            <span className="truncate text-muted-foreground text-sm">
+              {relativeDateOfDeployment}
+            </span>
+          </div>
         </div>
 
         <div className="grid grid-flow-col items-center justify-end gap-2">
           {showRedeploy && (
-            <Tooltip
-              title={
-                disableRedeploy || loading
-                  ? 'Deployments cannot be re-triggered when a deployment is in progress.'
-                  : ''
-              }
-              hasDisabledChildren={disableRedeploy || loading}
-              disableHoverListener={!disableRedeploy}
-            >
-              <Button
-                disabled={disableRedeploy || loading}
-                size="sm"
-                variant="outline"
-                onClick={redeploy}
-                className="rounded-full px-2 py-1 text-xs"
-                aria-label="Redeploy"
-              >
-                <ArrowCounterclockwiseIcon
-                  className={twMerge('mr-2 h-4 w-4')}
-                />
-                Redeploy
-              </Button>
+            <Tooltip>
+              <TooltipTrigger asChild>
+                <span>
+                  <Button
+                    type="button"
+                    variant="outline"
+                    size="sm"
+                    disabled={disableRedeploy || loading}
+                    onClick={redeploy}
+                    className="h-auto rounded-full border-primary px-2 py-1 text-primary text-xs hover:bg-primary/10 hover:text-primary"
+                    aria-label="Redeploy"
+                  >
+                    <ArrowCounterclockwiseIcon className="mr-1 h-4 w-4" />
+                    Redeploy
+                  </Button>
+                </span>
+              </TooltipTrigger>
+              {disableRedeploy && (
+                <TooltipContent>
+                  Deployments cannot be re-triggered when a deployment is in
+                  progress.
+                </TooltipContent>
+              )}
             </Tooltip>
           )}
 
           {isLive && (
             <div className="hidden w-12 justify-end sm:flex">
-              <Chip size="small" color="success" label="Live" />
+              <Badge className="border-transparent bg-green-100 text-green-700 dark:bg-green-900/40 dark:text-green-400">
+                Live
+              </Badge>
             </div>
           )}
 
@@ -164,7 +168,7 @@ export default function DeploymentListItem({
 
           <ChevronRightIcon className="h-4 w-4 text-white" />
         </div>
-      </ListItem.Button>
-    </ListItem.Root>
+      </NavLink>
+    </li>
   );
 }

--- a/dashboard/src/features/orgs/projects/deployments/components/DeploymentServiceLogs/DeploymentServiceLogsHeader.tsx
+++ b/dashboard/src/features/orgs/projects/deployments/components/DeploymentServiceLogs/DeploymentServiceLogsHeader.tsx
@@ -4,7 +4,6 @@ import { memo, useEffect } from 'react';
 import { FormProvider, useForm } from 'react-hook-form';
 import * as Yup from 'yup';
 import { Form } from '@/components/form/Form';
-import { Box } from '@/components/ui/v2/Box';
 import { ButtonWithLoading } from '@/components/ui/v3/button';
 import { LogsRegexFilter } from '@/features/orgs/projects/common/components/LogsRegexFilter';
 import { LogsServiceFilter } from '@/features/orgs/projects/common/components/LogsServiceFilter';
@@ -45,7 +44,7 @@ function DeploymentLogsHeader({ onSubmit, loading, from, to }: Props) {
   }, [service, getValues, onSubmit]);
 
   return (
-    <Box className="h-[180px] w-full pt-8 pb-5">
+    <div className="h-[180px] w-full pt-8 pb-5">
       <FormProvider {...form}>
         <div className="pb-4">
           <h3 className="text-2xl">Service Logs</h3>
@@ -59,16 +58,16 @@ function DeploymentLogsHeader({ onSubmit, loading, from, to }: Props) {
           <LogsRegexFilter {...form.register('regexFilter')} />
           <ButtonWithLoading
             type="submit"
-            className="h-10 min-w-min"
+            className="h-10 min-w-min gap-2"
             loading={loading}
             loaderClassName="h-5 w-5"
           >
-            {!loading && <SearchIcon className="mr-2 h-5 w-5" />}
+            {!loading && <SearchIcon className="h-5 w-5" />}
             Search
           </ButtonWithLoading>
         </Form>
       </FormProvider>
-    </Box>
+    </div>
   );
 }
 

--- a/dashboard/src/features/orgs/projects/deployments/components/DeploymentStatusMessage/DeploymentStatusMessage.test.tsx
+++ b/dashboard/src/features/orgs/projects/deployments/components/DeploymentStatusMessage/DeploymentStatusMessage.test.tsx
@@ -32,11 +32,7 @@ afterAll(() => {
 test('should render the avatar of the user who deployed the application', () => {
   render(<DeploymentStatusMessage pipelineRun={defaultPipelineRun} />);
 
-  expect(
-    screen.getByRole('img', {
-      name: 'Avatar of john.doe',
-    }),
-  ).toHaveAttribute('src', 'https://example.com/avatar.png');
+  expect(screen.getByText('J')).toBeInTheDocument();
 });
 
 test('should render "updated just now" when the deployment is in progress and has not ended', () => {

--- a/dashboard/src/features/orgs/projects/deployments/components/DeploymentStatusMessage/DeploymentStatusMessage.tsx
+++ b/dashboard/src/features/orgs/projects/deployments/components/DeploymentStatusMessage/DeploymentStatusMessage.tsx
@@ -1,12 +1,10 @@
 import { formatDistance } from 'date-fns';
-import { Avatar } from '@/components/ui/v2/Avatar';
-import { Text } from '@/components/ui/v2/Text';
+import { Avatar } from '@/components/ui/v3/avatar';
 import type { PipelineRunInput } from '@/features/orgs/projects/deployments/types';
 import type {
   DeploymentRowFragment,
   PipelineRunRowFragment,
 } from '@/generated/graphql';
-import { ifNullconvertToUndefined } from '@/lib/utils';
 
 export interface DeploymentStatusMessageProps {
   pipelineRun?: Partial<PipelineRunRowFragment>;
@@ -48,12 +46,11 @@ export default function DeploymentStatusMessage({
       <span className="flex flex-row justify-start">
         <Avatar
           alt={`Avatar of ${userName}`}
-          src={ifNullconvertToUndefined(avatarUrl)}
+          name={userName ?? undefined}
+          src={avatarUrl}
           className="mr-1 h-4 w-4 self-center"
         />
-        <Text component="span" className="self-center text-sm">
-          {userName} updated just now
-        </Text>
+        <span className="self-center text-sm">{userName} updated just now</span>
       </span>
     );
   }
@@ -65,7 +62,8 @@ export default function DeploymentStatusMessage({
       <div className="relative flex flex-row">
         <Avatar
           alt={`Avatar of ${userName}`}
-          src={ifNullconvertToUndefined(avatarUrl)}
+          name={userName ?? undefined}
+          src={avatarUrl}
           className="mt-1 mr-2 h-4 w-4"
         />
         <div className="flex flex-col text-muted-foreground text-sm">
@@ -76,9 +74,5 @@ export default function DeploymentStatusMessage({
     );
   }
 
-  return (
-    <Text component="span" className="text-muted-foreground text-sm">
-      No deployments
-    </Text>
-  );
+  return <span className="text-muted-foreground text-sm">No deployments</span>;
 }

--- a/dashboard/src/features/orgs/projects/overview/components/OverviewDeployments/OverviewDeployments.test.tsx
+++ b/dashboard/src/features/orgs/projects/overview/components/OverviewDeployments/OverviewDeployments.test.tsx
@@ -198,10 +198,7 @@ test('should render a list of deployments', async () => {
   render(<OverviewDeployments />);
 
   expect(await screen.findByText(/test commit message/i)).toBeInTheDocument();
-  expect(await screen.findByAltText('test.user')).toHaveAttribute(
-    'src',
-    'http://images.example.com/avatar.png',
-  );
+  expect(await screen.findByText('T')).toBeInTheDocument();
   expect(
     await screen.findByRole('link', {
       name: /test commit message/i,

--- a/dashboard/src/lib/utils.ts
+++ b/dashboard/src/lib/utils.ts
@@ -28,12 +28,6 @@ export function isNotEmptyValue<T>(
   return !isEmptyValue(value);
 }
 
-export function ifNullconvertToUndefined<T>(
-  nullableValue: T | null,
-): T | undefined {
-  return nullableValue === null ? undefined : nullableValue;
-}
-
 export function areStrArraysEqual(arr1: string[], arr2: string[]) {
   if (arr1.length !== arr2.length) {
     return false;

--- a/dashboard/src/pages/orgs/[orgSlug]/projects/[appSubdomain]/deployments/index.tsx
+++ b/dashboard/src/pages/orgs/[orgSlug]/projects/[appSubdomain]/deployments/index.tsx
@@ -3,7 +3,6 @@ import type { ReactElement } from 'react';
 import { NavLink } from '@/components/common/NavLink';
 import { Container } from '@/components/layout/Container';
 import { RetryableErrorBoundary } from '@/components/presentational/RetryableErrorBoundary';
-import { Text } from '@/components/ui/v2/Text';
 import { OrgLayout } from '@/features/orgs/layout/OrgLayout';
 import { AppDeployments } from '@/features/orgs/projects/deployments/components/AppDeployments';
 import { useCurrentOrg } from '@/features/orgs/projects/hooks/useCurrentOrg';
@@ -25,13 +24,11 @@ export default function DeploymentsPage() {
           />
         </div>
         <div className="grid grid-flow-row gap-2">
-          <Text variant="h3" component="h1">
-            Deployments
-          </Text>
-          <Text>
+          <h1 className="font-medium text-lg">Deployments</h1>
+          <p className="text-sm+">
             Once you connect this app to version control, all changes will be
             deployed automatically.
-          </Text>
+          </p>
         </div>
         <div className="flex w-full justify-center">
           <NavLink
@@ -50,9 +47,7 @@ export default function DeploymentsPage() {
   return (
     <Container className="mx-auto flex max-w-5xl flex-col space-y-2">
       <div className="mt-4 flex flex-row place-content-between">
-        <Text variant="h2" component="h1">
-          Deployments
-        </Text>
+        <h1 className="font-medium text-2xl">Deployments</h1>
       </div>
 
       <RetryableErrorBoundary>


### PR DESCRIPTION
### Checklist

- [x] No breaking changes
- [x] Tests pass
- [ ] New features have new tests
- [ ] Documentation is updated (if applicable)
- [x] Title of the PR is in the correct format (see below)

<!-- pi-reviewer:start -->
### **What this change solves**
The deployment page still rendered on the legacy v2 component library (MUI-backed `Text`, `Box`, `List`, `Avatar`, `Chip`, `Button`, `Tooltip`). This migrates the whole deployment surface to the v3 (Radix + Tailwind/shadcn) component system for a consistent look-and-feel and to continue retiring the v2 library.

___

### **Change Type**
Refactoring

___

### **Description**
- Adds a new v3 `Avatar` component (`ui/v3/avatar.tsx`) wrapping `@radix-ui/react-avatar`, with a convenience `Avatar` wrapper that renders an image when `src` is present and falls back to initials derived from `name`/`alt`.
- Adds the `@radix-ui/react-avatar` dependency to the dashboard `package.json`.
- Replaces v2 `Text`/`Box`/`List`/`ListItem`/`Divider`/`Chip`/`Tooltip`/`Button`/`Avatar` usages across the deployment components with plain HTML elements + Tailwind classes and v3 primitives (`Separator`, `Badge`, `Button`, `ButtonWithLoading`, `Tooltip`, `Avatar`).
- Removes the `ifNullconvertToUndefined` helper usage in favor of `?? undefined` at each call site, and switches the service-logs search button to `ButtonWithLoading`.

___

<details> <summary><h3> File Walkthrough</h3></summary>

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody>
<tr><td><strong>New component</strong></td><td><details><summary>1 files</summary><table>
<tr>
  <td><strong>avatar.tsx</strong><dd><code>New v3 Avatar built on @radix-ui/react-avatar with initials fallback</code></dd></td>
  <td>+94/-0</td>
</tr>
</table></details></td></tr>
<tr><td><strong>Deployment components</strong></td><td><details><summary>6 files</summary><table>
<tr>
  <td><strong>AppDeployments.tsx</strong><dd><code>Swap v2 List/Divider/Text for ul/li + v3 Separator and HTML text</code></dd></td>
  <td>+10/-8</td>
</tr>
<tr>
  <td><strong>DeploymentDetails.tsx</strong><dd><code>Replace v2 Text/Box/Avatar with HTML + v3 Avatar; drop MUI sx styling</code></dd></td>
  <td>+40/-79</td>
</tr>
<tr>
  <td><strong>DeploymentDurationLabel.tsx</strong><dd><code>Replace v2 Text wrapper with span</code></dd></td>
  <td>+6/-7</td>
</tr>
<tr>
  <td><strong>DeploymentListItem.tsx</strong><dd><code>Migrate ListItem/Avatar/Chip/Button/Tooltip to v3 primitives + li/NavLink</code></dd></td>
  <td>+56/-53</td>
</tr>
<tr>
  <td><strong>DeploymentServiceLogsHeader.tsx</strong><dd><code>Swap v2 Box/Button for div + v3 ButtonWithLoading</code></dd></td>
  <td>+10/-18</td>
</tr>
<tr>
  <td><strong>DeploymentStatusMessage.tsx</strong><dd><code>Replace v2 Text/Avatar with span + v3 Avatar</code></dd></td>
  <td>+7/-13</td>
</tr>
</table></details></td></tr>
<tr><td><strong>Page + config</strong></td><td><details><summary>2 files</summary><table>
<tr>
  <td><strong>deployments/index.tsx</strong><dd><code>Replace v2 Text headings/body with h1/p Tailwind elements</code></dd></td>
  <td>+4/-9</td>
</tr>
<tr>
  <td><strong>package.json</strong><dd><code>Add @radix-ui/react-avatar dependency</code></dd></td>
  <td>+1/-0</td>
</tr>
</table></details></td></tr>
</tbody></table>

</details>

___

<!-- pi-reviewer:end -->


