### PR TITLE
fix(dashboard): Show the correct dashboard version

### DIFF
--- a/.github/workflows/dashboard_wf_release.yaml
+++ b/.github/workflows/dashboard_wf_release.yaml
@@ -1,5 +1,5 @@
 ---
-name: 'dashboard: release'
+name: "dashboard: release"
 
 on:
   workflow_call:
@@ -51,6 +51,7 @@ jobs:
       NAME: dashboard
       GIT_REF: ${{ inputs.GIT_REF }}
       ENVIRONMENT: production
+      VERSION: ${{ inputs.VERSION }}
     secrets:
       AWS_ACCOUNT_ID: ${{ secrets.AWS_ACCOUNT_ID }}
       NIX_CACHE_PUB_KEY: ${{ secrets.NIX_CACHE_PUB_KEY }}

--- a/.github/workflows/wf_deploy_vercel.yaml
+++ b/.github/workflows/wf_deploy_vercel.yaml
@@ -1,4 +1,4 @@
-name: 'deploy to vercel'
+name: "deploy to vercel"
 
 on:
   workflow_call:
@@ -12,6 +12,10 @@ on:
       ENVIRONMENT:
         required: true
         type: string
+      VERSION:
+        required: false
+        type: string
+        default: ""
     secrets:
       AWS_ACCOUNT_ID:
         required: true
@@ -57,6 +61,10 @@ jobs:
         with:
           ref: ${{ inputs.GIT_REF }}
           allow-unsafe-pr-checkout: true
+
+      - name: Substitute release version
+        if: ${{ inputs.VERSION != '' && inputs.VERSION != '0.0.0-dev' }}
+        run: make -C ${{ inputs.NAME }} get-version VER=${{ inputs.VERSION }}
 
       - name: Configure aws
         uses: aws-actions/configure-aws-credentials@v6

--- a/dashboard/project.nix
+++ b/dashboard/project.nix
@@ -158,6 +158,8 @@ let
       '';
 
   vercelPrepare = ''
+    export NEXT_PUBLIC_DASHBOARD_VERSION=${version}
+
     cp -r ${node_modules}/node_modules/ node_modules
     cp -r ${node_modules}/dashboard/node_modules/ dashboard/node_modules
     chmod +w -R node_modules dashboard/node_modules


### PR DESCRIPTION
### Checklist

- [ ] No breaking changes
- [ ] Tests pass
- [ ] New features have new tests
- [ ] Documentation is updated (if applicable)
- [ ] Title of the PR is in the correct format (see below)

<!-- pi-reviewer:start -->
### **What this change solves**
This change ensures dashboard Vercel deployments publish the intended release version instead of falling back to the development version. It passes the release version through the reusable deployment workflow and exposes it during the dashboard build.

___

### **Change Type**
Bug fix

___

### **Description**
- Pass the dashboard release `VERSION` input into the reusable Vercel deployment workflow.
- Add an optional reusable workflow `VERSION` input and substitute it before deployment when it is a real release version.
- Export `NEXT_PUBLIC_DASHBOARD_VERSION` during dashboard Vercel preparation.

___

### Diagram Walkthrough

```mermaid
flowchart LR
  A["dashboard: release workflow"] -->|VERSION input| B["reusable Vercel deploy workflow"]
  B -->|make get-version| C["dashboard version files"]
  C --> D["Vercel dashboard build"]
```

<details> <summary><h3> File Walkthrough</h3></summary>

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody>
<tr><td><strong>CI / release workflows</strong></td><td><details><summary>2 files</summary><table>
<tr>
  <td><strong>.github/workflows/dashboard_wf_release.yaml</strong><dd><code>Passes the dashboard release VERSION to the reusable Vercel workflow.</code></dd></td>
  <td>+2/-1</td>
</tr>
<tr>
  <td><strong>.github/workflows/wf_deploy_vercel.yaml</strong><dd><code>Adds an optional VERSION input and substitutes release versions before deployment.</code></dd></td>
  <td>+12/-1</td>
</tr>
</table></details></td></tr>
<tr><td><strong>Dashboard build configuration</strong></td><td><details><summary>1 file</summary><table>
<tr>
  <td><strong>dashboard/project.nix</strong><dd><code>Exports NEXT_PUBLIC_DASHBOARD_VERSION during Vercel preparation.</code></dd></td>
  <td>+2/-0</td>
</tr>
</table></details></td></tr>
</tbody></table>

</details>

___

<!-- pi-reviewer:end -->
