### PR TITLE
fix(dashboard): Migrate hasura page to v3

### DIFF
--- a/dashboard/src/components/layout/UnauthenticatedLayout/UnauthenticatedLayout.tsx
+++ b/dashboard/src/components/layout/UnauthenticatedLayout/UnauthenticatedLayout.tsx
@@ -53,9 +53,7 @@ export default function UnauthenticatedLayout({
   if ((!isPlatform || isLoading || isAuthenticated) && !isOnResetPassword) {
     return (
       <BaseLayout {...props}>
-        <LoadingScreen
-          sx={{ backgroundColor: (theme) => theme.palette.background.default }}
-        />
+        <LoadingScreen className="bg-background" />
       </BaseLayout>
     );
   }

--- a/dashboard/src/components/presentational/LoadingScreen/LoadingScreen.tsx
+++ b/dashboard/src/components/presentational/LoadingScreen/LoadingScreen.tsx
@@ -1,36 +1,22 @@
+import type { ComponentPropsWithoutRef } from 'react';
 import { twMerge } from 'tailwind-merge';
-import type { BoxProps } from '@/components/ui/v2/Box';
-import { Box } from '@/components/ui/v2/Box';
 import { Spinner } from '@/components/ui/v3/spinner';
 
-export interface LoadingScreenProps extends BoxProps {
-  /**
-   * Props passed to individual component slots.
-   */
-  slotProps?: {
-    /**
-     * Props passed to the `<Box />` component.
-     */
-    root?: BoxProps;
-  };
-}
+export type LoadingScreenProps = ComponentPropsWithoutRef<'div'>;
 
 export default function LoadingScreen({
   className,
-  slotProps = { root: {} },
   ...props
 }: LoadingScreenProps) {
   return (
-    <Box
+    <div
       className={twMerge(
-        'absolute top-0 right-0 bottom-0 left-0 z-50 flex h-full w-full items-center justify-center',
+        'box absolute top-0 right-0 bottom-0 left-0 z-50 flex h-full w-full items-center justify-center',
         className,
-        slotProps?.root?.className,
       )}
-      {...slotProps?.root}
       {...props}
     >
       <Spinner className="h-5 w-5" />
-    </Box>
+    </div>
   );
 }

--- a/dashboard/src/pages/orgs/[orgSlug]/projects/[appSubdomain]/hasura.tsx
+++ b/dashboard/src/pages/orgs/[orgSlug]/projects/[appSubdomain]/hasura.tsx
@@ -2,12 +2,8 @@ import { ExternalLink as ArrowSquareOutIcon, CopyIcon } from 'lucide-react';
 import Image from 'next/image';
 import Link from 'next/link';
 import type { ReactElement } from 'react';
-import { Container } from '@/components/layout/Container';
 import { LoadingScreen } from '@/components/presentational/LoadingScreen';
 import { RetryableErrorBoundary } from '@/components/presentational/RetryableErrorBoundary';
-import { Box } from '@/components/ui/v2/Box';
-import { IconButton } from '@/components/ui/v2/IconButton';
-import { Text } from '@/components/ui/v2/Text';
 import { Button } from '@/components/ui/v3/button';
 import { OrgLayout } from '@/features/orgs/layout/OrgLayout';
 import { useIsPlatform } from '@/features/orgs/projects/common/hooks/useIsPlatform';
@@ -51,76 +47,65 @@ function HasuraPageContent() {
         });
 
   return (
-    <Container>
-      <div className="mx-auto w-full max-w-md px-6 py-4 text-left">
-        <div className="grid grid-flow-row gap-1">
-          <div className="mx-auto">
-            <Image
-              src="/assets/hasuramodal.svg"
-              width={72}
-              height={72}
-              alt="Hasura"
-            />
-          </div>
+    <div className="mx-auto w-full max-w-md px-6 py-4 text-left">
+      <div className="grid grid-flow-row gap-1">
+        <div className="mx-auto">
+          <Image
+            src="/assets/hasuramodal.svg"
+            width={72}
+            height={72}
+            alt="Hasura"
+          />
+        </div>
 
-          <Text variant="h3" component="h1" className="text-center">
-            Open Hasura
-          </Text>
+        <h1 className="text-center font-medium text-lg">Open Hasura</h1>
 
-          <Text className="text-center">
-            Hasura is the dashboard you&apos;ll use to edit your schema and
-            permissions as well as browse data. Copy the admin secret to your
-            clipboard and enter it in the next screen.
-          </Text>
+        <p className="text-center text-sm+">
+          Hasura is the dashboard you&apos;ll use to edit your schema and
+          permissions as well as browse data. Copy the admin secret to your
+          clipboard and enter it in the next screen.
+        </p>
 
-          <Box className="mt-6 border-y-1">
-            <div className="grid w-full grid-cols-1 place-content-between items-center py-2 sm:grid-cols-3">
-              <Text className="col-span-1 text-center font-medium sm:justify-start sm:text-left">
-                Admin Secret
-              </Text>
+        <div className="box mt-6 border-y-1">
+          <div className="grid w-full grid-cols-1 place-content-between items-center py-2 sm:grid-cols-3">
+            <p className="col-span-1 text-center font-medium text-sm+ sm:justify-start sm:text-left">
+              Admin Secret
+            </p>
 
-              <div className="col-span-1 grid grid-flow-col items-center justify-center gap-2 sm:col-span-2 sm:justify-end">
-                <Text className="font-medium" variant="subtitle2">
-                  {Array(projectAdminSecret.length).fill('•').join('')}
-                </Text>
+            <div className="col-span-1 grid grid-flow-col items-center justify-center gap-2 sm:col-span-2 sm:justify-end">
+              <span className="font-medium text-muted-foreground text-xs">
+                {Array(projectAdminSecret.length).fill('•').join('')}
+              </span>
 
-                <IconButton
-                  onClick={() =>
-                    copy(projectAdminSecret, 'Hasura admin secret')
-                  }
-                  variant="borderless"
-                  color="secondary"
-                  className="min-w-0 p-1"
-                  aria-label="Copy admin secret"
-                >
-                  <CopyIcon className="h-4 w-4" />
-                </IconButton>
-              </div>
+              <Button
+                onClick={() => copy(projectAdminSecret, 'Hasura admin secret')}
+                variant="ghost"
+                size="icon"
+                aria-label="Copy admin secret"
+              >
+                <CopyIcon className="h-4 w-4" />
+              </Button>
             </div>
-          </Box>
-
-          <div className="mt-6 grid grid-flow-row gap-2">
-            {settings?.enableConsole ? (
-              <Button asChild>
-                <Link
-                  href={hasuraUrl}
-                  target="_blank"
-                  rel="noreferrer noopener"
-                >
-                  Open Hasura
-                  <ArrowSquareOutIcon className="ml-2 h-4 w-4" />
-                </Link>
-              </Button>
-            ) : (
-              <Button variant="outline" disabled>
-                Open Hasura
-                <ArrowSquareOutIcon className="ml-2 h-4 w-4" />
-              </Button>
-            )}
           </div>
         </div>
+
+        <div className="mt-6 grid grid-flow-row gap-2">
+          {settings?.enableConsole ? (
+            <Button asChild>
+              <Link href={hasuraUrl} target="_blank" rel="noreferrer noopener">
+                Open Hasura
+                <ArrowSquareOutIcon className="ml-2 h-4 w-4" />
+              </Link>
+            </Button>
+          ) : (
+            <Button variant="outline" disabled>
+              Open Hasura
+              <ArrowSquareOutIcon className="ml-2 h-4 w-4" />
+            </Button>
+          )}
+        </div>
       </div>
-    </Container>
+    </div>
   );
 }
 


### PR DESCRIPTION
### Checklist

- [x] No breaking changes
- [ ] Tests pass
- [ ] New features have new tests
- [ ] Documentation is updated (if applicable)
- [x] Title of the PR is in the correct format (see below)

<!-- pi-reviewer:start -->
### **What this change solves**
The Hasura project page and the shared `LoadingScreen` still relied on legacy v2 MUI components (`Container`, `Box`, `Text`, `IconButton`) and MUI `sx` styling. This migrates them to v3 primitives / native HTML elements with Tailwind classes, continuing the dashboard-wide v2→v3 UI migration.

___

### **Change Type**
Refactoring

___

### **Description**
- Rewrote `LoadingScreen` to render a native `<div>` with Tailwind classes instead of the MUI `Box`, dropping the `slotProps`/`BoxProps` API in favor of a plain `ComponentPropsWithoutRef<'div'>` prop type.
- Updated `UnauthenticatedLayout` to pass `className="bg-background"` to `LoadingScreen` instead of the MUI `sx` background-color prop.
- Migrated the Hasura page (`hasura.tsx`) off `Container`, `Box`, `Text`, and `IconButton` to native `<div>`/`<h1>`/`<p>`/`<span>` elements and the v3 `Button` (`variant="ghost"`, `size="icon"`) with Tailwind typography utilities.

___

<details> <summary><h3> File Walkthrough</h3></summary>

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody>
<tr><td><strong>Refactoring</strong></td><td><details><summary>3 files</summary><table>
<tr>
  <td><strong>hasura.tsx</strong><dd><code>Replaced v2 Container/Box/Text/IconButton with native elements + v3 Button</code></dd></td>
  <td>+48/-63</td>
</tr>
<tr>
  <td><strong>LoadingScreen.tsx</strong><dd><code>Rewrote as native div; simplified props to ComponentPropsWithoutRef&lt;'div'&gt;</code></dd></td>
  <td>+4/-18</td>
</tr>
<tr>
  <td><strong>UnauthenticatedLayout.tsx</strong><dd><code>Pass className bg-background to LoadingScreen instead of MUI sx</code></dd></td>
  <td>+1/-3</td>
</tr>
</table></details></td></tr>
</tbody></table>

</details>

___

<!-- pi-reviewer:end -->


