### PR TITLE
fix(dashboard): migrate general settings page

### DIFF
--- a/dashboard/src/features/orgs/components/TransferProject/TransferProject.tsx
+++ b/dashboard/src/features/orgs/components/TransferProject/TransferProject.tsx
@@ -1,5 +1,10 @@
 import { useState } from 'react';
-import { SettingsContainer } from '@/components/layout/SettingsContainer';
+import {
+  SettingsCard,
+  SettingsCardFooter,
+  SettingsCardHeader,
+} from '@/components/layout/SettingsCard';
+import { ButtonWithLoading } from '@/components/ui/v3/button';
 import { TransferProjectDialog } from '@/features/orgs/components/common/TransferProjectDialog';
 import { useIsPlatform } from '@/features/orgs/projects/common/hooks/useIsPlatform';
 
@@ -9,20 +14,23 @@ export default function TransferProject() {
 
   return (
     <>
-      <SettingsContainer
-        title="Transfer Project"
-        description="Move the current project to a different organization."
-        submitButtonText="Transfer"
-        slotProps={{
-          submitButton: {
-            type: 'button',
-            color: 'primary',
-            variant: 'contained',
-            disabled: !isPlatform,
-            onClick: () => setOpen(true),
-          },
-        }}
-      />
+      <SettingsCard>
+        <SettingsCardHeader
+          title="Transfer Project"
+          description="Move the current project to a different organization."
+        />
+
+        <SettingsCardFooter>
+          <ButtonWithLoading
+            type="button"
+            disabled={!isPlatform}
+            onClick={() => setOpen(true)}
+            className="w-full sm:w-auto"
+          >
+            Transfer
+          </ButtonWithLoading>
+        </SettingsCardFooter>
+      </SettingsCard>
 
       <TransferProjectDialog open={open} setOpen={setOpen} />
     </>

--- a/dashboard/src/features/orgs/projects/common/components/RemoveApplicationModal/RemoveApplicationModal.tsx
+++ b/dashboard/src/features/orgs/projects/common/components/RemoveApplicationModal/RemoveApplicationModal.tsx
@@ -1,9 +1,6 @@
 import router from 'next/router';
 import { useState } from 'react';
-import { twMerge } from 'tailwind-merge';
-import { Box } from '@/components/ui/v2/Box';
-import { Button } from '@/components/ui/v2/Button';
-import { Text } from '@/components/ui/v2/Text';
+import { Button, ButtonWithLoading } from '@/components/ui/v3/button';
 import { Checkbox } from '@/components/ui/v3/checkbox';
 import { Label } from '@/components/ui/v3/label';
 import { useOrgs } from '@/features/orgs/projects/hooks/useOrgs';
@@ -13,7 +10,7 @@ import {
   useBillingDeleteAppMutation,
 } from '@/generated/graphql';
 import { useUserData } from '@/hooks/useUserData';
-import { isEmptyValue } from '@/lib/utils';
+import { cn, isEmptyValue } from '@/lib/utils';
 import { discordAnnounce } from '@/utils/discordAnnounce';
 import { triggerToast } from '@/utils/toast';
 
@@ -93,27 +90,19 @@ export default function RemoveApplicationModal({
   }
 
   return (
-    <Box
-      className={twMerge('w-full max-w-sm rounded-lg p-6 text-left', className)}
-    >
+    <div className={cn('w-full max-w-sm rounded-lg p-6 text-left', className)}>
       <div className="grid grid-flow-row gap-1">
-        <Text variant="h3" component="h2">
-          {title || 'Delete Project'}
-        </Text>
+        <h2 className="font-semibold text-lg">{title || 'Delete Project'}</h2>
 
-        <Text variant="subtitle2">
+        <p className="text-muted-foreground text-sm">
           {description || 'Are you sure you want to delete this app?'}
-        </Text>
+        </p>
 
-        <Text
-          variant="subtitle2"
-          className="font-bold"
-          sx={{ color: (theme) => `${theme.palette.error.main} !important` }}
-        >
+        <p className="font-bold text-destructive text-sm">
           This cannot be undone.
-        </Text>
+        </p>
 
-        <Box className="my-4 flex flex-col divide-y border-y">
+        <div className="my-4 flex flex-col divide-y border-y">
           <div className="flex items-start gap-2 py-3">
             <Checkbox
               id="accept-1"
@@ -164,23 +153,23 @@ export default function RemoveApplicationModal({
               </Label>
             </div>
           )}
-        </Box>
+        </div>
 
         <div className="grid grid-flow-row gap-2">
-          <Button
-            color="error"
+          <ButtonWithLoading
+            variant="destructive"
             onClick={handleClick}
             disabled={!remove || !remove2 || (isPaidPlan && !remove3)}
             loading={loadingRemove}
           >
             Delete Project
-          </Button>
+          </ButtonWithLoading>
 
-          <Button variant="outlined" color="secondary" onClick={close}>
+          <Button variant="outline" onClick={close}>
             Cancel
           </Button>
         </div>
       </div>
-    </Box>
+    </div>
   );
 }

--- a/dashboard/src/pages/orgs/[orgSlug]/projects/[appSubdomain]/settings/index.tsx
+++ b/dashboard/src/pages/orgs/[orgSlug]/projects/[appSubdomain]/settings/index.tsx
@@ -6,12 +6,16 @@ import { FormProvider, useForm } from 'react-hook-form';
 import * as Yup from 'yup';
 import { useDialog } from '@/components/common/DialogProvider';
 import { Form } from '@/components/form/Form';
-import { Container } from '@/components/layout/Container';
-import { SettingsContainer } from '@/components/layout/SettingsContainer';
+import { FormInput } from '@/components/form/FormInput';
+import {
+  SettingsCard,
+  SettingsCardContent,
+  SettingsCardFooter,
+  SettingsCardHeader,
+} from '@/components/layout/SettingsCard';
 import { LoadingScreen } from '@/components/presentational/LoadingScreen';
-import { Alert } from '@/components/ui/v2/Alert';
-import { Input } from '@/components/ui/v2/Input';
-import { Text } from '@/components/ui/v2/Text';
+import { Alert } from '@/components/ui/v3/alert';
+import { ButtonWithLoading } from '@/components/ui/v3/button';
 import { TransferProject } from '@/features/orgs/components/TransferProject';
 import { OrgLayout } from '@/features/orgs/layout/OrgLayout';
 import { SettingsLayout } from '@/features/orgs/layout/SettingsLayout';
@@ -105,7 +109,7 @@ export default function SettingsGeneralPage() {
     shouldFocusError: true,
   });
 
-  const { register, formState } = form;
+  const { formState } = form;
 
   useEffect(() => {
     if (!loading) {
@@ -215,87 +219,89 @@ export default function SettingsGeneralPage() {
   }
 
   return (
-    <Container
-      className="grid max-w-5xl grid-flow-row gap-8 bg-transparent"
-      rootClassName="bg-transparent"
-    >
+    <div className="grid grid-flow-row gap-8">
       <FormProvider {...form}>
         <Form onSubmit={handleProjectNameChange}>
-          <SettingsContainer
-            title="Project Name"
-            description="The name of the project."
-            className="grid grid-flow-row px-4 lg:grid-cols-4"
-            slotProps={{
-              submitButton: {
-                disabled: !formState.isDirty || !isPlatform,
-                loading: formState.isSubmitting,
-              },
-            }}
-          >
-            <Input
-              {...register('name')}
-              className="col-span-2"
-              variant="inline"
-              fullWidth
-              hideEmptyHelperText
-              helperText={formState.errors.name?.message}
-              error={Boolean(formState.errors.name)}
-              slotProps={{
-                helperText: { className: 'col-start-1' },
-              }}
+          <SettingsCard>
+            <SettingsCardHeader
+              title="Project Name"
+              description="The name of the project."
             />
-          </SettingsContainer>
+
+            <SettingsCardContent className="lg:grid-cols-4">
+              <FormInput
+                control={form.control}
+                name="name"
+                label="Project Name"
+                containerClassName="col-span-2"
+              />
+            </SettingsCardContent>
+
+            <SettingsCardFooter>
+              <ButtonWithLoading
+                type="submit"
+                disabled={!formState.isDirty || !isPlatform}
+                loading={formState.isSubmitting}
+                className="w-full sm:w-auto"
+              >
+                Save
+              </ButtonWithLoading>
+            </SettingsCardFooter>
+          </SettingsCard>
         </Form>
       </FormProvider>
 
       {isPaused || isPausing ? (
-        <SettingsContainer
-          title="Wake up Project"
-          description="Wake up your project to make it accessible again. Once reactivated, all features will be fully functional."
-          submitButtonText={isPausing ? 'Pausing...' : 'Wake up'}
-          slotProps={{
-            submitButton: {
-              type: 'button',
-              color: 'primary',
-              variant: 'contained',
-              loading: unpauseApplicationLoading || isPausing,
-              disabled: wakeUpDisabled,
-              onClick: handleTriggerUnpausing,
-            },
-          }}
-        />
+        <SettingsCard>
+          <SettingsCardHeader
+            title="Wake up Project"
+            description="Wake up your project to make it accessible again. Once reactivated, all features will be fully functional."
+          />
+
+          <SettingsCardFooter>
+            <ButtonWithLoading
+              type="button"
+              disabled={wakeUpDisabled}
+              loading={unpauseApplicationLoading || isPausing}
+              onClick={handleTriggerUnpausing}
+              className="w-full sm:w-auto"
+            >
+              {isPausing ? 'Pausing...' : 'Wake up'}
+            </ButtonWithLoading>
+          </SettingsCardFooter>
+        </SettingsCard>
       ) : null}
 
       {!isPaused && !isPausing && (
-        <SettingsContainer
-          title="Pause Project"
-          description="While your project is paused, it will not be accessible. You can wake it up anytime after."
-          submitButtonText="Pause"
-          slotProps={{
-            submitButton: {
-              type: 'button',
-              color: 'primary',
-              variant: 'contained',
-              loading: pauseApplicationLoading,
-              disabled: pausedDisabled,
-              onClick: () => {
+        <SettingsCard>
+          <SettingsCardHeader
+            title="Pause Project"
+            description="While your project is paused, it will not be accessible. You can wake it up anytime after."
+          />
+
+          <SettingsCardFooter>
+            <ButtonWithLoading
+              type="button"
+              disabled={pausedDisabled}
+              loading={pauseApplicationLoading}
+              onClick={() => {
                 openAlertDialog({
                   title: 'Pause Project?',
                   payload: (
                     <div className="flex flex-col gap-2">
                       {showWarning ? (
                         <Alert
-                          severity="warning"
+                          variant="warning"
                           className="flex flex-col gap-3 text-left"
                         >
                           <div className="flex flex-col gap-2 lg:flex-row lg:justify-between">
-                            <Text className="flex items-start gap-1 font-semibold">
+                            <p className="flex items-start gap-1 font-semibold">
                               <span>⚠</span> Warning: This action will delete
                               all volume data for your Run services.
-                            </Text>
+                            </p>
                           </div>
                           <div className="flex flex-col gap-4">
-                            <Text>
+                            <p>
                               Pausing this project will delete all persistent
                               volume data for your Run services. No automatic
                               backups are made. Please backup your data manually
@@ -309,7 +315,7 @@ export default function SettingsGeneralPage() {
                                 support
                               </Link>{' '}
                               with any questions.
-                            </Text>
+                            </p>
                           </div>
                         </Alert>
                       ) : null}
@@ -324,28 +330,28 @@ export default function SettingsGeneralPage() {
                     onPrimaryAction: handlePauseApplication,
                   },
                 });
-              },
-            },
-          }}
-        />
+              }}
+              className="w-full sm:w-auto"
+            >
+              Pause
+            </ButtonWithLoading>
+          </SettingsCardFooter>
+        </SettingsCard>
       )}
 
       <TransferProject />
 
       {isOwner && (
-        <SettingsContainer
-          title="Delete Project"
-          description="The project will be permanently deleted, including its database, metadata, files, etc. This action is irreversible and can not be undone."
-          submitButtonText="Delete"
-          slotProps={{
-            root: {
-              sx: { borderColor: (theme) => theme.palette.error.main },
-            },
-            submitButton: {
-              type: 'button',
-              color: 'error',
-              variant: 'contained',
-              onClick: () => {
+        <SettingsCard className="border-destructive">
+          <SettingsCardHeader
+            title="Delete Project"
+            description="The project will be permanently deleted, including its database, metadata, files, etc. This action is irreversible and can not be undone."
+          />
+
+          <SettingsCardFooter>
+            <ButtonWithLoading
+              type="button"
+              onClick={() => {
                 openDialog({
                   component: (
                     <RemoveApplicationModal
@@ -357,12 +363,16 @@ export default function SettingsGeneralPage() {
                     PaperProps: { className: 'max-w-sm' },
                   },
                 });
-              },
-            },
-          }}
-        />
+              }}
+              variant="destructive"
+              className="w-full sm:w-auto"
+            >
+              Delete
+            </ButtonWithLoading>
+          </SettingsCardFooter>
+        </SettingsCard>
       )}
-    </Container>
+    </div>
   );
 }
 
@@ -370,9 +380,7 @@ SettingsGeneralPage.getLayout = function getLayout(page: ReactElement) {
   return (
     <OrgLayout>
       <SettingsLayout>
-        <Container sx={{ backgroundColor: 'background.default' }}>
-          {page}
-        </Container>
+        <div className="mx-auto w-full max-w-5xl px-5 py-4">{page}</div>
       </SettingsLayout>
     </OrgLayout>
   );


### PR DESCRIPTION
<!-- pi-reviewer:start -->
### **What this change solves**
Migrates the project general settings page from the legacy v2 dashboard UI primitives (`SettingsContainer`, v2 `Box`/`Text`/`Input`/`Alert`/`Button`) to the current v3 card-based settings layout (`SettingsCard*`, `FormInput`, v3 `Alert`, `ButtonWithLoading`). Behavior is preserved; only the presentation layer and form wiring change.

___

### **Change Type**
Refactoring

___

### **Description**
- Rewrites the general settings route (`settings/index.tsx`) to use `SettingsCard`/`SettingsCardHeader`/`SettingsCardContent`/`SettingsCardFooter` for the Project Name, Wake up / Pause, and Delete Project sections.
- Switches the Project Name field from an uncontrolled v2 `Input` + `register` to the controlled v3 `FormInput` bound via `form.control`.
- Replaces v2 action buttons with `ButtonWithLoading` and moves the destructive styling onto the card (`border-destructive`) and button (`variant="destructive"`).
- Swaps the pause-warning v2 `Alert`/`Text` for the v3 `Alert` with `variant="warning"` and plain `<p>` elements.
- Migrates `TransferProject` to a `SettingsCard` with a footer `ButtonWithLoading`.
- Migrates `RemoveApplicationModal` off v2 `Box`/`Text`/`Button` to plain elements + v3 `Button`/`ButtonWithLoading`, replacing `twMerge` with `cn`.
- Updates the settings layout wrapper from a v2 `Container` to a plain `div` with equivalent max-width/padding utilities.

___

<details> <summary><h3> File Walkthrough</h3></summary>

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody>
<tr><td><strong>Dashboard settings</strong></td><td><details><summary>3 files</summary><table>
<tr>
  <td><strong>settings/index.tsx</strong><dd><code>Rewrites the general settings page to the v3 SettingsCard layout, FormInput, v3 Alert and ButtonWithLoading.</code></dd></td>
  <td>+97/-90</td>
</tr>
<tr>
  <td><strong>TransferProject.tsx</strong><dd><code>Moves the Transfer Project section to SettingsCard with a footer ButtonWithLoading.</code></dd></td>
  <td>+23/-15</td>
</tr>
<tr>
  <td><strong>RemoveApplicationModal.tsx</strong><dd><code>Replaces v2 Box/Text/Button with plain elements plus v3 Button/ButtonWithLoading and cn().</code></dd></td>
  <td>+15/-26</td>
</tr>
</table></details></td></tr>
</tbody></table>

</details>

___

<!-- pi-reviewer:end -->
