### PR TITLE
fix(dashboard): migrate editor settings page

### DIFF
--- a/dashboard/src/features/orgs/projects/common/components/settings/TOMLEditor/TOMLEditor.tsx
+++ b/dashboard/src/features/orgs/projects/common/components/settings/TOMLEditor/TOMLEditor.tsx
@@ -9,9 +9,7 @@ import { useCallback, useEffect, useState } from 'react';
 import toast from 'react-hot-toast';
 import { ApplyLocalSettingsDialog } from '@/components/common/ApplyLocalSettingsDialog';
 import { useDialog } from '@/components/common/DialogProvider';
-import { Box } from '@/components/ui/v2/Box';
-import { Button } from '@/components/ui/v2/Button';
-import { Text } from '@/components/ui/v2/Text';
+import { Button, ButtonWithLoading } from '@/components/ui/v3/button';
 import { useIsPlatform } from '@/features/orgs/projects/common/hooks/useIsPlatform';
 import { useLocalMimirClient } from '@/features/orgs/projects/hooks/useLocalMimirClient';
 import { useProject } from '@/features/orgs/projects/hooks/useProject';
@@ -144,15 +142,12 @@ export default function TOMLEditor() {
 
   return (
     <>
-      <Box className="flex w-full flex-col space-y-2 border-b p-4">
-        <Text className="font-semibold">Configuration Editor</Text>
-      </Box>
-      <Box className="h-full overflow-auto">
+      <div className="flex w-full flex-col space-y-2 border-b p-4">
+        <p className="font-semibold">Configuration Editor</p>
+      </div>
+      <div className="h-full overflow-auto">
         {loading ? (
-          <Box
-            className="h-full w-full animate-pulse"
-            sx={{ backgroundColor: 'grey.200' }}
-          />
+          <div className="h-full w-full animate-pulse bg-muted" />
         ) : (
           <CodeMirror
             value={tomlCode}
@@ -163,18 +158,18 @@ export default function TOMLEditor() {
             onChange={onChange}
           />
         )}
-      </Box>
-      <Box className="grid w-full grid-flow-col justify-end gap-3 place-self-end border-t-1 px-4 py-3 md:justify-between">
+      </div>
+      <div className="grid w-full grid-flow-col justify-end gap-3 place-self-end border-t-1 px-4 py-3 md:justify-between">
         <Button
-          variant="outlined"
+          type="button"
+          variant="outline"
           disabled={loading || !isDirty}
           onClick={handleRevert}
-          color="secondary"
         >
           Revert changes
         </Button>
 
-        <Button
+        <ButtonWithLoading
           type="submit"
           disabled={loading || !isDirty}
           loading={isSaving}
@@ -182,8 +177,8 @@ export default function TOMLEditor() {
           onClick={handleSave}
         >
           Save
-        </Button>
-      </Box>
+        </ButtonWithLoading>
+      </div>
     </>
   );
 }


### PR DESCRIPTION
<!-- pi-reviewer:start -->
### **What this change solves**
Migrates the TOML configuration editor component off the legacy v2 dashboard primitives (`Box`, `Text`, v2 `Button`) to plain HTML elements and the v3 `Button`/`ButtonWithLoading`. Behavior (revert/save, loading state, dirty gating) is preserved; only presentation changes.

___

### **Change Type**
Refactoring

___

### **Description**
- Replaces v2 `Box` wrappers with plain `<div>` elements and the `Configuration Editor` `Text` with a `<p>`.
- Swaps the loading placeholder's MUI `sx={{ backgroundColor: 'grey.200' }}` for the `bg-muted` utility.
- Converts the Revert button to the v3 `Button` (`variant="outline"`, adds explicit `type="button"`) and the Save button to `ButtonWithLoading` (keeps `type="submit"`, `disabled`, `loading`, `onClick`).

___

<details> <summary><h3> File Walkthrough</h3></summary>

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody>
<tr><td><strong>Dashboard settings</strong></td><td><details><summary>1 files</summary><table>
<tr>
  <td><strong>TOMLEditor.tsx</strong><dd><code>Migrates the TOML config editor from v2 Box/Text/Button to plain elements and v3 Button/ButtonWithLoading.</code></dd></td>
  <td>+13/-18</td>
</tr>
</table></details></td></tr>
</tbody></table>

</details>

___

<!-- pi-reviewer:end -->
