### PR TITLE
fix(dashboard): migrate ai settings page

### DIFF
--- a/dashboard/src/features/orgs/projects/ai/settings/components/AISettings.tsx
+++ b/dashboard/src/features/orgs/projects/ai/settings/components/AISettings.tsx
@@ -8,13 +8,28 @@ import { ApplyLocalSettingsDialog } from '@/components/common/ApplyLocalSettings
 import { useDialog } from '@/components/common/DialogProvider';
 import { Form } from '@/components/form/Form';
 import { FormFreeCombobox } from '@/components/form/FormFreeCombobox';
-import { SettingsContainer } from '@/components/layout/SettingsContainer';
-import { Alert } from '@/components/ui/v2/Alert';
-import { Box } from '@/components/ui/v2/Box';
-import { Input } from '@/components/ui/v2/Input';
-import { Switch } from '@/components/ui/v2/Switch';
-import { Text } from '@/components/ui/v2/Text';
-import { Tooltip } from '@/components/ui/v2/Tooltip';
+import { FormInput } from '@/components/form/FormInput';
+import {
+  SettingsCard,
+  SettingsCardContent,
+  SettingsCardFooter,
+} from '@/components/layout/SettingsCard';
+import { Alert } from '@/components/ui/v3/alert';
+import { ButtonWithLoading } from '@/components/ui/v3/button';
+import {
+  FormControl,
+  FormField,
+  FormItem,
+  FormLabel,
+  FormMessage,
+} from '@/components/ui/v3/form';
+import { Input } from '@/components/ui/v3/input';
+import { Switch } from '@/components/ui/v3/switch';
+import {
+  Tooltip,
+  TooltipContent,
+  TooltipTrigger,
+} from '@/components/ui/v3/tooltip';
 import { DisableAIServiceConfirmationDialog } from '@/features/orgs/projects/ai/settings/components/DisableAIServiceConfirmationDialog';
 import { isPostgresVersionValidForAI } from '@/features/orgs/projects/ai/settings/utils/isPostgresVersionValidForAI';
 import { useIsPlatform } from '@/features/orgs/projects/common/hooks/useIsPlatform';
@@ -46,6 +61,17 @@ const validationSchema = Yup.object({
 });
 
 export type AISettingsFormValues = Yup.InferType<typeof validationSchema>;
+
+function InfoTooltip({ children }: { children: string }) {
+  return (
+    <Tooltip>
+      <TooltipTrigger asChild>
+        <InfoIcon aria-label="Info" className="h-4 w-4 text-primary" />
+      </TooltipTrigger>
+      <TooltipContent>{children}</TooltipContent>
+    </Tooltip>
+  );
+}
 
 export default function AISettings() {
   const isPlatform = useIsPlatform();
@@ -111,7 +137,7 @@ export default function AISettings() {
     resolver: yupResolver(validationSchema),
   });
 
-  const { register, formState, reset, watch, setValue } = form;
+  const { formState, reset, watch, setValue } = form;
 
   const aiSettingsFormValues = watch();
 
@@ -246,193 +272,165 @@ export default function AISettings() {
   };
 
   return (
-    <Box className="space-y-4" sx={{ backgroundColor: 'background.default' }}>
-      <Box className="flex flex-row items-center justify-between rounded-lg border-1 p-4">
-        <Text className="font-semibold text-lg">Enable AI service</Text>
+    <div className="space-y-4">
+      <div className="flex flex-row items-center justify-between rounded-lg border-1 p-4">
+        <p className="font-semibold text-lg">Enable AI service</p>
         <Switch
           checked={aiServiceEnabled}
-          onChange={(e) => toggleAIService(e.target.checked)}
+          onCheckedChange={toggleAIService}
           className="self-center"
+          aria-label="Toggle AI service"
         />
-      </Box>
+      </div>
       {aiServiceEnabled && (
         <FormProvider {...form}>
           <Form onSubmit={handleSubmit}>
-            <SettingsContainer
-              title={null}
-              description={null}
-              slotProps={{
-                submitButton: {
-                  disabled: !formState.isDirty,
-                  loading: formState.isSubmitting,
-                },
-              }}
-              className="flex flex-col"
-            >
-              <Box className="space-y-4">
-                <Box className="space-y-2">
-                  <Box className="flex flex-row items-center space-x-2">
-                    <Text className="font-semibold text-lg">Version</Text>
-                    <Tooltip title="Version of the service to use.">
-                      <InfoIcon
-                        aria-label="Info"
-                        className="h-4 w-4 text-primary"
-                      />
-                    </Tooltip>
-                  </Box>
-                  <FormFreeCombobox
-                    name="version"
-                    className="col-span-4"
-                    options={availableVersions}
-                    control={form.control}
-                    placeholder="Select AI Version"
-                    customValueLabel={(val) => `Use custom value: "${val}"`}
-                  />
-                </Box>
+            <SettingsCard>
+              <SettingsCardContent>
+                <div className="space-y-4">
+                  <div className="space-y-2">
+                    <div className="flex flex-row items-center space-x-2">
+                      <p className="font-semibold text-lg">Version</p>
+                      <InfoTooltip>Version of the service to use.</InfoTooltip>
+                    </div>
+                    <FormFreeCombobox
+                      name="version"
+                      className="col-span-4"
+                      options={availableVersions}
+                      control={form.control}
+                      placeholder="Select AI Version"
+                      customValueLabel={(val) => `Use custom value: "${val}"`}
+                    />
+                  </div>
 
-                <Box className="space-y-2">
-                  <Box className="flex flex-row items-center space-x-2">
-                    <Text className="font-semibold text-lg">
-                      Webhook Secret
-                    </Text>
-                    <Tooltip title="Used to validate requests between postgres and the AI service. The AI service will also include the header X-Graphite-Webhook-Secret with this value set when calling external webhooks so the source of the request can be validated.">
-                      <InfoIcon
-                        aria-label="Info"
-                        className="h-4 w-4 text-primary"
-                      />
-                    </Tooltip>
-                  </Box>
-                  <Input
-                    {...register('webhookSecret')}
-                    id="webhookSecret"
-                    name="webhookSecret"
-                    placeholder="Webhook Secret"
-                    className="col-span-3"
-                    fullWidth
-                    hideEmptyHelperText
-                    error={Boolean(formState.errors.webhookSecret?.message)}
-                    helperText={formState.errors.webhookSecret?.message}
-                  />
-                </Box>
+                  <div className="space-y-2">
+                    <div className="flex flex-row items-center space-x-2">
+                      <p className="font-semibold text-lg">Webhook Secret</p>
+                      <InfoTooltip>
+                        Used to validate requests between postgres and the AI
+                        service. The AI service will also include the header
+                        X-Graphite-Webhook-Secret with this value set when
+                        calling external webhooks so the source of the request
+                        can be validated.
+                      </InfoTooltip>
+                    </div>
+                    <FormInput
+                      control={form.control}
+                      name="webhookSecret"
+                      placeholder="Webhook Secret"
+                      containerClassName="col-span-3"
+                      aria-label="Webhook Secret"
+                    />
+                  </div>
 
-                <Box className="space-y-2">
-                  <Box className="flex flex-row items-center space-x-2">
-                    <Text className="font-semibold text-lg">Resources</Text>
-                    <Tooltip title="Dedicated resources allocated for the service.">
-                      <InfoIcon
-                        aria-label="Info"
-                        className="h-4 w-4 text-primary"
-                      />
-                    </Tooltip>
-                  </Box>
+                  <div className="space-y-2">
+                    <div className="flex flex-row items-center space-x-2">
+                      <p className="font-semibold text-lg">Resources</p>
+                      <InfoTooltip>
+                        Dedicated resources allocated for the service.
+                      </InfoTooltip>
+                    </div>
 
-                  {isPlatform ? (
-                    <Alert
-                      severity="info"
-                      className="flex items-center justify-between space-x-2"
-                    >
-                      <span>{getAIResourcesCost()}</span>
-                      <b>
-                        $
-                        {parseFloat(
-                          (
-                            aiSettingsFormValues.compute.cpu * COST_PER_VCPU
-                          ).toFixed(2),
-                        )}
-                      </b>
-                    </Alert>
-                  ) : null}
+                    {isPlatform ? (
+                      <Alert
+                        variant="info"
+                        className="flex items-center justify-between space-x-2"
+                      >
+                        <span>{getAIResourcesCost()}</span>
+                        <b>
+                          $
+                          {parseFloat(
+                            (
+                              aiSettingsFormValues.compute.cpu * COST_PER_VCPU
+                            ).toFixed(2),
+                          )}
+                        </b>
+                      </Alert>
+                    ) : null}
 
-                  <ComputeFormSection />
-                </Box>
+                    <ComputeFormSection />
+                  </div>
 
-                <Box className="space-y-2">
-                  <Text className="font-semibold text-lg">OpenAI</Text>
+                  <div className="space-y-2">
+                    <p className="font-semibold text-lg">OpenAI</p>
 
-                  <Input
-                    {...register('apiKey')}
-                    name="apiKey"
-                    placeholder="API Key"
-                    id="apiKey"
-                    label={
-                      <Box className="flex flex-row items-center space-x-2">
-                        <Text>OpenAI API key</Text>
-                        <Tooltip title="Key to use for authenticating API requests to OpenAI">
-                          <InfoIcon
-                            aria-label="Info"
-                            className="h-4 w-4 text-primary"
-                          />
-                        </Tooltip>
-                      </Box>
-                    }
-                    className="col-span-3"
-                    fullWidth
-                    hideEmptyHelperText
-                    error={Boolean(formState.errors.apiKey?.message)}
-                    helperText={formState.errors.apiKey?.message}
-                  />
+                    <FormInput
+                      control={form.control}
+                      name="apiKey"
+                      placeholder="API Key"
+                      label={
+                        <div className="flex flex-row items-center space-x-2">
+                          <span>OpenAI API key</span>
+                          <InfoTooltip>
+                            Key to use for authenticating API requests to OpenAI
+                          </InfoTooltip>
+                        </div>
+                      }
+                      containerClassName="col-span-3"
+                    />
 
-                  <Input
-                    {...register('organization')}
-                    id="organization"
-                    name="organization"
-                    label={
-                      <Box className="flex flex-row items-center space-x-2">
-                        <Text>OpenAI Organization</Text>
-                        <Tooltip title="Optional. OpenAI organization to use.">
-                          <InfoIcon
-                            aria-label="Info"
-                            className="h-4 w-4 text-primary"
-                          />
-                        </Tooltip>
-                      </Box>
-                    }
-                    placeholder="Organization"
-                    className="col-span-3"
-                    fullWidth
-                    hideEmptyHelperText
-                    error={Boolean(formState.errors.organization?.message)}
-                    helperText={formState.errors.organization?.message}
-                  />
-                </Box>
+                    <FormInput
+                      control={form.control}
+                      name="organization"
+                      label={
+                        <div className="flex flex-row items-center space-x-2">
+                          <span>OpenAI Organization</span>
+                          <InfoTooltip>
+                            Optional. OpenAI organization to use.
+                          </InfoTooltip>
+                        </div>
+                      }
+                      placeholder="Organization"
+                      containerClassName="col-span-3"
+                    />
+                  </div>
 
-                <Box className="space-y-2">
-                  <Text className="font-semibold text-lg">Auto-Embeddings</Text>
-                  <Input
-                    {...register('synchPeriodMinutes')}
-                    id="synchPeriodMinutes"
-                    name="synchPeriodMinutes"
-                    type="number"
-                    label={
-                      <Box className="flex flex-row items-center space-x-2">
-                        <Text>Synch Period Minutes</Text>
-                        <Tooltip title="How often to run the job that keeps embeddings up to date.">
-                          <InfoIcon
-                            aria-label="Info"
-                            className="h-4 w-4 text-primary"
-                          />
-                        </Tooltip>
-                      </Box>
-                    }
-                    placeholder="Synch Period Minutes"
-                    fullWidth
-                    className="lg:col-span-2"
-                    error={Boolean(
-                      formState.errors.synchPeriodMinutes?.message,
-                    )}
-                    helperText={formState.errors.synchPeriodMinutes?.message}
-                    slotProps={{
-                      inputRoot: {
-                        min: 0,
-                      },
-                    }}
-                  />
-                </Box>
-              </Box>
-            </SettingsContainer>
+                  <div className="space-y-2">
+                    <p className="font-semibold text-lg">Auto-Embeddings</p>
+                    <FormField
+                      control={form.control}
+                      name="synchPeriodMinutes"
+                      render={({ field }) => (
+                        <FormItem className="lg:col-span-2">
+                          <FormLabel>
+                            <div className="flex flex-row items-center space-x-2">
+                              <span>Synch Period Minutes</span>
+                              <InfoTooltip>
+                                How often to run the job that keeps embeddings
+                                up to date.
+                              </InfoTooltip>
+                            </div>
+                          </FormLabel>
+                          <FormControl>
+                            <Input
+                              type="number"
+                              min={0}
+                              placeholder="Synch Period Minutes"
+                              {...field}
+                            />
+                          </FormControl>
+                          <FormMessage />
+                        </FormItem>
+                      )}
+                    />
+                  </div>
+                </div>
+              </SettingsCardContent>
+
+              <SettingsCardFooter>
+                <ButtonWithLoading
+                  type="submit"
+                  disabled={!formState.isDirty}
+                  loading={formState.isSubmitting}
+                  className="w-full sm:w-auto"
+                >
+                  Save
+                </ButtonWithLoading>
+              </SettingsCardFooter>
+            </SettingsCard>
           </Form>
         </FormProvider>
       )}
-    </Box>
+    </div>
   );
 }

--- a/dashboard/src/features/orgs/projects/ai/settings/components/DisableAIServiceConfirmationDialog/DisableAIServiceConfirmationDialog.tsx
+++ b/dashboard/src/features/orgs/projects/ai/settings/components/DisableAIServiceConfirmationDialog/DisableAIServiceConfirmationDialog.tsx
@@ -2,8 +2,6 @@ import { useState } from 'react';
 import { twMerge } from 'tailwind-merge';
 import { ApplyLocalSettingsDialog } from '@/components/common/ApplyLocalSettingsDialog';
 import { useDialog } from '@/components/common/DialogProvider';
-import { Box } from '@/components/ui/v2/Box';
-import { Text } from '@/components/ui/v2/Text';
 import { Button, ButtonWithLoading } from '@/components/ui/v3/button';
 import { useIsPlatform } from '@/features/orgs/projects/common/hooks/useIsPlatform';
 import { useLocalMimirClient } from '@/features/orgs/projects/hooks/useLocalMimirClient';
@@ -75,19 +73,15 @@ export default function DisableAIServiceConfirmationDialog({
   }
 
   return (
-    <Box className={twMerge('w-full rounded-lg p-6 pt-0 text-left')}>
+    <div className={twMerge('w-full rounded-lg p-6 pt-0 text-left')}>
       <div className="grid grid-flow-row gap-1">
-        <Text variant="subtitle2">
+        <p className="text-muted-foreground text-sm">
           Are you sure you want to disable this service?
-        </Text>
+        </p>
 
-        <Text
-          variant="subtitle2"
-          className="font-bold"
-          sx={{ color: (theme) => `${theme.palette.error.main} !important` }}
-        >
+        <p className="font-bold text-destructive text-sm">
           This cannot be undone.
-        </Text>
+        </p>
 
         <div className="grid grid-flow-row gap-2">
           <ButtonWithLoading
@@ -109,6 +103,6 @@ export default function DisableAIServiceConfirmationDialog({
           </Button>
         </div>
       </div>
-    </Box>
+    </div>
   );
 }

--- a/dashboard/src/pages/orgs/[orgSlug]/projects/[appSubdomain]/settings/ai.tsx
+++ b/dashboard/src/pages/orgs/[orgSlug]/projects/[appSubdomain]/settings/ai.tsx
@@ -1,6 +1,5 @@
 import type { ReactElement } from 'react';
 import { UpgradeToProBanner } from '@/components/common/UpgradeToProBanner';
-import { Container } from '@/components/layout/Container';
 import { Spinner } from '@/components/ui/v3/spinner';
 import { OrgLayout } from '@/features/orgs/layout/OrgLayout';
 import { SettingsLayout } from '@/features/orgs/layout/SettingsLayout';
@@ -35,15 +34,12 @@ export default function AISettingsPage() {
 
   if (org?.plan?.isFree) {
     return (
-      <Container
-        className="grid grid-flow-row gap-6 bg-transparent"
-        rootClassName="bg-transparent"
-      >
+      <div className="grid grid-flow-row gap-6">
         <UpgradeToProBanner
           title="To unlock AI, transfer this project to a Pro or Team organization."
           description=""
         />
-      </Container>
+      </div>
     );
   }
 
@@ -66,29 +62,17 @@ export default function AISettingsPage() {
   }
 
   return (
-    <Container
-      className="grid max-w-5xl grid-flow-row gap-y-6 bg-transparent"
-      rootClassName="bg-transparent"
-    >
+    <div className="grid grid-flow-row gap-y-6">
       <AISettings />
-    </Container>
+    </div>
   );
 }
 
 AISettingsPage.getLayout = function getLayout(page: ReactElement) {
   return (
-    <OrgLayout
-      mainContainerProps={{
-        className: 'flex h-full overflow-auto',
-      }}
-    >
+    <OrgLayout>
       <SettingsLayout>
-        <Container
-          sx={{ backgroundColor: 'background.default' }}
-          className="max-w-5xl"
-        >
-          {page}
-        </Container>
+        <div className="mx-auto w-full max-w-5xl px-5 py-4">{page}</div>
       </SettingsLayout>
     </OrgLayout>
   );


### PR DESCRIPTION
<!-- pi-reviewer:start -->
### **What this change solves**
Migrates the AI settings page from the legacy v2 dashboard primitives (`SettingsContainer`, v2 `Box`/`Text`/`Input`/`Switch`/`Alert`/`Tooltip`) to the current v3 card layout and form primitives (`SettingsCard*`, `FormInput`, v3 `Alert`/`Switch`/`Tooltip`, RHF `FormField`, `ButtonWithLoading`). Behavior is intended to be preserved; the presentation and form wiring change.

___

### **Change Type**
Refactoring

___

### **Description**
- Rewrites `AISettings.tsx` onto `SettingsCard`/`SettingsCardContent`/`SettingsCardFooter`, extracting a local `InfoTooltip` helper from the repeated v2 `Tooltip` + `InfoIcon` blocks.
- Converts the "Enable AI service" toggle from v2 `Switch` `onChange={(e) => toggleAIService(e.target.checked)}` to v3 `Switch` `onCheckedChange={toggleAIService}`, adding an `aria-label`.
- Migrates `webhookSecret`, `apiKey`, and `organization` fields from uncontrolled v2 `Input` + `register` (with manual `error`/`helperText`) to controlled `FormInput` bound via `form.control`.
- Rebuilds the `synchPeriodMinutes` field as an RHF `FormField` wrapping a v3 `Input type="number" min={0} {...field}`.
- Swaps the resources-cost v2 `Alert severity="info"` for v3 `Alert variant="info"`.
- Migrates `DisableAIServiceConfirmationDialog` off v2 `Box`/`Text` to plain elements with themed utility classes.
- Simplifies the `ai.tsx` route/layout wrappers from v2 `Container` to plain `div`s.

___

<details> <summary><h3> File Walkthrough</h3></summary>

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody>
<tr><td><strong>Dashboard settings</strong></td><td><details><summary>3 files</summary><table>
<tr>
  <td><strong>AISettings.tsx</strong><dd><code>Migrates the AI settings form to v3 SettingsCard, FormInput, FormField, v3 Alert/Switch/Tooltip and ButtonWithLoading.</code></dd></td>
  <td>+184/-186</td>
</tr>
<tr>
  <td><strong>DisableAIServiceConfirmationDialog.tsx</strong><dd><code>Replaces v2 Box/Text with plain elements and themed utility classes.</code></dd></td>
  <td>+6/-12</td>
</tr>
<tr>
  <td><strong>ai.tsx</strong><dd><code>Simplifies the AI settings route and layout wrappers from v2 Container to plain divs.</code></dd></td>
  <td>+6/-22</td>
</tr>
</table></details></td></tr>
</tbody></table>

</details>

___

<!-- pi-reviewer:end -->
