### PR TITLE
fix(dashboard): migrate sign-in methods settings page

### DIFF
--- a/dashboard/src/features/orgs/projects/authentication/settings/OTPEmailSettings/OTPEmailSettings.tsx
+++ b/dashboard/src/features/orgs/projects/authentication/settings/OTPEmailSettings/OTPEmailSettings.tsx
@@ -5,7 +5,14 @@ import * as Yup from 'yup';
 import { ApplyLocalSettingsDialog } from '@/components/common/ApplyLocalSettingsDialog';
 import { useDialog } from '@/components/common/DialogProvider';
 import { Form } from '@/components/form/Form';
-import { SettingsContainer } from '@/components/layout/SettingsContainer';
+import {
+  SettingsCard,
+  SettingsCardFooter,
+  SettingsCardHeader,
+} from '@/components/layout/SettingsCard';
+import { ButtonWithLoading } from '@/components/ui/v3/button';
+import { FormField } from '@/components/ui/v3/form';
+import { Switch } from '@/components/ui/v3/switch';
 import { useIsPlatform } from '@/features/orgs/projects/common/hooks/useIsPlatform';
 import { useLocalMimirClient } from '@/features/orgs/projects/hooks/useLocalMimirClient';
 import { useProject } from '@/features/orgs/projects/hooks/useProject';
@@ -107,19 +114,36 @@ export default function OTPEmailSettings() {
   return (
     <FormProvider {...form}>
       <Form onSubmit={handleOTPEmailSettingsChange}>
-        <SettingsContainer
-          title="One-Time Passwords over email"
-          description="Allow users to sign in with a one-time password sent to their email address."
-          slotProps={{
-            submitButton: {
-              disabled: !form.formState.isDirty,
-              loading: form.formState.isSubmitting,
-            },
-          }}
-          switchId="enabled"
-          showSwitch
-          className="hidden"
-        />
+        <SettingsCard>
+          <SettingsCardHeader
+            title="One-Time Passwords over email"
+            description="Allow users to sign in with a one-time password sent to their email address."
+            control={
+              <FormField
+                control={form.control}
+                name="enabled"
+                render={({ field }) => (
+                  <Switch
+                    checked={field.value}
+                    onCheckedChange={field.onChange}
+                    aria-label="Toggle One-Time Passwords over email"
+                  />
+                )}
+              />
+            }
+          />
+
+          <SettingsCardFooter>
+            <ButtonWithLoading
+              type="submit"
+              disabled={!form.formState.isDirty}
+              loading={form.formState.isSubmitting}
+              className="w-full sm:w-auto"
+            >
+              Save
+            </ButtonWithLoading>
+          </SettingsCardFooter>
+        </SettingsCard>
       </Form>
     </FormProvider>
   );

--- a/dashboard/src/features/orgs/projects/authentication/settings/components/AnonymousSignInSettings/AnonymousSignInSettings.tsx
+++ b/dashboard/src/features/orgs/projects/authentication/settings/components/AnonymousSignInSettings/AnonymousSignInSettings.tsx
@@ -5,7 +5,14 @@ import * as Yup from 'yup';
 import { ApplyLocalSettingsDialog } from '@/components/common/ApplyLocalSettingsDialog';
 import { useDialog } from '@/components/common/DialogProvider';
 import { Form } from '@/components/form/Form';
-import { SettingsContainer } from '@/components/layout/SettingsContainer';
+import {
+  SettingsCard,
+  SettingsCardFooter,
+  SettingsCardHeader,
+} from '@/components/layout/SettingsCard';
+import { ButtonWithLoading } from '@/components/ui/v3/button';
+import { FormField } from '@/components/ui/v3/form';
+import { Switch } from '@/components/ui/v3/switch';
 import { useIsPlatform } from '@/features/orgs/projects/common/hooks/useIsPlatform';
 import { useLocalMimirClient } from '@/features/orgs/projects/hooks/useLocalMimirClient';
 import { useProject } from '@/features/orgs/projects/hooks/useProject';
@@ -102,19 +109,36 @@ export default function AnonymousSignInSettings() {
   return (
     <FormProvider {...form}>
       <Form onSubmit={handlePasswordProtectionSettingsChange}>
-        <SettingsContainer
-          title="Anonymous Users"
-          description="Allow users to sign in anonymously."
-          slotProps={{
-            submitButton: {
-              disabled: !form.formState.isDirty,
-              loading: form.formState.isSubmitting,
-            },
-          }}
-          switchId="enabled"
-          showSwitch
-          className="hidden"
-        />
+        <SettingsCard>
+          <SettingsCardHeader
+            title="Anonymous Users"
+            description="Allow users to sign in anonymously."
+            control={
+              <FormField
+                control={form.control}
+                name="enabled"
+                render={({ field }) => (
+                  <Switch
+                    checked={field.value}
+                    onCheckedChange={field.onChange}
+                    aria-label="Toggle Anonymous Users"
+                  />
+                )}
+              />
+            }
+          />
+
+          <SettingsCardFooter>
+            <ButtonWithLoading
+              type="submit"
+              disabled={!form.formState.isDirty}
+              loading={form.formState.isSubmitting}
+              className="w-full sm:w-auto"
+            >
+              Save
+            </ButtonWithLoading>
+          </SettingsCardFooter>
+        </SettingsCard>
       </Form>
     </FormProvider>
   );

--- a/dashboard/src/features/orgs/projects/authentication/settings/components/AppleProviderSettings/AppleProviderSettings.tsx
+++ b/dashboard/src/features/orgs/projects/authentication/settings/components/AppleProviderSettings/AppleProviderSettings.tsx
@@ -2,7 +2,6 @@
 
 import { yupResolver } from '@hookform/resolvers/yup';
 import { useTheme } from '@mui/material';
-import { CopyIcon } from 'lucide-react';
 import { useEffect } from 'react';
 import { FormProvider, useForm } from 'react-hook-form';
 import { twMerge } from 'tailwind-merge';
@@ -10,10 +9,19 @@ import * as Yup from 'yup';
 import { ApplyLocalSettingsDialog } from '@/components/common/ApplyLocalSettingsDialog';
 import { useDialog } from '@/components/common/DialogProvider';
 import { Form } from '@/components/form/Form';
-import { SettingsContainer } from '@/components/layout/SettingsContainer';
-import { IconButton } from '@/components/ui/v2/IconButton';
-import { Input } from '@/components/ui/v2/Input';
-import { InputAdornment } from '@/components/ui/v2/InputAdornment';
+import { FormInput } from '@/components/form/FormInput';
+import { FormTextarea } from '@/components/form/FormTextarea';
+import {
+  SettingsCard,
+  SettingsCardContent,
+  SettingsCardFooter,
+  SettingsCardHeader,
+  SettingsDocsLink,
+} from '@/components/layout/SettingsCard';
+import { ButtonWithLoading } from '@/components/ui/v3/button';
+import { FormField } from '@/components/ui/v3/form';
+import { Switch } from '@/components/ui/v3/switch';
+import { ProviderRedirectUrlInput } from '@/features/orgs/projects/authentication/settings/components/ProviderRedirectUrlInput';
 import { useIsPlatform } from '@/features/orgs/projects/common/hooks/useIsPlatform';
 import { generateAppServiceUrl } from '@/features/orgs/projects/common/utils/generateAppServiceUrl';
 import { useLocalMimirClient } from '@/features/orgs/projects/hooks/useLocalMimirClient';
@@ -23,7 +31,6 @@ import {
   useGetSignInMethodsQuery,
   useUpdateConfigMutation,
 } from '@/generated/graphql';
-import { copy } from '@/utils/copy';
 
 const validationSchema = Yup.object({
   teamId: Yup.string()
@@ -105,7 +112,7 @@ export default function AppleProviderSettings() {
     throw error;
   }
 
-  const { register, formState, watch } = form;
+  const { formState, watch } = form;
   const authEnabled = watch('enabled');
 
   async function handleSubmit(formValues: AppleProviderFormValues) {
@@ -156,128 +163,99 @@ export default function AppleProviderSettings() {
   return (
     <FormProvider {...form}>
       <Form onSubmit={handleSubmit}>
-        <SettingsContainer
-          title="Apple"
-          description="Allow users to sign in with Apple."
-          slotProps={{
-            submitButton: {
-              disabled: !formState.isDirty,
-              loading: formState.isSubmitting,
-            },
-          }}
-          docsLink="https://docs.nhost.io/products/auth/providers/sign-in-apple"
-          docsTitle="how to sign in users with Apple"
-          icon={
-            theme.palette.mode === 'dark'
-              ? '/assets/brands/light/apple.svg'
-              : '/assets/brands/apple.svg'
-          }
-          switchId="enabled"
-          showSwitch
-          className={twMerge(
-            'grid-flow-rows grid grid-cols-2 grid-rows-2 gap-x-3 gap-y-4 px-4 py-2',
-            !authEnabled && 'hidden',
-          )}
-        >
-          <Input
-            {...register('teamId')}
-            name="teamId"
-            id="teamId"
-            label="Team ID"
-            placeholder="Apple Team ID"
-            className="col-span-1"
-            fullWidth
-            hideEmptyHelperText
-            error={!!formState.errors?.teamId}
-            helperText={formState.errors?.teamId?.message}
-          />
-          <Input
-            {...register('clientId')}
-            name="clientId"
-            id="clientId"
-            label="Service ID"
-            placeholder="Apple Service ID"
-            className="col-span-1"
-            fullWidth
-            hideEmptyHelperText
-            error={!!formState.errors?.clientId}
-            helperText={formState.errors?.clientId?.message}
-          />
-          <Input
-            {...register('keyId')}
-            name="keyId"
-            id="keyId"
-            label="Key ID"
-            placeholder="Apple Key ID"
-            className="col-span-2"
-            fullWidth
-            hideEmptyHelperText
-            error={!!formState.errors?.keyId}
-            helperText={formState.errors?.keyId?.message}
-          />
-          <Input
-            {...register('privateKey')}
-            multiline
-            rows={4}
-            name="privateKey"
-            id="privateKey"
-            label="Private Key"
-            placeholder="Paste Private Key here"
-            className="col-span-2"
-            fullWidth
-            hideEmptyHelperText
-            error={!!formState.errors?.privateKey}
-            helperText={formState.errors?.privateKey?.message}
-          />
-          <Input
-            {...register('audience')}
-            name="audience"
-            id="audience"
-            label="Audience, set it to enable idtokens (optional)"
-            placeholder="AppleAudience1,AppleAudience2"
-            className="col-span-2"
-            fullWidth
-            hideEmptyHelperText
-            error={!!formState.errors?.audience}
-            helperText={formState.errors?.audience?.message}
-          />
-          <Input
-            name="redirectUrl"
-            id="apple-redirectUrl"
-            defaultValue={`${generateAppServiceUrl(
-              project!.subdomain,
-              project!.region,
-              'auth',
-            )}/signin/provider/apple/callback`}
-            className="col-span-2"
-            fullWidth
-            hideEmptyHelperText
-            label="Redirect URL"
-            disabled
-            endAdornment={
-              <InputAdornment position="end" className="absolute right-2">
-                <IconButton
-                  sx={{ minWidth: 0, padding: 0 }}
-                  color="secondary"
-                  variant="borderless"
-                  onClick={(e) => {
-                    e.stopPropagation();
-                    copy(
-                      `${generateAppServiceUrl(
-                        project!.subdomain,
-                        project!.region,
-                        'auth',
-                      )}/signin/provider/apple/callback`,
-                      'Redirect URL',
-                    );
-                  }}
-                >
-                  <CopyIcon className="h-4 w-4" />
-                </IconButton>
-              </InputAdornment>
+        <SettingsCard>
+          <SettingsCardHeader
+            title="Apple"
+            description="Allow users to sign in with Apple."
+            icon={
+              theme.palette.mode === 'dark'
+                ? '/assets/brands/light/apple.svg'
+                : '/assets/brands/apple.svg'
+            }
+            control={
+              <FormField
+                control={form.control}
+                name="enabled"
+                render={({ field }) => (
+                  <Switch
+                    checked={field.value}
+                    onCheckedChange={field.onChange}
+                    aria-label="Toggle Apple"
+                  />
+                )}
+              />
             }
           />
-        </SettingsContainer>
+
+          <SettingsCardContent
+            className={twMerge(
+              'grid grid-flow-row grid-cols-2 grid-rows-2 gap-x-3 gap-y-4 px-4 py-2',
+              !authEnabled && 'hidden',
+            )}
+          >
+            <FormInput
+              control={form.control}
+              name="teamId"
+              label="Team ID"
+              placeholder="Apple Team ID"
+              containerClassName="col-span-1"
+            />
+            <FormInput
+              control={form.control}
+              name="clientId"
+              label="Service ID"
+              placeholder="Apple Service ID"
+              containerClassName="col-span-1"
+            />
+            <FormInput
+              control={form.control}
+              name="keyId"
+              label="Key ID"
+              placeholder="Apple Key ID"
+              containerClassName="col-span-2"
+            />
+            <div className="col-span-2">
+              <FormTextarea
+                control={form.control}
+                name="privateKey"
+                label="Private Key"
+                placeholder="Paste Private Key here"
+              />
+            </div>
+            <FormInput
+              control={form.control}
+              name="audience"
+              label="Audience, set it to enable idtokens (optional)"
+              placeholder="AppleAudience1,AppleAudience2"
+              containerClassName="col-span-2"
+            />
+            <ProviderRedirectUrlInput
+              id="apple-redirectUrl"
+              value={`${generateAppServiceUrl(
+                project!.subdomain,
+                project!.region,
+                'auth',
+              )}/signin/provider/apple/callback`}
+              className="col-span-2"
+            />
+          </SettingsCardContent>
+
+          <SettingsCardFooter>
+            <SettingsDocsLink
+              href="https://docs.nhost.io/products/auth/providers/sign-in-apple"
+              title="how to sign in users with Apple"
+            />
+
+            <ButtonWithLoading
+              type="submit"
+              disabled={!formState.isDirty}
+              loading={formState.isSubmitting}
+              className="w-full sm:w-auto"
+            >
+              Save
+            </ButtonWithLoading>
+          </SettingsCardFooter>
+        </SettingsCard>
       </Form>
     </FormProvider>
   );

--- a/dashboard/src/features/orgs/projects/authentication/settings/components/AzureADProviderSettings/AzureADProviderSettings.tsx
+++ b/dashboard/src/features/orgs/projects/authentication/settings/components/AzureADProviderSettings/AzureADProviderSettings.tsx
@@ -1,7 +1,6 @@
 /** biome-ignore-all lint/suspicious/noThenProperty: yup thing */
 
 import { yupResolver } from '@hookform/resolvers/yup';
-import { CopyIcon } from 'lucide-react';
 import { useEffect } from 'react';
 import { FormProvider, useForm } from 'react-hook-form';
 import { twMerge } from 'tailwind-merge';
@@ -9,11 +8,18 @@ import * as Yup from 'yup';
 import { ApplyLocalSettingsDialog } from '@/components/common/ApplyLocalSettingsDialog';
 import { useDialog } from '@/components/common/DialogProvider';
 import { Form } from '@/components/form/Form';
-import { SettingsContainer } from '@/components/layout/SettingsContainer';
-import { IconButton } from '@/components/ui/v2/IconButton';
-import { Input } from '@/components/ui/v2/Input';
-import { InputAdornment } from '@/components/ui/v2/InputAdornment';
+import { FormInput } from '@/components/form/FormInput';
+import {
+  SettingsCard,
+  SettingsCardContent,
+  SettingsCardFooter,
+  SettingsCardHeader,
+} from '@/components/layout/SettingsCard';
+import { ButtonWithLoading } from '@/components/ui/v3/button';
+import { FormField } from '@/components/ui/v3/form';
+import { Switch } from '@/components/ui/v3/switch';
 import { BaseProviderSettings } from '@/features/orgs/projects/authentication/settings/components/BaseProviderSettings';
+import { ProviderRedirectUrlInput } from '@/features/orgs/projects/authentication/settings/components/ProviderRedirectUrlInput';
 import { useIsPlatform } from '@/features/orgs/projects/common/hooks/useIsPlatform';
 import { generateAppServiceUrl } from '@/features/orgs/projects/common/utils/generateAppServiceUrl';
 import { useLocalMimirClient } from '@/features/orgs/projects/hooks/useLocalMimirClient';
@@ -23,7 +29,6 @@ import {
   useGetSignInMethodsQuery,
   useUpdateConfigMutation,
 } from '@/generated/graphql';
-import { copy } from '@/utils/copy';
 
 const validationSchema = Yup.object({
   clientId: Yup.string()
@@ -93,7 +98,7 @@ export default function AzureADProviderSettings() {
     throw error;
   }
 
-  const { register, formState, watch } = form;
+  const { formState, watch } = form;
   const authEnabled = watch('enabled');
 
   async function handleSubmit(formValues: AzureADProviderFormValues) {
@@ -141,73 +146,62 @@ export default function AzureADProviderSettings() {
   return (
     <FormProvider {...form}>
       <Form onSubmit={handleSubmit}>
-        <SettingsContainer
-          title="Azure AD"
-          description="⚠️ Azure AD is deprecated in favor of Entra ID. Please use Entra ID for new configurations."
-          slotProps={{
-            submitButton: {
-              disabled: !formState.isDirty,
-              loading: formState.isSubmitting,
-            },
-          }}
-          icon="/assets/brands/azuread.svg"
-          switchId="enabled"
-          showSwitch
-          className={twMerge(
-            'grid grid-flow-row grid-cols-2 gap-x-3 gap-y-4 px-4 py-2',
-            !authEnabled && 'hidden',
-          )}
-        >
-          <BaseProviderSettings providerName="azuread" />
-          <Input
-            {...register('tenant')}
-            name="tenant"
-            id="tenant"
-            label="Tenant ID"
-            placeholder="Tenant ID"
-            className="col-span-2"
-            fullWidth
-            hideEmptyHelperText
-            error={!!formState.errors?.tenant}
-            helperText={formState.errors?.tenant?.message}
-          />
-          <Input
-            name="redirectUrl"
-            id="azuerad-redirectUrl"
-            defaultValue={`${generateAppServiceUrl(
-              project!.subdomain,
-              project!.region,
-              'auth',
-            )}/signin/provider/azuread/callback`}
-            className="col-span-2"
-            fullWidth
-            hideEmptyHelperText
-            label="Redirect URL"
-            disabled
-            endAdornment={
-              <InputAdornment position="end" className="absolute right-2">
-                <IconButton
-                  sx={{ minWidth: 0, padding: 0 }}
-                  color="secondary"
-                  variant="borderless"
-                  onClick={(e) => {
-                    e.stopPropagation();
-                    copy(
-                      `${generateAppServiceUrl(
-                        project!.subdomain,
-                        project!.region,
-                        'auth',
-                      )}/signin/provider/azuread/callback`,
-                      'Redirect URL',
-                    );
-                  }}
-                >
-                  <CopyIcon className="h-4 w-4" />
-                </IconButton>
-              </InputAdornment>
+        <SettingsCard>
+          <SettingsCardHeader
+            title="Azure AD"
+            description="⚠️ Azure AD is deprecated in favor of Entra ID. Please use Entra ID for new configurations."
+            icon="/assets/brands/azuread.svg"
+            control={
+              <FormField
+                control={form.control}
+                name="enabled"
+                render={({ field }) => (
+                  <Switch
+                    checked={field.value}
+                    onCheckedChange={field.onChange}
+                    aria-label="Toggle Azure AD"
+                  />
+                )}
+              />
             }
           />
-        </SettingsContainer>
+
+          <SettingsCardContent
+            className={twMerge(
+              'grid grid-flow-row grid-cols-2 gap-x-3 gap-y-4 px-4 py-2',
+              !authEnabled && 'hidden',
+            )}
+          >
+            <BaseProviderSettings />
+            <FormInput
+              control={form.control}
+              name="tenant"
+              label="Tenant ID"
+              placeholder="Tenant ID"
+              containerClassName="col-span-2"
+            />
+            <ProviderRedirectUrlInput
+              id="azuerad-redirectUrl"
+              value={`${generateAppServiceUrl(
+                project!.subdomain,
+                project!.region,
+                'auth',
+              )}/signin/provider/azuread/callback`}
+              className="col-span-2"
+            />
+          </SettingsCardContent>
+
+          <SettingsCardFooter>
+            <ButtonWithLoading
+              type="submit"
+              disabled={!formState.isDirty}
+              loading={formState.isSubmitting}
+              className="w-full sm:w-auto"
+            >
+              Save
+            </ButtonWithLoading>
+          </SettingsCardFooter>
+        </SettingsCard>
       </Form>
     </FormProvider>
   );

--- a/dashboard/src/features/orgs/projects/authentication/settings/components/BaseProviderSettings/BaseProviderSettings.tsx
+++ b/dashboard/src/features/orgs/projects/authentication/settings/components/BaseProviderSettings/BaseProviderSettings.tsx
@@ -2,7 +2,7 @@
 
 import { useFormContext } from 'react-hook-form';
 import * as Yup from 'yup';
-import { Input } from '@/components/ui/v2/Input';
+import { FormInput } from '@/components/form/FormInput';
 
 export const baseProviderValidationSchema = Yup.object({
   clientId: Yup.string()
@@ -24,42 +24,24 @@ export type BaseProviderSettingsFormValues = Yup.InferType<
   typeof baseProviderValidationSchema
 >;
 
-export interface BaseProviderSettingsProps {
-  /**
-   * The name of the provider. Used to provide unique IDs to the inputs.
-   */
-  providerName: string;
-}
-
-export default function BaseProviderSettings({
-  providerName,
-}: BaseProviderSettingsProps) {
-  const { register, formState } =
-    useFormContext<BaseProviderSettingsFormValues>();
+export default function BaseProviderSettings() {
+  const { control } = useFormContext<BaseProviderSettingsFormValues>();
 
   return (
     <>
-      <Input
-        {...register('clientId')}
-        id={`${providerName}-clientId`}
+      <FormInput
+        control={control}
+        name="clientId"
         label="Client ID"
         placeholder="Enter your Client ID"
-        className="col-span-1"
-        fullWidth
-        hideEmptyHelperText
-        error={!!formState.errors?.clientId}
-        helperText={formState.errors?.clientId?.message}
+        containerClassName="col-span-1"
       />
-      <Input
-        {...register('clientSecret')}
-        id={`${providerName}-clientSecret`}
+      <FormInput
+        control={control}
+        name="clientSecret"
         label="Client Secret"
         placeholder="Enter your Client Secret"
-        className="col-span-1"
-        fullWidth
-        hideEmptyHelperText
-        error={!!formState.errors?.clientSecret}
-        helperText={formState.errors?.clientSecret?.message}
+        containerClassName="col-span-1"
       />
     </>
   );

--- a/dashboard/src/features/orgs/projects/authentication/settings/components/BitbucketProviderSettings/BitbucketProviderSettings.tsx
+++ b/dashboard/src/features/orgs/projects/authentication/settings/components/BitbucketProviderSettings/BitbucketProviderSettings.tsx
@@ -103,7 +103,7 @@ export default function BitbucketProviderSettings() {
             !authEnabled && 'hidden',
           )}
         >
-          <BaseProviderSettings providerName="bitbucket" />
+          <BaseProviderSettings />
           <Input
             name="redirectUrl"
             id="bitbucket-redirectUrl"

--- a/dashboard/src/features/orgs/projects/authentication/settings/components/DiscordProviderSettings/DiscordProviderSettings.tsx
+++ b/dashboard/src/features/orgs/projects/authentication/settings/components/DiscordProviderSettings/DiscordProviderSettings.tsx
@@ -1,20 +1,26 @@
 import { yupResolver } from '@hookform/resolvers/yup';
-import { CopyIcon } from 'lucide-react';
 import { useEffect } from 'react';
 import { FormProvider, useForm } from 'react-hook-form';
 import { twMerge } from 'tailwind-merge';
 import { ApplyLocalSettingsDialog } from '@/components/common/ApplyLocalSettingsDialog';
 import { useDialog } from '@/components/common/DialogProvider';
 import { Form } from '@/components/form/Form';
-import { SettingsContainer } from '@/components/layout/SettingsContainer';
-import { IconButton } from '@/components/ui/v2/IconButton';
-import { Input } from '@/components/ui/v2/Input';
-import { InputAdornment } from '@/components/ui/v2/InputAdornment';
+import {
+  SettingsCard,
+  SettingsCardContent,
+  SettingsCardFooter,
+  SettingsCardHeader,
+  SettingsDocsLink,
+} from '@/components/layout/SettingsCard';
+import { ButtonWithLoading } from '@/components/ui/v3/button';
+import { FormField } from '@/components/ui/v3/form';
+import { Switch } from '@/components/ui/v3/switch';
 import type { BaseProviderSettingsFormValues } from '@/features/orgs/projects/authentication/settings/components/BaseProviderSettings';
 import {
   BaseProviderSettings,
   baseProviderValidationSchema,
 } from '@/features/orgs/projects/authentication/settings/components/BaseProviderSettings';
+import { ProviderRedirectUrlInput } from '@/features/orgs/projects/authentication/settings/components/ProviderRedirectUrlInput';
 import { useIsPlatform } from '@/features/orgs/projects/common/hooks/useIsPlatform';
 import { generateAppServiceUrl } from '@/features/orgs/projects/common/utils/generateAppServiceUrl';
 import { useLocalMimirClient } from '@/features/orgs/projects/hooks/useLocalMimirClient';
@@ -24,7 +30,6 @@ import {
   useGetSignInMethodsQuery,
   useUpdateConfigMutation,
 } from '@/generated/graphql';
-import { copy } from '@/utils/copy';
 
 export default function DiscordProviderSettings() {
   const { project } = useProject();
@@ -119,63 +124,60 @@ export default function DiscordProviderSettings() {
   return (
     <FormProvider {...form}>
       <Form onSubmit={handleSubmit}>
-        <SettingsContainer
-          title="Discord"
-          description="Allow users to sign in with Discord."
-          slotProps={{
-            submitButton: {
-              disabled: !formState.isDirty,
-              loading: formState.isSubmitting,
-            },
-          }}
-          docsLink="https://docs.nhost.io/products/auth/providers/sign-in-discord"
-          docsTitle="how to sign in users with Discord"
-          icon="/assets/brands/discord.svg"
-          switchId="enabled"
-          showSwitch
-          className={twMerge(
-            'grid-flow-rows grid grid-cols-2 grid-rows-2 gap-x-3 gap-y-4 px-4 py-2',
-            !authEnabled && 'hidden',
-          )}
-        >
-          <BaseProviderSettings providerName="discord" />
-          <Input
-            name="redirectUrl"
-            id="discord-redirectUrl"
-            className="col-span-2"
-            fullWidth
-            hideEmptyHelperText
-            label="Redirect URL"
-            defaultValue={`${generateAppServiceUrl(
-              project!.subdomain,
-              project!.region,
-              'auth',
-            )}/signin/provider/discord/callback`}
-            disabled
-            endAdornment={
-              <InputAdornment position="end" className="absolute right-2">
-                <IconButton
-                  sx={{ minWidth: 0, padding: 0 }}
-                  color="secondary"
-                  variant="borderless"
-                  onClick={(e) => {
-                    e.stopPropagation();
-                    copy(
-                      `${generateAppServiceUrl(
-                        project!.subdomain,
-                        project!.region,
-                        'auth',
-                      )}/signin/provider/discord/callback`,
-                      'Redirect URL',
-                    );
-                  }}
-                >
-                  <CopyIcon className="h-4 w-4" />
-                </IconButton>
-              </InputAdornment>
+        <SettingsCard>
+          <SettingsCardHeader
+            title="Discord"
+            description="Allow users to sign in with Discord."
+            icon="/assets/brands/discord.svg"
+            control={
+              <FormField
+                control={form.control}
+                name="enabled"
+                render={({ field }) => (
+                  <Switch
+                    checked={field.value}
+                    onCheckedChange={field.onChange}
+                    aria-label="Toggle Discord"
+                  />
+                )}
+              />
             }
           />
-        </SettingsContainer>
+
+          <SettingsCardContent
+            className={twMerge(
+              'grid grid-flow-row grid-cols-2 grid-rows-2 gap-x-3 gap-y-4 px-4 py-2',
+              !authEnabled && 'hidden',
+            )}
+          >
+            <BaseProviderSettings />
+            <ProviderRedirectUrlInput
+              id="discord-redirectUrl"
+              value={`${generateAppServiceUrl(
+                project!.subdomain,
+                project!.region,
+                'auth',
+              )}/signin/provider/discord/callback`}
+              className="col-span-2"
+            />
+          </SettingsCardContent>
+
+          <SettingsCardFooter>
+            <SettingsDocsLink
+              href="https://docs.nhost.io/products/auth/providers/sign-in-discord"
+              title="how to sign in users with Discord"
+            />
+
+            <ButtonWithLoading
+              type="submit"
+              disabled={!formState.isDirty}
+              loading={formState.isSubmitting}
+              className="w-full sm:w-auto"
+            >
+              Save
+            </ButtonWithLoading>
+          </SettingsCardFooter>
+        </SettingsCard>
       </Form>
     </FormProvider>
   );

--- a/dashboard/src/features/orgs/projects/authentication/settings/components/EmailAndPasswordSettings/EmailAndPasswordSettings.tsx
+++ b/dashboard/src/features/orgs/projects/authentication/settings/components/EmailAndPasswordSettings/EmailAndPasswordSettings.tsx
@@ -6,8 +6,16 @@ import { ApplyLocalSettingsDialog } from '@/components/common/ApplyLocalSettings
 import { useDialog } from '@/components/common/DialogProvider';
 import { Form } from '@/components/form/Form';
 import { FormCheckbox } from '@/components/form/FormCheckbox';
-import { SettingsContainer } from '@/components/layout/SettingsContainer';
-import { Input } from '@/components/ui/v2/Input';
+import { FormInput } from '@/components/form/FormInput';
+import {
+  SettingsCard,
+  SettingsCardContent,
+  SettingsCardFooter,
+  SettingsCardHeader,
+  SettingsDocsLink,
+} from '@/components/layout/SettingsCard';
+import { ButtonWithLoading } from '@/components/ui/v3/button';
+import { Switch } from '@/components/ui/v3/switch';
 import { useIsPlatform } from '@/features/orgs/projects/common/hooks/useIsPlatform';
 import { useLocalMimirClient } from '@/features/orgs/projects/hooks/useLocalMimirClient';
 import { useProject } from '@/features/orgs/projects/hooks/useProject';
@@ -77,7 +85,7 @@ export default function EmailAndPasswordSettings() {
     throw error;
   }
 
-  const { formState, register } = form;
+  const { formState } = form;
 
   async function handleSubmit(formValues: EmailAndPasswordFormValues) {
     const updateConfigPromise = updateConfig({
@@ -123,49 +131,59 @@ export default function EmailAndPasswordSettings() {
   return (
     <FormProvider {...form}>
       <Form onSubmit={handleSubmit}>
-        <SettingsContainer
-          title="Email and Password"
-          description="Allow users to sign in with email and password."
-          docsLink="https://docs.nhost.io/products/auth/sign-in-email-password"
-          docsTitle="how to sign in users with email and password"
-          className="grid grid-flow-row"
-          showSwitch
-          enabled
-          slotProps={{
-            switch: { disabled: true },
-            submitButton: {
-              disabled: !formState.isDirty,
-              loading: formState.isSubmitting,
-            },
-          }}
-        >
-          <Input
-            {...register('passwordMinLength')}
-            id="passwordMinLength"
-            name="passwordMinLength"
-            type="number"
-            label="Minimum required password length"
-            fullWidth
-            className="lg:max-w-[50%]"
-            error={Boolean(formState.errors.passwordMinLength?.message)}
-            helperText={formState.errors.passwordMinLength?.message}
-            slotProps={{ inputRoot: { min: 3 } }}
+        <SettingsCard>
+          <SettingsCardHeader
+            title="Email and Password"
+            description="Allow users to sign in with email and password."
+            control={
+              <Switch
+                checked={true}
+                aria-label="Toggle Email and Password"
+                disabled={true}
+              />
+            }
           />
 
-          <FormCheckbox
-            control={form.control}
-            name="emailVerificationRequired"
-            label="Require Verified Emails"
-            helperText="Users must verify their email to be able to sign in."
-          />
+          <SettingsCardContent>
+            <FormInput
+              control={form.control}
+              name="passwordMinLength"
+              type="number"
+              label="Minimum required password length"
+              containerClassName="lg:max-w-[50%]"
+            />
 
-          <FormCheckbox
-            control={form.control}
-            name="hibpEnabled"
-            label="Password Protection"
-            helperText="Passwords must pass haveibeenpwned.com during sign-up."
-          />
-        </SettingsContainer>
+            <FormCheckbox
+              control={form.control}
+              name="emailVerificationRequired"
+              label="Require Verified Emails"
+              helperText="Users must verify their email to be able to sign in."
+            />
+
+            <FormCheckbox
+              control={form.control}
+              name="hibpEnabled"
+              label="Password Protection"
+              helperText="Passwords must pass haveibeenpwned.com during sign-up."
+            />
+          </SettingsCardContent>
+
+          <SettingsCardFooter>
+            <SettingsDocsLink
+              href="https://docs.nhost.io/products/auth/sign-in-email-password"
+              title="how to sign in users with email and password"
+            />
+
+            <ButtonWithLoading
+              type="submit"
+              disabled={!formState.isDirty}
+              loading={formState.isSubmitting}
+              className="w-full sm:w-auto"
+            >
+              Save
+            </ButtonWithLoading>
+          </SettingsCardFooter>
+        </SettingsCard>
       </Form>
     </FormProvider>
   );

--- a/dashboard/src/features/orgs/projects/authentication/settings/components/EntraIDProviderSettings/EntraIDProviderSettings.tsx
+++ b/dashboard/src/features/orgs/projects/authentication/settings/components/EntraIDProviderSettings/EntraIDProviderSettings.tsx
@@ -1,7 +1,6 @@
 /** biome-ignore-all lint/suspicious/noThenProperty: yup thing */
 
 import { yupResolver } from '@hookform/resolvers/yup';
-import { CopyIcon } from 'lucide-react';
 import { useEffect } from 'react';
 import { FormProvider, useForm } from 'react-hook-form';
 import { twMerge } from 'tailwind-merge';
@@ -9,11 +8,18 @@ import * as Yup from 'yup';
 import { ApplyLocalSettingsDialog } from '@/components/common/ApplyLocalSettingsDialog';
 import { useDialog } from '@/components/common/DialogProvider';
 import { Form } from '@/components/form/Form';
-import { SettingsContainer } from '@/components/layout/SettingsContainer';
-import { IconButton } from '@/components/ui/v2/IconButton';
-import { Input } from '@/components/ui/v2/Input';
-import { InputAdornment } from '@/components/ui/v2/InputAdornment';
+import { FormInput } from '@/components/form/FormInput';
+import {
+  SettingsCard,
+  SettingsCardContent,
+  SettingsCardFooter,
+  SettingsCardHeader,
+} from '@/components/layout/SettingsCard';
+import { ButtonWithLoading } from '@/components/ui/v3/button';
+import { FormField } from '@/components/ui/v3/form';
+import { Switch } from '@/components/ui/v3/switch';
 import { BaseProviderSettings } from '@/features/orgs/projects/authentication/settings/components/BaseProviderSettings';
+import { ProviderRedirectUrlInput } from '@/features/orgs/projects/authentication/settings/components/ProviderRedirectUrlInput';
 import { useIsPlatform } from '@/features/orgs/projects/common/hooks/useIsPlatform';
 import { generateAppServiceUrl } from '@/features/orgs/projects/common/utils/generateAppServiceUrl';
 import { useLocalMimirClient } from '@/features/orgs/projects/hooks/useLocalMimirClient';
@@ -23,7 +29,6 @@ import {
   useGetSignInMethodsQuery,
   useUpdateConfigMutation,
 } from '@/generated/graphql';
-import { copy } from '@/utils/copy';
 
 const validationSchema = Yup.object({
   clientId: Yup.string()
@@ -93,7 +98,7 @@ export default function EntraIDProviderSettings() {
     throw error;
   }
 
-  const { register, formState, watch } = form;
+  const { formState, watch } = form;
   const authEnabled = watch('enabled');
 
   async function handleSubmit(formValues: EntraIDProviderFormValues) {
@@ -141,73 +146,62 @@ export default function EntraIDProviderSettings() {
   return (
     <FormProvider {...form}>
       <Form onSubmit={handleSubmit}>
-        <SettingsContainer
-          title="Entra ID"
-          description="Allow users to sign in with Microsoft Entra ID."
-          slotProps={{
-            submitButton: {
-              disabled: !formState.isDirty,
-              loading: formState.isSubmitting,
-            },
-          }}
-          icon="/assets/brands/entraid.svg"
-          switchId="enabled"
-          showSwitch
-          className={twMerge(
-            'grid grid-flow-row grid-cols-2 gap-x-3 gap-y-4 px-4 py-2',
-            !authEnabled && 'hidden',
-          )}
-        >
-          <BaseProviderSettings providerName="entraid" />
-          <Input
-            {...register('tenant')}
-            name="tenant"
-            id="tenant"
-            label="Tenant ID"
-            placeholder="Tenant ID"
-            className="col-span-2"
-            fullWidth
-            hideEmptyHelperText
-            error={!!formState.errors?.tenant}
-            helperText={formState.errors?.tenant?.message}
-          />
-          <Input
-            name="redirectUrl"
-            id="entraid-redirectUrl"
-            defaultValue={`${generateAppServiceUrl(
-              project!.subdomain,
-              project!.region,
-              'auth',
-            )}/signin/provider/entraid/callback`}
-            className="col-span-2"
-            fullWidth
-            hideEmptyHelperText
-            label="Redirect URL"
-            disabled
-            endAdornment={
-              <InputAdornment position="end" className="absolute right-2">
-                <IconButton
-                  sx={{ minWidth: 0, padding: 0 }}
-                  color="secondary"
-                  variant="borderless"
-                  onClick={(e) => {
-                    e.stopPropagation();
-                    copy(
-                      `${generateAppServiceUrl(
-                        project!.subdomain,
-                        project!.region,
-                        'auth',
-                      )}/signin/provider/entraid/callback`,
-                      'Redirect URL',
-                    );
-                  }}
-                >
-                  <CopyIcon className="h-4 w-4" />
-                </IconButton>
-              </InputAdornment>
+        <SettingsCard>
+          <SettingsCardHeader
+            title="Entra ID"
+            description="Allow users to sign in with Microsoft Entra ID."
+            icon="/assets/brands/entraid.svg"
+            control={
+              <FormField
+                control={form.control}
+                name="enabled"
+                render={({ field }) => (
+                  <Switch
+                    checked={field.value}
+                    onCheckedChange={field.onChange}
+                    aria-label="Toggle Entra ID"
+                  />
+                )}
+              />
             }
           />
-        </SettingsContainer>
+
+          <SettingsCardContent
+            className={twMerge(
+              'grid grid-flow-row grid-cols-2 gap-x-3 gap-y-4 px-4 py-2',
+              !authEnabled && 'hidden',
+            )}
+          >
+            <BaseProviderSettings />
+            <FormInput
+              control={form.control}
+              name="tenant"
+              label="Tenant ID"
+              placeholder="Tenant ID"
+              containerClassName="col-span-2"
+            />
+            <ProviderRedirectUrlInput
+              id="entraid-redirectUrl"
+              value={`${generateAppServiceUrl(
+                project!.subdomain,
+                project!.region,
+                'auth',
+              )}/signin/provider/entraid/callback`}
+              className="col-span-2"
+            />
+          </SettingsCardContent>
+
+          <SettingsCardFooter>
+            <ButtonWithLoading
+              type="submit"
+              disabled={!formState.isDirty}
+              loading={formState.isSubmitting}
+              className="w-full sm:w-auto"
+            >
+              Save
+            </ButtonWithLoading>
+          </SettingsCardFooter>
+        </SettingsCard>
       </Form>
     </FormProvider>
   );

--- a/dashboard/src/features/orgs/projects/authentication/settings/components/FacebookProviderSettings/FacebookProviderSettings.tsx
+++ b/dashboard/src/features/orgs/projects/authentication/settings/components/FacebookProviderSettings/FacebookProviderSettings.tsx
@@ -1,20 +1,26 @@
 import { yupResolver } from '@hookform/resolvers/yup';
-import { CopyIcon } from 'lucide-react';
 import { useEffect } from 'react';
 import { FormProvider, useForm } from 'react-hook-form';
 import { twMerge } from 'tailwind-merge';
 import { ApplyLocalSettingsDialog } from '@/components/common/ApplyLocalSettingsDialog';
 import { useDialog } from '@/components/common/DialogProvider';
 import { Form } from '@/components/form/Form';
-import { SettingsContainer } from '@/components/layout/SettingsContainer';
-import { IconButton } from '@/components/ui/v2/IconButton';
-import { Input } from '@/components/ui/v2/Input';
-import { InputAdornment } from '@/components/ui/v2/InputAdornment';
+import {
+  SettingsCard,
+  SettingsCardContent,
+  SettingsCardFooter,
+  SettingsCardHeader,
+  SettingsDocsLink,
+} from '@/components/layout/SettingsCard';
+import { ButtonWithLoading } from '@/components/ui/v3/button';
+import { FormField } from '@/components/ui/v3/form';
+import { Switch } from '@/components/ui/v3/switch';
 import type { BaseProviderSettingsFormValues } from '@/features/orgs/projects/authentication/settings/components/BaseProviderSettings';
 import {
   BaseProviderSettings,
   baseProviderValidationSchema,
 } from '@/features/orgs/projects/authentication/settings/components/BaseProviderSettings';
+import { ProviderRedirectUrlInput } from '@/features/orgs/projects/authentication/settings/components/ProviderRedirectUrlInput';
 import { useIsPlatform } from '@/features/orgs/projects/common/hooks/useIsPlatform';
 import { generateAppServiceUrl } from '@/features/orgs/projects/common/utils/generateAppServiceUrl';
 import { useLocalMimirClient } from '@/features/orgs/projects/hooks/useLocalMimirClient';
@@ -24,7 +30,6 @@ import {
   useGetSignInMethodsQuery,
   useUpdateConfigMutation,
 } from '@/generated/graphql';
-import { copy } from '@/utils/copy';
 
 export default function FacebookProviderSettings() {
   const { project } = useProject();
@@ -119,63 +124,60 @@ export default function FacebookProviderSettings() {
   return (
     <FormProvider {...form}>
       <Form onSubmit={handleSubmit}>
-        <SettingsContainer
-          title="Facebook"
-          description="Allow users to sign in with Facebook."
-          slotProps={{
-            submitButton: {
-              disabled: !formState.isDirty,
-              loading: formState.isSubmitting,
-            },
-          }}
-          docsLink="https://docs.nhost.io/products/auth/providers/sign-in-facebook"
-          docsTitle="how to sign in users with Facebook"
-          icon="/assets/brands/facebook.svg"
-          switchId="enabled"
-          showSwitch
-          className={twMerge(
-            'grid-flow-rows grid grid-cols-2 grid-rows-2 gap-x-3 gap-y-4 px-4 py-2',
-            !authEnabled && 'hidden',
-          )}
-        >
-          <BaseProviderSettings providerName="facebook" />
-          <Input
-            name="redirectUrl"
-            id="facebook-redirectUrl"
-            className="col-span-2"
-            fullWidth
-            hideEmptyHelperText
-            label="Redirect URL"
-            defaultValue={`${generateAppServiceUrl(
-              project!.subdomain,
-              project!.region,
-              'auth',
-            )}/signin/provider/facebook/callback`}
-            disabled
-            endAdornment={
-              <InputAdornment position="end" className="absolute right-2">
-                <IconButton
-                  sx={{ minWidth: 0, padding: 0 }}
-                  color="secondary"
-                  variant="borderless"
-                  onClick={(e) => {
-                    e.stopPropagation();
-                    copy(
-                      `${generateAppServiceUrl(
-                        project!.subdomain,
-                        project!.region,
-                        'auth',
-                      )}/signin/provider/facebook/callback`,
-                      'Redirect URL',
-                    );
-                  }}
-                >
-                  <CopyIcon className="h-4 w-4" />
-                </IconButton>
-              </InputAdornment>
+        <SettingsCard>
+          <SettingsCardHeader
+            title="Facebook"
+            description="Allow users to sign in with Facebook."
+            icon="/assets/brands/facebook.svg"
+            control={
+              <FormField
+                control={form.control}
+                name="enabled"
+                render={({ field }) => (
+                  <Switch
+                    checked={field.value}
+                    onCheckedChange={field.onChange}
+                    aria-label="Toggle Facebook"
+                  />
+                )}
+              />
             }
           />
-        </SettingsContainer>
+
+          <SettingsCardContent
+            className={twMerge(
+              'grid grid-flow-row grid-cols-2 grid-rows-2 gap-x-3 gap-y-4 px-4 py-2',
+              !authEnabled && 'hidden',
+            )}
+          >
+            <BaseProviderSettings />
+            <ProviderRedirectUrlInput
+              id="facebook-redirectUrl"
+              value={`${generateAppServiceUrl(
+                project!.subdomain,
+                project!.region,
+                'auth',
+              )}/signin/provider/facebook/callback`}
+              className="col-span-2"
+            />
+          </SettingsCardContent>
+
+          <SettingsCardFooter>
+            <SettingsDocsLink
+              href="https://docs.nhost.io/products/auth/providers/sign-in-facebook"
+              title="how to sign in users with Facebook"
+            />
+
+            <ButtonWithLoading
+              type="submit"
+              disabled={!formState.isDirty}
+              loading={formState.isSubmitting}
+              className="w-full sm:w-auto"
+            >
+              Save
+            </ButtonWithLoading>
+          </SettingsCardFooter>
+        </SettingsCard>
       </Form>
     </FormProvider>
   );

--- a/dashboard/src/features/orgs/projects/authentication/settings/components/GitHubProviderSettings/GitHubProviderSettings.tsx
+++ b/dashboard/src/features/orgs/projects/authentication/settings/components/GitHubProviderSettings/GitHubProviderSettings.tsx
@@ -1,21 +1,27 @@
 import { yupResolver } from '@hookform/resolvers/yup';
 import { useTheme } from '@mui/material';
-import { CopyIcon } from 'lucide-react';
 import { useEffect } from 'react';
 import { FormProvider, useForm } from 'react-hook-form';
 import { twMerge } from 'tailwind-merge';
 import { ApplyLocalSettingsDialog } from '@/components/common/ApplyLocalSettingsDialog';
 import { useDialog } from '@/components/common/DialogProvider';
 import { Form } from '@/components/form/Form';
-import { SettingsContainer } from '@/components/layout/SettingsContainer';
-import { IconButton } from '@/components/ui/v2/IconButton';
-import { Input } from '@/components/ui/v2/Input';
-import { InputAdornment } from '@/components/ui/v2/InputAdornment';
+import {
+  SettingsCard,
+  SettingsCardContent,
+  SettingsCardFooter,
+  SettingsCardHeader,
+  SettingsDocsLink,
+} from '@/components/layout/SettingsCard';
+import { ButtonWithLoading } from '@/components/ui/v3/button';
+import { FormField } from '@/components/ui/v3/form';
+import { Switch } from '@/components/ui/v3/switch';
 import type { BaseProviderSettingsFormValues } from '@/features/orgs/projects/authentication/settings/components/BaseProviderSettings';
 import {
   BaseProviderSettings,
   baseProviderValidationSchema,
 } from '@/features/orgs/projects/authentication/settings/components/BaseProviderSettings';
+import { ProviderRedirectUrlInput } from '@/features/orgs/projects/authentication/settings/components/ProviderRedirectUrlInput';
 import { useIsPlatform } from '@/features/orgs/projects/common/hooks/useIsPlatform';
 import { generateAppServiceUrl } from '@/features/orgs/projects/common/utils/generateAppServiceUrl';
 import { useLocalMimirClient } from '@/features/orgs/projects/hooks/useLocalMimirClient';
@@ -25,7 +31,6 @@ import {
   useGetSignInMethodsQuery,
   useUpdateConfigMutation,
 } from '@/generated/graphql';
-import { copy } from '@/utils/copy';
 
 export default function GitHubProviderSettings() {
   const theme = useTheme();
@@ -121,67 +126,64 @@ export default function GitHubProviderSettings() {
   return (
     <FormProvider {...form}>
       <Form onSubmit={handleSubmit}>
-        <SettingsContainer
-          title="GitHub"
-          description="Allow users to sign in with GitHub."
-          slotProps={{
-            submitButton: {
-              disabled: !formState.isDirty,
-              loading: formState.isSubmitting,
-            },
-          }}
-          docsLink="https://docs.nhost.io/products/auth/providers/sign-in-github"
-          docsTitle="how to sign in users with GitHub"
-          icon={
-            theme.palette.mode === 'dark'
-              ? '/assets/brands/light/github.svg'
-              : '/assets/brands/github.svg'
-          }
-          switchId="enabled"
-          showSwitch
-          className={twMerge(
-            'grid-flow-rows grid grid-cols-2 grid-rows-2 gap-x-3 gap-y-4 px-4 py-2',
-            !authEnabled && 'hidden',
-          )}
-        >
-          <BaseProviderSettings providerName="github" />
-          <Input
-            name="redirectUrl"
-            id="github-redirectUrl"
-            className="col-span-2"
-            fullWidth
-            hideEmptyHelperText
-            label="Redirect URL"
-            defaultValue={`${generateAppServiceUrl(
-              project!.subdomain,
-              project!.region,
-              'auth',
-            )}/signin/provider/github/callback`}
-            disabled
-            endAdornment={
-              <InputAdornment position="end" className="absolute right-2">
-                <IconButton
-                  sx={{ minWidth: 0, padding: 0 }}
-                  color="secondary"
-                  variant="borderless"
-                  onClick={(e) => {
-                    e.stopPropagation();
-                    copy(
-                      `${generateAppServiceUrl(
-                        project!.subdomain,
-                        project!.region,
-                        'auth',
-                      )}/signin/provider/github/callback`,
-                      'Redirect URL',
-                    );
-                  }}
-                >
-                  <CopyIcon className="h-4 w-4" />
-                </IconButton>
-              </InputAdornment>
+        <SettingsCard>
+          <SettingsCardHeader
+            title="GitHub"
+            description="Allow users to sign in with GitHub."
+            icon={
+              theme.palette.mode === 'dark'
+                ? '/assets/brands/light/github.svg'
+                : '/assets/brands/github.svg'
+            }
+            control={
+              <FormField
+                control={form.control}
+                name="enabled"
+                render={({ field }) => (
+                  <Switch
+                    checked={field.value}
+                    onCheckedChange={field.onChange}
+                    aria-label="Toggle GitHub"
+                  />
+                )}
+              />
             }
           />
-        </SettingsContainer>
+
+          <SettingsCardContent
+            className={twMerge(
+              'grid grid-flow-row grid-cols-2 grid-rows-2 gap-x-3 gap-y-4 px-4 py-2',
+              !authEnabled && 'hidden',
+            )}
+          >
+            <BaseProviderSettings />
+            <ProviderRedirectUrlInput
+              id="github-redirectUrl"
+              value={`${generateAppServiceUrl(
+                project!.subdomain,
+                project!.region,
+                'auth',
+              )}/signin/provider/github/callback`}
+              className="col-span-2"
+            />
+          </SettingsCardContent>
+
+          <SettingsCardFooter>
+            <SettingsDocsLink
+              href="https://docs.nhost.io/products/auth/providers/sign-in-github"
+              title="how to sign in users with GitHub"
+            />
+
+            <ButtonWithLoading
+              type="submit"
+              disabled={!formState.isDirty}
+              loading={formState.isSubmitting}
+              className="w-full sm:w-auto"
+            >
+              Save
+            </ButtonWithLoading>
+          </SettingsCardFooter>
+        </SettingsCard>
       </Form>
     </FormProvider>
   );

--- a/dashboard/src/features/orgs/projects/authentication/settings/components/GitLabProviderSettings/GitLabProviderSettings.tsx
+++ b/dashboard/src/features/orgs/projects/authentication/settings/components/GitLabProviderSettings/GitLabProviderSettings.tsx
@@ -106,7 +106,7 @@ export default function GitLabProviderSettings() {
             !authEnabled && 'hidden',
           )}
         >
-          <BaseProviderSettings providerName="gitlab" />
+          <BaseProviderSettings />
           <Input
             name="redirectUrl"
             id="gitlab-redirectUrl"

--- a/dashboard/src/features/orgs/projects/authentication/settings/components/GoogleProviderSettings/GoogleProviderSettings.tsx
+++ b/dashboard/src/features/orgs/projects/authentication/settings/components/GoogleProviderSettings/GoogleProviderSettings.tsx
@@ -1,7 +1,6 @@
 /** biome-ignore-all lint/suspicious/noThenProperty: yup thing */
 
 import { yupResolver } from '@hookform/resolvers/yup';
-import { CopyIcon } from 'lucide-react';
 import { useEffect } from 'react';
 import { FormProvider, useForm } from 'react-hook-form';
 import { twMerge } from 'tailwind-merge';
@@ -9,11 +8,19 @@ import * as Yup from 'yup';
 import { ApplyLocalSettingsDialog } from '@/components/common/ApplyLocalSettingsDialog';
 import { useDialog } from '@/components/common/DialogProvider';
 import { Form } from '@/components/form/Form';
-import { SettingsContainer } from '@/components/layout/SettingsContainer';
-import { IconButton } from '@/components/ui/v2/IconButton';
-import { Input } from '@/components/ui/v2/Input';
-import { InputAdornment } from '@/components/ui/v2/InputAdornment';
+import { FormInput } from '@/components/form/FormInput';
+import {
+  SettingsCard,
+  SettingsCardContent,
+  SettingsCardFooter,
+  SettingsCardHeader,
+  SettingsDocsLink,
+} from '@/components/layout/SettingsCard';
+import { ButtonWithLoading } from '@/components/ui/v3/button';
+import { FormField } from '@/components/ui/v3/form';
+import { Switch } from '@/components/ui/v3/switch';
 import type { BaseProviderSettingsFormValues } from '@/features/orgs/projects/authentication/settings/components/BaseProviderSettings';
+import { ProviderRedirectUrlInput } from '@/features/orgs/projects/authentication/settings/components/ProviderRedirectUrlInput';
 import { useIsPlatform } from '@/features/orgs/projects/common/hooks/useIsPlatform';
 import { generateAppServiceUrl } from '@/features/orgs/projects/common/utils/generateAppServiceUrl';
 import { useLocalMimirClient } from '@/features/orgs/projects/hooks/useLocalMimirClient';
@@ -23,7 +30,6 @@ import {
   useGetSignInMethodsQuery,
   useUpdateConfigMutation,
 } from '@/generated/graphql';
-import { copy } from '@/utils/copy';
 
 const googleProviderValidationSchema = Yup.object({
   clientId: Yup.string()
@@ -90,7 +96,7 @@ export default function GoogleProviderSettings() {
     throw error;
   }
 
-  const { formState, watch, register } = form;
+  const { formState, watch } = form;
   const authEnabled = watch('enabled');
 
   async function handleSubmit(formValues: BaseProviderSettingsFormValues) {
@@ -141,96 +147,80 @@ export default function GoogleProviderSettings() {
   return (
     <FormProvider {...form}>
       <Form onSubmit={handleSubmit}>
-        <SettingsContainer
-          title="Google"
-          description="Allow users to sign in with Google."
-          slotProps={{
-            submitButton: {
-              disabled: !formState.isDirty,
-              loading: formState.isSubmitting,
-            },
-          }}
-          docsLink="https://docs.nhost.io/products/auth/providers/sign-in-google"
-          docsTitle="how to sign in users with Google"
-          icon="/assets/brands/google.svg"
-          switchId="enabled"
-          showSwitch
-          className={twMerge(
-            'grid-flow-rows grid grid-cols-2 grid-rows-3 gap-x-3 gap-y-4 px-4 py-2',
-            !authEnabled && 'hidden',
-          )}
-        >
-          <Input
-            {...register('clientId')}
-            id="google-clientId"
-            label="Client ID"
-            placeholder="Enter your Client ID"
-            className="col-span-1"
-            fullWidth
-            hideEmptyHelperText
-            error={!!formState.errors?.clientId}
-            helperText={formState.errors?.clientId?.message}
-          />
-          <Input
-            {...register('clientSecret')}
-            id="google-clientSecret"
-            label="Client Secret"
-            placeholder="Enter your Client Secret"
-            className="col-span-1"
-            fullWidth
-            hideEmptyHelperText
-            error={!!formState.errors?.clientSecret}
-            helperText={formState.errors?.clientSecret?.message}
-          />
-          <Input
-            {...register('audience')}
-            name="audience"
-            id="audience"
-            label="Audience, set it to enable idtokens (optional)"
-            placeholder="GoogleAudience1,GoogleAudience2"
-            className="col-span-2"
-            fullWidth
-            hideEmptyHelperText
-            error={!!formState.errors?.audience}
-            helperText={formState.errors?.audience?.message}
-          />
-          <Input
-            name="redirectUrl"
-            id="google-redirectUrl"
-            className="col-span-2"
-            fullWidth
-            hideEmptyHelperText
-            label="Redirect URL"
-            defaultValue={`${generateAppServiceUrl(
-              project!.subdomain,
-              project!.region,
-              'auth',
-            )}/signin/provider/google/callback`}
-            disabled
-            endAdornment={
-              <InputAdornment position="end" className="absolute right-2">
-                <IconButton
-                  sx={{ minWidth: 0, padding: 0 }}
-                  color="secondary"
-                  variant="borderless"
-                  onClick={(e) => {
-                    e.stopPropagation();
-                    copy(
-                      `${generateAppServiceUrl(
-                        project!.subdomain,
-                        project!.region,
-                        'auth',
-                      )}/signin/provider/google/callback`,
-                      'Redirect URL',
-                    );
-                  }}
-                >
-                  <CopyIcon className="h-4 w-4" />
-                </IconButton>
-              </InputAdornment>
+        <SettingsCard>
+          <SettingsCardHeader
+            title="Google"
+            description="Allow users to sign in with Google."
+            icon="/assets/brands/google.svg"
+            control={
+              <FormField
+                control={form.control}
+                name="enabled"
+                render={({ field }) => (
+                  <Switch
+                    checked={field.value}
+                    onCheckedChange={field.onChange}
+                    aria-label="Toggle Google"
+                  />
+                )}
+              />
             }
           />
-        </SettingsContainer>
+
+          <SettingsCardContent
+            className={twMerge(
+              'grid grid-flow-row grid-cols-2 grid-rows-3 gap-x-3 gap-y-4 px-4 py-2',
+              !authEnabled && 'hidden',
+            )}
+          >
+            <FormInput
+              control={form.control}
+              name="clientId"
+              label="Client ID"
+              placeholder="Enter your Client ID"
+              containerClassName="col-span-1"
+            />
+            <FormInput
+              control={form.control}
+              name="clientSecret"
+              label="Client Secret"
+              placeholder="Enter your Client Secret"
+              containerClassName="col-span-1"
+            />
+            <FormInput
+              control={form.control}
+              name="audience"
+              label="Audience, set it to enable idtokens (optional)"
+              placeholder="GoogleAudience1,GoogleAudience2"
+              containerClassName="col-span-2"
+            />
+            <ProviderRedirectUrlInput
+              id="google-redirectUrl"
+              value={`${generateAppServiceUrl(
+                project!.subdomain,
+                project!.region,
+                'auth',
+              )}/signin/provider/google/callback`}
+              className="col-span-2"
+            />
+          </SettingsCardContent>
+
+          <SettingsCardFooter>
+            <SettingsDocsLink
+              href="https://docs.nhost.io/products/auth/providers/sign-in-google"
+              title="how to sign in users with Google"
+            />
+
+            <ButtonWithLoading
+              type="submit"
+              disabled={!formState.isDirty}
+              loading={formState.isSubmitting}
+              className="w-full sm:w-auto"
+            >
+              Save
+            </ButtonWithLoading>
+          </SettingsCardFooter>
+        </SettingsCard>
       </Form>
     </FormProvider>
   );

--- a/dashboard/src/features/orgs/projects/authentication/settings/components/LinkedInProviderSettings/LinkedInProviderSettings.tsx
+++ b/dashboard/src/features/orgs/projects/authentication/settings/components/LinkedInProviderSettings/LinkedInProviderSettings.tsx
@@ -1,20 +1,26 @@
 import { yupResolver } from '@hookform/resolvers/yup';
-import { CopyIcon } from 'lucide-react';
 import { useEffect } from 'react';
 import { FormProvider, useForm } from 'react-hook-form';
 import { twMerge } from 'tailwind-merge';
 import { ApplyLocalSettingsDialog } from '@/components/common/ApplyLocalSettingsDialog';
 import { useDialog } from '@/components/common/DialogProvider';
 import { Form } from '@/components/form/Form';
-import { SettingsContainer } from '@/components/layout/SettingsContainer';
-import { IconButton } from '@/components/ui/v2/IconButton';
-import { Input } from '@/components/ui/v2/Input';
-import { InputAdornment } from '@/components/ui/v2/InputAdornment';
+import {
+  SettingsCard,
+  SettingsCardContent,
+  SettingsCardFooter,
+  SettingsCardHeader,
+  SettingsDocsLink,
+} from '@/components/layout/SettingsCard';
+import { ButtonWithLoading } from '@/components/ui/v3/button';
+import { FormField } from '@/components/ui/v3/form';
+import { Switch } from '@/components/ui/v3/switch';
 import type { BaseProviderSettingsFormValues } from '@/features/orgs/projects/authentication/settings/components/BaseProviderSettings';
 import {
   BaseProviderSettings,
   baseProviderValidationSchema,
 } from '@/features/orgs/projects/authentication/settings/components/BaseProviderSettings';
+import { ProviderRedirectUrlInput } from '@/features/orgs/projects/authentication/settings/components/ProviderRedirectUrlInput';
 import { useIsPlatform } from '@/features/orgs/projects/common/hooks/useIsPlatform';
 import { generateAppServiceUrl } from '@/features/orgs/projects/common/utils/generateAppServiceUrl';
 import { useLocalMimirClient } from '@/features/orgs/projects/hooks/useLocalMimirClient';
@@ -24,7 +30,6 @@ import {
   useGetSignInMethodsQuery,
   useUpdateConfigMutation,
 } from '@/generated/graphql';
-import { copy } from '@/utils/copy';
 
 export default function LinkedInProviderSettings() {
   const { project } = useProject();
@@ -119,63 +124,60 @@ export default function LinkedInProviderSettings() {
   return (
     <FormProvider {...form}>
       <Form onSubmit={handleSubmit}>
-        <SettingsContainer
-          title="LinkedIn"
-          description="Allow users to sign in with LinkedIn."
-          slotProps={{
-            submitButton: {
-              disabled: !formState.isDirty,
-              loading: formState.isSubmitting,
-            },
-          }}
-          docsLink="https://docs.nhost.io/products/auth/providers/sign-in-linkedin"
-          docsTitle="how to sign in users with LinkedIn"
-          icon="/assets/brands/linkedin.svg"
-          switchId="enabled"
-          showSwitch
-          className={twMerge(
-            'grid-flow-rows grid grid-cols-2 grid-rows-2 gap-x-3 gap-y-4 px-4 py-2',
-            !authEnabled && 'hidden',
-          )}
-        >
-          <BaseProviderSettings providerName="linkedin" />
-          <Input
-            name="redirectUrl"
-            id="linkedin-redirectUrl"
-            className="col-span-2"
-            fullWidth
-            hideEmptyHelperText
-            label="Redirect URL"
-            defaultValue={`${generateAppServiceUrl(
-              project!.subdomain,
-              project!.region,
-              'auth',
-            )}/signin/provider/linkedin/callback`}
-            disabled
-            endAdornment={
-              <InputAdornment position="end" className="absolute right-2">
-                <IconButton
-                  sx={{ minWidth: 0, padding: 0 }}
-                  color="secondary"
-                  variant="borderless"
-                  onClick={(e) => {
-                    e.stopPropagation();
-                    copy(
-                      `${generateAppServiceUrl(
-                        project!.subdomain,
-                        project!.region,
-                        'auth',
-                      )}/signin/provider/linkedin/callback`,
-                      'Redirect URL',
-                    );
-                  }}
-                >
-                  <CopyIcon className="h-4 w-4" />
-                </IconButton>
-              </InputAdornment>
+        <SettingsCard>
+          <SettingsCardHeader
+            title="LinkedIn"
+            description="Allow users to sign in with LinkedIn."
+            icon="/assets/brands/linkedin.svg"
+            control={
+              <FormField
+                control={form.control}
+                name="enabled"
+                render={({ field }) => (
+                  <Switch
+                    checked={field.value}
+                    onCheckedChange={field.onChange}
+                    aria-label="Toggle LinkedIn"
+                  />
+                )}
+              />
             }
           />
-        </SettingsContainer>
+
+          <SettingsCardContent
+            className={twMerge(
+              'grid grid-flow-row grid-cols-2 grid-rows-2 gap-x-3 gap-y-4 px-4 py-2',
+              !authEnabled && 'hidden',
+            )}
+          >
+            <BaseProviderSettings />
+            <ProviderRedirectUrlInput
+              id="linkedin-redirectUrl"
+              value={`${generateAppServiceUrl(
+                project!.subdomain,
+                project!.region,
+                'auth',
+              )}/signin/provider/linkedin/callback`}
+              className="col-span-2"
+            />
+          </SettingsCardContent>
+
+          <SettingsCardFooter>
+            <SettingsDocsLink
+              href="https://docs.nhost.io/products/auth/providers/sign-in-linkedin"
+              title="how to sign in users with LinkedIn"
+            />
+
+            <ButtonWithLoading
+              type="submit"
+              disabled={!formState.isDirty}
+              loading={formState.isSubmitting}
+              className="w-full sm:w-auto"
+            >
+              Save
+            </ButtonWithLoading>
+          </SettingsCardFooter>
+        </SettingsCard>
       </Form>
     </FormProvider>
   );

--- a/dashboard/src/features/orgs/projects/authentication/settings/components/MagicLinkSettings/MagicLinkSettings.tsx
+++ b/dashboard/src/features/orgs/projects/authentication/settings/components/MagicLinkSettings/MagicLinkSettings.tsx
@@ -5,7 +5,15 @@ import * as Yup from 'yup';
 import { ApplyLocalSettingsDialog } from '@/components/common/ApplyLocalSettingsDialog';
 import { useDialog } from '@/components/common/DialogProvider';
 import { Form } from '@/components/form/Form';
-import { SettingsContainer } from '@/components/layout/SettingsContainer';
+import {
+  SettingsCard,
+  SettingsCardFooter,
+  SettingsCardHeader,
+  SettingsDocsLink,
+} from '@/components/layout/SettingsCard';
+import { ButtonWithLoading } from '@/components/ui/v3/button';
+import { FormField } from '@/components/ui/v3/form';
+import { Switch } from '@/components/ui/v3/switch';
 import { useIsPlatform } from '@/features/orgs/projects/common/hooks/useIsPlatform';
 import { useLocalMimirClient } from '@/features/orgs/projects/hooks/useLocalMimirClient';
 import { useProject } from '@/features/orgs/projects/hooks/useProject';
@@ -101,21 +109,41 @@ export default function MagicLinkSettings() {
   return (
     <FormProvider {...form}>
       <Form onSubmit={handleMagicLinkSettingsUpdate}>
-        <SettingsContainer
-          title="Magic Link"
-          description="Allow users to sign in with a Magic Link."
-          slotProps={{
-            submitButton: {
-              disabled: !formState.isDirty,
-              loading: formState.isSubmitting,
-            },
-          }}
-          docsLink="https://docs.nhost.io/products/auth/sign-in-magic-link"
-          docsTitle="how to sign in users with Magic Link"
-          switchId="enabled"
-          showSwitch
-          className="hidden"
-        />
+        <SettingsCard>
+          <SettingsCardHeader
+            title="Magic Link"
+            description="Allow users to sign in with a Magic Link."
+            control={
+              <FormField
+                control={form.control}
+                name="enabled"
+                render={({ field }) => (
+                  <Switch
+                    checked={field.value}
+                    onCheckedChange={field.onChange}
+                    aria-label="Toggle Magic Link"
+                  />
+                )}
+              />
+            }
+          />
+
+          <SettingsCardFooter>
+            <SettingsDocsLink
+              href="https://docs.nhost.io/products/auth/sign-in-magic-link"
+              title="how to sign in users with Magic Link"
+            />
+
+            <ButtonWithLoading
+              type="submit"
+              disabled={!formState.isDirty}
+              loading={formState.isSubmitting}
+              className="w-full sm:w-auto"
+            >
+              Save
+            </ButtonWithLoading>
+          </SettingsCardFooter>
+        </SettingsCard>
       </Form>
     </FormProvider>
   );

--- a/dashboard/src/features/orgs/projects/authentication/settings/components/ProviderRedirectUrlInput/ProviderRedirectUrlInput.tsx
+++ b/dashboard/src/features/orgs/projects/authentication/settings/components/ProviderRedirectUrlInput/ProviderRedirectUrlInput.tsx
@@ -1,0 +1,42 @@
+import { CopyIcon } from 'lucide-react';
+import {
+  InputGroup,
+  InputGroupAddon,
+  InputGroupButton,
+  InputGroupInput,
+} from '@/components/ui/v3/input-group';
+import { Label } from '@/components/ui/v3/label';
+import { cn } from '@/lib/utils';
+import { copy } from '@/utils/copy';
+
+export interface ProviderRedirectUrlInputProps {
+  id: string;
+  value: string;
+  className?: string;
+}
+
+export default function ProviderRedirectUrlInput({
+  id,
+  value,
+  className,
+}: ProviderRedirectUrlInputProps) {
+  return (
+    <div className={cn('space-y-2', className)}>
+      <Label htmlFor={id}>Redirect URL</Label>
+      <InputGroup className="bg-transparent dark:bg-transparent">
+        <InputGroupInput id={id} value={value} disabled readOnly />
+        <InputGroupAddon align="inline-end">
+          <InputGroupButton
+            aria-label="Copy Redirect URL"
+            onClick={(e) => {
+              e.stopPropagation();
+              copy(value, 'Redirect URL');
+            }}
+          >
+            <CopyIcon className="h-4 w-4" />
+          </InputGroupButton>
+        </InputGroupAddon>
+      </InputGroup>
+    </div>
+  );
+}

--- a/dashboard/src/features/orgs/projects/authentication/settings/components/ProviderRedirectUrlInput/index.ts
+++ b/dashboard/src/features/orgs/projects/authentication/settings/components/ProviderRedirectUrlInput/index.ts
@@ -1,0 +1,1 @@
+export { default as ProviderRedirectUrlInput } from './ProviderRedirectUrlInput';

--- a/dashboard/src/features/orgs/projects/authentication/settings/components/SMSSettings/SMSSettings.tsx
+++ b/dashboard/src/features/orgs/projects/authentication/settings/components/SMSSettings/SMSSettings.tsx
@@ -9,8 +9,16 @@ import * as Yup from 'yup';
 import { ApplyLocalSettingsDialog } from '@/components/common/ApplyLocalSettingsDialog';
 import { useDialog } from '@/components/common/DialogProvider';
 import { Form } from '@/components/form/Form';
-import { SettingsContainer } from '@/components/layout/SettingsContainer';
-import { Input } from '@/components/ui/v2/Input';
+import { FormInput } from '@/components/form/FormInput';
+import {
+  SettingsCard,
+  SettingsCardContent,
+  SettingsCardFooter,
+  SettingsCardHeader,
+  SettingsDocsLink,
+} from '@/components/layout/SettingsCard';
+import { ButtonWithLoading } from '@/components/ui/v3/button';
+import { FormField } from '@/components/ui/v3/form';
 import {
   Select,
   SelectContent,
@@ -18,6 +26,7 @@ import {
   SelectTrigger,
   SelectValue,
 } from '@/components/ui/v3/select';
+import { Switch } from '@/components/ui/v3/switch';
 import { useIsPlatform } from '@/features/orgs/projects/common/hooks/useIsPlatform';
 import { useLocalMimirClient } from '@/features/orgs/projects/hooks/useLocalMimirClient';
 import { useProject } from '@/features/orgs/projects/hooks/useProject';
@@ -96,7 +105,7 @@ export default function SMSSettings() {
     throw error;
   }
 
-  const { register, formState, watch } = form;
+  const { formState, watch } = form;
   const authSmsPasswordlessEnabled = watch('enabled');
 
   const handleSMSSettingsChange = async (values: SMSSettingsFormValues) => {
@@ -150,84 +159,93 @@ export default function SMSSettings() {
   return (
     <FormProvider {...form}>
       <Form onSubmit={handleSMSSettingsChange}>
-        <SettingsContainer
-          title="Phone Number (SMS)"
-          description="Allow users to sign in with Phone Number (SMS)."
-          slotProps={{
-            submitButton: {
-              disabled: !formState.isDirty,
-              loading: formState.isSubmitting,
-            },
-          }}
-          switchId="enabled"
-          showSwitch
-          docsLink="https://docs.nhost.io/products/auth/otp/sms"
-          docsTitle="how to sign in users with a phone number (SMS)"
-          className={twMerge(
-            'grid grid-flow-col grid-cols-2 grid-rows-4 gap-x-3 gap-y-4 px-4 py-2',
-            !authSmsPasswordlessEnabled && 'hidden',
-          )}
-        >
-          <div className="col-span-2 grid gap-1 lg:col-span-1">
-            <label htmlFor="provider" className="font-medium text-sm+">
-              Provider
-            </label>
-            <Select disabled value="twilio">
-              <SelectTrigger id="provider">
-                <SelectValue placeholder="Provider" />
-              </SelectTrigger>
-              <SelectContent>
-                <SelectItem value="twilio" textContent="Twilio">
-                  <span className="grid grid-flow-col items-center gap-1 text-sm+">
-                    <Image
-                      src="/assets/brands/twilio.svg"
-                      alt="Logo of Twilio"
-                      width={20}
-                      height={20}
-                    />
-                    <span>Twilio</span>
-                  </span>
-                </SelectItem>
-              </SelectContent>
-            </Select>
-          </div>
-          <Input
-            {...register('accountSid')}
-            name="accountSid"
-            id="accountSid"
-            placeholder="Account SID"
-            className="col-span-2 lg:col-span-1"
-            fullWidth
-            hideEmptyHelperText
-            label="Account SID"
-            error={!!formState.errors?.accountSid}
-            helperText={formState.errors?.accountSid?.message}
+        <SettingsCard>
+          <SettingsCardHeader
+            title="Phone Number (SMS)"
+            description="Allow users to sign in with Phone Number (SMS)."
+            control={
+              <FormField
+                control={form.control}
+                name="enabled"
+                render={({ field }) => (
+                  <Switch
+                    checked={field.value}
+                    onCheckedChange={field.onChange}
+                    aria-label="Toggle Phone Number (SMS)"
+                  />
+                )}
+              />
+            }
           />
-          <Input
-            {...register('authToken')}
-            name="authToken"
-            id="authToken"
-            placeholder="Auth Token"
-            className="col-span-2 lg:col-span-1"
-            fullWidth
-            hideEmptyHelperText
-            label="Auth Token"
-            error={!!formState.errors?.authToken}
-            helperText={formState.errors?.authToken?.message}
-          />
-          <Input
-            {...register('messagingServiceId')}
-            name="messagingServiceId"
-            id="messagingServiceId"
-            placeholder="Messaging Service ID"
-            className="col-span-2 lg:col-span-1"
-            fullWidth
-            hideEmptyHelperText
-            label="Messaging Service ID"
-            error={!!formState.errors?.messagingServiceId}
-            helperText={formState.errors?.messagingServiceId?.message}
-          />
-        </SettingsContainer>
+
+          <SettingsCardContent
+            className={twMerge(
+              'grid grid-flow-col grid-cols-2 grid-rows-4 gap-x-3 gap-y-4 px-4 py-2',
+              !authSmsPasswordlessEnabled && 'hidden',
+            )}
+          >
+            <div className="col-span-2 grid gap-1 lg:col-span-1">
+              <label htmlFor="provider" className="font-medium text-sm+">
+                Provider
+              </label>
+              <Select disabled value="twilio">
+                <SelectTrigger id="provider">
+                  <SelectValue placeholder="Provider" />
+                </SelectTrigger>
+                <SelectContent>
+                  <SelectItem value="twilio" textContent="Twilio">
+                    <span className="grid grid-flow-col items-center gap-1 text-sm+">
+                      <Image
+                        src="/assets/brands/twilio.svg"
+                        alt="Logo of Twilio"
+                        width={20}
+                        height={20}
+                      />
+                      <span>Twilio</span>
+                    </span>
+                  </SelectItem>
+                </SelectContent>
+              </Select>
+            </div>
+            <FormInput
+              control={form.control}
+              name="accountSid"
+              label="Account SID"
+              placeholder="Account SID"
+              containerClassName="col-span-2 lg:col-span-1"
+            />
+            <FormInput
+              control={form.control}
+              name="authToken"
+              label="Auth Token"
+              placeholder="Auth Token"
+              containerClassName="col-span-2 lg:col-span-1"
+            />
+            <FormInput
+              control={form.control}
+              name="messagingServiceId"
+              label="Messaging Service ID"
+              placeholder="Messaging Service ID"
+              containerClassName="col-span-2 lg:col-span-1"
+            />
+          </SettingsCardContent>
+
+          <SettingsCardFooter>
+            <SettingsDocsLink
+              href="https://docs.nhost.io/products/auth/otp/sms"
+              title="how to sign in users with a phone number (SMS)"
+            />
+
+            <ButtonWithLoading
+              type="submit"
+              disabled={!formState.isDirty}
+              loading={formState.isSubmitting}
+              className="w-full sm:w-auto"
+            >
+              Save
+            </ButtonWithLoading>
+          </SettingsCardFooter>
+        </SettingsCard>
       </Form>
     </FormProvider>
   );

--- a/dashboard/src/features/orgs/projects/authentication/settings/components/SpotifyProviderSettings/SpotifyProviderSettings.tsx
+++ b/dashboard/src/features/orgs/projects/authentication/settings/components/SpotifyProviderSettings/SpotifyProviderSettings.tsx
@@ -1,20 +1,26 @@
 import { yupResolver } from '@hookform/resolvers/yup';
-import { CopyIcon } from 'lucide-react';
 import { useEffect } from 'react';
 import { FormProvider, useForm } from 'react-hook-form';
 import { twMerge } from 'tailwind-merge';
 import { ApplyLocalSettingsDialog } from '@/components/common/ApplyLocalSettingsDialog';
 import { useDialog } from '@/components/common/DialogProvider';
 import { Form } from '@/components/form/Form';
-import { SettingsContainer } from '@/components/layout/SettingsContainer';
-import { IconButton } from '@/components/ui/v2/IconButton';
-import { Input } from '@/components/ui/v2/Input';
-import { InputAdornment } from '@/components/ui/v2/InputAdornment';
+import {
+  SettingsCard,
+  SettingsCardContent,
+  SettingsCardFooter,
+  SettingsCardHeader,
+  SettingsDocsLink,
+} from '@/components/layout/SettingsCard';
+import { ButtonWithLoading } from '@/components/ui/v3/button';
+import { FormField } from '@/components/ui/v3/form';
+import { Switch } from '@/components/ui/v3/switch';
 import type { BaseProviderSettingsFormValues } from '@/features/orgs/projects/authentication/settings/components/BaseProviderSettings';
 import {
   BaseProviderSettings,
   baseProviderValidationSchema,
 } from '@/features/orgs/projects/authentication/settings/components/BaseProviderSettings';
+import { ProviderRedirectUrlInput } from '@/features/orgs/projects/authentication/settings/components/ProviderRedirectUrlInput';
 import { useIsPlatform } from '@/features/orgs/projects/common/hooks/useIsPlatform';
 import { generateAppServiceUrl } from '@/features/orgs/projects/common/utils/generateAppServiceUrl';
 import { useLocalMimirClient } from '@/features/orgs/projects/hooks/useLocalMimirClient';
@@ -24,7 +30,6 @@ import {
   useGetSignInMethodsQuery,
   useUpdateConfigMutation,
 } from '@/generated/graphql';
-import { copy } from '@/utils/copy';
 
 export default function SpotifyProviderSettings() {
   const { project } = useProject();
@@ -119,63 +124,60 @@ export default function SpotifyProviderSettings() {
   return (
     <FormProvider {...form}>
       <Form onSubmit={handleSubmit}>
-        <SettingsContainer
-          title="Spotify"
-          description="Allow users to sign in with Spotify."
-          slotProps={{
-            submitButton: {
-              disabled: !formState.isDirty,
-              loading: formState.isSubmitting,
-            },
-          }}
-          docsLink="https://docs.nhost.io/products/auth/providers/sign-in-spotify"
-          docsTitle="how to sign in users with Spotify"
-          icon="/assets/brands/spotify.svg"
-          switchId="enabled"
-          showSwitch
-          className={twMerge(
-            'grid-flow-rows grid grid-cols-2 grid-rows-2 gap-x-3 gap-y-4 px-4 py-2',
-            !authEnabled && 'hidden',
-          )}
-        >
-          <BaseProviderSettings providerName="spotify" />
-          <Input
-            name="redirectUrl"
-            id="spotify-redirectUrl"
-            className="col-span-2"
-            fullWidth
-            hideEmptyHelperText
-            label="Redirect URL"
-            defaultValue={`${generateAppServiceUrl(
-              project!.subdomain,
-              project!.region,
-              'auth',
-            )}/signin/provider/spotify/callback`}
-            disabled
-            endAdornment={
-              <InputAdornment position="end" className="absolute right-2">
-                <IconButton
-                  sx={{ minWidth: 0, padding: 0 }}
-                  color="secondary"
-                  variant="borderless"
-                  onClick={(e) => {
-                    e.stopPropagation();
-                    copy(
-                      `${generateAppServiceUrl(
-                        project!.subdomain,
-                        project!.region,
-                        'auth',
-                      )}/signin/provider/spotify/callback`,
-                      'Redirect URL',
-                    );
-                  }}
-                >
-                  <CopyIcon className="h-4 w-4" />
-                </IconButton>
-              </InputAdornment>
+        <SettingsCard>
+          <SettingsCardHeader
+            title="Spotify"
+            description="Allow users to sign in with Spotify."
+            icon="/assets/brands/spotify.svg"
+            control={
+              <FormField
+                control={form.control}
+                name="enabled"
+                render={({ field }) => (
+                  <Switch
+                    checked={field.value}
+                    onCheckedChange={field.onChange}
+                    aria-label="Toggle Spotify"
+                  />
+                )}
+              />
             }
           />
-        </SettingsContainer>
+
+          <SettingsCardContent
+            className={twMerge(
+              'grid grid-flow-row grid-cols-2 grid-rows-2 gap-x-3 gap-y-4 px-4 py-2',
+              !authEnabled && 'hidden',
+            )}
+          >
+            <BaseProviderSettings />
+            <ProviderRedirectUrlInput
+              id="spotify-redirectUrl"
+              value={`${generateAppServiceUrl(
+                project!.subdomain,
+                project!.region,
+                'auth',
+              )}/signin/provider/spotify/callback`}
+              className="col-span-2"
+            />
+          </SettingsCardContent>
+
+          <SettingsCardFooter>
+            <SettingsDocsLink
+              href="https://docs.nhost.io/products/auth/providers/sign-in-spotify"
+              title="how to sign in users with Spotify"
+            />
+
+            <ButtonWithLoading
+              type="submit"
+              disabled={!formState.isDirty}
+              loading={formState.isSubmitting}
+              className="w-full sm:w-auto"
+            >
+              Save
+            </ButtonWithLoading>
+          </SettingsCardFooter>
+        </SettingsCard>
       </Form>
     </FormProvider>
   );

--- a/dashboard/src/features/orgs/projects/authentication/settings/components/StravaProviderSettings/StravaProviderSettings.tsx
+++ b/dashboard/src/features/orgs/projects/authentication/settings/components/StravaProviderSettings/StravaProviderSettings.tsx
@@ -106,7 +106,7 @@ export default function StravaProviderSettings() {
             !authEnabled && 'hidden',
           )}
         >
-          <BaseProviderSettings providerName="strava" />
+          <BaseProviderSettings />
           <Input
             name="redirectUrl"
             id="strava-redirectUrl"

--- a/dashboard/src/features/orgs/projects/authentication/settings/components/TwitchProviderSettings/TwitchProviderSettings.tsx
+++ b/dashboard/src/features/orgs/projects/authentication/settings/components/TwitchProviderSettings/TwitchProviderSettings.tsx
@@ -1,21 +1,27 @@
 import { yupResolver } from '@hookform/resolvers/yup';
 import { useTheme } from '@mui/material';
-import { CopyIcon } from 'lucide-react';
 import { useEffect } from 'react';
 import { FormProvider, useForm } from 'react-hook-form';
 import { twMerge } from 'tailwind-merge';
 import { ApplyLocalSettingsDialog } from '@/components/common/ApplyLocalSettingsDialog';
 import { useDialog } from '@/components/common/DialogProvider';
 import { Form } from '@/components/form/Form';
-import { SettingsContainer } from '@/components/layout/SettingsContainer';
-import { IconButton } from '@/components/ui/v2/IconButton';
-import { Input } from '@/components/ui/v2/Input';
-import { InputAdornment } from '@/components/ui/v2/InputAdornment';
+import {
+  SettingsCard,
+  SettingsCardContent,
+  SettingsCardFooter,
+  SettingsCardHeader,
+  SettingsDocsLink,
+} from '@/components/layout/SettingsCard';
+import { ButtonWithLoading } from '@/components/ui/v3/button';
+import { FormField } from '@/components/ui/v3/form';
+import { Switch } from '@/components/ui/v3/switch';
 import type { BaseProviderSettingsFormValues } from '@/features/orgs/projects/authentication/settings/components/BaseProviderSettings';
 import {
   BaseProviderSettings,
   baseProviderValidationSchema,
 } from '@/features/orgs/projects/authentication/settings/components/BaseProviderSettings';
+import { ProviderRedirectUrlInput } from '@/features/orgs/projects/authentication/settings/components/ProviderRedirectUrlInput';
 import { useIsPlatform } from '@/features/orgs/projects/common/hooks/useIsPlatform';
 import { generateAppServiceUrl } from '@/features/orgs/projects/common/utils/generateAppServiceUrl';
 import { useLocalMimirClient } from '@/features/orgs/projects/hooks/useLocalMimirClient';
@@ -25,7 +31,6 @@ import {
   useGetSignInMethodsQuery,
   useUpdateConfigMutation,
 } from '@/generated/graphql';
-import { copy } from '@/utils/copy';
 
 export default function TwitchProviderSettings() {
   const theme = useTheme();
@@ -121,67 +126,64 @@ export default function TwitchProviderSettings() {
   return (
     <FormProvider {...form}>
       <Form onSubmit={handleSubmit}>
-        <SettingsContainer
-          title="Twitch"
-          description="Allow users to sign in with Twitch."
-          slotProps={{
-            submitButton: {
-              disabled: !formState.isDirty,
-              loading: formState.isSubmitting,
-            },
-          }}
-          docsLink="https://docs.nhost.io/products/auth/providers/sign-in-twitch"
-          docsTitle="how to sign in users with Twitch"
-          icon={
-            theme.palette.mode === 'dark'
-              ? '/assets/brands/light/twitch.svg'
-              : '/assets/brands/twitch.svg'
-          }
-          switchId="enabled"
-          showSwitch
-          className={twMerge(
-            'grid-flow-rows grid grid-cols-2 grid-rows-2 gap-x-3 gap-y-4 px-4 py-2',
-            !authEnabled && 'hidden',
-          )}
-        >
-          <BaseProviderSettings providerName="twitch" />
-          <Input
-            name="redirectUrl"
-            id="twitch-redirectUrl"
-            className="col-span-2"
-            fullWidth
-            hideEmptyHelperText
-            label="Redirect URL"
-            defaultValue={`${generateAppServiceUrl(
-              project!.subdomain,
-              project!.region,
-              'auth',
-            )}/signin/provider/twitch/callback`}
-            disabled
-            endAdornment={
-              <InputAdornment position="end" className="absolute right-2">
-                <IconButton
-                  sx={{ minWidth: 0, padding: 0 }}
-                  color="secondary"
-                  variant="borderless"
-                  onClick={(e) => {
-                    e.stopPropagation();
-                    copy(
-                      `${generateAppServiceUrl(
-                        project!.subdomain,
-                        project!.region,
-                        'auth',
-                      )}/signin/provider/twitch/callback`,
-                      'Redirect URL',
-                    );
-                  }}
-                >
-                  <CopyIcon className="h-4 w-4" />
-                </IconButton>
-              </InputAdornment>
+        <SettingsCard>
+          <SettingsCardHeader
+            title="Twitch"
+            description="Allow users to sign in with Twitch."
+            icon={
+              theme.palette.mode === 'dark'
+                ? '/assets/brands/light/twitch.svg'
+                : '/assets/brands/twitch.svg'
+            }
+            control={
+              <FormField
+                control={form.control}
+                name="enabled"
+                render={({ field }) => (
+                  <Switch
+                    checked={field.value}
+                    onCheckedChange={field.onChange}
+                    aria-label="Toggle Twitch"
+                  />
+                )}
+              />
             }
           />
-        </SettingsContainer>
+
+          <SettingsCardContent
+            className={twMerge(
+              'grid grid-flow-row grid-cols-2 grid-rows-2 gap-x-3 gap-y-4 px-4 py-2',
+              !authEnabled && 'hidden',
+            )}
+          >
+            <BaseProviderSettings />
+            <ProviderRedirectUrlInput
+              id="twitch-redirectUrl"
+              value={`${generateAppServiceUrl(
+                project!.subdomain,
+                project!.region,
+                'auth',
+              )}/signin/provider/twitch/callback`}
+              className="col-span-2"
+            />
+          </SettingsCardContent>
+
+          <SettingsCardFooter>
+            <SettingsDocsLink
+              href="https://docs.nhost.io/products/auth/providers/sign-in-twitch"
+              title="how to sign in users with Twitch"
+            />
+
+            <ButtonWithLoading
+              type="submit"
+              disabled={!formState.isDirty}
+              loading={formState.isSubmitting}
+              className="w-full sm:w-auto"
+            >
+              Save
+            </ButtonWithLoading>
+          </SettingsCardFooter>
+        </SettingsCard>
       </Form>
     </FormProvider>
   );

--- a/dashboard/src/features/orgs/projects/authentication/settings/components/TwitterProviderSettings/TwitterProviderSettings.tsx
+++ b/dashboard/src/features/orgs/projects/authentication/settings/components/TwitterProviderSettings/TwitterProviderSettings.tsx
@@ -1,7 +1,6 @@
 /** biome-ignore-all lint/suspicious/noThenProperty: yup thing */
 
 import { yupResolver } from '@hookform/resolvers/yup';
-import { CopyIcon } from 'lucide-react';
 import { useEffect } from 'react';
 import { FormProvider, useForm } from 'react-hook-form';
 import { twMerge } from 'tailwind-merge';
@@ -9,10 +8,17 @@ import * as Yup from 'yup';
 import { ApplyLocalSettingsDialog } from '@/components/common/ApplyLocalSettingsDialog';
 import { useDialog } from '@/components/common/DialogProvider';
 import { Form } from '@/components/form/Form';
-import { SettingsContainer } from '@/components/layout/SettingsContainer';
-import { IconButton } from '@/components/ui/v2/IconButton';
-import { Input } from '@/components/ui/v2/Input';
-import { InputAdornment } from '@/components/ui/v2/InputAdornment';
+import { FormInput } from '@/components/form/FormInput';
+import {
+  SettingsCard,
+  SettingsCardContent,
+  SettingsCardFooter,
+  SettingsCardHeader,
+} from '@/components/layout/SettingsCard';
+import { ButtonWithLoading } from '@/components/ui/v3/button';
+import { FormField } from '@/components/ui/v3/form';
+import { Switch } from '@/components/ui/v3/switch';
+import { ProviderRedirectUrlInput } from '@/features/orgs/projects/authentication/settings/components/ProviderRedirectUrlInput';
 import { useIsPlatform } from '@/features/orgs/projects/common/hooks/useIsPlatform';
 import { generateAppServiceUrl } from '@/features/orgs/projects/common/utils/generateAppServiceUrl';
 import { useLocalMimirClient } from '@/features/orgs/projects/hooks/useLocalMimirClient';
@@ -22,7 +28,6 @@ import {
   useGetSignInMethodsQuery,
   useUpdateConfigMutation,
 } from '@/generated/graphql';
-import { copy } from '@/utils/copy';
 
 const validationSchema = Yup.object({
   consumerSecret: Yup.string()
@@ -84,7 +89,7 @@ export default function TwitterProviderSettings() {
     throw error;
   }
 
-  const { register, formState, watch } = form;
+  const { formState, watch } = form;
   const authEnabled = watch('enabled');
 
   async function handleSubmit(formValues: TwitterProviderFormValues) {
@@ -131,85 +136,68 @@ export default function TwitterProviderSettings() {
   return (
     <FormProvider {...form}>
       <Form onSubmit={handleSubmit}>
-        <SettingsContainer
-          title="Twitter"
-          description="Allow users to sign in with Twitter."
-          slotProps={{
-            submitButton: {
-              disabled: !formState.isDirty,
-              loading: formState.isSubmitting,
-            },
-          }}
-          docsTitle="how to sign in users with Twitter"
-          icon="/assets/brands/twitter.svg"
-          switchId="enabled"
-          showSwitch
-          className={twMerge(
-            'grid-flow-rows grid grid-cols-2 grid-rows-2 gap-x-3 gap-y-4 px-4 py-2',
-            !authEnabled && 'hidden',
-          )}
-        >
-          <Input
-            {...register(`consumerKey`)}
-            name="consumerKey"
-            id="consumerKey"
-            label="Twitter Consumer Key"
-            placeholder="Twitter Consumer Key"
-            className="col-span-1"
-            fullWidth
-            hideEmptyHelperText
-            error={!!formState.errors?.consumerKey}
-            helperText={formState.errors?.consumerKey?.message}
-          />
-          <Input
-            {...register('consumerSecret')}
-            name="consumerSecret"
-            id="consumerSecret"
-            label="Twitter Consumer Secret"
-            placeholder="Twitter Consumer Secret"
-            className="col-span-1"
-            fullWidth
-            hideEmptyHelperText
-            error={!!formState.errors?.consumerSecret}
-            helperText={formState.errors?.consumerSecret?.message}
-          />
-          <Input
-            name="redirectUrl"
-            id="twitter-redirectUrl"
-            defaultValue={`${generateAppServiceUrl(
-              project!.subdomain,
-              project!.region,
-              'auth',
-            )}/signin/provider/twitter/callback`}
-            className="col-span-2"
-            fullWidth
-            hideEmptyHelperText
-            label="Redirect URL"
-            disabled
-            endAdornment={
-              <InputAdornment position="end" className="absolute right-2">
-                <IconButton
-                  sx={{ minWidth: 0, padding: 0 }}
-                  color="secondary"
-                  variant="borderless"
-                  onClick={(e) => {
-                    e.stopPropagation();
-                    copy(
-                      `${generateAppServiceUrl(
-                        project!.subdomain,
-                        project!.region,
-                        'auth',
-                      )}/signin/provider/twitter/callback`,
-                      'Redirect URL',
-                    );
-                  }}
-                >
-                  <CopyIcon className="h-4 w-4" />
-                </IconButton>
-              </InputAdornment>
+        <SettingsCard>
+          <SettingsCardHeader
+            title="Twitter"
+            description="Allow users to sign in with Twitter."
+            icon="/assets/brands/twitter.svg"
+            control={
+              <FormField
+                control={form.control}
+                name="enabled"
+                render={({ field }) => (
+                  <Switch
+                    checked={field.value}
+                    onCheckedChange={field.onChange}
+                    aria-label="Toggle Twitter"
+                  />
+                )}
+              />
             }
           />
-        </SettingsContainer>
+
+          <SettingsCardContent
+            className={twMerge(
+              'grid grid-flow-row grid-cols-2 grid-rows-2 gap-x-3 gap-y-4 px-4 py-2',
+              !authEnabled && 'hidden',
+            )}
+          >
+            <FormInput
+              control={form.control}
+              name="consumerKey"
+              label="Twitter Consumer Key"
+              placeholder="Twitter Consumer Key"
+              containerClassName="col-span-1"
+            />
+            <FormInput
+              control={form.control}
+              name="consumerSecret"
+              label="Twitter Consumer Secret"
+              placeholder="Twitter Consumer Secret"
+              containerClassName="col-span-1"
+            />
+            <ProviderRedirectUrlInput
+              id="twitter-redirectUrl"
+              value={`${generateAppServiceUrl(
+                project!.subdomain,
+                project!.region,
+                'auth',
+              )}/signin/provider/twitter/callback`}
+              className="col-span-2"
+            />
+          </SettingsCardContent>
+
+          <SettingsCardFooter>
+            <ButtonWithLoading
+              type="submit"
+              disabled={!formState.isDirty}
+              loading={formState.isSubmitting}
+              className="w-full sm:w-auto"
+            >
+              Save
+            </ButtonWithLoading>
+          </SettingsCardFooter>
+        </SettingsCard>
       </Form>
     </FormProvider>
   );

--- a/dashboard/src/features/orgs/projects/authentication/settings/components/WebAuthnSettings/WebAuthnSettings.tsx
+++ b/dashboard/src/features/orgs/projects/authentication/settings/components/WebAuthnSettings/WebAuthnSettings.tsx
@@ -5,7 +5,15 @@ import * as Yup from 'yup';
 import { ApplyLocalSettingsDialog } from '@/components/common/ApplyLocalSettingsDialog';
 import { useDialog } from '@/components/common/DialogProvider';
 import { Form } from '@/components/form/Form';
-import { SettingsContainer } from '@/components/layout/SettingsContainer';
+import {
+  SettingsCard,
+  SettingsCardFooter,
+  SettingsCardHeader,
+  SettingsDocsLink,
+} from '@/components/layout/SettingsCard';
+import { ButtonWithLoading } from '@/components/ui/v3/button';
+import { FormField } from '@/components/ui/v3/form';
+import { Switch } from '@/components/ui/v3/switch';
 import { useIsPlatform } from '@/features/orgs/projects/common/hooks/useIsPlatform';
 import { useLocalMimirClient } from '@/features/orgs/projects/hooks/useLocalMimirClient';
 import { useProject } from '@/features/orgs/projects/hooks/useProject';
@@ -105,21 +113,41 @@ export default function WebAuthnSettings() {
   return (
     <FormProvider {...form}>
       <Form onSubmit={handleWebAuthnSettingsUpdate}>
-        <SettingsContainer
-          title="Security Keys"
-          description="Allow users to sign in with security keys using WebAuthn."
-          slotProps={{
-            submitButton: {
-              disabled: !formState.isDirty,
-              loading: formState.isSubmitting,
-            },
-          }}
-          docsLink="https://docs.nhost.io/products/auth/webauthn"
-          docsTitle="how to sign in users with security keys"
-          switchId="enabled"
-          showSwitch
-          className="hidden"
-        />
+        <SettingsCard>
+          <SettingsCardHeader
+            title="Security Keys"
+            description="Allow users to sign in with security keys using WebAuthn."
+            control={
+              <FormField
+                control={form.control}
+                name="enabled"
+                render={({ field }) => (
+                  <Switch
+                    checked={field.value}
+                    onCheckedChange={field.onChange}
+                    aria-label="Toggle Security Keys"
+                  />
+                )}
+              />
+            }
+          />
+
+          <SettingsCardFooter>
+            <SettingsDocsLink
+              href="https://docs.nhost.io/products/auth/webauthn"
+              title="how to sign in users with security keys"
+            />
+
+            <ButtonWithLoading
+              type="submit"
+              disabled={!formState.isDirty}
+              loading={formState.isSubmitting}
+              className="w-full sm:w-auto"
+            >
+              Save
+            </ButtonWithLoading>
+          </SettingsCardFooter>
+        </SettingsCard>
       </Form>
     </FormProvider>
   );

--- a/dashboard/src/features/orgs/projects/authentication/settings/components/WindowsLiveProviderSettings/WindowsLiveProviderSettings.tsx
+++ b/dashboard/src/features/orgs/projects/authentication/settings/components/WindowsLiveProviderSettings/WindowsLiveProviderSettings.tsx
@@ -1,20 +1,25 @@
 import { yupResolver } from '@hookform/resolvers/yup';
-import { CopyIcon } from 'lucide-react';
 import { useEffect } from 'react';
 import { FormProvider, useForm } from 'react-hook-form';
 import { twMerge } from 'tailwind-merge';
 import { ApplyLocalSettingsDialog } from '@/components/common/ApplyLocalSettingsDialog';
 import { useDialog } from '@/components/common/DialogProvider';
 import { Form } from '@/components/form/Form';
-import { SettingsContainer } from '@/components/layout/SettingsContainer';
-import { IconButton } from '@/components/ui/v2/IconButton';
-import { Input } from '@/components/ui/v2/Input';
-import { InputAdornment } from '@/components/ui/v2/InputAdornment';
+import {
+  SettingsCard,
+  SettingsCardContent,
+  SettingsCardFooter,
+  SettingsCardHeader,
+} from '@/components/layout/SettingsCard';
+import { ButtonWithLoading } from '@/components/ui/v3/button';
+import { FormField } from '@/components/ui/v3/form';
+import { Switch } from '@/components/ui/v3/switch';
 import type { BaseProviderSettingsFormValues } from '@/features/orgs/projects/authentication/settings/components/BaseProviderSettings';
 import {
   BaseProviderSettings,
   baseProviderValidationSchema,
 } from '@/features/orgs/projects/authentication/settings/components/BaseProviderSettings';
+import { ProviderRedirectUrlInput } from '@/features/orgs/projects/authentication/settings/components/ProviderRedirectUrlInput';
 import { useIsPlatform } from '@/features/orgs/projects/common/hooks/useIsPlatform';
 import { generateAppServiceUrl } from '@/features/orgs/projects/common/utils/generateAppServiceUrl';
 import { useLocalMimirClient } from '@/features/orgs/projects/hooks/useLocalMimirClient';
@@ -24,7 +29,6 @@ import {
   useGetSignInMethodsQuery,
   useUpdateConfigMutation,
 } from '@/generated/graphql';
-import { copy } from '@/utils/copy';
 
 export default function WindowsLiveProviderSettings() {
   const { project } = useProject();
@@ -118,62 +122,55 @@ export default function WindowsLiveProviderSettings() {
   return (
     <FormProvider {...form}>
       <Form onSubmit={handleSubmit}>
-        <SettingsContainer
-          title="Windows Live"
-          description="Allow users to sign in with Windows Live."
-          slotProps={{
-            submitButton: {
-              disabled: !formState.isDirty,
-              loading: formState.isSubmitting,
-            },
-          }}
-          docsTitle="how to sign in users with Windows Live"
-          icon="/assets/brands/windowslive.svg"
-          switchId="enabled"
-          showSwitch
-          className={twMerge(
-            'grid-flow-rows grid grid-cols-2 grid-rows-2 gap-x-3 gap-y-4 px-4 py-2',
-            !authEnabled && 'hidden',
-          )}
-        >
-          <BaseProviderSettings providerName="windowslive" />
-          <Input
-            name="redirectUrl"
-            id="windowslive-redirectUrl"
-            className="col-span-2"
-            fullWidth
-            hideEmptyHelperText
-            label="Redirect URL"
-            defaultValue={`${generateAppServiceUrl(
-              project!.subdomain,
-              project!.region,
-              'auth',
-            )}/signin/provider/windowslive/callback`}
-            disabled
-            endAdornment={
-              <InputAdornment position="end" className="absolute right-2">
-                <IconButton
-                  sx={{ minWidth: 0, padding: 0 }}
-                  color="secondary"
-                  variant="borderless"
-                  onClick={(e) => {
-                    e.stopPropagation();
-                    copy(
-                      `${generateAppServiceUrl(
-                        project!.subdomain,
-                        project!.region,
-                        'auth',
-                      )}/signin/provider/windowslive/callback`,
-                      'Redirect URL',
-                    );
-                  }}
-                >
-                  <CopyIcon className="h-4 w-4" />
-                </IconButton>
-              </InputAdornment>
+        <SettingsCard>
+          <SettingsCardHeader
+            title="Windows Live"
+            description="Allow users to sign in with Windows Live."
+            icon="/assets/brands/windowslive.svg"
+            control={
+              <FormField
+                control={form.control}
+                name="enabled"
+                render={({ field }) => (
+                  <Switch
+                    checked={field.value}
+                    onCheckedChange={field.onChange}
+                    aria-label="Toggle Windows Live"
+                  />
+                )}
+              />
             }
           />
-        </SettingsContainer>
+
+          <SettingsCardContent
+            className={twMerge(
+              'grid grid-flow-row grid-cols-2 grid-rows-2 gap-x-3 gap-y-4 px-4 py-2',
+              !authEnabled && 'hidden',
+            )}
+          >
+            <BaseProviderSettings />
+            <ProviderRedirectUrlInput
+              id="windowslive-redirectUrl"
+              value={`${generateAppServiceUrl(
+                project!.subdomain,
+                project!.region,
+                'auth',
+              )}/signin/provider/windowslive/callback`}
+              className="col-span-2"
+            />
+          </SettingsCardContent>
+
+          <SettingsCardFooter>
+            <ButtonWithLoading
+              type="submit"
+              disabled={!formState.isDirty}
+              loading={formState.isSubmitting}
+              className="w-full sm:w-auto"
+            >
+              Save
+            </ButtonWithLoading>
+          </SettingsCardFooter>
+        </SettingsCard>
       </Form>
     </FormProvider>
   );

--- a/dashboard/src/features/orgs/projects/authentication/settings/components/WorkOsProviderSettings/WorkOsProviderSettings.tsx
+++ b/dashboard/src/features/orgs/projects/authentication/settings/components/WorkOsProviderSettings/WorkOsProviderSettings.tsx
@@ -1,7 +1,6 @@
 /** biome-ignore-all lint/suspicious/noThenProperty: yup thing */
 
 import { yupResolver } from '@hookform/resolvers/yup';
-import { CopyIcon } from 'lucide-react';
 import { useEffect } from 'react';
 import { FormProvider, useForm } from 'react-hook-form';
 import { twMerge } from 'tailwind-merge';
@@ -9,11 +8,19 @@ import * as Yup from 'yup';
 import { ApplyLocalSettingsDialog } from '@/components/common/ApplyLocalSettingsDialog';
 import { useDialog } from '@/components/common/DialogProvider';
 import { Form } from '@/components/form/Form';
-import { SettingsContainer } from '@/components/layout/SettingsContainer';
-import { IconButton } from '@/components/ui/v2/IconButton';
-import { Input } from '@/components/ui/v2/Input';
-import { InputAdornment } from '@/components/ui/v2/InputAdornment';
+import { FormInput } from '@/components/form/FormInput';
+import {
+  SettingsCard,
+  SettingsCardContent,
+  SettingsCardFooter,
+  SettingsCardHeader,
+  SettingsDocsLink,
+} from '@/components/layout/SettingsCard';
+import { ButtonWithLoading } from '@/components/ui/v3/button';
+import { FormField } from '@/components/ui/v3/form';
+import { Switch } from '@/components/ui/v3/switch';
 import { BaseProviderSettings } from '@/features/orgs/projects/authentication/settings/components/BaseProviderSettings';
+import { ProviderRedirectUrlInput } from '@/features/orgs/projects/authentication/settings/components/ProviderRedirectUrlInput';
 import { useIsPlatform } from '@/features/orgs/projects/common/hooks/useIsPlatform';
 import { generateAppServiceUrl } from '@/features/orgs/projects/common/utils/generateAppServiceUrl';
 import { useLocalMimirClient } from '@/features/orgs/projects/hooks/useLocalMimirClient';
@@ -23,7 +30,6 @@ import {
   useGetSignInMethodsQuery,
   useUpdateConfigMutation,
 } from '@/generated/graphql';
-import { copy } from '@/utils/copy';
 
 const validationSchema = Yup.object({
   clientId: Yup.string()
@@ -109,7 +115,7 @@ export default function WorkOsProviderSettings() {
     throw error;
   }
 
-  const { register, formState, watch } = form;
+  const { formState, watch } = form;
   const authEnabled = watch('enabled');
 
   async function handleSubmit(formValues: WorkOsProviderFormValues) {
@@ -157,87 +163,74 @@ export default function WorkOsProviderSettings() {
   return (
     <FormProvider {...form}>
       <Form onSubmit={handleSubmit}>
-        <SettingsContainer
-          title="WorkOS"
-          description="Allow users to sign in with WorkOS."
-          slotProps={{
-            submitButton: {
-              disabled: !formState.isDirty,
-              loading: formState.isSubmitting,
-            },
-          }}
-          docsLink="https://docs.nhost.io/products/auth/providers/sign-in-workos"
-          docsTitle="how to sign in users with WorkOS"
-          icon="/assets/brands/workos.svg"
-          switchId="enabled"
-          showSwitch
-          className={twMerge(
-            'grid grid-flow-row grid-cols-2 gap-x-3 gap-y-4 px-4 py-2',
-            !authEnabled && 'hidden',
-          )}
-        >
-          <BaseProviderSettings providerName="workos" />
-          <Input
-            {...register('organization')}
-            name="organization"
-            id="organization"
-            label="Default Organization ID (optional)"
-            placeholder="Default Organization ID"
-            className="col-span-1"
-            fullWidth
-            hideEmptyHelperText
-            error={!!formState.errors?.organization}
-            helperText={formState.errors?.organization?.message}
-          />
-          <Input
-            {...register('connection')}
-            name="connection"
-            id="connection"
-            label="Default Connection (optional)"
-            placeholder="Default Connection"
-            className="col-span-1"
-            fullWidth
-            hideEmptyHelperText
-            error={!!formState.errors?.connection}
-            helperText={formState.errors?.connection?.message}
-          />
-          <Input
-            name="redirectUrl"
-            id="workos-redirectUrl"
-            defaultValue={`${generateAppServiceUrl(
-              project!.subdomain,
-              project!.region,
-              'auth',
-            )}/signin/provider/workos/callback`}
-            className="col-span-2"
-            fullWidth
-            hideEmptyHelperText
-            label="Redirect URL"
-            disabled
-            endAdornment={
-              <InputAdornment position="end" className="absolute right-2">
-                <IconButton
-                  sx={{ minWidth: 0, padding: 0 }}
-                  color="secondary"
-                  variant="borderless"
-                  onClick={(e) => {
-                    e.stopPropagation();
-                    copy(
-                      `${generateAppServiceUrl(
-                        project!.subdomain,
-                        project!.region,
-                        'auth',
-                      )}/signin/provider/workos/callback`,
-                      'Redirect URL',
-                    );
-                  }}
-                >
-                  <CopyIcon className="h-4 w-4" />
-                </IconButton>
-              </InputAdornment>
+        <SettingsCard>
+          <SettingsCardHeader
+            title="WorkOS"
+            description="Allow users to sign in with WorkOS."
+            icon="/assets/brands/workos.svg"
+            control={
+              <FormField
+                control={form.control}
+                name="enabled"
+                render={({ field }) => (
+                  <Switch
+                    checked={field.value}
+                    onCheckedChange={field.onChange}
+                    aria-label="Toggle WorkOS"
+                  />
+                )}
+              />
             }
           />
-        </SettingsContainer>
+
+          <SettingsCardContent
+            className={twMerge(
+              'grid grid-flow-row grid-cols-2 gap-x-3 gap-y-4 px-4 py-2',
+              !authEnabled && 'hidden',
+            )}
+          >
+            <BaseProviderSettings />
+            <FormInput
+              control={form.control}
+              name="organization"
+              label="Default Organization ID (optional)"
+              placeholder="Default Organization ID"
+              containerClassName="col-span-1"
+            />
+            <FormInput
+              control={form.control}
+              name="connection"
+              label="Default Connection (optional)"
+              placeholder="Default Connection"
+              containerClassName="col-span-1"
+            />
+            <ProviderRedirectUrlInput
+              id="workos-redirectUrl"
+              value={`${generateAppServiceUrl(
+                project!.subdomain,
+                project!.region,
+                'auth',
+              )}/signin/provider/workos/callback`}
+              className="col-span-2"
+            />
+          </SettingsCardContent>
+
+          <SettingsCardFooter>
+            <SettingsDocsLink
+              href="https://docs.nhost.io/products/auth/providers/sign-in-workos"
+              title="how to sign in users with WorkOS"
+            />
+
+            <ButtonWithLoading
+              type="submit"
+              disabled={!formState.isDirty}
+              loading={formState.isSubmitting}
+              className="w-full sm:w-auto"
+            >
+              Save
+            </ButtonWithLoading>
+          </SettingsCardFooter>
+        </SettingsCard>
       </Form>
     </FormProvider>
   );

--- a/dashboard/src/pages/orgs/[orgSlug]/projects/[appSubdomain]/settings/sign-in-methods.tsx
+++ b/dashboard/src/pages/orgs/[orgSlug]/projects/[appSubdomain]/settings/sign-in-methods.tsx
@@ -1,5 +1,4 @@
 import type { ReactElement } from 'react';
-import { Container } from '@/components/layout/Container';
 import { Spinner } from '@/components/ui/v3/spinner';
 import { OrgLayout } from '@/features/orgs/layout/OrgLayout';
 import { SettingsLayout } from '@/features/orgs/layout/SettingsLayout';
@@ -54,10 +53,7 @@ export default function SettingsSignInMethodsPage() {
   }
 
   return (
-    <Container
-      className="max-w-5xl space-y-8 bg-transparent"
-      rootClassName="bg-transparent"
-    >
+    <div className="space-y-8">
       <EmailAndPasswordSettings />
       <MagicLinkSettings />
       <WebAuthnSettings />
@@ -77,24 +73,15 @@ export default function SettingsSignInMethodsPage() {
       <TwitterProviderSettings />
       <WindowsLiveProviderSettings />
       <WorkOsProviderSettings />
-    </Container>
+    </div>
   );
 }
 
 SettingsSignInMethodsPage.getLayout = function getLayout(page: ReactElement) {
   return (
-    <OrgLayout
-      mainContainerProps={{
-        className: 'flex h-full overflow-auto',
-      }}
-    >
+    <OrgLayout>
       <SettingsLayout>
-        <Container
-          sx={{ backgroundColor: 'background.default' }}
-          className="max-w-5xl"
-        >
-          {page}
-        </Container>
+        <div className="mx-auto w-full max-w-5xl px-5 py-4">{page}</div>
       </SettingsLayout>
     </OrgLayout>
   );


### PR DESCRIPTION
<!-- pi-reviewer:start -->
### **What this change solves**
Migrates the entire sign-in methods settings page from the legacy v2 `SettingsContainer` pattern to the v3 card layout. Every sign-in method and OAuth provider section is rebuilt with `SettingsCard*`, `FormInput`/`FormTextarea`/`FormField`, v3 `Switch`, `SettingsDocsLink`, and `ButtonWithLoading`, and a new shared `ProviderRedirectUrlInput` replaces the ad-hoc read-only redirect-URL input + copy button.

___

### **Change Type**
Refactoring

___

### **Description**
- Adds a shared `ProviderRedirectUrlInput` component (v3 `InputGroup` with a read-only field and a copy button) and its barrel `index.ts`, replacing the per-provider inline v2 `Input` + `InputAdornment`/`IconButton` copy pattern.
- Migrates `BaseProviderSettings` off v2 `Input` to `FormInput` (client id/secret); the `providerName` prop is now unused (`_props`).
- Converts 13 OAuth provider components (Apple, Azure AD, Discord, EntraID, Facebook, GitHub, Google, LinkedIn, Spotify, Twitch, Twitter, Windows Live, WorkOS) to `SettingsCard` with the enable toggle in the header `control` slot and `ProviderRedirectUrlInput` in the content.
- Migrates the 6 non-OAuth methods (Email+Password, Magic Link, SMS, WebAuthn, Anonymous, OTP Email) to the same card pattern; Apple's private key moves to `FormTextarea`.
- Drops manual `error`/`helperText` wiring on inputs in favor of `FormInput`/`FormTextarea` built-in `FormMessage`.
- Simplifies the page body and `getLayout` from v2 `Container` to plain `div`s (drops `OrgLayout mainContainerProps`).

___

<details> <summary><h3> File Walkthrough</h3></summary>

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody>
<tr><td><strong>Shared primitives</strong></td><td><details><summary>4 files</summary><table>
<tr><td><strong>ProviderRedirectUrlInput.tsx</strong><dd><code>New read-only redirect-URL field with copy button (v3 InputGroup).</code></dd></td><td>+42/-0</td></tr>
<tr><td><strong>ProviderRedirectUrlInput/index.ts</strong><dd><code>Barrel export.</code></dd></td><td>+1/-0</td></tr>
<tr><td><strong>BaseProviderSettings.tsx</strong><dd><code>Client id/secret migrated to FormInput; providerName prop now unused.</code></dd></td><td>+13/-22</td></tr>
<tr><td><strong>sign-in-methods.tsx</strong><dd><code>Drops v2 Container wrappers for plain divs.</code></dd></td><td>+3/-12</td></tr>
</table></details></td></tr>
<tr><td><strong>OAuth providers</strong></td><td><details><summary>13 files</summary><table>
<tr><td><strong>AppleProviderSettings.tsx</strong><dd><code>Card layout + FormInputs + FormTextarea (private key) + ProviderRedirectUrlInput.</code></dd></td><td>+105/-127</td></tr>
<tr><td><strong>AzureADProviderSettings.tsx</strong><dd><code>Card layout + BaseProviderSettings + redirect URL.</code></dd></td><td>+66/-72</td></tr>
<tr><td><strong>DiscordProviderSettings.tsx</strong><dd><code>Card layout + BaseProviderSettings + redirect URL.</code></dd></td><td>+63/-61</td></tr>
<tr><td><strong>EntraIDProviderSettings.tsx</strong><dd><code>Card layout + BaseProviderSettings + redirect URL.</code></dd></td><td>+66/-72</td></tr>
<tr><td><strong>FacebookProviderSettings.tsx</strong><dd><code>Card layout + BaseProviderSettings + redirect URL.</code></dd></td><td>+63/-61</td></tr>
<tr><td><strong>GitHubProviderSettings.tsx</strong><dd><code>Card layout + BaseProviderSettings + redirect URL.</code></dd></td><td>+67/-65</td></tr>
<tr><td><strong>GoogleProviderSettings.tsx</strong><dd><code>Card layout + BaseProviderSettings + scopes + redirect URL.</code></dd></td><td>+85/-95</td></tr>
<tr><td><strong>LinkedInProviderSettings.tsx</strong><dd><code>Card layout + BaseProviderSettings + redirect URL.</code></dd></td><td>+63/-61</td></tr>
<tr><td><strong>SpotifyProviderSettings.tsx</strong><dd><code>Card layout + BaseProviderSettings + redirect URL.</code></dd></td><td>+63/-61</td></tr>
<tr><td><strong>TwitchProviderSettings.tsx</strong><dd><code>Card layout + BaseProviderSettings + redirect URL.</code></dd></td><td>+63/-61</td></tr>
<tr><td><strong>TwitterProviderSettings.tsx</strong><dd><code>Card layout + consumer key/secret + redirect URL.</code></dd></td><td>+63/-61</td></tr>
<tr><td><strong>WindowsLiveProviderSettings.tsx</strong><dd><code>Card layout + BaseProviderSettings + redirect URL.</code></dd></td><td>+63/-61</td></tr>
<tr><td><strong>WorkOsProviderSettings.tsx</strong><dd><code>Card layout + connection/organization + redirect URL.</code></dd></td><td>+85/-80</td></tr>
</table></details></td></tr>
<tr><td><strong>Other sign-in methods</strong></td><td><details><summary>6 files</summary><table>
<tr><td><strong>EmailAndPasswordSettings.tsx</strong><dd><code>Card layout + toggles.</code></dd></td><td>+62/-44</td></tr>
<tr><td><strong>MagicLinkSettings.tsx</strong><dd><code>Card layout + header toggle.</code></dd></td><td>+44/-16</td></tr>
<tr><td><strong>SMSSettings.tsx</strong><dd><code>Card layout + Twilio select + FormInputs.</code></dd></td><td>+98/-80</td></tr>
<tr><td><strong>WebAuthnSettings.tsx</strong><dd><code>Card layout + header toggle.</code></dd></td><td>+? </td></tr>
<tr><td><strong>AnonymousSignInSettings.tsx</strong><dd><code>Card layout + header toggle.</code></dd></td><td>+38/-14</td></tr>
<tr><td><strong>OTPEmailSettings.tsx</strong><dd><code>Card layout + header toggle.</code></dd></td><td>+38/-14</td></tr>
</table></details></td></tr>
</tbody></table>

</details>

___

<!-- pi-reviewer:end -->
