### PR TITLE
fix(dashboard): migrate smtp settings page

### DIFF
--- a/dashboard/src/features/orgs/projects/authentication/settings/components/DeleteSMTPSettings/DeleteSMTPSettings.tsx
+++ b/dashboard/src/features/orgs/projects/authentication/settings/components/DeleteSMTPSettings/DeleteSMTPSettings.tsx
@@ -1,10 +1,11 @@
 import { useState } from 'react';
-import { twMerge } from 'tailwind-merge';
 import { ApplyLocalSettingsDialog } from '@/components/common/ApplyLocalSettingsDialog';
 import { useDialog } from '@/components/common/DialogProvider';
-import { SettingsContainer } from '@/components/layout/SettingsContainer';
-import { Box } from '@/components/ui/v2/Box';
-import { Text } from '@/components/ui/v2/Text';
+import {
+  SettingsCard,
+  SettingsCardContent,
+  SettingsCardHeader,
+} from '@/components/layout/SettingsCard';
 import { Button, ButtonWithLoading } from '@/components/ui/v3/button';
 import { useIsPlatform } from '@/features/orgs/projects/common/hooks/useIsPlatform';
 import { useLocalMimirClient } from '@/features/orgs/projects/hooks/useLocalMimirClient';
@@ -28,13 +29,13 @@ function ConfirmDeleteSMTPSettingsModal({
   };
 
   return (
-    <Box className={twMerge('w-full rounded-lg p-6 text-left')}>
+    <div className="w-full rounded-lg p-6 text-left">
       <div className="grid grid-flow-row gap-4">
-        <Text variant="h3" component="h2">
-          Delete SMTP Settings?
-        </Text>
+        <h2 className="font-semibold text-lg">Delete SMTP Settings?</h2>
 
-        <Text>This will reset all your SMTP and Postmark settings.</Text>
+        <p className="text-muted-foreground">
+          This will reset all your SMTP and Postmark settings.
+        </p>
 
         <div className="grid grid-flow-row gap-2">
           <Button variant="destructive" onClick={onClickDelete}>
@@ -46,7 +47,7 @@ function ConfirmDeleteSMTPSettingsModal({
           </Button>
         </div>
       </div>
-    </Box>
+    </div>
   );
 }
 
@@ -127,26 +128,25 @@ export default function DeleteSMTPSettings() {
   };
 
   return (
-    <SettingsContainer
-      title="Delete SMTP Settings"
-      description="Delete SMTP settings and revert to default values"
-      className="px-0"
-      slotProps={{
-        submitButton: { className: 'hidden' },
-        footer: { className: 'hidden' },
-      }}
-    >
-      <Box className="grid grid-flow-row border-t-1">
-        <ButtonWithLoading
-          variant="destructive"
-          className="mx-4 mt-4 justify-self-end"
-          onClick={confirmDeleteSMTPSettings}
-          disabled={loading || !isSMTPConfigured}
-          loading={loading}
-        >
-          Delete
-        </ButtonWithLoading>
-      </Box>
-    </SettingsContainer>
+    <SettingsCard>
+      <SettingsCardHeader
+        title="Delete SMTP Settings"
+        description="Delete SMTP settings and revert to default values"
+      />
+
+      <SettingsCardContent className="px-0">
+        <div className="grid grid-flow-row border-t">
+          <ButtonWithLoading
+            variant="destructive"
+            className="mx-4 mt-4 justify-self-end"
+            onClick={confirmDeleteSMTPSettings}
+            disabled={loading || !isSMTPConfigured}
+            loading={loading}
+          >
+            Delete
+          </ButtonWithLoading>
+        </div>
+      </SettingsCardContent>
+    </SettingsCard>
   );
 }

--- a/dashboard/src/features/orgs/projects/authentication/settings/components/PostmarkSettings/PostmarkSettings.tsx
+++ b/dashboard/src/features/orgs/projects/authentication/settings/components/PostmarkSettings/PostmarkSettings.tsx
@@ -4,8 +4,14 @@ import * as yup from 'yup';
 import { ApplyLocalSettingsDialog } from '@/components/common/ApplyLocalSettingsDialog';
 import { useDialog } from '@/components/common/DialogProvider';
 import { Form } from '@/components/form/Form';
-import { SettingsContainer } from '@/components/layout/SettingsContainer';
-import { Input } from '@/components/ui/v2/Input';
+import { FormInput } from '@/components/form/FormInput';
+import {
+  SettingsCard,
+  SettingsCardContent,
+  SettingsCardFooter,
+  SettingsCardHeader,
+} from '@/components/layout/SettingsCard';
+import { ButtonWithLoading } from '@/components/ui/v3/button';
 import { useIsPlatform } from '@/features/orgs/projects/common/hooks/useIsPlatform';
 import { useLocalMimirClient } from '@/features/orgs/projects/hooks/useLocalMimirClient';
 import { useProject } from '@/features/orgs/projects/hooks/useProject';
@@ -58,8 +64,7 @@ export default function PostmarkSettings() {
   });
 
   const {
-    register,
-    formState: { errors, isDirty, isSubmitting },
+    formState: { isDirty, isSubmitting },
   } = form;
 
   const handleEditPostmarkSettings = async (values: PostmarkFormValues) => {
@@ -104,44 +109,42 @@ export default function PostmarkSettings() {
   return (
     <FormProvider {...form}>
       <Form onSubmit={handleEditPostmarkSettings}>
-        <SettingsContainer
-          title="Postmark Settings"
-          description="Configure postmark's native integration to send emails from your email domain."
-          submitButtonText="Save"
-          className="grid grid-cols-1 gap-4 lg:grid-cols-9"
-          slotProps={{
-            submitButton: {
-              disabled: !isDirty,
-              loading: isSubmitting,
-            },
-          }}
-        >
-          <Input
-            {...register('sender')}
-            id="sender"
-            name="sender"
-            label="From Email"
-            placeholder="noreply@nhost.app"
-            className="lg:col-span-4"
-            hideEmptyHelperText
-            fullWidth
-            error={Boolean(errors.sender)}
-            helperText={errors.sender?.message}
+        <SettingsCard>
+          <SettingsCardHeader
+            title="Postmark Settings"
+            description="Configure postmark's native integration to send emails from your email domain."
           />
 
-          <Input
-            {...register('password')}
-            id="password"
-            label="Password"
-            type="password"
-            placeholder="Enter password"
-            className="lg:col-span-5"
-            hideEmptyHelperText
-            fullWidth
-            error={Boolean(errors.password)}
-            helperText={errors.password?.message}
-          />
-        </SettingsContainer>
+          <SettingsCardContent className="grid-cols-1 lg:grid-cols-9">
+            <FormInput
+              control={form.control}
+              name="sender"
+              label="From Email"
+              placeholder="noreply@nhost.app"
+              containerClassName="lg:col-span-4"
+            />
+
+            <FormInput
+              control={form.control}
+              name="password"
+              type="password"
+              label="Password"
+              placeholder="Enter password"
+              containerClassName="lg:col-span-5"
+            />
+          </SettingsCardContent>
+
+          <SettingsCardFooter>
+            <ButtonWithLoading
+              type="submit"
+              disabled={!isDirty}
+              loading={isSubmitting}
+              className="w-full sm:w-auto"
+            >
+              Save
+            </ButtonWithLoading>
+          </SettingsCardFooter>
+        </SettingsCard>
       </Form>
     </FormProvider>
   );

--- a/dashboard/src/features/orgs/projects/authentication/settings/components/SMTPSettings/SMTPSettings.tsx
+++ b/dashboard/src/features/orgs/projects/authentication/settings/components/SMTPSettings/SMTPSettings.tsx
@@ -6,8 +6,14 @@ import { ApplyLocalSettingsDialog } from '@/components/common/ApplyLocalSettings
 import { useDialog } from '@/components/common/DialogProvider';
 import { Form } from '@/components/form/Form';
 import { FormCheckbox } from '@/components/form/FormCheckbox';
-import { SettingsContainer } from '@/components/layout/SettingsContainer';
-import { Input } from '@/components/ui/v2/Input';
+import { FormInput } from '@/components/form/FormInput';
+import {
+  SettingsCard,
+  SettingsCardContent,
+  SettingsCardFooter,
+  SettingsCardHeader,
+} from '@/components/layout/SettingsCard';
+import { ButtonWithLoading } from '@/components/ui/v3/button';
 import { useIsPlatform } from '@/features/orgs/projects/common/hooks/useIsPlatform';
 import { useLocalMimirClient } from '@/features/orgs/projects/hooks/useLocalMimirClient';
 import { useProject } from '@/features/orgs/projects/hooks/useProject';
@@ -75,8 +81,7 @@ export default function SMTPSettings() {
   });
 
   const {
-    register: registerSmtp,
-    formState: { errors, isDirty, isSubmitting },
+    formState: { isDirty, isSubmitting },
   } = form;
 
   const [updateConfig] = useUpdateConfigMutation({
@@ -127,103 +132,86 @@ export default function SMTPSettings() {
   return (
     <FormProvider {...form}>
       <Form onSubmit={handleEditSMTPSettings}>
-        <SettingsContainer
-          title="SMTP Settings"
-          description="Configure your SMTP settings to send emails from your email domain."
-          submitButtonText="Save"
-          className="grid grid-cols-1 gap-4 lg:grid-cols-9"
-          slotProps={{
-            submitButton: {
-              disabled: !isDirty,
-              loading: isSubmitting,
-            },
-          }}
-        >
-          <Input
-            {...registerSmtp('sender')}
-            id="sender"
-            name="sender"
-            label="From Email"
-            placeholder="noreply@nhost.app"
-            className="lg:col-span-4"
-            hideEmptyHelperText
-            fullWidth
-            error={Boolean(errors.sender)}
-            helperText={errors.sender?.message}
+        <SettingsCard>
+          <SettingsCardHeader
+            title="SMTP Settings"
+            description="Configure your SMTP settings to send emails from your email domain."
           />
 
-          <Input
-            {...registerSmtp('host')}
-            id="host"
-            name="host"
-            label="SMTP Host"
-            className="lg:col-span-4"
-            placeholder="e.g. smtp.sendgrid.net"
-            hideEmptyHelperText
-            fullWidth
-            error={Boolean(errors.host)}
-            helperText={errors.host?.message}
-          />
+          <SettingsCardContent className="grid-cols-1 lg:grid-cols-9">
+            <FormInput
+              control={form.control}
+              name="sender"
+              label="From Email"
+              placeholder="noreply@nhost.app"
+              containerClassName="lg:col-span-4"
+            />
 
-          <Input
-            {...registerSmtp('port')}
-            id="port"
-            name="port"
-            label="Port"
-            type="number"
-            placeholder="587"
-            className="lg:col-span-1"
-            hideEmptyHelperText
-            fullWidth
-            error={Boolean(errors.port)}
-            helperText={errors.port?.message}
-          />
+            <FormInput
+              control={form.control}
+              name="host"
+              label="SMTP Host"
+              placeholder="e.g. smtp.sendgrid.net"
+              containerClassName="lg:col-span-4"
+            />
 
-          <Input
-            {...registerSmtp('user')}
-            id="user"
-            label="SMTP Username"
-            placeholder="SMTP Username"
-            className="lg:col-span-4"
-            hideEmptyHelperText
-            fullWidth
-            error={Boolean(errors.user)}
-            helperText={errors.user?.message}
-          />
+            <FormInput
+              control={form.control}
+              name="port"
+              type="number"
+              label="Port"
+              placeholder="587"
+              containerClassName="lg:col-span-1"
+              transform={{
+                in: (value) => value ?? '',
+                out: (event) => event,
+              }}
+            />
 
-          <Input
-            {...registerSmtp('password')}
-            id="password"
-            label="SMTP Password"
-            type="password"
-            placeholder="Enter SMTP password"
-            className="lg:col-span-5"
-            hideEmptyHelperText
-            fullWidth
-            error={Boolean(errors.password)}
-            helperText={errors.password?.message}
-          />
+            <FormInput
+              control={form.control}
+              name="user"
+              label="SMTP Username"
+              placeholder="SMTP Username"
+              containerClassName="lg:col-span-4"
+            />
 
-          <Input
-            {...registerSmtp('method')}
-            id="method"
-            name="method"
-            label="SMTP Auth Method"
-            placeholder="LOGIN"
-            hideEmptyHelperText
-            className="lg:col-span-4"
-            fullWidth
-            error={Boolean(errors.method)}
-            helperText={errors.method?.message}
-          />
+            <FormInput
+              control={form.control}
+              name="password"
+              type="password"
+              label="SMTP Password"
+              placeholder="Enter SMTP password"
+              containerClassName="lg:col-span-5"
+            />
 
-          <FormCheckbox
-            control={form.control}
-            name="secure"
-            label="Use SSL"
-            containerClassName="lg:col-span-9"
-          />
-        </SettingsContainer>
+            <FormInput
+              control={form.control}
+              name="method"
+              label="SMTP Auth Method"
+              placeholder="LOGIN"
+              containerClassName="lg:col-span-4"
+            />
+
+            <FormCheckbox
+              control={form.control}
+              name="secure"
+              label="Use SSL"
+              containerClassName="lg:col-span-9"
+            />
+          </SettingsCardContent>
+
+          <SettingsCardFooter>
+            <ButtonWithLoading
+              type="submit"
+              disabled={!isDirty}
+              loading={isSubmitting}
+              className="w-full sm:w-auto"
+            >
+              Save
+            </ButtonWithLoading>
+          </SettingsCardFooter>
+        </SettingsCard>
       </Form>
     </FormProvider>
   );

--- a/dashboard/src/pages/orgs/[orgSlug]/projects/[appSubdomain]/settings/smtp.tsx
+++ b/dashboard/src/pages/orgs/[orgSlug]/projects/[appSubdomain]/settings/smtp.tsx
@@ -1,6 +1,5 @@
 import { type ReactElement, useEffect, useState } from 'react';
 import { UpgradeToProBanner } from '@/components/common/UpgradeToProBanner';
-import { Container } from '@/components/layout/Container';
 import {
   Select,
   SelectContent,
@@ -50,15 +49,12 @@ export default function SMTPSettingsPage() {
 
   if (isPlatform && org?.plan?.isFree) {
     return (
-      <Container
-        className="grid grid-flow-row gap-6 bg-transparent"
-        rootClassName="bg-transparent"
-      >
+      <div className="grid grid-flow-row gap-6">
         <UpgradeToProBanner
           title="To unlock custom SMTP, transfer this project to a Pro or Team organization."
           description=""
         />
-      </Container>
+      </div>
     );
   }
 
@@ -67,10 +63,7 @@ export default function SMTPSettingsPage() {
   }
 
   return (
-    <Container
-      className="grid max-w-5xl grid-flow-row gap-4 bg-transparent"
-      rootClassName="bg-transparent"
-    >
+    <div className="grid grid-flow-row gap-4">
       <Select value={mode} onValueChange={setMode}>
         <SelectTrigger aria-label="SMTP provider">
           <SelectValue />
@@ -83,24 +76,15 @@ export default function SMTPSettingsPage() {
 
       {mode === 'postmark' ? <PostmarkSettings /> : <SMTPSettings />}
       <DeleteSMTPSettings />
-    </Container>
+    </div>
   );
 }
 
 SMTPSettingsPage.getLayout = function getLayout(page: ReactElement) {
   return (
-    <OrgLayout
-      mainContainerProps={{
-        className: 'flex h-full overflow-auto',
-      }}
-    >
+    <OrgLayout>
       <SettingsLayout>
-        <Container
-          sx={{ backgroundColor: 'background.default' }}
-          className="max-w-5xl"
-        >
-          {page}
-        </Container>
+        <div className="mx-auto w-full max-w-5xl px-5 py-4">{page}</div>
       </SettingsLayout>
     </OrgLayout>
   );


### PR DESCRIPTION
<!-- pi-reviewer:start -->
### **What this change solves**
Migrates the SMTP settings page (SMTP, Postmark, and delete-SMTP sections plus the page shell) from the legacy v2 UI primitives (`SettingsContainer`, v2 `Input`, `Box`, `Text`, `Container`) to the v3 `SettingsCard` / `FormInput` / plain-element component system, keeping the same fields, validation, and save behavior.

___

### **Change Type**
Refactoring

___

### **Description**
- Replace `SettingsContainer` + register-based v2 `Input` with `SettingsCard`/`SettingsCardHeader`/`SettingsCardContent`/`SettingsCardFooter` and RHF-driven `FormInput` in `SMTPSettings` and `PostmarkSettings`, moving the Save action into a `SettingsCardFooter` `ButtonWithLoading`.
- Migrate `DeleteSMTPSettings` (and its confirm modal) off `Box`/`Text`/`SettingsContainer` to `SettingsCard` + plain `div`/`h2`/`p`, and normalize the `border-t-1` token to `border-t`.
- Simplify the `smtp.tsx` page shell: drop `Container`/`sx`-based layout in favor of plain `div` wrappers and a standard `OrgLayout`/`SettingsLayout` shell.
- Drop now-unused `register`/`errors` destructuring and the `twMerge`/v2 imports.

___

<details> <summary><h3> File Walkthrough</h3></summary>

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody>
<tr><td><strong>SMTP settings components</strong></td><td><details><summary>3 files</summary><table>
<tr>
  <td><strong>SMTPSettings.tsx</strong><dd><code>Migrate 6 SMTP fields + SSL checkbox to FormInput/SettingsCard; footer Save button</code></dd></td>
  <td>+83/-99</td>
</tr>
<tr>
  <td><strong>PostmarkSettings.tsx</strong><dd><code>Migrate sender/password fields to FormInput/SettingsCard; footer Save button</code></dd></td>
  <td>+43/-40</td>
</tr>
<tr>
  <td><strong>DeleteSMTPSettings.tsx</strong><dd><code>Migrate section + confirm modal off Box/Text/SettingsContainer to SettingsCard/div</code></dd></td>
  <td>+31/-31</td>
</tr>
</table></details></td></tr>
<tr><td><strong>Page shell</strong></td><td><details><summary>1 files</summary><table>
<tr>
  <td><strong>settings/smtp.tsx</strong><dd><code>Replace Container/sx layout with plain div wrappers and standard layout shell</code></dd></td>
  <td>+6/-22</td>
</tr>
</table></details></td></tr>
</tbody></table>

</details>

___

<!-- pi-reviewer:end -->
