### PR TITLE
fix(dashboard): migrate oauth2 provider settings page

### DIFF
--- a/dashboard/src/features/orgs/projects/authentication/settings/components/OAuth2ProviderSettings/OAuth2ProviderSettings.tsx
+++ b/dashboard/src/features/orgs/projects/authentication/settings/components/OAuth2ProviderSettings/OAuth2ProviderSettings.tsx
@@ -4,11 +4,26 @@ import { FormProvider, useForm } from 'react-hook-form';
 import * as Yup from 'yup';
 import { ApplyLocalSettingsDialog } from '@/components/common/ApplyLocalSettingsDialog';
 import { useDialog } from '@/components/common/DialogProvider';
-import { ControlledSwitch } from '@/components/form/ControlledSwitch';
 import { Form } from '@/components/form/Form';
-import { SettingsContainer } from '@/components/layout/SettingsContainer';
-import { Input } from '@/components/ui/v2/Input';
-import { Text } from '@/components/ui/v2/Text';
+import { FormInput } from '@/components/form/FormInput';
+import {
+  SettingsCard,
+  SettingsCardContent,
+  SettingsCardFooter,
+  SettingsCardHeader,
+  SettingsDocsLink,
+} from '@/components/layout/SettingsCard';
+import { ButtonWithLoading } from '@/components/ui/v3/button';
+import {
+  FormControl,
+  FormDescription,
+  FormField,
+  FormItem,
+  FormLabel,
+  FormMessage,
+} from '@/components/ui/v3/form';
+import { Input } from '@/components/ui/v3/input';
+import { Switch } from '@/components/ui/v3/switch';
 import { TextLink } from '@/components/ui/v3/text-link';
 import { useIsPlatform } from '@/features/orgs/projects/common/hooks/useIsPlatform';
 import { useLocalMimirClient } from '@/features/orgs/projects/hooks/useLocalMimirClient';
@@ -101,7 +116,7 @@ export default function OAuth2ProviderSettings() {
     throw error;
   }
 
-  const { register, formState, watch } = form;
+  const { formState, watch } = form;
   const oauth2Enabled = watch('enabled');
 
   const handleSubmit = async (values: OAuth2ProviderSettingsFormValues) => {
@@ -154,85 +169,118 @@ export default function OAuth2ProviderSettings() {
   return (
     <FormProvider {...form}>
       <Form onSubmit={handleSubmit}>
-        <SettingsContainer
-          title="OAuth2 Provider"
-          description={
-            <>
-              Enable the OAuth2 provider to allow third-party applications to
-              authenticate users via OAuth2.
-            </>
-          }
-          docsLink="https://docs.nhost.io/products/auth/oauth2-provider"
-          docsTitle="OAuth2 Providers"
-          slotProps={{
-            submitButton: {
-              disabled: !formState.isDirty,
-              loading: formState.isSubmitting,
-            },
-          }}
-          switchId="enabled"
-          showSwitch
-          className={cn('grid grid-cols-5 gap-y-6', !oauth2Enabled && 'hidden')}
-        >
-          <Input
-            {...register('loginURL')}
-            id="loginURL"
-            label="Login URL"
-            placeholder="https://example.com/oauth2/login"
-            helperText={
-              formState.errors.loginURL?.message || (
-                <>
-                  The authorization/consent page URL for the OAuth2 flow. Learn
-                  more about{' '}
-                  <TextLink
-                    href="https://docs.nhost.io/products/auth/oauth2-provider/authorization-flow/#what-you-build-the-consent-page"
-                    external
-                    className="font-medium"
-                  >
-                    building the consent page
-                  </TextLink>
-                </>
-              )
+        <SettingsCard>
+          <SettingsCardHeader
+            title="OAuth2 Provider"
+            description={
+              <>
+                Enable the OAuth2 provider to allow third-party applications to
+                authenticate users via OAuth2.
+              </>
             }
-            fullWidth
-            className="col-span-5"
-            error={Boolean(formState.errors.loginURL?.message)}
-            hideEmptyHelperText
+            control={
+              <FormField
+                control={form.control}
+                name="enabled"
+                render={({ field }) => (
+                  <Switch
+                    checked={field.value}
+                    onCheckedChange={field.onChange}
+                    aria-label="Toggle OAuth2 Provider"
+                  />
+                )}
+              />
+            }
           />
 
-          <Input
-            {...register('accessTokenExpiresIn')}
-            id="accessTokenExpiresIn"
-            type="number"
-            label="Access Token Expires In (Seconds)"
-            fullWidth
-            className="col-span-5 lg:col-span-2"
-            error={Boolean(formState.errors.accessTokenExpiresIn?.message)}
-            helperText={formState.errors.accessTokenExpiresIn?.message}
-          />
+          <SettingsCardContent
+            className={cn(
+              'grid grid-cols-5 gap-y-6',
+              !oauth2Enabled && 'hidden',
+            )}
+          >
+            <FormField
+              control={form.control}
+              name="loginURL"
+              render={({ field }) => (
+                <FormItem className="col-span-5">
+                  <FormLabel>Login URL</FormLabel>
+                  <FormControl>
+                    <Input
+                      placeholder="https://example.com/oauth2/login"
+                      {...field}
+                    />
+                  </FormControl>
+                  <FormDescription>
+                    The authorization/consent page URL for the OAuth2 flow.
+                    Learn more about{' '}
+                    <TextLink
+                      href="https://docs.nhost.io/products/auth/oauth2-provider/authorization-flow/#what-you-build-the-consent-page"
+                      external
+                      className="font-medium"
+                    >
+                      building the consent page
+                    </TextLink>
+                  </FormDescription>
+                  <FormMessage />
+                </FormItem>
+              )}
+            />
 
-          <Input
-            {...register('refreshTokenExpiresIn')}
-            id="refreshTokenExpiresIn"
-            type="number"
-            label="Refresh Token Expires In (Seconds)"
-            fullWidth
-            className="col-span-5 lg:col-span-2"
-            error={Boolean(formState.errors.refreshTokenExpiresIn?.message)}
-            helperText={formState.errors.refreshTokenExpiresIn?.message}
-          />
+            <FormInput
+              control={form.control}
+              name="accessTokenExpiresIn"
+              type="number"
+              label="Access Token Expires In (Seconds)"
+              containerClassName="col-span-5 lg:col-span-2"
+            />
 
-          <div className="col-span-5 flex items-center justify-between">
-            <div>
-              <Text className="font-medium">Client ID Metadata Document</Text>
-              <Text className="text-muted-foreground text-sm">
-                Enable the client ID metadata document endpoint for client
-                discovery.
-              </Text>
+            <FormInput
+              control={form.control}
+              name="refreshTokenExpiresIn"
+              type="number"
+              label="Refresh Token Expires In (Seconds)"
+              containerClassName="col-span-5 lg:col-span-2"
+            />
+
+            <div className="col-span-5 flex items-center justify-between">
+              <div>
+                <p className="font-medium">Client ID Metadata Document</p>
+                <p className="text-muted-foreground text-sm">
+                  Enable the client ID metadata document endpoint for client
+                  discovery.
+                </p>
+              </div>
+              <FormField
+                control={form.control}
+                name="clientIdMetadataDocumentEnabled"
+                render={({ field }) => (
+                  <Switch
+                    checked={field.value}
+                    onCheckedChange={field.onChange}
+                    aria-label="Toggle Client ID Metadata Document"
+                  />
+                )}
+              />
             </div>
-            <ControlledSwitch name="clientIdMetadataDocumentEnabled" />
-          </div>
-        </SettingsContainer>
+          </SettingsCardContent>
+
+          <SettingsCardFooter>
+            <SettingsDocsLink
+              href="https://docs.nhost.io/products/auth/oauth2-provider"
+              title="OAuth2 Providers"
+            />
+
+            <ButtonWithLoading
+              type="submit"
+              disabled={!formState.isDirty}
+              loading={formState.isSubmitting}
+              className="w-full sm:w-auto"
+            >
+              Save
+            </ButtonWithLoading>
+          </SettingsCardFooter>
+        </SettingsCard>
       </Form>
     </FormProvider>
   );

--- a/dashboard/src/pages/orgs/[orgSlug]/projects/[appSubdomain]/settings/oauth2-provider.tsx
+++ b/dashboard/src/pages/orgs/[orgSlug]/projects/[appSubdomain]/settings/oauth2-provider.tsx
@@ -1,8 +1,10 @@
 import { useRouter } from 'next/router';
 import type { ReactElement } from 'react';
-import { Container } from '@/components/layout/Container';
-import { Box } from '@/components/ui/v2/Box';
-import { Text } from '@/components/ui/v2/Text';
+import {
+  SettingsCard,
+  SettingsCardContent,
+  SettingsCardHeader,
+} from '@/components/layout/SettingsCard';
 import { Button } from '@/components/ui/v3/button';
 import { Spinner } from '@/components/ui/v3/spinner';
 import { OrgLayout } from '@/features/orgs/layout/OrgLayout';
@@ -50,19 +52,14 @@ export default function SettingsOAuth2ProviderPage() {
     !isVersionGte(auth.configuredVersion, MIN_AUTH_VERSION_OAUTH2)
   ) {
     return (
-      <Container className="mx-auto max-w-5xl space-y-5">
-        <Box className="flex flex-col items-center justify-center space-y-5 rounded-lg border px-48 py-12 shadow-sm">
-          <div className="flex flex-col space-y-1">
-            <Text className="text-center font-medium" variant="h3">
-              Auth Version Too Old
-            </Text>
-            <Text variant="subtitle1" className="text-center">
-              OAuth2 Provider settings require Auth version{' '}
-              {MIN_AUTH_VERSION_OAUTH2} or later. Please upgrade your Auth
-              service in the Settings page.
-            </Text>
-          </div>
+      <SettingsCard>
+        <SettingsCardHeader
+          title="Auth Version Too Old"
+          description={`OAuth2 Provider settings require Auth version ${MIN_AUTH_VERSION_OAUTH2} or later. Please upgrade your Auth service in the Settings page.`}
+        />
+        <SettingsCardContent>
           <Button
+            className="justify-self-start"
             onClick={() =>
               router.push(
                 `/orgs/${router.query.orgSlug}/projects/${router.query.appSubdomain}/settings/authentication`,
@@ -71,18 +68,15 @@ export default function SettingsOAuth2ProviderPage() {
           >
             Go to Auth Settings
           </Button>
-        </Box>
-      </Container>
+        </SettingsCardContent>
+      </SettingsCard>
     );
   }
 
   return (
-    <Container
-      className="grid max-w-5xl grid-flow-row gap-y-6 bg-transparent"
-      rootClassName="bg-transparent"
-    >
+    <div className="grid grid-flow-row gap-y-6">
       <OAuth2ProviderSettings />
-    </Container>
+    </div>
   );
 }
 
@@ -90,12 +84,7 @@ SettingsOAuth2ProviderPage.getLayout = function getLayout(page: ReactElement) {
   return (
     <OrgLayout>
       <SettingsLayout>
-        <Container
-          sx={{ backgroundColor: 'background.default' }}
-          className="max-w-5xl"
-        >
-          {page}
-        </Container>
+        <div className="mx-auto w-full max-w-5xl px-5 py-4">{page}</div>
       </SettingsLayout>
     </OrgLayout>
   );


### PR DESCRIPTION
<!-- pi-reviewer:start -->
### **What this change solves**
Migrates the OAuth2 provider settings page and its page shell from the legacy v2 UI primitives (`SettingsContainer`, v2 `Input`, `Box`, `Text`, `Container`, `ControlledSwitch`) to the v3 `SettingsCard` / `FormInput` / `Switch` system, preserving fields, the enable toggle, validation, and save behavior.

___

### **Change Type**
Refactoring

___

### **Description**
- Replace `SettingsContainer` with `SettingsCard`/`SettingsCardHeader`/`SettingsCardContent`/`SettingsCardFooter`; move the "enabled" toggle into the header `control` slot as an inline `FormField` + v3 `Switch`, and the Save action + docs link into the footer.
- Migrate the `loginURL` field from a v2 `Input` (whose `helperText` toggled between error and a rich consent-page description) to a `FormField` with a persistent `FormDescription` plus a separate `FormMessage` for errors.
- Migrate the two numeric fields (`accessTokenExpiresIn`, `refreshTokenExpiresIn`) to `FormInput`, and replace `ControlledSwitch` for `clientIdMetadataDocumentEnabled` with an inline `FormField` + `Switch`.
- Rebuild the "Auth Version Too Old" gate and the page shell on `SettingsCard`/`div` instead of `Container`/`Box`/`Text`; drop unused `register` destructuring and v2 imports.

___

<details> <summary><h3> File Walkthrough</h3></summary>

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody>
<tr><td><strong>OAuth2 provider settings</strong></td><td><details><summary>1 files</summary><table>
<tr>
  <td><strong>OAuth2ProviderSettings.tsx</strong><dd><code>Migrate form to SettingsCard; enable/metadata switches to FormField+Switch; loginURL to FormDescription+FormMessage</code></dd></td>
  <td>+118/-85</td>
</tr>
</table></details></td></tr>
<tr><td><strong>Page shell</strong></td><td><details><summary>1 files</summary><table>
<tr>
  <td><strong>settings/oauth2-provider.tsx</strong><dd><code>Rebuild version gate + page shell on SettingsCard/div; drop Container/Box/Text</code></dd></td>
  <td>+16/-24</td>
</tr>
</table></details></td></tr>
</tbody></table>

</details>

___

<!-- pi-reviewer:end -->
