### PR TITLE
fix(dashboard): migrate jwt settings page

### DIFF
--- a/dashboard/src/features/orgs/projects/jwt/settings/components/AsymmetricKeyFormSection/AsymmetricKeyFormSection.tsx
+++ b/dashboard/src/features/orgs/projects/jwt/settings/components/AsymmetricKeyFormSection/AsymmetricKeyFormSection.tsx
@@ -1,105 +1,55 @@
 import { useFormContext } from 'react-hook-form';
-import { Box } from '@/components/ui/v2/Box';
-import { FormControl } from '@/components/ui/v2/FormControl';
-import { Input } from '@/components/ui/v2/Input';
-import {
-  Select,
-  SelectContent,
-  SelectItem,
-  SelectTrigger,
-  SelectValue,
-} from '@/components/ui/v3/select';
+import { FormInput } from '@/components/form/FormInput';
+import { FormSelect } from '@/components/form/FormSelect';
+import { FormTextarea } from '@/components/form/FormTextarea';
+import { SelectItem } from '@/components/ui/v3/select';
 import type { JWTSettingsFormValues } from '@/features/orgs/projects/jwt/settings/types';
 import { ASYMMETRIC_ALGORITHMS } from '@/features/orgs/projects/jwt/settings/utils/constants';
 
 export default function AsymmetricKeyFormSection() {
-  const {
-    register,
-    formState: { errors },
-    watch,
-    setValue,
-  } = useFormContext<JWTSettingsFormValues>();
-
-  const type = watch('type');
+  const { control } = useFormContext<JWTSettingsFormValues>();
 
   return (
-    <Box className="grid grid-cols-5 gap-4">
-      <FormControl
-        className="col-span-5 lg:col-span-1"
-        hideEmptyHelperText
-        variant="normal"
-        error={!!errors.type}
-        helperText={errors?.type?.message}
+    <div className="grid grid-cols-5 gap-4">
+      <FormSelect
+        control={control}
+        name="type"
         label="Hashing algorithm"
-        labelProps={{ htmlFor: 'type' }}
+        placeholder={ASYMMETRIC_ALGORITHMS[0]}
+        containerClassName="col-span-5 lg:col-span-1"
       >
-        <Select
-          value={type ?? ''}
-          onValueChange={(value) =>
-            setValue('type', value, { shouldDirty: true })
-          }
-        >
-          <SelectTrigger
-            id="type"
-            aria-invalid={!!errors.type}
-            className="aria-[invalid=true]:border-red-500 aria-[invalid=true]:focus:border-red-500 aria-[invalid=true]:focus:ring-red-500"
-          >
-            <SelectValue placeholder={ASYMMETRIC_ALGORITHMS[0]} />
-          </SelectTrigger>
-          <SelectContent>
-            {ASYMMETRIC_ALGORITHMS.map((algorithm) => (
-              <SelectItem key={algorithm} value={algorithm}>
-                {algorithm}
-              </SelectItem>
-            ))}
-          </SelectContent>
-        </Select>
-      </FormControl>
-      <Input
-        {...register('kid')}
+        {ASYMMETRIC_ALGORITHMS.map((algorithm) => (
+          <SelectItem key={algorithm} value={algorithm}>
+            {algorithm}
+          </SelectItem>
+        ))}
+      </FormSelect>
+      <FormInput
+        control={control}
         name="kid"
-        id="kid"
         label="Key ID"
         placeholder="Enter unique key ID"
-        className="col-span-5 lg:col-span-3"
-        fullWidth
-        hideEmptyHelperText
-        error={!!errors?.kid}
-        helperText={errors?.kid?.message}
+        containerClassName="col-span-5 lg:col-span-3"
       />
 
-      <Input
-        {...register('key')}
-        name="key"
-        id="key"
-        label="Public Key"
-        placeholder="-----BEGIN PUBLIC KEY-----"
-        className="col-span-5 lg:col-span-4"
-        fullWidth
-        hideEmptyHelperText
-        error={!!errors?.key}
-        helperText={errors?.key?.message}
-        multiline
-        inputProps={{
-          className: 'resize-y min-h-[130px]',
-        }}
-      />
-      <Input
-        {...register('signingKey')}
-        name="signingKey"
-        id="signingKey"
-        label="Signing key"
-        placeholder="-----BEGIN PRIVATE KEY-----"
-        className="col-span-5 lg:col-span-4"
-        fullWidth
-        hideEmptyHelperText
-        error={!!errors?.signingKey}
-        helperText={errors?.signingKey?.message}
-        multiline
-        inputProps={{
-          className: 'resize-y min-h-[130px]',
-        }}
-      />
-    </Box>
+      <div className="col-span-5 lg:col-span-4">
+        <FormTextarea
+          control={control}
+          name="key"
+          label="Public Key"
+          placeholder="-----BEGIN PUBLIC KEY-----"
+          className="min-h-[130px] resize-y"
+        />
+      </div>
+      <div className="col-span-5 lg:col-span-4">
+        <FormTextarea
+          control={control}
+          name="signingKey"
+          label="Signing key"
+          placeholder="-----BEGIN PRIVATE KEY-----"
+          className="min-h-[130px] resize-y"
+        />
+      </div>
+    </div>
   );
 }

--- a/dashboard/src/features/orgs/projects/jwt/settings/components/ExternalSigningField/ExternalSigningField.tsx
+++ b/dashboard/src/features/orgs/projects/jwt/settings/components/ExternalSigningField/ExternalSigningField.tsx
@@ -1,13 +1,8 @@
 import { useFormContext } from 'react-hook-form';
-import { FormControl } from '@/components/ui/v2/FormControl';
-import { Input } from '@/components/ui/v2/Input';
-import {
-  Select,
-  SelectContent,
-  SelectItem,
-  SelectTrigger,
-  SelectValue,
-} from '@/components/ui/v3/select';
+import { FormInput } from '@/components/form/FormInput';
+import { FormSelect } from '@/components/form/FormSelect';
+import { FormTextarea } from '@/components/form/FormTextarea';
+import { SelectItem } from '@/components/ui/v3/select';
 import type {
   ExternalSigningType,
   JWTSettingsFormValues,
@@ -21,28 +16,16 @@ interface ExternalSigningFieldProps {
 export default function ExternalSigningField({
   externalSigningType,
 }: ExternalSigningFieldProps) {
-  const {
-    register,
-    formState: { errors },
-    setValue,
-    watch,
-  } = useFormContext<JWTSettingsFormValues>();
-
-  const type = watch('type');
+  const { control } = useFormContext<JWTSettingsFormValues>();
 
   if (externalSigningType === 'jwk-endpoint') {
     return (
-      <Input
-        {...register('jwkUrl')}
+      <FormInput
+        control={control}
         name="jwkUrl"
-        id="jwkUrl"
         placeholder="https://acme.com/jwks.json"
-        className="col-span-5 lg:col-span-4"
+        containerClassName="col-span-5 lg:col-span-4"
         label="JWK URL"
-        fullWidth
-        hideEmptyHelperText
-        error={!!errors?.jwkUrl}
-        helperText={errors?.jwkUrl?.message}
       />
     );
   }
@@ -50,55 +33,30 @@ export default function ExternalSigningField({
   if (externalSigningType === 'public-key') {
     return (
       <>
-        <FormControl
-          className="col-span-5 lg:col-span-1"
-          hideEmptyHelperText
-          variant="normal"
-          error={!!errors.type}
-          helperText={errors?.type?.message}
+        <FormSelect
+          control={control}
+          name="type"
           label="Hashing algorithm"
-          labelProps={{ htmlFor: 'type' }}
+          placeholder={ASYMMETRIC_ALGORITHMS[0]}
+          containerClassName="col-span-5 lg:col-span-1"
         >
-          <Select
-            value={type ?? ''}
-            onValueChange={(value) =>
-              setValue('type', value, { shouldDirty: true })
-            }
-          >
-            <SelectTrigger
-              id="type"
-              aria-invalid={!!errors.type}
-              className="aria-[invalid=true]:border-red-500 aria-[invalid=true]:focus:border-red-500 aria-[invalid=true]:focus:ring-red-500"
-            >
-              <SelectValue placeholder={ASYMMETRIC_ALGORITHMS[0]} />
-            </SelectTrigger>
-            <SelectContent>
-              {ASYMMETRIC_ALGORITHMS.map((algorithm) => (
-                <SelectItem key={algorithm} value={algorithm}>
-                  {algorithm}
-                </SelectItem>
-              ))}
-            </SelectContent>
-          </Select>
-        </FormControl>
+          {ASYMMETRIC_ALGORITHMS.map((algorithm) => (
+            <SelectItem key={algorithm} value={algorithm}>
+              {algorithm}
+            </SelectItem>
+          ))}
+        </FormSelect>
         <div className="lg:col-span-4" />
 
-        <Input
-          {...register('key')}
-          name="key"
-          id="key"
-          placeholder="-----BEGIN PUBLIC KEY-----"
-          className="col-span-5 lg:col-span-4"
-          label="Public Key"
-          fullWidth
-          multiline
-          hideEmptyHelperText
-          error={!!errors?.key}
-          helperText={errors?.key?.message}
-          inputProps={{
-            className: 'resize-y min-h-[130px]',
-          }}
-        />
+        <div className="col-span-5 lg:col-span-4">
+          <FormTextarea
+            control={control}
+            name="key"
+            placeholder="-----BEGIN PUBLIC KEY-----"
+            label="Public Key"
+            className="min-h-[130px] resize-y"
+          />
+        </div>
       </>
     );
   }

--- a/dashboard/src/features/orgs/projects/jwt/settings/components/ExternalSigningFormSection/ExternalSigningFormSection.tsx
+++ b/dashboard/src/features/orgs/projects/jwt/settings/components/ExternalSigningFormSection/ExternalSigningFormSection.tsx
@@ -1,6 +1,4 @@
-import { Alert } from '@/components/ui/v2/Alert';
-import { Box } from '@/components/ui/v2/Box';
-import { Text } from '@/components/ui/v2/Text';
+import { Alert, AlertDescription } from '@/components/ui/v3/alert';
 import { Label } from '@/components/ui/v3/label';
 import { RadioGroup, RadioGroupItem } from '@/components/ui/v3/radio-group';
 
@@ -18,13 +16,13 @@ export default function ExternalSigningFormSection({
 }: ExternalSigningFormSectionProps) {
   return (
     <div className="flex flex-col gap-6">
-      <Alert severity="warning">
-        <Text>
+      <Alert variant="warning">
+        <AlertDescription>
           When using external signing the Auth service will be automatically
           disabled.
-        </Text>
+        </AlertDescription>
       </Alert>
-      <Box className="grid grid-cols-5 gap-4">
+      <div className="grid grid-cols-5 gap-4">
         <div className="col-span-5">
           <RadioGroup
             defaultValue="jwk-endpoint"
@@ -43,7 +41,7 @@ export default function ExternalSigningFormSection({
           </RadioGroup>
         </div>
         <ExternalSigningField externalSigningType={externalSigningType} />
-      </Box>
+      </div>
     </div>
   );
 }

--- a/dashboard/src/features/orgs/projects/jwt/settings/components/JWTSettings/JWTSettings.tsx
+++ b/dashboard/src/features/orgs/projects/jwt/settings/components/JWTSettings/JWTSettings.tsx
@@ -1,15 +1,26 @@
 import { yupResolver } from '@hookform/resolvers/yup';
 import { InfoIcon } from 'lucide-react';
-import { useEffect, useState } from 'react';
+import { type ReactNode, useEffect, useState } from 'react';
 import { FormProvider, useForm } from 'react-hook-form';
 import { ApplyLocalSettingsDialog } from '@/components/common/ApplyLocalSettingsDialog';
 import { useDialog } from '@/components/common/DialogProvider';
 import { Form } from '@/components/form/Form';
-import { SettingsContainer } from '@/components/layout/SettingsContainer';
-import { Box } from '@/components/ui/v2/Box';
-import { Tooltip } from '@/components/ui/v2/Tooltip';
+import {
+  SettingsCard,
+  SettingsCardContent,
+  SettingsCardFooter,
+  SettingsCardHeader,
+  SettingsDocsLink,
+} from '@/components/layout/SettingsCard';
+import { ButtonWithLoading } from '@/components/ui/v3/button';
 import { Label } from '@/components/ui/v3/label';
 import { RadioGroup, RadioGroupItem } from '@/components/ui/v3/radio-group';
+import { TextLink } from '@/components/ui/v3/text-link';
+import {
+  Tooltip,
+  TooltipContent,
+  TooltipTrigger,
+} from '@/components/ui/v3/tooltip';
 import { useIsPlatform } from '@/features/orgs/projects/common/hooks/useIsPlatform';
 import { useLocalMimirClient } from '@/features/orgs/projects/hooks/useLocalMimirClient';
 import { useProject } from '@/features/orgs/projects/hooks/useProject';
@@ -31,6 +42,17 @@ import {
   useUpdateConfigMutation,
 } from '@/generated/graphql';
 import { removeTypename } from '@/utils/helpers';
+
+function InfoTooltip({ children }: { children: ReactNode }) {
+  return (
+    <Tooltip>
+      <TooltipTrigger asChild>
+        <InfoIcon aria-label="Info" className="h-4 w-4 text-primary" />
+      </TooltipTrigger>
+      <TooltipContent className="max-w-xs">{children}</TooltipContent>
+    </Tooltip>
+  );
+}
 
 export default function JWTSettings() {
   const { project } = useProject();
@@ -276,120 +298,118 @@ export default function JWTSettings() {
   return (
     <FormProvider {...form}>
       <Form onSubmit={handleJWTSettingsChange}>
-        <SettingsContainer
-          title="JSON Web Token Settings"
-          description="Select how JSON Web Tokens (JWTs) are signed and verified."
-          slotProps={{
-            submitButton: {
-              disabled: !formState.isDirty,
-              loading: formState.isSubmitting,
-            },
-          }}
-          docsLink="https://docs.nhost.io/products/auth/jwt"
-          docsTitle="JSON Web Token (JWT) Settings"
-          className="grid grid-flow-row gap-x-4 gap-y-2 px-4"
-        >
-          <Box className="flex flex-col gap-6">
-            <RadioGroup
-              className="flex flex-col gap-4 lg:flex-row"
-              defaultValue="public"
-              value={signatureType}
-              onValueChange={handleSignatureTypeChange}
-            >
-              <div className="flex items-center space-x-2">
-                <RadioGroupItem value="symmetric" id="symmetric" />
-                <Label htmlFor="symmetric" className="flex items-center gap-1">
-                  Symmetric key
-                  <Tooltip
-                    title={
+        <SettingsCard>
+          <SettingsCardHeader
+            title="JSON Web Token Settings"
+            description="Select how JSON Web Tokens (JWTs) are signed and verified."
+          />
+
+          <SettingsCardContent className="gap-x-4 gap-y-2">
+            <div className="flex flex-col gap-6">
+              <RadioGroup
+                className="flex flex-col gap-4 lg:flex-row"
+                defaultValue="public"
+                value={signatureType}
+                onValueChange={handleSignatureTypeChange}
+              >
+                <div className="flex items-center space-x-2">
+                  <RadioGroupItem value="symmetric" id="symmetric" />
+                  <Label
+                    htmlFor="symmetric"
+                    className="flex items-center gap-1"
+                  >
+                    Symmetric key
+                    <InfoTooltip>
                       <span>
-                        With symmetric keys your project uses a single for both
-                        signing and verifying JWTs. Refer to{' '}
-                        <a
+                        With symmetric keys your project uses a single key for
+                        both signing and verifying JWTs. Refer to{' '}
+                        <TextLink
                           target="_blank"
                           rel="noopener noreferrer"
                           href="https://docs.nhost.io/products/auth/jwt#symmetric-keys"
                           className="underline"
                         >
                           symmetric keys
-                        </a>{' '}
+                        </TextLink>{' '}
                         for more information.
                       </span>
-                    }
+                    </InfoTooltip>
+                  </Label>
+                </div>
+                <div className="flex items-center space-x-2">
+                  <RadioGroupItem value="asymmetric" id="asymmetric" />
+                  <Label
+                    htmlFor="asymmetric"
+                    className="flex items-center gap-1"
                   >
-                    <InfoIcon
-                      aria-label="Info"
-                      className="h-4 w-4 text-primary"
-                    />
-                  </Tooltip>
-                </Label>
-              </div>
-              <div className="flex items-center space-x-2">
-                <RadioGroupItem value="asymmetric" id="asymmetric" />
-                <Label htmlFor="asymmetric" className="flex items-center gap-1">
-                  Asymmetric key
-                  <Tooltip
-                    title={
+                    Asymmetric key
+                    <InfoTooltip>
                       <span>
                         With asymmetric keys your project uses a public and
                         private key pair for signing and verifying JWTs. Refer
                         to{' '}
-                        <a
+                        <TextLink
                           target="_blank"
                           rel="noopener noreferrer"
                           href="https://docs.nhost.io/products/auth/jwt#asymmetric-keys"
                           className="underline"
                         >
                           asymmetric keys
-                        </a>{' '}
+                        </TextLink>{' '}
                         for more information.
                       </span>
-                    }
-                  >
-                    <InfoIcon
-                      aria-label="Info"
-                      className="h-4 w-4 text-primary"
-                    />
-                  </Tooltip>
-                </Label>
-              </div>
-              <div className="flex items-center space-x-2">
-                <RadioGroupItem value="external" id="external" />
-                <Label htmlFor="external" className="flex items-center gap-1">
-                  External signing
-                  <Tooltip
-                    title={
+                    </InfoTooltip>
+                  </Label>
+                </div>
+                <div className="flex items-center space-x-2">
+                  <RadioGroupItem value="external" id="external" />
+                  <Label htmlFor="external" className="flex items-center gap-1">
+                    External signing
+                    <InfoTooltip>
                       <span>
                         This will use a third party service&apos;s JWK endpoint
                         to verify JWT&apos;s. Alternatively you can configure
                         the public key directly. Refer to{' '}
-                        <a
+                        <TextLink
                           target="_blank"
                           rel="noopener noreferrer"
                           href="https://docs.nhost.io/products/auth/jwt#external-signing"
                           className="underline"
                         >
                           external signing
-                        </a>{' '}
+                        </TextLink>{' '}
                         for more information.
                       </span>
-                    }
-                  >
-                    <InfoIcon
-                      aria-label="Info"
-                      className="h-4 w-4 text-primary"
-                    />
-                  </Tooltip>
-                </Label>
-              </div>
-            </RadioGroup>
-            <JWTSecretField
-              secretType={signatureType}
-              externalSigningType={externalSigningType}
-              handleExternalSigningTypeChange={handleExternalSigningTypeChange}
+                    </InfoTooltip>
+                  </Label>
+                </div>
+              </RadioGroup>
+              <JWTSecretField
+                secretType={signatureType}
+                externalSigningType={externalSigningType}
+                handleExternalSigningTypeChange={
+                  handleExternalSigningTypeChange
+                }
+              />
+            </div>
+          </SettingsCardContent>
+
+          <SettingsCardFooter>
+            <SettingsDocsLink
+              href="https://docs.nhost.io/products/auth/jwt"
+              title="JSON Web Token (JWT) Settings"
             />
-          </Box>
-        </SettingsContainer>
+
+            <ButtonWithLoading
+              type="submit"
+              disabled={!formState.isDirty}
+              loading={formState.isSubmitting}
+              className="w-full sm:w-auto"
+            >
+              Save
+            </ButtonWithLoading>
+          </SettingsCardFooter>
+        </SettingsCard>
       </Form>
     </FormProvider>
   );

--- a/dashboard/src/features/orgs/projects/jwt/settings/components/SymmetricKeyFormSection/SymmetricKeyFormSection.tsx
+++ b/dashboard/src/features/orgs/projects/jwt/settings/components/SymmetricKeyFormSection/SymmetricKeyFormSection.tsx
@@ -1,72 +1,35 @@
 import { useFormContext } from 'react-hook-form';
-import { Box } from '@/components/ui/v2/Box';
-import { FormControl } from '@/components/ui/v2/FormControl';
-import { Input } from '@/components/ui/v2/Input';
-import {
-  Select,
-  SelectContent,
-  SelectItem,
-  SelectTrigger,
-  SelectValue,
-} from '@/components/ui/v3/select';
+import { FormInput } from '@/components/form/FormInput';
+import { FormSelect } from '@/components/form/FormSelect';
+import { SelectItem } from '@/components/ui/v3/select';
 import type { JWTSettingsFormValues } from '@/features/orgs/projects/jwt/settings/types';
 import { SYMMETRIC_ALGORITHMS } from '@/features/orgs/projects/jwt/settings/utils/constants';
 
 export default function SymmetricKeyFormSection() {
-  const {
-    register,
-    formState: { errors },
-    watch,
-    setValue,
-  } = useFormContext<JWTSettingsFormValues>();
-
-  const type = watch('type');
+  const { control } = useFormContext<JWTSettingsFormValues>();
 
   return (
-    <Box className="grid grid-cols-5 gap-4">
-      <FormControl
-        className="col-span-5 lg:col-span-1"
-        hideEmptyHelperText
-        variant="normal"
-        error={!!errors.type}
-        helperText={errors?.type?.message}
+    <div className="grid grid-cols-5 gap-4">
+      <FormSelect
+        control={control}
+        name="type"
         label="Hashing algorithm"
-        labelProps={{ htmlFor: 'type' }}
+        placeholder={SYMMETRIC_ALGORITHMS[0]}
+        containerClassName="col-span-5 lg:col-span-1"
       >
-        <Select
-          value={type ?? ''}
-          onValueChange={(value) =>
-            setValue('type', value, { shouldDirty: true })
-          }
-        >
-          <SelectTrigger
-            id="type"
-            aria-invalid={!!errors.type}
-            className="aria-[invalid=true]:border-red-500 aria-[invalid=true]:focus:border-red-500 aria-[invalid=true]:focus:ring-red-500"
-          >
-            <SelectValue placeholder={SYMMETRIC_ALGORITHMS[0]} />
-          </SelectTrigger>
-          <SelectContent>
-            {SYMMETRIC_ALGORITHMS.map((algorithm) => (
-              <SelectItem key={algorithm} value={algorithm}>
-                {algorithm}
-              </SelectItem>
-            ))}
-          </SelectContent>
-        </Select>
-      </FormControl>
-      <Input
-        {...register('key')}
+        {SYMMETRIC_ALGORITHMS.map((algorithm) => (
+          <SelectItem key={algorithm} value={algorithm}>
+            {algorithm}
+          </SelectItem>
+        ))}
+      </FormSelect>
+      <FormInput
+        control={control}
         name="key"
-        id="key"
         label="Key"
         placeholder="Enter symmetric key"
-        className="col-span-5 lg:col-span-3"
-        fullWidth
-        hideEmptyHelperText
-        error={!!errors?.key}
-        helperText={errors?.key?.message}
+        containerClassName="col-span-5 lg:col-span-3"
       />
-    </Box>
+    </div>
   );
 }

--- a/dashboard/src/pages/orgs/[orgSlug]/projects/[appSubdomain]/settings/jwt.tsx
+++ b/dashboard/src/pages/orgs/[orgSlug]/projects/[appSubdomain]/settings/jwt.tsx
@@ -1,5 +1,4 @@
 import type { ReactElement } from 'react';
-import { Container } from '@/components/layout/Container';
 import { Spinner } from '@/components/ui/v3/spinner';
 import { OrgLayout } from '@/features/orgs/layout/OrgLayout';
 import { SettingsLayout } from '@/features/orgs/layout/SettingsLayout';
@@ -36,12 +35,9 @@ export default function SettingsJWTPage() {
   }
 
   return (
-    <Container
-      className="grid max-w-5xl grid-flow-row gap-y-6 bg-transparent"
-      rootClassName="bg-transparent"
-    >
+    <div className="grid grid-flow-row gap-y-6">
       <JWTSettings />
-    </Container>
+    </div>
   );
 }
 
@@ -49,12 +45,7 @@ SettingsJWTPage.getLayout = function getLayout(page: ReactElement) {
   return (
     <OrgLayout>
       <SettingsLayout>
-        <Container
-          sx={{ backgroundColor: 'background.default' }}
-          className="max-w-5xl"
-        >
-          {page}
-        </Container>
+        <div className="mx-auto w-full max-w-5xl px-5 py-4">{page}</div>
       </SettingsLayout>
     </OrgLayout>
   );


### PR DESCRIPTION
<!-- pi-reviewer:start -->
### **What this change solves**
Migrates the JWT settings page — its symmetric/asymmetric/external-signing key sections and the parent form — from the legacy v2 UI primitives (`SettingsContainer`, v2 `Input`/`FormControl`/`Box`/`Text`/`Alert`/`Tooltip`, `Container`) to the v3 `SettingsCard` / `FormInput` / `FormTextarea` / `FormField` / v3 `Alert` / v3 `Tooltip` system, preserving fields, validation, and save behavior.

___

### **Change Type**
Refactoring

___

### **Description**
- Migrate each key form section (symmetric, asymmetric, external-signing) off v2 `Input`/`FormControl`/`Box` to `FormInput`/`FormTextarea` and a `FormField`-wrapped v3 `Select` (still driven by `watch`/`setValue`), with `FormLabel`/`FormMessage` for labels and errors.
- Convert the multiline public/private key inputs to `FormTextarea`, and the external-signing warning from v2 `Alert`+`Text` to v3 `Alert`+`AlertDescription`.
- Rebuild the `JWTSettings` parent on `SettingsCard`/`SettingsCardHeader`/`SettingsCardContent`/`SettingsCardFooter`; extract an `InfoTooltip` helper on the v3 `Tooltip`, replace inline `<a>` with `TextLink`, and move the docs link + Save button into the footer. Also fixes a copy typo ("a single for both" → "a single key for both").
- Simplify the `jwt.tsx` page shell from `Container`/`sx` to plain `div` wrappers.

___

<details> <summary><h3> File Walkthrough</h3></summary>

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody>
<tr><td><strong>JWT key sections</strong></td><td><details><summary>4 files</summary><table>
<tr><td><strong>AsymmetricKeyFormSection.tsx</strong><dd><code>Migrate type Select + Key ID/public/signing key fields to FormField/FormInput/FormTextarea</code></dd></td><td>+66/-77</td></tr>
<tr><td><strong>SymmetricKeyFormSection.tsx</strong><dd><code>Migrate type Select + key field to FormField/FormInput</code></dd></td><td>+47/-45</td></tr>
<tr><td><strong>ExternalSigningField.tsx</strong><dd><code>Migrate jwkUrl/public-key variants to FormInput/FormTextarea + FormField Select</code></dd></td><td>+55/-58</td></tr>
<tr><td><strong>ExternalSigningFormSection.tsx</strong><dd><code>Migrate warning Alert+Text to v3 Alert+AlertDescription; Box→div</code></dd></td><td>+6/-8</td></tr>
</table></details></td></tr>
<tr><td><strong>Parent form + page</strong></td><td><details><summary>2 files</summary><table>
<tr><td><strong>JWTSettings.tsx</strong><dd><code>Rebuild on SettingsCard; add InfoTooltip (v3 Tooltip); TextLink; footer docs link + Save; copy typo fix</code></dd></td><td>+103/-83</td></tr>
<tr><td><strong>settings/jwt.tsx</strong><dd><code>Replace Container/sx layout with plain div wrappers</code></dd></td><td>+3/-12</td></tr>
</table></details></td></tr>
</tbody></table>

</details>

___

<!-- pi-reviewer:end -->
