### PR TITLE
fix(dashboard): migrate storage settings page

### DIFF
--- a/dashboard/src/features/orgs/projects/storage/settings/components/StorageAVSettings/HasuraStorageAVSettings.tsx
+++ b/dashboard/src/features/orgs/projects/storage/settings/components/StorageAVSettings/HasuraStorageAVSettings.tsx
@@ -5,7 +5,15 @@ import * as Yup from 'yup';
 import { ApplyLocalSettingsDialog } from '@/components/common/ApplyLocalSettingsDialog';
 import { useDialog } from '@/components/common/DialogProvider';
 import { Form } from '@/components/form/Form';
-import { SettingsContainer } from '@/components/layout/SettingsContainer';
+import {
+  SettingsCard,
+  SettingsCardFooter,
+  SettingsCardHeader,
+  SettingsDocsLink,
+} from '@/components/layout/SettingsCard';
+import { ButtonWithLoading } from '@/components/ui/v3/button';
+import { FormField } from '@/components/ui/v3/form';
+import { Switch } from '@/components/ui/v3/switch';
 import { useIsPlatform } from '@/features/orgs/projects/common/hooks/useIsPlatform';
 import { useLocalMimirClient } from '@/features/orgs/projects/hooks/useLocalMimirClient';
 import { useProject } from '@/features/orgs/projects/hooks/useProject';
@@ -107,21 +115,41 @@ export default function HasuraStorageAVSettings() {
   return (
     <FormProvider {...form}>
       <Form onSubmit={handleSubmit}>
-        <SettingsContainer
-          title="Antivirus"
-          description="Enable or disable Antivirus."
-          slotProps={{
-            submitButton: {
-              disabled: !form.formState.isDirty,
-              loading: form.formState.isSubmitting,
-            },
-          }}
-          switchId="enabled"
-          docsTitle="enabling or disabling Antivirus"
-          docsLink="https://docs.nhost.io/products/storage/antivirus#antivirus"
-          showSwitch
-          className="hidden"
-        />
+        <SettingsCard>
+          <SettingsCardHeader
+            title="Antivirus"
+            description="Enable or disable Antivirus."
+            control={
+              <FormField
+                control={form.control}
+                name="enabled"
+                render={({ field }) => (
+                  <Switch
+                    checked={field.value}
+                    onCheckedChange={field.onChange}
+                    aria-label="Toggle Antivirus"
+                  />
+                )}
+              />
+            }
+          />
+
+          <SettingsCardFooter>
+            <SettingsDocsLink
+              href="https://docs.nhost.io/products/storage/antivirus#antivirus"
+              title="enabling or disabling Antivirus"
+            />
+
+            <ButtonWithLoading
+              type="submit"
+              disabled={!form.formState.isDirty}
+              loading={form.formState.isSubmitting}
+              className="w-full sm:w-auto"
+            >
+              Save
+            </ButtonWithLoading>
+          </SettingsCardFooter>
+        </SettingsCard>
       </Form>
     </FormProvider>
   );

--- a/dashboard/src/features/orgs/projects/storage/settings/components/StorageServiceVersionSettings/StorageServiceVersionSettings.tsx
+++ b/dashboard/src/features/orgs/projects/storage/settings/components/StorageServiceVersionSettings/StorageServiceVersionSettings.tsx
@@ -6,7 +6,14 @@ import { ApplyLocalSettingsDialog } from '@/components/common/ApplyLocalSettings
 import { useDialog } from '@/components/common/DialogProvider';
 import { Form } from '@/components/form/Form';
 import { FormFreeCombobox } from '@/components/form/FormFreeCombobox';
-import { SettingsContainer } from '@/components/layout/SettingsContainer';
+import {
+  SettingsCard,
+  SettingsCardContent,
+  SettingsCardFooter,
+  SettingsCardHeader,
+  SettingsDocsLink,
+} from '@/components/layout/SettingsCard';
+import { ButtonWithLoading } from '@/components/ui/v3/button';
 import { useIsPlatform } from '@/features/orgs/projects/common/hooks/useIsPlatform';
 import { useLocalMimirClient } from '@/features/orgs/projects/hooks/useLocalMimirClient';
 import { useProject } from '@/features/orgs/projects/hooks/useProject';
@@ -133,28 +140,39 @@ export default function StorageServiceVersionSettings() {
   return (
     <FormProvider {...form}>
       <Form onSubmit={handleStorageServiceVersionsChange}>
-        <SettingsContainer
-          title="Storage Version"
-          description="The version of Storage to use."
-          slotProps={{
-            submitButton: {
-              disabled: !formState.isDirty,
-              loading: formState.isSubmitting,
-            },
-          }}
-          docsLink="https://github.com/nhost/hasura-storage/releases"
-          docsTitle="the latest releases"
-          className="grid grid-flow-row gap-x-4 gap-y-2 px-4 lg:grid-cols-5"
-        >
-          <FormFreeCombobox
-            name="version"
-            className="lg:col-span-3"
-            options={availableVersions}
-            control={form.control}
-            placeholder="Select Storage Version"
-            customValueLabel={(val) => `Use custom value: "${val}"`}
+        <SettingsCard>
+          <SettingsCardHeader
+            title="Storage Version"
+            description="The version of Storage to use."
           />
-        </SettingsContainer>
+
+          <SettingsCardContent className="gap-x-4 gap-y-2 lg:grid-cols-5">
+            <FormFreeCombobox
+              name="version"
+              className="lg:col-span-3"
+              options={availableVersions}
+              control={form.control}
+              placeholder="Select Storage Version"
+              customValueLabel={(val) => `Use custom value: "${val}"`}
+            />
+          </SettingsCardContent>
+
+          <SettingsCardFooter>
+            <SettingsDocsLink
+              href="https://github.com/nhost/hasura-storage/releases"
+              title="the latest releases"
+            />
+
+            <ButtonWithLoading
+              type="submit"
+              disabled={!formState.isDirty}
+              loading={formState.isSubmitting}
+              className="w-full sm:w-auto"
+            >
+              Save
+            </ButtonWithLoading>
+          </SettingsCardFooter>
+        </SettingsCard>
       </Form>
     </FormProvider>
   );

--- a/dashboard/src/pages/orgs/[orgSlug]/projects/[appSubdomain]/settings/storage.tsx
+++ b/dashboard/src/pages/orgs/[orgSlug]/projects/[appSubdomain]/settings/storage.tsx
@@ -1,5 +1,4 @@
 import type { ReactElement } from 'react';
-import { Container } from '@/components/layout/Container';
 import { Spinner } from '@/components/ui/v3/spinner';
 import { OrgLayout } from '@/features/orgs/layout/OrgLayout';
 import { SettingsLayout } from '@/features/orgs/layout/SettingsLayout';
@@ -36,30 +35,18 @@ export default function StorageSettingsPage() {
   }
 
   return (
-    <Container
-      className="grid max-w-5xl grid-flow-row gap-y-6 bg-transparent"
-      rootClassName="bg-transparent"
-    >
+    <div className="grid grid-flow-row gap-y-6">
       <StorageServiceVersionSettings />
       <HasuraStorageAVSettings />
-    </Container>
+    </div>
   );
 }
 
 StorageSettingsPage.getLayout = function getLayout(page: ReactElement) {
   return (
-    <OrgLayout
-      mainContainerProps={{
-        className: 'flex h-full overflow-auto',
-      }}
-    >
+    <OrgLayout>
       <SettingsLayout>
-        <Container
-          sx={{ backgroundColor: 'background.default' }}
-          className="max-w-5xl"
-        >
-          {page}
-        </Container>
+        <div className="mx-auto w-full max-w-5xl px-5 py-4">{page}</div>
       </SettingsLayout>
     </OrgLayout>
   );


### PR DESCRIPTION
<!-- pi-reviewer:start -->
### **What this change solves**
Migrates the storage settings page (Antivirus toggle, Storage version selector, and the page shell) from the legacy v2 `SettingsContainer`/`Container` primitives to the v3 `SettingsCard` / `Switch` / `FormFreeCombobox` system, preserving the toggle, version selection, validation, and save behavior.

___

### **Change Type**
Refactoring

___

### **Description**
- Rebuild `HasuraStorageAVSettings` on `SettingsCard`: move the Antivirus `enabled` toggle from the container's `showSwitch`/`switchId` into the header `control` slot as an inline `FormField` + v3 `Switch`, and move the docs link + Save into a `SettingsCardFooter` (dropping the old `className="hidden"` empty-content container).
- Rebuild `StorageServiceVersionSettings` on `SettingsCard` with the `FormFreeCombobox` in `SettingsCardContent` and the docs link + Save in the footer.
- Simplify the `storage.tsx` page shell from `Container`/`sx`/`mainContainerProps` to plain `div` wrappers and a standard layout.

___

<details> <summary><h3> File Walkthrough</h3></summary>

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody>
<tr><td><strong>Storage settings components</strong></td><td><details><summary>2 files</summary><table>
<tr><td><strong>HasuraStorageAVSettings.tsx</strong><dd><code>Migrate AV toggle to SettingsCard header Switch + footer Save; drop hidden empty container</code></dd></td><td>+44/-16</td></tr>
<tr><td><strong>StorageServiceVersionSettings.tsx</strong><dd><code>Migrate version FormFreeCombobox to SettingsCard content + footer Save</code></dd></td><td>+40/-22</td></tr>
</table></details></td></tr>
<tr><td><strong>Page shell</strong></td><td><details><summary>1 files</summary><table>
<tr><td><strong>settings/storage.tsx</strong><dd><code>Replace Container/sx/mainContainerProps layout with plain div wrappers</code></dd></td><td>+4/-17</td></tr>
</table></details></td></tr>
</tbody></table>

</details>

___

<!-- pi-reviewer:end -->
