### PR TITLE
fix(dashboard): migrate compute resources settings page

### DIFF
--- a/dashboard/src/components/form/FormSwitch/FormSwitch.tsx
+++ b/dashboard/src/components/form/FormSwitch/FormSwitch.tsx
@@ -1,4 +1,9 @@
-import { type ForwardedRef, forwardRef, type ReactNode } from 'react';
+import {
+  type ComponentProps,
+  type ForwardedRef,
+  forwardRef,
+  type ReactNode,
+} from 'react';
 import type { Control, FieldPath, FieldValues } from 'react-hook-form';
 import { mergeRefs } from 'react-merge-refs';
 import {
@@ -24,6 +29,11 @@ interface FormSwitchProps<
   inline?: boolean;
   helperText?: string | null;
   disabled?: boolean;
+  /**
+   * Called after the field's checked state changes. Use for side effects like
+   * syncing dependent fields.
+   */
+  onCheckedChange?: (checked: boolean) => void;
 }
 
 function InnerFormSwitch<
@@ -40,6 +50,7 @@ function InnerFormSwitch<
     inline,
     helperText,
     disabled,
+    onCheckedChange,
   }: FormSwitchProps<TFieldValues, TName>,
   ref?: ForwardedRef<HTMLButtonElement>,
 ) {
@@ -47,46 +58,55 @@ function InnerFormSwitch<
     <FormField
       control={control}
       name={name}
-      render={({ field }) => (
-        <FormItem
-          className={cn(
-            { 'flex w-full items-center gap-4 py-3': inline },
-            containerClassName,
-          )}
-        >
-          <FormLabel
+      render={({ field }) => {
+        const handleCheckedChange: ComponentProps<
+          typeof Switch
+        >['onCheckedChange'] = (checked) => {
+          field.onChange(checked);
+          onCheckedChange?.(checked);
+        };
+
+        return (
+          <FormItem
             className={cn(
-              {
-                'mt-2 w-52 max-w-52 flex-shrink-0 self-start': inline,
-              },
-              labelClassName,
+              { 'flex w-full items-center gap-4 py-3': inline },
+              containerClassName,
             )}
           >
-            {label}
-          </FormLabel>
-          <div
-            className={cn({
-              'flex w-[calc(100%-13.5rem)] max-w-[calc(100%-13.5rem)] flex-col gap-2':
-                inline,
-            })}
-          >
-            <FormControl>
-              <Switch
-                checked={field.value}
-                onCheckedChange={field.onChange}
-                disabled={disabled}
-                ref={mergeRefs([field.ref, ref])}
-                className={className}
-              />
-            </FormControl>
-            {!!helperText && (
-              <FormDescription className="break-all px-[1px]">
-                {helperText}
-              </FormDescription>
-            )}
-          </div>
-        </FormItem>
-      )}
+            <FormLabel
+              className={cn(
+                {
+                  'mt-2 w-52 max-w-52 flex-shrink-0 self-start': inline,
+                },
+                labelClassName,
+              )}
+            >
+              {label}
+            </FormLabel>
+            <div
+              className={cn({
+                'flex w-[calc(100%-13.5rem)] max-w-[calc(100%-13.5rem)] flex-col gap-2':
+                  inline,
+              })}
+            >
+              <FormControl>
+                <Switch
+                  checked={field.value}
+                  onCheckedChange={handleCheckedChange}
+                  disabled={disabled}
+                  ref={mergeRefs([field.ref, ref])}
+                  className={className}
+                />
+              </FormControl>
+              {!!helperText && (
+                <FormDescription className="break-all px-[1px]">
+                  {helperText}
+                </FormDescription>
+              )}
+            </div>
+          </FormItem>
+        );
+      }}
     />
   );
 }

--- a/dashboard/src/features/orgs/projects/resources/settings/components/ResourcesForm/ResourcesForm.test.tsx
+++ b/dashboard/src/features/orgs/projects/resources/settings/components/ResourcesForm/ResourcesForm.test.tsx
@@ -59,6 +59,8 @@ const getStorageCPUValue = () =>
   screen.getByRole('status', { name: /^Storage vCPU$/i });
 const getAuthMemoryValue = () =>
   screen.getByRole('status', { name: /^Auth Memory$/i });
+const getMasterSwitch = () =>
+  screen.getByRole('switch', { name: /toggle compute resources/i });
 
 const switchToAdvancedTab = async (user: TestUserEvent) => {
   await user.click(screen.getByRole('tab', { name: /advanced/i }));
@@ -81,7 +83,7 @@ test('enabling the master switch reveals the Overview tab with presets', async (
 
   expect(await screen.findByText(/enable this feature/i)).toBeInTheDocument();
 
-  await user.click(screen.getByRole('checkbox'));
+  await user.click(getMasterSwitch());
 
   await waitFor(() => {
     expect(screen.queryByText(/enable this feature/i)).not.toBeInTheDocument();
@@ -99,8 +101,8 @@ test('toggling the master switch on then off leaves Save disabled', async () => 
 
   expect(await screen.findByText(/enable this feature/i)).toBeInTheDocument();
 
-  const checkbox = screen.getByRole('checkbox');
-  await user.click(checkbox);
+  const masterSwitch = getMasterSwitch();
+  await user.click(masterSwitch);
 
   await screen.findByRole('button', { name: /^starter/i });
 
@@ -109,7 +111,7 @@ test('toggling the master switch on then off leaves Save disabled', async () => 
   }) as HTMLButtonElement;
   expect(saveWhenEnabled.disabled).toBe(false);
 
-  await user.click(checkbox);
+  await user.click(masterSwitch);
 
   await screen.findByText(/enable this feature/i);
   const saveWhenDisabled = screen.getByRole('button', {
@@ -257,7 +259,7 @@ test('disabling resources surfaces the destructive confirm dialog', async () => 
 
   await screen.findByRole('tab', { name: /advanced/i });
 
-  await user.click(screen.getByRole('checkbox'));
+  await user.click(getMasterSwitch());
 
   await user.click(screen.getByRole('button', { name: /^save$/i }));
 

--- a/dashboard/src/features/orgs/projects/resources/settings/components/ResourcesForm/ResourcesForm.tsx
+++ b/dashboard/src/features/orgs/projects/resources/settings/components/ResourcesForm/ResourcesForm.tsx
@@ -3,7 +3,12 @@ import { FormProvider, useForm, useWatch } from 'react-hook-form';
 import { ApplyLocalSettingsDialog } from '@/components/common/ApplyLocalSettingsDialog';
 import { useDialog } from '@/components/common/DialogProvider';
 import { Form } from '@/components/form/Form';
-import { SettingsContainer } from '@/components/layout/SettingsContainer';
+import { FormSwitch } from '@/components/form/FormSwitch';
+import {
+  SettingsCard,
+  SettingsCardContent,
+  SettingsCardHeader,
+} from '@/components/layout/SettingsCard';
 import { Alert, AlertDescription } from '@/components/ui/v3/alert';
 import { Spinner } from '@/components/ui/v3/spinner';
 import {
@@ -436,31 +441,32 @@ export default function ResourcesForm() {
   return (
     <FormProvider {...form}>
       <Form onSubmit={handleConfirm}>
-        <SettingsContainer
-          title="Compute Resources"
-          description="Customize CPU and memory for the services in your project."
-          className="gap-0 px-0"
-          showSwitch
-          switchId="enabled"
-          slotProps={{
-            submitButton: {
-              className: 'hidden',
-              'aria-hidden': true,
-            },
-            switch: {
-              onChange: (event) => {
-                if (event.target.checked && !hasInitialValues) {
-                  applyPresetToForm(form.setValue, form.trigger, 'standard', {
-                    shouldDirty: false,
-                  });
-                }
-              },
-            },
-            footer: { className: 'hidden', 'aria-hidden': true },
-          }}
-        >
-          <ResourcesFormBody initialPrice={initialPrice} />
-        </SettingsContainer>
+        <SettingsCard>
+          <SettingsCardHeader
+            title="Compute Resources"
+            description="Customize CPU and memory for the services in your project."
+            control={
+              <FormSwitch
+                control={form.control}
+                name="enabled"
+                label="Toggle Compute Resources"
+                labelClassName="sr-only"
+                containerClassName="space-y-0"
+                onCheckedChange={(checked) => {
+                  if (checked && !hasInitialValues) {
+                    applyPresetToForm(form.setValue, form.trigger, 'standard', {
+                      shouldDirty: false,
+                    });
+                  }
+                }}
+              />
+            }
+          />
+
+          <SettingsCardContent className="gap-0 px-0">
+            <ResourcesFormBody initialPrice={initialPrice} />
+          </SettingsCardContent>
+        </SettingsCard>
       </Form>
     </FormProvider>
   );

--- a/dashboard/src/pages/orgs/[orgSlug]/projects/[appSubdomain]/settings/compute-resources.tsx
+++ b/dashboard/src/pages/orgs/[orgSlug]/projects/[appSubdomain]/settings/compute-resources.tsx
@@ -1,6 +1,5 @@
 import type { ReactElement } from 'react';
 import { UpgradeToProBanner } from '@/components/common/UpgradeToProBanner';
-import { Container } from '@/components/layout/Container';
 import { OrgLayout } from '@/features/orgs/layout/OrgLayout';
 import { SettingsLayout } from '@/features/orgs/layout/SettingsLayout';
 import { useCurrentOrg } from '@/features/orgs/projects/hooks/useCurrentOrg';
@@ -11,15 +10,12 @@ export default function ResourceSettingsPage() {
 
   if (org?.plan?.isFree) {
     return (
-      <Container
-        className="grid grid-flow-row gap-6 bg-transparent"
-        rootClassName="bg-transparent"
-      >
+      <div className="grid grid-flow-row gap-6">
         <UpgradeToProBanner
           title="To unlock Compute Resources, transfer this project to a Pro or Team organization."
           description=""
         />
-      </Container>
+      </div>
     );
   }
 
@@ -28,18 +24,9 @@ export default function ResourceSettingsPage() {
 
 ResourceSettingsPage.getLayout = function getLayout(page: ReactElement) {
   return (
-    <OrgLayout
-      mainContainerProps={{
-        className: 'flex w-full flex-auto flex-col',
-      }}
-    >
+    <OrgLayout>
       <SettingsLayout>
-        <Container
-          sx={{ backgroundColor: 'background.default' }}
-          className="max-w-5xl"
-        >
-          {page}
-        </Container>
+        <div className="mx-auto w-full max-w-5xl px-5 py-4">{page}</div>
       </SettingsLayout>
     </OrgLayout>
   );


### PR DESCRIPTION
<!-- pi-reviewer:start -->
### **What this change solves**
Migrates the Compute Resources settings page to the newer settings card layout while keeping the existing form behavior. The change standardizes the page shell and replaces the legacy container/switch wiring with v3 UI components.

___

### **Change Type**
Refactoring

___

### **Description**
- Replaces `SettingsContainer` usage in the resources form with `SettingsCard`, `SettingsCardHeader`, and `SettingsCardContent`.
- Rewires the compute resources enable switch through the v3 `FormField` and `Switch` components while preserving default preset application.
- Simplifies the Compute Resources settings page layout to use the shared settings layout shell and local max-width wrapper.

___

<details> <summary><h3> File Walkthrough</h3></summary>

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody>
<tr><td><strong>Dashboard settings</strong></td><td><details><summary>2 files</summary><table>
<tr>
  <td><strong>dashboard/src/features/orgs/projects/resources/settings/components/ResourcesForm/ResourcesForm.tsx</strong><dd><code>Migrates the compute resources form wrapper and enable switch to SettingsCard/v3 form controls.</code></dd></td>
  <td>+43/-26</td>
</tr>
<tr>
  <td><strong>dashboard/src/pages/orgs/[orgSlug]/projects/[appSubdomain]/settings/compute-resources.tsx</strong><dd><code>Simplifies the page-level settings layout and Pro-plan banner wrapper.</code></dd></td>
  <td>+4/-17</td>
</tr>
</table></details></td></tr>
</tbody></table>

</details>

___

<!-- pi-reviewer:end -->
