### PR TITLE
fix(dashboard): migrate custom domains settings page

### DIFF
--- a/dashboard/src/features/orgs/projects/custom-domains/settings/components/AuthDomain/AuthDomain.tsx
+++ b/dashboard/src/features/orgs/projects/custom-domains/settings/components/AuthDomain/AuthDomain.tsx
@@ -5,8 +5,14 @@ import * as Yup from 'yup';
 import { ApplyLocalSettingsDialog } from '@/components/common/ApplyLocalSettingsDialog';
 import { useDialog } from '@/components/common/DialogProvider';
 import { Form } from '@/components/form/Form';
-import { SettingsContainer } from '@/components/layout/SettingsContainer';
-import { Input } from '@/components/ui/v2/Input';
+import { FormInput } from '@/components/form/FormInput';
+import {
+  SettingsCard,
+  SettingsCardContent,
+  SettingsCardFooter,
+  SettingsCardHeader,
+} from '@/components/layout/SettingsCard';
+import { ButtonWithLoading } from '@/components/ui/v3/button';
 import { useIsPlatform } from '@/features/orgs/projects/common/hooks/useIsPlatform';
 import { VerifyDomain } from '@/features/orgs/projects/custom-domains/settings/components/VerifyDomain';
 import { useLocalMimirClient } from '@/features/orgs/projects/hooks/useLocalMimirClient';
@@ -53,7 +59,7 @@ export default function AuthDomain() {
   const { networking } = data?.config?.auth?.resources || {};
   const initialValue = networking?.ingresses?.[0]?.fqdn?.[0];
 
-  const { formState, watch, setValue } = form;
+  const { formState, watch } = form;
   const isDirty = Object.keys(formState.dirtyFields).length > 0;
 
   const auth_fqdn = watch('auth_fqdn');
@@ -137,45 +143,46 @@ export default function AuthDomain() {
   return (
     <FormProvider {...form}>
       <Form onSubmit={handleSubmit}>
-        <SettingsContainer
-          title="Auth Domain"
-          description="Enter below your custom domain for the authentication service."
-          slotProps={{
-            submitButton: {
-              disabled: submitButtonDisabled,
-              loading: formState.isSubmitting,
-            },
-          }}
-          className="grid grid-flow-row gap-x-4 gap-y-4 px-4 lg:grid-cols-5"
-        >
-          <Input
-            value={auth_fqdn}
-            onChange={(e) => {
-              setValue('auth_fqdn', e.target.value, { shouldDirty: true });
-              if (isVerified) {
-                setIsVerified(false);
-              }
-            }}
-            id="auth_fqdn"
-            name="auth_fqdn"
-            type="string"
-            fullWidth
-            className="col-span-5 lg:col-span-2"
-            placeholder="auth.mydomain.dev"
-            error={Boolean(formState.errors.auth_fqdn?.message)}
-            helperText={formState.errors.auth_fqdn?.message}
-            slotProps={{ inputRoot: { min: 1, max: 100 } }}
+        <SettingsCard>
+          <SettingsCardHeader
+            title="Auth Domain"
+            description="Enter below your custom domain for the authentication service."
           />
-          <div className="col-span-5 row-start-2">
-            <VerifyDomain
-              recordType="CNAME"
-              hostname={auth_fqdn}
-              value={`lb.${project?.region.name}.${project?.region.domain}.`}
-              onHostNameVerified={() => setIsVerified(true)}
-              saveEnabled={!submitButtonDisabled}
+
+          <SettingsCardContent className="gap-x-4 gap-y-4 lg:grid-cols-5">
+            <FormInput
+              control={form.control}
+              name="auth_fqdn"
+              containerClassName="col-span-5 lg:col-span-2"
+              placeholder="auth.mydomain.dev"
+              onChange={() => {
+                if (isVerified) {
+                  setIsVerified(false);
+                }
+              }}
             />
-          </div>
-        </SettingsContainer>
+            <div className="col-span-5 row-start-2">
+              <VerifyDomain
+                recordType="CNAME"
+                hostname={auth_fqdn}
+                value={`lb.${project?.region.name}.${project?.region.domain}.`}
+                onHostNameVerified={() => setIsVerified(true)}
+                saveEnabled={!submitButtonDisabled}
+              />
+            </div>
+          </SettingsCardContent>
+
+          <SettingsCardFooter>
+            <ButtonWithLoading
+              type="submit"
+              disabled={submitButtonDisabled}
+              loading={formState.isSubmitting}
+              className="w-full sm:w-auto"
+            >
+              Save
+            </ButtonWithLoading>
+          </SettingsCardFooter>
+        </SettingsCard>
       </Form>
     </FormProvider>
   );

--- a/dashboard/src/features/orgs/projects/custom-domains/settings/components/DatabaseDomain/DatabaseDomain.tsx
+++ b/dashboard/src/features/orgs/projects/custom-domains/settings/components/DatabaseDomain/DatabaseDomain.tsx
@@ -1,7 +1,11 @@
 import { useState } from 'react';
 import * as Yup from 'yup';
-import { SettingsContainer } from '@/components/layout/SettingsContainer';
-import { Input } from '@/components/ui/v2/Input';
+import {
+  SettingsCard,
+  SettingsCardContent,
+  SettingsCardHeader,
+} from '@/components/layout/SettingsCard';
+import { Input } from '@/components/ui/v3/input';
 import { generateAppServiceUrl } from '@/features/orgs/projects/common/utils/generateAppServiceUrl';
 import { VerifyDomain } from '@/features/orgs/projects/custom-domains/settings/components/VerifyDomain';
 import { useProject } from '@/features/orgs/projects/hooks/useProject';
@@ -28,38 +32,30 @@ export default function DatabaseDomain() {
   ).replace('https://', '');
 
   return (
-    <SettingsContainer
-      title="Database Domain"
-      description="Enter below your custom domain for the PostgreSQL database to verify. Once verified there is no need to save this value as no configuration on our end is required."
-      slotProps={{
-        submitButton: {
-          hidden: true,
-        },
-        footer: {
-          className: 'hidden',
-        },
-      }}
-      className="grid grid-flow-row gap-x-4 gap-y-4 px-4 lg:grid-cols-5"
-    >
-      <Input
-        id="database_fqdn"
-        name="database_fqdn"
-        type="string"
-        fullWidth
-        className="col-span-5 lg:col-span-2"
-        placeholder="db.mydomain.dev"
-        onChange={(e) => {
-          setDbFQDN(e.target.value);
-        }}
-        slotProps={{ inputRoot: { min: 1, max: 100 } }}
+    <SettingsCard>
+      <SettingsCardHeader
+        title="Database Domain"
+        description="Enter below your custom domain for the PostgreSQL database to verify. Once verified there is no need to save this value as no configuration on our end is required."
       />
-      <div className="col-span-5 row-start-2">
-        <VerifyDomain
-          recordType="CNAME"
-          hostname={dbFQDN}
-          value={`${postgresHost}.`}
+
+      <SettingsCardContent className="gap-x-4 gap-y-4 lg:grid-cols-5">
+        <Input
+          id="database_fqdn"
+          name="database_fqdn"
+          wrapperClassName="col-span-5 lg:col-span-2"
+          placeholder="db.mydomain.dev"
+          onChange={(e) => {
+            setDbFQDN(e.target.value);
+          }}
         />
-      </div>
-    </SettingsContainer>
+        <div className="col-span-5 row-start-2">
+          <VerifyDomain
+            recordType="CNAME"
+            hostname={dbFQDN}
+            value={`${postgresHost}.`}
+          />
+        </div>
+      </SettingsCardContent>
+    </SettingsCard>
   );
 }

--- a/dashboard/src/features/orgs/projects/custom-domains/settings/components/HasuraDomain/HasuraDomain.tsx
+++ b/dashboard/src/features/orgs/projects/custom-domains/settings/components/HasuraDomain/HasuraDomain.tsx
@@ -5,8 +5,14 @@ import * as Yup from 'yup';
 import { ApplyLocalSettingsDialog } from '@/components/common/ApplyLocalSettingsDialog';
 import { useDialog } from '@/components/common/DialogProvider';
 import { Form } from '@/components/form/Form';
-import { SettingsContainer } from '@/components/layout/SettingsContainer';
-import { Input } from '@/components/ui/v2/Input';
+import { FormInput } from '@/components/form/FormInput';
+import {
+  SettingsCard,
+  SettingsCardContent,
+  SettingsCardFooter,
+  SettingsCardHeader,
+} from '@/components/layout/SettingsCard';
+import { ButtonWithLoading } from '@/components/ui/v3/button';
 import { useIsPlatform } from '@/features/orgs/projects/common/hooks/useIsPlatform';
 import { VerifyDomain } from '@/features/orgs/projects/custom-domains/settings/components/VerifyDomain';
 import { useLocalMimirClient } from '@/features/orgs/projects/hooks/useLocalMimirClient';
@@ -59,7 +65,7 @@ export default function HasuraDomain() {
     }
   }, [data, loading, form, initialValue]);
 
-  const { formState, watch, setValue } = form;
+  const { formState, watch } = form;
   const isDirty = Object.keys(formState.dirtyFields).length > 0;
 
   const hasura_fqdn = watch('hasura_fqdn');
@@ -137,47 +143,46 @@ export default function HasuraDomain() {
   return (
     <FormProvider {...form}>
       <Form onSubmit={handleSubmit}>
-        <SettingsContainer
-          title="Hasura Domain"
-          description="Enter below your custom domain for the Hasura/GraphQL service."
-          slotProps={{
-            submitButton: {
-              disabled: submitButtonDisabled,
-              loading: formState.isSubmitting,
-            },
-          }}
-          className="grid grid-flow-row gap-x-4 gap-y-4 px-4 lg:grid-cols-5"
-        >
-          <Input
-            value={hasura_fqdn}
-            onChange={(e) => {
-              setValue('hasura_fqdn', e.target.value, {
-                shouldDirty: true,
-              });
-              if (isVerified) {
-                setIsVerified(false);
-              }
-            }}
-            id="hasura_fqdn"
-            name="hasura_fqdn"
-            type="string"
-            fullWidth
-            className="col-span-5 lg:col-span-2"
-            placeholder="graphql.mydomain.dev"
-            error={Boolean(formState.errors.hasura_fqdn?.message)}
-            helperText={formState.errors.hasura_fqdn?.message}
-            slotProps={{ inputRoot: { min: 1, max: 100 } }}
+        <SettingsCard>
+          <SettingsCardHeader
+            title="Hasura Domain"
+            description="Enter below your custom domain for the Hasura/GraphQL service."
           />
-          <div className="col-span-5 row-start-2">
-            <VerifyDomain
-              recordType="CNAME"
-              hostname={hasura_fqdn}
-              value={`lb.${project?.region.name}.${project?.region.domain}.`}
-              onHostNameVerified={() => setIsVerified(true)}
-              saveEnabled={!submitButtonDisabled}
+
+          <SettingsCardContent className="gap-x-4 gap-y-4 lg:grid-cols-5">
+            <FormInput
+              control={form.control}
+              name="hasura_fqdn"
+              containerClassName="col-span-5 lg:col-span-2"
+              placeholder="graphql.mydomain.dev"
+              onChange={() => {
+                if (isVerified) {
+                  setIsVerified(false);
+                }
+              }}
             />
-          </div>
-        </SettingsContainer>
+            <div className="col-span-5 row-start-2">
+              <VerifyDomain
+                recordType="CNAME"
+                hostname={hasura_fqdn}
+                value={`lb.${project?.region.name}.${project?.region.domain}.`}
+                onHostNameVerified={() => setIsVerified(true)}
+                saveEnabled={!submitButtonDisabled}
+              />
+            </div>
+          </SettingsCardContent>
+
+          <SettingsCardFooter>
+            <ButtonWithLoading
+              type="submit"
+              disabled={submitButtonDisabled}
+              loading={formState.isSubmitting}
+              className="w-full sm:w-auto"
+            >
+              Save
+            </ButtonWithLoading>
+          </SettingsCardFooter>
+        </SettingsCard>
       </Form>
     </FormProvider>
   );

--- a/dashboard/src/features/orgs/projects/custom-domains/settings/components/RunServiceDomains/RunServiceDomains.tsx
+++ b/dashboard/src/features/orgs/projects/custom-domains/settings/components/RunServiceDomains/RunServiceDomains.tsx
@@ -1,7 +1,10 @@
 import { ExternalLink as ArrowSquareOutIcon } from 'lucide-react';
 import Link from 'next/link';
-import { SettingsContainer } from '@/components/layout/SettingsContainer';
-import { Text } from '@/components/ui/v2/Text';
+import {
+  SettingsCard,
+  SettingsCardContent,
+  SettingsCardHeader,
+} from '@/components/layout/SettingsCard';
 import type { RunService } from '@/features/orgs/projects/common/hooks/useRunServices';
 import { RunServicePortDomain } from '@/features/orgs/projects/custom-domains/settings/components/RunServicePortDomain';
 
@@ -23,43 +26,36 @@ export default function RunServiceDomains({
       {services
         .filter((service) => (service.config?.ports?.length ?? 0) > 0)
         .map((service) => (
-          <SettingsContainer
-            key={service.id ?? service.serviceID}
-            title={
-              <div className="flex flex-row items-center">
-                <Text className="font-semibold text-lg">
-                  {service.config?.name ?? 'unset'}
-                </Text>
-                <Link
-                  href={`/orgs/${org?.slug}/projects/${project?.subdomain}/services`}
-                  target="_blank"
-                  rel="noopener noreferrer"
-                  className="font-medium text-primary hover:underline"
-                >
-                  <ArrowSquareOutIcon className="mb-1 ml-1 h-4 w-4" />
-                </Link>
-              </div>
-            }
-            description="Enter below your custom domain for the published ports."
-            docsTitle={service.config?.name ?? 'unset'}
-            slotProps={{
-              submitButton: {
-                hidden: true,
-              },
-              footer: {
-                className: 'hidden',
-              },
-            }}
-            className="grid gap-x-4 gap-y-4 px-4"
-          >
-            {service.config?.ports?.map((port) => (
-              <RunServicePortDomain
-                key={String(port.port)}
-                service={service}
-                port={port.port}
-              />
-            ))}
-          </SettingsContainer>
+          <SettingsCard key={service.id ?? service.serviceID}>
+            <SettingsCardHeader
+              title={
+                <div className="flex flex-row items-center">
+                  <p className="font-semibold text-lg">
+                    {service.config?.name ?? 'unset'}
+                  </p>
+                  <Link
+                    href={`/orgs/${org?.slug}/projects/${project?.subdomain}/services`}
+                    target="_blank"
+                    rel="noopener noreferrer"
+                    className="font-medium text-primary hover:underline"
+                  >
+                    <ArrowSquareOutIcon className="mb-1 ml-1 h-4 w-4" />
+                  </Link>
+                </div>
+              }
+              description="Enter below your custom domain for the published ports."
+            />
+
+            <SettingsCardContent className="gap-x-4 gap-y-4">
+              {service.config?.ports?.map((port) => (
+                <RunServicePortDomain
+                  key={String(port.port)}
+                  service={service}
+                  port={port.port}
+                />
+              ))}
+            </SettingsCardContent>
+          </SettingsCard>
         ))}
     </div>
   );

--- a/dashboard/src/features/orgs/projects/custom-domains/settings/components/RunServicePortDomain/RunServicePortDomain.tsx
+++ b/dashboard/src/features/orgs/projects/custom-domains/settings/components/RunServicePortDomain/RunServicePortDomain.tsx
@@ -5,8 +5,8 @@ import * as Yup from 'yup';
 import { ApplyLocalSettingsDialog } from '@/components/common/ApplyLocalSettingsDialog';
 import { useDialog } from '@/components/common/DialogProvider';
 import { Form } from '@/components/form/Form';
-import { Input } from '@/components/ui/v2/Input';
-import { Text } from '@/components/ui/v2/Text';
+import { FormInput } from '@/components/form/FormInput';
+
 import { Button } from '@/components/ui/v3/button';
 import { useIsPlatform } from '@/features/orgs/projects/common/hooks/useIsPlatform';
 import type { RunService } from '@/features/orgs/projects/common/hooks/useRunServices';
@@ -54,7 +54,7 @@ export default function RunServicePortDomain({
     resolver: yupResolver(validationSchema),
   });
 
-  const { formState, register, watch } = form;
+  const { formState, watch } = form;
   const isDirty = Object.keys(formState.dirtyFields).length > 0;
 
   const runServicePortFQDN = watch('runServicePortFQDN');
@@ -130,23 +130,15 @@ export default function RunServicePortDomain({
     <FormProvider {...form}>
       <Form onSubmit={handleSubmit}>
         <div className="space-y-2">
-          <Text className="font-semibold text-sm">{`${runServicePort?.type} <--> ${runServicePort?.port}`}</Text>
+          <p className="font-semibold text-sm">{`${runServicePort?.type} <--> ${runServicePort?.port}`}</p>
           <div className="flex flex-row space-x-4">
-            <Input
-              {...register('runServicePortFQDN')}
-              id="runServicePortFQDN"
+            <FormInput
+              control={form.control}
               name="runServicePortFQDN"
-              type="string"
-              fullWidth
-              className=""
+              containerClassName="flex-1"
               placeholder={`${service.config?.name ?? 'unset'}-${
                 runServicePort?.port
               }.mydomain.dev`}
-              error={Boolean(formState.errors.runServicePortFQDN?.message)}
-              helperText={formState.errors.runServicePortFQDN?.message}
-              slotProps={{
-                inputRoot: { min: 1, max: 100 },
-              }}
             />
             <Button variant="outline" type="submit" disabled={isDisabled()}>
               Save

--- a/dashboard/src/features/orgs/projects/custom-domains/settings/components/ServerlessFunctionsDomain/ServerlessFunctionsDomain.tsx
+++ b/dashboard/src/features/orgs/projects/custom-domains/settings/components/ServerlessFunctionsDomain/ServerlessFunctionsDomain.tsx
@@ -5,8 +5,14 @@ import * as Yup from 'yup';
 import { ApplyLocalSettingsDialog } from '@/components/common/ApplyLocalSettingsDialog';
 import { useDialog } from '@/components/common/DialogProvider';
 import { Form } from '@/components/form/Form';
-import { SettingsContainer } from '@/components/layout/SettingsContainer';
-import { Input } from '@/components/ui/v2/Input';
+import { FormInput } from '@/components/form/FormInput';
+import {
+  SettingsCard,
+  SettingsCardContent,
+  SettingsCardFooter,
+  SettingsCardHeader,
+} from '@/components/layout/SettingsCard';
+import { ButtonWithLoading } from '@/components/ui/v3/button';
 import { useIsPlatform } from '@/features/orgs/projects/common/hooks/useIsPlatform';
 import { VerifyDomain } from '@/features/orgs/projects/custom-domains/settings/components/VerifyDomain';
 import { useLocalMimirClient } from '@/features/orgs/projects/hooks/useLocalMimirClient';
@@ -60,7 +66,7 @@ export default function ServerlessFunctionsDomain() {
     }
   }, [data, loading, form, initialValue]);
 
-  const { formState, watch, setValue } = form;
+  const { formState, watch } = form;
   const isDirty = Object.keys(formState.dirtyFields).length > 0;
 
   const functions_fqdn = watch('functions_fqdn');
@@ -140,45 +146,46 @@ export default function ServerlessFunctionsDomain() {
   return (
     <FormProvider {...form}>
       <Form onSubmit={handleSubmit}>
-        <SettingsContainer
-          title="Serverless Functions Domain"
-          description="Enter below your custom domain for Serverless Functions."
-          slotProps={{
-            submitButton: {
-              disabled: submitButtonDisabled,
-              loading: formState.isSubmitting,
-            },
-          }}
-          className="grid grid-flow-row gap-x-4 gap-y-4 px-4 lg:grid-cols-5"
-        >
-          <Input
-            value={functions_fqdn}
-            onChange={(e) => {
-              setValue('functions_fqdn', e.target.value, { shouldDirty: true });
-              if (isVerified) {
-                setIsVerified(false);
-              }
-            }}
-            id="functions_fqdn"
-            name="functions_fqdn"
-            type="string"
-            fullWidth
-            className="col-span-5 lg:col-span-2"
-            placeholder="functions.mydomain.dev"
-            error={Boolean(formState.errors.functions_fqdn?.message)}
-            helperText={formState.errors.functions_fqdn?.message}
-            slotProps={{ inputRoot: { min: 1, max: 100 } }}
+        <SettingsCard>
+          <SettingsCardHeader
+            title="Serverless Functions Domain"
+            description="Enter below your custom domain for Serverless Functions."
           />
-          <div className="col-span-5 row-start-2">
-            <VerifyDomain
-              recordType="CNAME"
-              hostname={functions_fqdn}
-              value={`lb.${project!.region.name}.${project!.region.domain}.`}
-              onHostNameVerified={() => setIsVerified(true)}
-              saveEnabled={!submitButtonDisabled}
+
+          <SettingsCardContent className="gap-x-4 gap-y-4 lg:grid-cols-5">
+            <FormInput
+              control={form.control}
+              name="functions_fqdn"
+              containerClassName="col-span-5 lg:col-span-2"
+              placeholder="functions.mydomain.dev"
+              onChange={() => {
+                if (isVerified) {
+                  setIsVerified(false);
+                }
+              }}
             />
-          </div>
-        </SettingsContainer>
+            <div className="col-span-5 row-start-2">
+              <VerifyDomain
+                recordType="CNAME"
+                hostname={functions_fqdn}
+                value={`lb.${project!.region.name}.${project!.region.domain}.`}
+                onHostNameVerified={() => setIsVerified(true)}
+                saveEnabled={!submitButtonDisabled}
+              />
+            </div>
+          </SettingsCardContent>
+
+          <SettingsCardFooter>
+            <ButtonWithLoading
+              type="submit"
+              disabled={submitButtonDisabled}
+              loading={formState.isSubmitting}
+              className="w-full sm:w-auto"
+            >
+              Save
+            </ButtonWithLoading>
+          </SettingsCardFooter>
+        </SettingsCard>
       </Form>
     </FormProvider>
   );

--- a/dashboard/src/features/orgs/projects/custom-domains/settings/components/VerifyDomain/VerifyDomain.tsx
+++ b/dashboard/src/features/orgs/projects/custom-domains/settings/components/VerifyDomain/VerifyDomain.tsx
@@ -1,8 +1,6 @@
 import { CopyIcon } from 'lucide-react';
 import { useEffect, useState } from 'react';
-import { Box } from '@/components/ui/v2/Box';
-import { IconButton } from '@/components/ui/v2/IconButton';
-import { Text } from '@/components/ui/v2/Text';
+
 import { Button } from '@/components/ui/v3/button';
 import { useIsPlatform } from '@/features/orgs/projects/common/hooks/useIsPlatform';
 import { execPromiseWithErrorToast } from '@/features/orgs/utils/execPromiseWithErrorToast';
@@ -75,69 +73,61 @@ export default function VerifyDomain({
   };
 
   return (
-    <Box
-      sx={[
-        { backgroundColor: 'primary.light' },
-        verificationFailed && {
-          backgroundColor: 'error.light',
-          color: 'error.main',
-        },
-        verificationSucceeded && {
-          backgroundColor: 'success.light',
-          color: 'success.dark',
-        },
-        !isPlatform && {
-          backgroundColor: 'grey.300',
-        },
-      ]}
-      className="flex flex-col space-y-4 rounded-md p-4"
+    <div
+      className={`flex flex-col space-y-4 rounded-md p-4 ${
+        verificationFailed
+          ? 'bg-destructive/10 text-destructive'
+          : verificationSucceeded
+            ? 'bg-green-100 text-green-900 dark:bg-green-900/30 dark:text-green-400'
+            : !isPlatform
+              ? 'bg-muted text-muted-foreground'
+              : 'bg-primary/10 text-foreground'
+      }`}
     >
       <div className="flex flex-row items-center justify-between">
         {!verificationFailed && !verificationSucceeded && (
-          <Text>
-            Add the record below in your DNS provider to verify {hostname}
-          </Text>
+          <p>Add the record below in your DNS provider to verify {hostname}</p>
         )}
 
         {verificationSucceeded && (
-          <Text>
+          <p>
             <span className="font-semibold">{hostname}</span> was verified
             successfully. {saveEnabled ? 'Hit save to apply.' : ''}
-          </Text>
+          </p>
         )}
 
         {verificationFailed && (
-          <Text>
+          <p>
             An error occurred while trying to verify{' '}
             <span className="font-semibold">{hostname}</span>. Make sure you
             correctly added the <span className="font-semibold">CNAME</span> and
             try again.
-          </Text>
+          </p>
         )}
       </div>
 
       <div className="relative flex flex-col text-slate-500">
         <div className="flex space-x-2">
-          <Text>Record type: </Text>
-          <Text className="font-bold">{recordType}</Text>
+          <p>Record type: </p>
+          <p className="font-bold">{recordType}</p>
         </div>
         <div className="flex space-x-2">
-          <Text>Host:</Text>
-          <Text className="font-bold">{hostname}</Text>
+          <p>Host:</p>
+          <p className="font-bold">{hostname}</p>
         </div>
         <div className="flex flex-row space-x-2">
-          <Text>Value:</Text>
+          <p>Value:</p>
           {isPlatform ? (
             <>
-              <Text className="font-bold">{value}</Text>
-              <IconButton
-                aria-label="Copy Personal Access Token"
-                variant="borderless"
-                color="secondary"
+              <p className="font-bold">{value}</p>
+              <Button
+                aria-label="Copy CNAME value"
+                variant="ghost"
+                size="icon"
                 onClick={() => copy(value, 'CNAME Value')}
               >
                 <CopyIcon className="h-4 w-4" />
-              </IconButton>
+              </Button>
             </>
           ) : null}
         </div>
@@ -151,6 +141,6 @@ export default function VerifyDomain({
           </Button>
         ) : null}
       </div>
-    </Box>
+    </div>
   );
 }

--- a/dashboard/src/pages/orgs/[orgSlug]/projects/[appSubdomain]/settings/custom-domains.tsx
+++ b/dashboard/src/pages/orgs/[orgSlug]/projects/[appSubdomain]/settings/custom-domains.tsx
@@ -1,10 +1,12 @@
 import type { ReactElement } from 'react';
 import { UpgradeToProBanner } from '@/components/common/UpgradeToProBanner';
-import { Container } from '@/components/layout/Container';
-import { Box } from '@/components/ui/v2/Box';
-import { Text } from '@/components/ui/v2/Text';
+import {
+  SettingsCard,
+  SettingsCardFooter,
+  SettingsCardHeader,
+  SettingsDocsLink,
+} from '@/components/layout/SettingsCard';
 import { Spinner } from '@/components/ui/v3/spinner';
-import { TextLink } from '@/components/ui/v3/text-link';
 import { OrgLayout } from '@/features/orgs/layout/OrgLayout';
 import { SettingsLayout } from '@/features/orgs/layout/SettingsLayout';
 import { useIsPlatform } from '@/features/orgs/projects/common/hooks/useIsPlatform';
@@ -55,15 +57,12 @@ export default function CustomDomains() {
 
   if (org?.plan?.isFree) {
     return (
-      <Container
-        className="grid grid-flow-row gap-6 bg-transparent"
-        rootClassName="bg-transparent"
-      >
+      <div className="grid grid-flow-row gap-6">
         <UpgradeToProBanner
           title="To unlock Custom Domains, transfer this project to a Pro or Team organization."
           description=""
         />
-      </Container>
+      </div>
     );
   }
 
@@ -88,27 +87,19 @@ export default function CustomDomains() {
   }
 
   return (
-    <Container
-      className="grid max-w-5xl grid-flow-row gap-6 bg-transparent"
-      rootClassName="bg-transparent"
-    >
-      <Box className="flex flex-row items-center gap-4 overflow-hidden rounded-lg border-1 p-4">
-        <div className="flex flex-col space-y-2">
-          <Text className="font-semibold text-lg">Custom Domains</Text>
-
-          <Text color="secondary">
-            Add a custom domain to Auth, Hasura, PostgreSQL, and your Run
-            services for only a $10 flat fee 🚀 <br /> Learn more about
-            <TextLink
-              href="https://docs.nhost.io/platform/cloud/custom-domains"
-              external
-              className="ml-1 font-medium"
-            >
-              Custom Domains
-            </TextLink>
-          </Text>
-        </div>
-      </Box>
+    <div className="grid grid-flow-row gap-6">
+      <SettingsCard>
+        <SettingsCardHeader
+          title="Custom Domains"
+          description="Add a custom domain to Auth, Hasura, PostgreSQL, and your Run services for only a $10 flat fee 🚀"
+        />
+        <SettingsCardFooter>
+          <SettingsDocsLink
+            href="https://docs.nhost.io/platform/cloud/custom-domains"
+            title="Custom Domains"
+          />
+        </SettingsCardFooter>
+      </SettingsCard>
 
       <AuthDomain />
       <HasuraDomain />
@@ -116,24 +107,15 @@ export default function CustomDomains() {
 
       <ServerlessFunctionsDomain />
       <RunServiceDomains services={services} />
-    </Container>
+    </div>
   );
 }
 
 CustomDomains.getLayout = function getLayout(page: ReactElement) {
   return (
-    <OrgLayout
-      mainContainerProps={{
-        className: 'flex h-full overflow-auto',
-      }}
-    >
+    <OrgLayout>
       <SettingsLayout>
-        <Container
-          sx={{ backgroundColor: 'background.default' }}
-          className="max-w-5xl"
-        >
-          {page}
-        </Container>
+        <div className="mx-auto w-full max-w-5xl px-5 py-4">{page}</div>
       </SettingsLayout>
     </OrgLayout>
   );


### PR DESCRIPTION
<!-- pi-reviewer:start -->
### **What this change solves**
Migrates the Custom Domains settings page to the new settings card UI while preserving custom domain verification and save flows. The change replaces legacy containers and v2 inputs with v3 card/form controls for a consistent settings experience.

___

### **Change Type**
Refactoring

___

### **Description**
- Replaces legacy `SettingsContainer` wrappers across custom-domain panels with `SettingsCard` components.
- Updates domain input controls to v3 `Input`/`FormInput` and explicit card footers where saves are available.
- Simplifies the Custom Domains settings page shell and reorganizes service-domain layout content.

___

<details> <summary><h3> File Walkthrough</h3></summary>

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody>
<tr><td><strong>Dashboard custom domains</strong></td><td><details><summary>8 files</summary><table>
<tr><td><strong>dashboard/src/features/orgs/projects/custom-domains/settings/components/AuthDomain/AuthDomain.tsx</strong><dd><code>Migrates the auth domain form to SettingsCard, FormInput, and v3 loading button.</code></dd></td><td>+47/-40</td></tr>
<tr><td><strong>dashboard/src/features/orgs/projects/custom-domains/settings/components/DatabaseDomain/DatabaseDomain.tsx</strong><dd><code>Migrates the database domain verification panel to SettingsCard and v3 Input.</code></dd></td><td>+29/-33</td></tr>
<tr><td><strong>dashboard/src/features/orgs/projects/custom-domains/settings/components/HasuraDomain/HasuraDomain.tsx</strong><dd><code>Migrates the Hasura domain form to SettingsCard, FormInput, and v3 loading button.</code></dd></td><td>+47/-42</td></tr>
<tr><td><strong>dashboard/src/features/orgs/projects/custom-domains/settings/components/RunServiceDomains/RunServiceDomains.tsx</strong><dd><code>Migrates Run service domain entries to SettingsCard layout.</code></dd></td><td>+35/-39</td></tr>
<tr><td><strong>dashboard/src/features/orgs/projects/custom-domains/settings/components/RunServicePortDomain/RunServicePortDomain.tsx</strong><dd><code>Updates individual Run service port domain input styling to the v3 layout.</code></dd></td><td>+7/-15</td></tr>
<tr><td><strong>dashboard/src/features/orgs/projects/custom-domains/settings/components/ServerlessFunctionsDomain/ServerlessFunctionsDomain.tsx</strong><dd><code>Migrates the functions domain form to SettingsCard, FormInput, and v3 loading button.</code></dd></td><td>+47/-40</td></tr>
<tr><td><strong>dashboard/src/features/orgs/projects/custom-domains/settings/components/VerifyDomain/VerifyDomain.tsx</strong><dd><code>Updates verification UI from v2 buttons and icons to v3 alert/button components.</code></dd></td><td>+28/-38</td></tr>
<tr><td><strong>dashboard/src/pages/orgs/[orgSlug]/projects/[appSubdomain]/settings/custom-domains.tsx</strong><dd><code>Simplifies the Custom Domains page wrapper and stacks the migrated domain panels.</code></dd></td><td>+24/-42</td></tr>
</table></details></td></tr>
</tbody></table>

</details>

___

<!-- pi-reviewer:end -->
