### PR TITLE
fix(dashboard): migrate metrics settings page

### DIFF
--- a/dashboard/src/components/form/FormPasswordInput/FormPasswordInput.tsx
+++ b/dashboard/src/components/form/FormPasswordInput/FormPasswordInput.tsx
@@ -1,0 +1,175 @@
+import {
+  type ChangeEventHandler,
+  type FocusEventHandler,
+  type ForwardedRef,
+  forwardRef,
+  type ReactNode,
+} from 'react';
+import type {
+  Control,
+  FieldPath,
+  FieldValues,
+  PathValue,
+} from 'react-hook-form';
+import { mergeRefs } from 'react-merge-refs';
+import getTransformedFieldProps, {
+  type Transformer,
+} from '@/components/form/utils/getTransformedFieldProps';
+import {
+  FormControl,
+  FormDescription,
+  FormField,
+  FormItem,
+  FormLabel,
+  FormMessage,
+} from '@/components/ui/v3/form';
+import {
+  PasswordInput,
+  type PasswordInputProps,
+} from '@/components/ui/v3/password-input';
+import { cn, isNotEmptyValue } from '@/lib/utils';
+
+const inputClasses =
+  '!bg-transparent aria-[invalid=true]:border-red-500 aria-[invalid=true]:focus:border-red-500 aria-[invalid=true]:focus:ring-red-500 disabled:!bg-data-cell-bg-disabled disabled:text-disabled disabled:placeholder:text-disabled disabled:opacity-100';
+
+interface FormPasswordInputProps<
+  TFieldValues extends FieldValues = FieldValues,
+  TName extends FieldPath<TFieldValues> = FieldPath<TFieldValues>,
+> {
+  control: Control<TFieldValues>;
+  name: TName;
+  label?: ReactNode;
+  placeholder?: string;
+  'aria-label'?: string;
+  className?: string;
+  containerClassName?: string;
+  inline?: boolean;
+  helperText?: string | null;
+  transform?: Transformer;
+  transformValue?: (
+    value: PathValue<TFieldValues, TName>,
+  ) => PathValue<TFieldValues, TName>;
+  disabled?: boolean;
+  autoComplete?: PasswordInputProps['autoComplete'];
+  'data-testid'?: string;
+  /**
+   * Called after the field's onChange runs. Use for side effects like syncing
+   * dependent fields.
+   */
+  onChange?: ChangeEventHandler<HTMLInputElement>;
+  /**
+   * Called after the field's onBlur runs.
+   */
+  onBlur?: FocusEventHandler<HTMLInputElement>;
+}
+
+function InnerFormPasswordInput<
+  TFieldValues extends FieldValues = FieldValues,
+  TName extends FieldPath<TFieldValues> = FieldPath<TFieldValues>,
+>(
+  {
+    control,
+    name,
+    label,
+    placeholder,
+    className = '',
+    containerClassName = '',
+    inline,
+    helperText,
+    disabled,
+    autoComplete,
+    transform,
+    'data-testid': dataTestId,
+    'aria-label': ariaLabel,
+    onChange: onChangeProp,
+    onBlur: onBlurProp,
+  }: FormPasswordInputProps<TFieldValues, TName>,
+  ref?: ForwardedRef<HTMLInputElement>,
+) {
+  return (
+    <FormField
+      control={control}
+      name={name}
+      render={({ field, fieldState }) => {
+        const baseFieldProps = isNotEmptyValue(transform)
+          ? getTransformedFieldProps(field, transform)
+          : field;
+        const {
+          onChange: fieldOnChange,
+          onBlur: fieldOnBlur,
+          ...restFieldProps
+        } = baseFieldProps;
+        const handleChange: ChangeEventHandler<HTMLInputElement> = (event) => {
+          fieldOnChange(event);
+          onChangeProp?.(event);
+        };
+        const handleBlur: FocusEventHandler<HTMLInputElement> = (event) => {
+          fieldOnBlur();
+          onBlurProp?.(event);
+        };
+        return (
+          <FormItem
+            className={cn(
+              {
+                'sm:flex sm:w-full sm:items-center sm:gap-4 sm:py-3': inline,
+              },
+              containerClassName,
+            )}
+          >
+            {!!label && (
+              <FormLabel
+                className={cn({
+                  'sm:mt-2 sm:w-52 sm:max-w-52 sm:flex-shrink-0 sm:self-start':
+                    inline,
+                })}
+              >
+                {label}
+              </FormLabel>
+            )}
+            <div
+              className={cn({
+                'space-y-2': !!helperText,
+                'sm:flex sm:w-[calc(100%-13.5rem)] sm:max-w-[calc(100%-13.5rem)] sm:flex-col sm:gap-2':
+                  inline,
+              })}
+            >
+              <FormControl>
+                <PasswordInput
+                  placeholder={placeholder}
+                  disabled={disabled}
+                  autoComplete={autoComplete}
+                  data-testid={dataTestId}
+                  aria-label={ariaLabel}
+                  aria-invalid={fieldState.invalid}
+                  {...restFieldProps}
+                  onChange={handleChange}
+                  onBlur={handleBlur}
+                  ref={mergeRefs([field.ref, ref])}
+                  className={cn(inputClasses, className)}
+                  wrapperClassName={cn({ 'w-full': !inline })}
+                />
+              </FormControl>
+              {!!helperText && (
+                <FormDescription className="break-all px-[1px]">
+                  {helperText}
+                </FormDescription>
+              )}
+              <FormMessage />
+            </div>
+          </FormItem>
+        );
+      }}
+    />
+  );
+}
+
+const FormPasswordInput = forwardRef(InnerFormPasswordInput) as <
+  TFieldValues extends FieldValues = FieldValues,
+  TName extends FieldPath<TFieldValues> = FieldPath<TFieldValues>,
+>(
+  props: FormPasswordInputProps<TFieldValues, TName> & {
+    ref?: ForwardedRef<HTMLInputElement>;
+  },
+) => ReturnType<typeof InnerFormPasswordInput>;
+
+export default FormPasswordInput;

--- a/dashboard/src/components/form/FormPasswordInput/index.ts
+++ b/dashboard/src/components/form/FormPasswordInput/index.ts
@@ -1,0 +1,1 @@
+export { default as FormPasswordInput } from './FormPasswordInput';

--- a/dashboard/src/components/ui/v3/password-input.tsx
+++ b/dashboard/src/components/ui/v3/password-input.tsx
@@ -1,0 +1,57 @@
+import { EyeIcon, EyeOffIcon } from 'lucide-react';
+import * as React from 'react';
+import type { InputProps } from '@/components/ui/v3/input';
+import {
+  InputGroup,
+  InputGroupAddon,
+  InputGroupButton,
+  InputGroupInput,
+} from '@/components/ui/v3/input-group';
+import { cn } from '@/lib/utils';
+
+export interface PasswordInputProps
+  extends Omit<InputProps, 'prefix' | 'type'> {}
+
+const PasswordInput = React.forwardRef<HTMLInputElement, PasswordInputProps>(
+  ({ className, disabled, wrapperClassName, ...props }, ref) => {
+    const [showPassword, setShowPassword] = React.useState(false);
+
+    return (
+      <InputGroup
+        className={cn(
+          'h-10 bg-transparent dark:bg-transparent',
+          wrapperClassName,
+        )}
+      >
+        <InputGroupInput
+          type={showPassword ? 'text' : 'password'}
+          disabled={disabled}
+          className={className}
+          ref={ref}
+          {...props}
+        />
+        <InputGroupAddon align="inline-end">
+          <InputGroupButton
+            aria-label={showPassword ? 'Hide password' : 'Show password'}
+            aria-pressed={showPassword}
+            disabled={disabled}
+            onClick={() => {
+              setShowPassword((currentShowPassword) => !currentShowPassword);
+            }}
+            size="icon-xs"
+            variant="ghost"
+          >
+            {showPassword ? (
+              <EyeOffIcon className="h-4 w-4" />
+            ) : (
+              <EyeIcon className="h-4 w-4" />
+            )}
+          </InputGroupButton>
+        </InputGroupAddon>
+      </InputGroup>
+    );
+  },
+);
+PasswordInput.displayName = 'PasswordInput';
+
+export { PasswordInput };

--- a/dashboard/src/features/orgs/projects/metrics/settings/components/ContactPointsSettings/ContactPointsSettings.tsx
+++ b/dashboard/src/features/orgs/projects/metrics/settings/components/ContactPointsSettings/ContactPointsSettings.tsx
@@ -4,9 +4,14 @@ import { twMerge } from 'tailwind-merge';
 import { ApplyLocalSettingsDialog } from '@/components/common/ApplyLocalSettingsDialog';
 import { useDialog } from '@/components/common/DialogProvider';
 import { Form } from '@/components/form/Form';
-import { SettingsContainer } from '@/components/layout/SettingsContainer';
-
-import { Divider } from '@/components/ui/v2/Divider';
+import {
+  SettingsCard,
+  SettingsCardContent,
+  SettingsCardFooter,
+  SettingsCardHeader,
+  SettingsDocsLink,
+} from '@/components/layout/SettingsCard';
+import { ButtonWithLoading } from '@/components/ui/v3/button';
 import { useIsPlatform } from '@/features/orgs/projects/common/hooks/useIsPlatform';
 import { useLocalMimirClient } from '@/features/orgs/projects/hooks/useLocalMimirClient';
 import { useProject } from '@/features/orgs/projects/hooks/useProject';
@@ -172,30 +177,41 @@ export default function ContactPointsSettings() {
   return (
     <FormProvider {...form}>
       <Form onSubmit={handleSubmit}>
-        <SettingsContainer
-          title="Contact Points"
-          description="Define the contact points where your notifications will be sent."
-          docsLink="https://docs.nhost.io/platform/cloud/metrics#configure-contact-points"
-          rootClassName="gap-0"
-          className={twMerge('my-2 px-0')}
-          slotProps={{
-            submitButton: {
-              disabled: !form.formState.isDirty,
-              loading: form.formState.isSubmitting,
-            },
-          }}
-        >
-          <Divider />
-          <EmailsFormSection />
-          <Divider />
-          <PagerdutyFormSection />
-          <Divider />
-          <DiscordFormSection />
-          <Divider />
-          <SlackFormSection />
-          <Divider />
-          <WebhookFormSection />
-        </SettingsContainer>
+        <SettingsCard className="gap-0">
+          <SettingsCardHeader
+            title="Contact Points"
+            description="Define the contact points where your notifications will be sent."
+          />
+
+          <SettingsCardContent className={twMerge('my-2 px-0')}>
+            <div className="border-t" />
+            <EmailsFormSection />
+            <div className="border-t" />
+            <PagerdutyFormSection />
+            <div className="border-t" />
+            <DiscordFormSection />
+            <div className="border-t" />
+            <SlackFormSection />
+            <div className="border-t" />
+            <WebhookFormSection />
+          </SettingsCardContent>
+
+          <SettingsCardFooter>
+            <SettingsDocsLink
+              href="https://docs.nhost.io/platform/cloud/metrics#configure-contact-points"
+              title="Contact Points"
+            />
+
+            <ButtonWithLoading
+              type="submit"
+              disabled={!form.formState.isDirty}
+              loading={form.formState.isSubmitting}
+              className="w-full sm:w-auto"
+            >
+              Save
+            </ButtonWithLoading>
+          </SettingsCardFooter>
+        </SettingsCard>
       </Form>
     </FormProvider>
   );

--- a/dashboard/src/features/orgs/projects/metrics/settings/components/DiscordFormSection/DiscordFormSection.tsx
+++ b/dashboard/src/features/orgs/projects/metrics/settings/components/DiscordFormSection/DiscordFormSection.tsx
@@ -1,41 +1,38 @@
 import { InfoIcon, PlusIcon, Trash2 as TrashIcon } from 'lucide-react';
 import { useFieldArray, useFormContext } from 'react-hook-form';
-import { Box } from '@/components/ui/v2/Box';
-import { Input } from '@/components/ui/v2/Input';
-import { Text } from '@/components/ui/v2/Text';
-import { Tooltip } from '@/components/ui/v2/Tooltip';
+import { FormInput } from '@/components/form/FormInput';
 import { Button } from '@/components/ui/v3/button';
+import {
+  Tooltip,
+  TooltipContent,
+  TooltipTrigger,
+} from '@/components/ui/v3/tooltip';
 import type { ContactPointsFormValues } from '@/features/orgs/projects/metrics/settings/components/ContactPointsSettings/ContactPointsSettingsTypes';
 
 export default function DiscordFormSection() {
-  const {
-    register,
-    formState: { errors },
-    control,
-  } = useFormContext<ContactPointsFormValues>();
+  const { control } = useFormContext<ContactPointsFormValues>();
   const { fields, append, remove } = useFieldArray({
     control,
     name: 'discord',
   });
 
   return (
-    <Box className="flex flex-col gap-4 p-4">
-      <Box className="flex flex-row items-center justify-between">
-        <Box className="flex flex-row items-center space-x-2">
-          <Text variant="h4" className="font-semibold">
-            Discord
-          </Text>
-          <Tooltip
-            title={
+    <div className="flex flex-col gap-4 p-4">
+      <div className="flex flex-row items-center justify-between">
+        <div className="flex flex-row items-center space-x-2">
+          <h3 className="font-semibold">Discord</h3>
+          <Tooltip>
+            <TooltipTrigger asChild>
+              <InfoIcon aria-label="Info" className="h-4 w-4 text-primary" />
+            </TooltipTrigger>
+            <TooltipContent>
               <span>
                 Receive alert notifications in your Discord channels when your
                 Grafana alert rules are triggered and resolved.
               </span>
-            }
-          >
-            <InfoIcon aria-label="Info" className="h-4 w-4 text-primary" />
+            </TooltipContent>
           </Tooltip>
-        </Box>
+        </div>
         <Button
           variant="ghost"
           size="icon"
@@ -44,37 +41,29 @@ export default function DiscordFormSection() {
         >
           <PlusIcon className="h-5 w-5" />
         </Button>
-      </Box>
+      </div>
       {fields?.length > 0 ? (
-        <Box className="flex flex-col gap-12">
+        <div className="flex flex-col gap-12">
           {fields.map((field, index) => (
-            <Box key={field.id} className="flex w-full items-center gap-2">
-              <Box className="flex flex-1 flex-col gap-2">
-                <Input
-                  {...register(`discord.${index}.url`)}
-                  id={`${field.id}-discord`}
+            <div key={field.id} className="flex w-full items-center gap-2">
+              <div className="flex flex-1 flex-col gap-2">
+                <FormInput
+                  control={control}
+                  name={`discord.${index}.url`}
                   label="Discord URL"
                   placeholder="https://discord.com/api/webhooks/..."
-                  className="w-full"
-                  hideEmptyHelperText
-                  error={!!errors?.discord?.[index]?.url}
-                  helperText={errors?.discord?.[index]?.url?.message}
-                  fullWidth
+                  containerClassName="w-full"
                   autoComplete="off"
                 />
-                <Input
-                  {...register(`discord.${index}.avatarUrl`)}
-                  id={`${field.id}-discord-avatar`}
+                <FormInput
+                  control={control}
+                  name={`discord.${index}.avatarUrl`}
                   label="Avatar URL"
                   placeholder="https://discord.com/api/avatar/..."
-                  className="w-full"
-                  hideEmptyHelperText
-                  error={!!errors?.discord?.[index]?.avatarUrl}
-                  helperText={errors?.discord?.[index]?.avatarUrl?.message}
-                  fullWidth
+                  containerClassName="w-full"
                   autoComplete="off"
                 />
-              </Box>
+              </div>
               <Button
                 variant="ghost"
                 className="text-destructive hover:text-destructive"
@@ -83,10 +72,10 @@ export default function DiscordFormSection() {
               >
                 <TrashIcon className="h-6 w-4" />
               </Button>
-            </Box>
+            </div>
           ))}
-        </Box>
+        </div>
       ) : null}
-    </Box>
+    </div>
   );
 }

--- a/dashboard/src/features/orgs/projects/metrics/settings/components/EmailsFormSection/EmailsFormSection.tsx
+++ b/dashboard/src/features/orgs/projects/metrics/settings/components/EmailsFormSection/EmailsFormSection.tsx
@@ -1,41 +1,38 @@
 import { InfoIcon, PlusIcon, Trash2 as TrashIcon } from 'lucide-react';
 import { useFieldArray, useFormContext } from 'react-hook-form';
-import { Box } from '@/components/ui/v2/Box';
-import { Input } from '@/components/ui/v2/Input';
-import { Text } from '@/components/ui/v2/Text';
-import { Tooltip } from '@/components/ui/v2/Tooltip';
+import { FormInput } from '@/components/form/FormInput';
 import { Button } from '@/components/ui/v3/button';
+import {
+  Tooltip,
+  TooltipContent,
+  TooltipTrigger,
+} from '@/components/ui/v3/tooltip';
 import type { ContactPointsFormValues } from '@/features/orgs/projects/metrics/settings/components/ContactPointsSettings/ContactPointsSettingsTypes';
 
 export default function EmailsFormSection() {
-  const {
-    register,
-    formState: { errors },
-    control,
-  } = useFormContext<ContactPointsFormValues>();
+  const { control } = useFormContext<ContactPointsFormValues>();
   const { fields, append, remove } = useFieldArray({
     control,
     name: 'emails',
   });
 
   return (
-    <Box className="flex flex-col gap-4 p-4">
-      <Box className="flex flex-row items-center justify-between">
-        <Box className="flex flex-row items-center space-x-2">
-          <Text variant="h4" className="font-semibold">
-            Email
-          </Text>
-          <Tooltip
-            title={
+    <div className="flex flex-col gap-4 p-4">
+      <div className="flex flex-row items-center justify-between">
+        <div className="flex flex-row items-center space-x-2">
+          <h3 className="font-semibold">Email</h3>
+          <Tooltip>
+            <TooltipTrigger asChild>
+              <InfoIcon aria-label="Info" className="h-4 w-4 text-primary" />
+            </TooltipTrigger>
+            <TooltipContent>
               <span>
                 Select your preferred emails for receiving notifications when
                 your alert rules are firing.
               </span>
-            }
-          >
-            <InfoIcon aria-label="Info" className="h-4 w-4 text-primary" />
+            </TooltipContent>
           </Tooltip>
-        </Box>
+        </div>
         <Button
           variant="ghost"
           size="icon"
@@ -44,22 +41,18 @@ export default function EmailsFormSection() {
         >
           <PlusIcon className="h-5 w-5" />
         </Button>
-      </Box>
+      </div>
 
       {fields?.length > 0 ? (
-        <Box className="flex flex-col gap-6">
+        <div className="flex flex-col gap-6">
           {fields.map((field, index) => (
-            <Box key={field.id} className="flex w-full items-center gap-2">
-              <Input
-                {...register(`emails.${index}.email`)}
-                id={`${field.id}-email`}
-                placeholder="Enter email address"
-                className="w-full"
+            <div key={field.id} className="flex w-full items-center gap-2">
+              <FormInput
+                control={control}
+                name={`emails.${index}.email`}
                 label={`Email #${index + 1}`}
-                hideEmptyHelperText
-                error={!!errors?.emails?.[index]?.email}
-                helperText={errors?.emails?.[index]?.email?.message}
-                fullWidth
+                placeholder="Enter email address"
+                containerClassName="w-full"
                 autoComplete="off"
               />
               <Button
@@ -70,10 +63,10 @@ export default function EmailsFormSection() {
               >
                 <TrashIcon className="h-6 w-4" />
               </Button>
-            </Box>
+            </div>
           ))}
-        </Box>
+        </div>
       ) : null}
-    </Box>
+    </div>
   );
 }

--- a/dashboard/src/features/orgs/projects/metrics/settings/components/MetricsSMTPSettings/MetricsSMTPSettings.tsx
+++ b/dashboard/src/features/orgs/projects/metrics/settings/components/MetricsSMTPSettings/MetricsSMTPSettings.tsx
@@ -5,8 +5,15 @@ import * as yup from 'yup';
 import { ApplyLocalSettingsDialog } from '@/components/common/ApplyLocalSettingsDialog';
 import { useDialog } from '@/components/common/DialogProvider';
 import { Form } from '@/components/form/Form';
-import { SettingsContainer } from '@/components/layout/SettingsContainer';
-import { Input } from '@/components/ui/v2/Input';
+import { FormInput } from '@/components/form/FormInput';
+import {
+  SettingsCard,
+  SettingsCardContent,
+  SettingsCardFooter,
+  SettingsCardHeader,
+  SettingsDocsLink,
+} from '@/components/layout/SettingsCard';
+import { ButtonWithLoading } from '@/components/ui/v3/button';
 import { useIsPlatform } from '@/features/orgs/projects/common/hooks/useIsPlatform';
 import { useLocalMimirClient } from '@/features/orgs/projects/hooks/useLocalMimirClient';
 import { useProject } from '@/features/orgs/projects/hooks/useProject';
@@ -68,8 +75,8 @@ export default function MetricsSMTPSettings() {
   });
 
   const {
-    register: registerSmtp,
-    formState: { errors, isDirty, isSubmitting },
+    control,
+    formState: { isDirty, isSubmitting },
   } = form;
 
   const [updateConfig] = useUpdateConfigMutation({
@@ -119,84 +126,72 @@ export default function MetricsSMTPSettings() {
   return (
     <FormProvider {...form}>
       <Form onSubmit={handleEditSMTPSettings}>
-        <SettingsContainer
-          title="SMTP Settings"
-          description="Configure your SMTP settings to send emails as part of your alerting."
-          docsLink="https://docs.nhost.io/platform/cloud/metrics#smtp"
-          submitButtonText="Save"
-          className="grid gap-4 lg:grid-cols-9"
-          slotProps={{
-            submitButton: {
-              disabled: !isDirty,
-              loading: isSubmitting,
-            },
-          }}
-        >
-          <Input
-            {...registerSmtp('sender')}
-            id="sender"
-            name="sender"
-            label="From Email"
-            placeholder="admin@localhost"
-            className="lg:col-span-4"
-            hideEmptyHelperText
-            fullWidth
-            error={Boolean(errors.sender)}
-            helperText={errors.sender?.message}
+        <SettingsCard>
+          <SettingsCardHeader
+            title="SMTP Settings"
+            description="Configure your SMTP settings to send emails as part of your alerting."
           />
 
-          <Input
-            {...registerSmtp('host')}
-            id="host"
-            name="host"
-            label="SMTP Host"
-            className="lg:col-span-4"
-            placeholder="localhost"
-            hideEmptyHelperText
-            fullWidth
-            error={Boolean(errors.host)}
-            helperText={errors.host?.message}
-          />
+          <SettingsCardContent className="lg:grid-cols-9">
+            <FormInput
+              control={control}
+              name="sender"
+              label="From Email"
+              placeholder="admin@localhost"
+              containerClassName="lg:col-span-4"
+            />
 
-          <Input
-            {...registerSmtp('port')}
-            id="port"
-            name="port"
-            label="Port"
-            type="number"
-            placeholder="25"
-            className="lg:col-span-1"
-            hideEmptyHelperText
-            fullWidth
-            error={Boolean(errors.port)}
-            helperText={errors.port?.message}
-          />
+            <FormInput
+              control={control}
+              name="host"
+              label="SMTP Host"
+              placeholder="localhost"
+              containerClassName="lg:col-span-4"
+            />
 
-          <Input
-            {...registerSmtp('user')}
-            id="user"
-            label="SMTP Username"
-            placeholder="Enter SMTP Username"
-            className="lg:col-span-4"
-            hideEmptyHelperText
-            fullWidth
-            error={Boolean(errors.user)}
-            helperText={errors.user?.message}
-          />
+            <FormInput
+              control={control}
+              name="port"
+              label="Port"
+              placeholder="25"
+              type="number"
+              containerClassName="lg:col-span-1"
+            />
 
-          <Input
-            {...registerSmtp('password')}
-            id="password"
-            label="SMTP Password"
-            type="password"
-            placeholder="Enter SMTP password"
-            className="lg:col-span-5"
-            hideEmptyHelperText
-            fullWidth
-            error={Boolean(errors.password)}
-            helperText={errors.password?.message}
-          />
-        </SettingsContainer>
+            <FormInput
+              control={control}
+              name="user"
+              label="SMTP Username"
+              placeholder="Enter SMTP Username"
+              containerClassName="lg:col-span-4"
+            />
+
+            <FormInput
+              control={control}
+              name="password"
+              label="SMTP Password"
+              placeholder="Enter SMTP password"
+              type="password"
+              containerClassName="lg:col-span-5"
+            />
+          </SettingsCardContent>
+
+          <SettingsCardFooter>
+            <SettingsDocsLink
+              href="https://docs.nhost.io/platform/cloud/metrics#smtp"
+              title="SMTP Settings"
+            />
+
+            <ButtonWithLoading
+              type="submit"
+              disabled={!isDirty}
+              loading={isSubmitting}
+              className="w-full sm:w-auto"
+            >
+              Save
+            </ButtonWithLoading>
+          </SettingsCardFooter>
+        </SettingsCard>
       </Form>
     </FormProvider>
   );

--- a/dashboard/src/features/orgs/projects/metrics/settings/components/MetricsSettings/MetricsSettings.tsx
+++ b/dashboard/src/features/orgs/projects/metrics/settings/components/MetricsSettings/MetricsSettings.tsx
@@ -5,7 +5,15 @@ import * as Yup from 'yup';
 import { ApplyLocalSettingsDialog } from '@/components/common/ApplyLocalSettingsDialog';
 import { useDialog } from '@/components/common/DialogProvider';
 import { Form } from '@/components/form/Form';
-import { SettingsContainer } from '@/components/layout/SettingsContainer';
+import {
+  SettingsCard,
+  SettingsCardFooter,
+  SettingsCardHeader,
+  SettingsDocsLink,
+} from '@/components/layout/SettingsCard';
+import { ButtonWithLoading } from '@/components/ui/v3/button';
+import { FormField } from '@/components/ui/v3/form';
+import { Switch } from '@/components/ui/v3/switch';
 import { useIsPlatform } from '@/features/orgs/projects/common/hooks/useIsPlatform';
 import { useLocalMimirClient } from '@/features/orgs/projects/hooks/useLocalMimirClient';
 import { useProject } from '@/features/orgs/projects/hooks/useProject';
@@ -116,24 +124,44 @@ export default function MetricsSettings() {
   }
 
   return (
-    <div className="grid max-w-5xl grid-flow-row gap-y-6 bg-transparent">
+    <div className="grid grid-flow-row gap-y-6">
       <FormProvider {...alertingForm}>
         <Form onSubmit={handleSubmit}>
-          <SettingsContainer
-            title="Alerting"
-            description="Enable or disable Alerting."
-            slotProps={{
-              submitButton: {
-                disabled: !alertingForm.formState.isDirty,
-                loading: alertingForm.formState.isSubmitting,
-              },
-            }}
-            switchId="enabled"
-            docsTitle="enabling or disabling Alerting"
-            docsLink="https://docs.nhost.io/platform/cloud/metrics#alerting"
-            showSwitch
-            className="hidden"
-          />
+          <SettingsCard>
+            <SettingsCardHeader
+              title="Alerting"
+              description="Enable or disable Alerting."
+              control={
+                <FormField
+                  control={alertingForm.control}
+                  name="enabled"
+                  render={({ field }) => (
+                    <Switch
+                      checked={field.value}
+                      onCheckedChange={field.onChange}
+                      aria-label="Toggle Alerting"
+                    />
+                  )}
+                />
+              }
+            />
+
+            <SettingsCardFooter>
+              <SettingsDocsLink
+                href="https://docs.nhost.io/platform/cloud/metrics#alerting"
+                title="enabling or disabling Alerting"
+              />
+
+              <ButtonWithLoading
+                type="submit"
+                disabled={!alertingForm.formState.isDirty}
+                loading={alertingForm.formState.isSubmitting}
+                className="w-full sm:w-auto"
+              >
+                Save
+              </ButtonWithLoading>
+            </SettingsCardFooter>
+          </SettingsCard>
         </Form>
       </FormProvider>
       {alerting ? (

--- a/dashboard/src/features/orgs/projects/metrics/settings/components/PagerdutyFormSection/PagerdutyFormSection.tsx
+++ b/dashboard/src/features/orgs/projects/metrics/settings/components/PagerdutyFormSection/PagerdutyFormSection.tsx
@@ -1,9 +1,6 @@
 import { InfoIcon, PlusIcon, Trash2 as TrashIcon } from 'lucide-react';
 import { useFieldArray, useFormContext, useWatch } from 'react-hook-form';
-import { Box } from '@/components/ui/v2/Box';
-import { Input } from '@/components/ui/v2/Input';
-import { Text } from '@/components/ui/v2/Text';
-import { Tooltip } from '@/components/ui/v2/Tooltip';
+import { FormInput } from '@/components/form/FormInput';
 import { Button } from '@/components/ui/v3/button';
 import {
   Select,
@@ -12,16 +9,16 @@ import {
   SelectTrigger,
   SelectValue,
 } from '@/components/ui/v3/select';
+import {
+  Tooltip,
+  TooltipContent,
+  TooltipTrigger,
+} from '@/components/ui/v3/tooltip';
 import type { ContactPointsFormValues } from '@/features/orgs/projects/metrics/settings/components/ContactPointsSettings/ContactPointsSettingsTypes';
 import { EventSeverity } from './PagerdutyFormSectionTypes';
 
 export default function PagerdutyFormSection() {
-  const {
-    register,
-    formState: { errors },
-    setValue,
-    control,
-  } = useFormContext<ContactPointsFormValues>();
+  const { setValue, control } = useFormContext<ContactPointsFormValues>();
   const formValues = useWatch<ContactPointsFormValues>();
   const { fields, append, remove } = useFieldArray({
     control,
@@ -32,23 +29,22 @@ export default function PagerdutyFormSection() {
     setValue(`pagerduty.${index}.severity`, value as EventSeverity);
 
   return (
-    <Box className="flex flex-col gap-4 p-4">
-      <Box className="flex flex-row items-center justify-between">
-        <Box className="flex flex-row items-center space-x-2">
-          <Text variant="h4" className="font-semibold">
-            PagerDuty
-          </Text>
-          <Tooltip
-            title={
+    <div className="flex flex-col gap-4 p-4">
+      <div className="flex flex-row items-center justify-between">
+        <div className="flex flex-row items-center space-x-2">
+          <h3 className="font-semibold">PagerDuty</h3>
+          <Tooltip>
+            <TooltipTrigger asChild>
+              <InfoIcon aria-label="Info" className="h-4 w-4 text-primary" />
+            </TooltipTrigger>
+            <TooltipContent>
               <span>
                 Receive notifications in PagerDuty when your alert rules are
                 firing.
               </span>
-            }
-          >
-            <InfoIcon aria-label="Info" className="h-4 w-4 text-primary" />
+            </TooltipContent>
           </Tooltip>
-        </Box>
+        </div>
         <Button
           variant="ghost"
           size="icon"
@@ -65,25 +61,19 @@ export default function PagerdutyFormSection() {
         >
           <PlusIcon className="h-5 w-5" />
         </Button>
-      </Box>
+      </div>
 
       {fields?.length > 0 ? (
-        <Box className="flex flex-col gap-12">
+        <div className="flex flex-col gap-12">
           {fields.map((field, index) => (
-            <Box key={field.id} className="flex w-full items-center gap-2">
-              <Box className="grid flex-grow gap-4 lg:grid-cols-9">
-                <Input
-                  {...register(`pagerduty.${index}.integrationKey`)}
-                  id={`${field.id}-integrationKey`}
-                  placeholder="Enter PagerDuty Integration Key"
-                  className="w-full lg:col-span-7"
-                  hideEmptyHelperText
-                  error={!!errors?.pagerduty?.[index]?.integrationKey}
-                  helperText={
-                    errors?.pagerduty?.[index]?.integrationKey?.message
-                  }
-                  fullWidth
+            <div key={field.id} className="flex w-full items-center gap-2">
+              <div className="grid flex-grow gap-4 lg:grid-cols-9">
+                <FormInput
+                  control={control}
+                  name={`pagerduty.${index}.integrationKey`}
                   label="Integration Key"
+                  placeholder="Enter PagerDuty Integration Key"
+                  containerClassName="w-full lg:col-span-7"
                   autoComplete="off"
                 />
 
@@ -111,44 +101,32 @@ export default function PagerdutyFormSection() {
                   </Select>
                 </div>
 
-                <Input
-                  {...register(`pagerduty.${index}.class`)}
-                  id={`${field.id}-class`}
-                  placeholder="Enter type of the event"
+                <FormInput
+                  control={control}
+                  name={`pagerduty.${index}.class`}
                   label="Class"
-                  className="w-full lg:col-span-3"
-                  hideEmptyHelperText
-                  error={!!errors?.pagerduty?.[index]?.class}
-                  helperText={errors?.pagerduty?.[index]?.class?.message}
-                  fullWidth
+                  placeholder="Enter type of the event"
+                  containerClassName="w-full lg:col-span-3"
                   autoComplete="off"
                 />
 
-                <Input
-                  {...register(`pagerduty.${index}.component`)}
-                  id={`${field.id}-component`}
-                  placeholder="Enter component of the event"
+                <FormInput
+                  control={control}
+                  name={`pagerduty.${index}.component`}
                   label="Component"
-                  className="w-full lg:col-span-3"
-                  hideEmptyHelperText
-                  error={!!errors?.pagerduty?.[index]?.component}
-                  helperText={errors?.pagerduty?.[index]?.component?.message}
-                  fullWidth
+                  placeholder="Enter component of the event"
+                  containerClassName="w-full lg:col-span-3"
                   autoComplete="off"
                 />
-                <Input
-                  {...register(`pagerduty.${index}.group`)}
-                  id={`${field.id}-group`}
-                  placeholder="Enter logical group of components"
+                <FormInput
+                  control={control}
+                  name={`pagerduty.${index}.group`}
                   label="Group"
-                  className="w-full lg:col-span-3"
-                  hideEmptyHelperText
-                  error={!!errors?.pagerduty?.[index]?.group}
-                  helperText={errors?.pagerduty?.[index]?.group?.message}
-                  fullWidth
+                  placeholder="Enter logical group of components"
+                  containerClassName="w-full lg:col-span-3"
                   autoComplete="off"
                 />
-              </Box>
+              </div>
 
               <Button
                 variant="ghost"
@@ -158,10 +136,10 @@ export default function PagerdutyFormSection() {
               >
                 <TrashIcon className="h-6 w-4" />
               </Button>
-            </Box>
+            </div>
           ))}
-        </Box>
+        </div>
       ) : null}
-    </Box>
+    </div>
   );
 }

--- a/dashboard/src/features/orgs/projects/metrics/settings/components/SlackFormSection/SlackFormSection.tsx
+++ b/dashboard/src/features/orgs/projects/metrics/settings/components/SlackFormSection/SlackFormSection.tsx
@@ -1,17 +1,18 @@
 import { InfoIcon, PlusIcon, Trash2 as TrashIcon } from 'lucide-react';
 import { useFieldArray, useFormContext } from 'react-hook-form';
-import { Alert } from '@/components/ui/v2/Alert';
-import { Box } from '@/components/ui/v2/Box';
-import { Input } from '@/components/ui/v2/Input';
-import { Text } from '@/components/ui/v2/Text';
-import { Tooltip } from '@/components/ui/v2/Tooltip';
+import { FormInput } from '@/components/form/FormInput';
+import { Alert } from '@/components/ui/v3/alert';
 import { Button } from '@/components/ui/v3/button';
+import {
+  Tooltip,
+  TooltipContent,
+  TooltipTrigger,
+} from '@/components/ui/v3/tooltip';
 import type { ContactPointsFormValues } from '@/features/orgs/projects/metrics/settings/components/ContactPointsSettings/ContactPointsSettingsTypes';
 
 export default function SlackFormSection() {
   const {
     control,
-    register,
     formState: { errors },
     trigger: triggerValidation,
   } = useFormContext<ContactPointsFormValues>();
@@ -27,23 +28,22 @@ export default function SlackFormSection() {
     }
   };
   return (
-    <Box className="flex flex-col gap-4 p-4">
-      <Box className="flex flex-row items-center justify-between">
-        <Box className="flex flex-row items-center space-x-2">
-          <Text variant="h4" className="font-semibold">
-            Slack
-          </Text>
-          <Tooltip
-            title={
+    <div className="flex flex-col gap-4 p-4">
+      <div className="flex flex-row items-center justify-between">
+        <div className="flex flex-row items-center space-x-2">
+          <h3 className="font-semibold">Slack</h3>
+          <Tooltip>
+            <TooltipTrigger asChild>
+              <InfoIcon aria-label="Info" className="h-4 w-4 text-primary" />
+            </TooltipTrigger>
+            <TooltipContent>
               <span>
                 Select your preferred Slack channels for receiving notifications
                 when your alert rules are firing.
               </span>
-            }
-          >
-            <InfoIcon aria-label="Info" className="h-4 w-4 text-primary" />
+            </TooltipContent>
           </Tooltip>
-        </Box>
+        </div>
         <Button
           variant="ghost"
           size="icon"
@@ -65,145 +65,105 @@ export default function SlackFormSection() {
         >
           <PlusIcon className="h-5 w-5" />
         </Button>
-      </Box>
+      </div>
       {fields?.length > 0 ? (
-        <Box className="flex flex-col gap-12">
+        <div className="flex flex-col gap-12">
           {!!errors?.slack?.root?.message && (
-            <Alert severity="error" className="w-full">
+            <Alert variant="destructive" className="w-full">
               {errors?.slack?.root?.message}
             </Alert>
           )}
           {fields.map((field, index) => (
-            <Box key={field.id} className="flex w-full items-center gap-2">
-              <Box className="grid flex-grow gap-4 lg:grid-cols-9">
-                <Input
-                  {...register(`slack.${index}.recipient`)}
-                  id={`${field.id}-recipient`}
-                  placeholder="Enter recipient"
-                  className="w-full lg:col-span-3"
-                  hideEmptyHelperText
-                  error={!!errors?.slack?.[index]?.recipient}
-                  helperText={errors?.slack?.[index]?.recipient?.message}
-                  fullWidth
+            <div key={field.id} className="flex w-full items-center gap-2">
+              <div className="grid flex-grow gap-4 lg:grid-cols-9">
+                <FormInput
+                  control={control}
+                  name={`slack.${index}.recipient`}
                   label="Recipient"
+                  placeholder="Enter recipient"
+                  containerClassName="w-full lg:col-span-3"
                   autoComplete="off"
                 />
 
-                <Input
-                  {...register(`slack.${index}.token`)}
-                  id={`${field.id}-token`}
-                  placeholder="Enter Slack API token"
+                <FormInput
+                  control={control}
+                  name={`slack.${index}.token`}
                   label="Token"
-                  className="w-full lg:col-span-6"
-                  hideEmptyHelperText
-                  error={!!errors?.slack?.[index]?.token}
-                  helperText={errors?.slack?.[index]?.token?.message}
-                  fullWidth
+                  placeholder="Enter Slack API token"
+                  containerClassName="w-full lg:col-span-6"
                   autoComplete="off"
                 />
 
-                <Input
-                  {...register(`slack.${index}.username`)}
-                  id={`${field.id}-username`}
-                  placeholder="Enter bot's username"
+                <FormInput
+                  control={control}
+                  name={`slack.${index}.username`}
                   label="Bot Username"
-                  className="w-full lg:col-span-5"
-                  hideEmptyHelperText
-                  error={!!errors?.slack?.[index]?.username}
-                  helperText={errors?.slack?.[index]?.username?.message}
-                  fullWidth
+                  placeholder="Enter bot's username"
+                  containerClassName="w-full lg:col-span-5"
                   autoComplete="off"
                 />
-                <Input
-                  {...register(`slack.${index}.mentionChannel`)}
-                  id={`${field.id}-mentionChannel`}
-                  placeholder="Enter channel to mention"
+                <FormInput
+                  control={control}
+                  name={`slack.${index}.mentionChannel`}
                   label="Mention Channel"
-                  className="w-full lg:col-span-4"
-                  hideEmptyHelperText
-                  error={!!errors?.slack?.[index]?.mentionChannel}
-                  helperText={errors?.slack?.[index]?.mentionChannel?.message}
-                  fullWidth
+                  placeholder="Enter channel to mention"
+                  containerClassName="w-full lg:col-span-4"
                   autoComplete="off"
                 />
 
-                <Input
-                  {...register(`slack.${index}.mentionUsers`)}
-                  id={`${field.id}-mentionUsers`}
-                  placeholder="Enter users to mention (separated by commas)"
+                <FormInput
+                  control={control}
+                  name={`slack.${index}.mentionUsers`}
                   label="Mention Users"
-                  className="w-full lg:col-span-9"
-                  hideEmptyHelperText
-                  error={!!errors?.slack?.[index]?.mentionUsers}
-                  helperText={errors?.slack?.[index]?.mentionUsers?.message}
-                  fullWidth
+                  placeholder="Enter users to mention (separated by commas)"
+                  containerClassName="w-full lg:col-span-9"
                   autoComplete="off"
                 />
 
-                <Input
-                  {...register(`slack.${index}.mentionGroups`)}
-                  id={`${field.id}-mentionGroups`}
-                  placeholder="Enter groups to mention (separated by commas)"
+                <FormInput
+                  control={control}
+                  name={`slack.${index}.mentionGroups`}
                   label="Mention Groups"
-                  className="w-full lg:col-span-9"
-                  hideEmptyHelperText
-                  error={!!errors?.slack?.[index]?.mentionGroups}
-                  helperText={errors?.slack?.[index]?.mentionGroups?.message}
-                  fullWidth
+                  placeholder="Enter groups to mention (separated by commas)"
+                  containerClassName="w-full lg:col-span-9"
                   autoComplete="off"
                 />
 
-                <Input
-                  {...register(`slack.${index}.iconEmoji`)}
-                  id={`${field.id}-iconEmoji`}
-                  placeholder="Enter emoji icon"
+                <FormInput
+                  control={control}
+                  name={`slack.${index}.iconEmoji`}
                   label="Emoji Icon"
-                  className="w-full lg:col-span-3"
-                  hideEmptyHelperText
-                  error={!!errors?.slack?.[index]?.iconEmoji}
-                  helperText={errors?.slack?.[index]?.iconEmoji?.message}
-                  fullWidth
+                  placeholder="Enter emoji icon"
+                  containerClassName="w-full lg:col-span-3"
                   autoComplete="off"
                 />
-                <Input
-                  {...register(`slack.${index}.iconURL`)}
-                  id={`${field.id}-iconURL`}
-                  placeholder="Enter emoji icon URL"
+                <FormInput
+                  control={control}
+                  name={`slack.${index}.iconURL`}
                   label="Emoji Icon URL"
-                  className="w-full lg:col-span-6"
-                  hideEmptyHelperText
-                  error={!!errors?.slack?.[index]?.iconURL}
-                  helperText={errors?.slack?.[index]?.iconURL?.message}
-                  fullWidth
+                  placeholder="Enter emoji icon URL"
+                  containerClassName="w-full lg:col-span-6"
                   autoComplete="off"
                 />
 
-                <Input
-                  {...register(`slack.${index}.url`)}
-                  id={`${field.id}-url`}
-                  placeholder="Enter Slack Webhook URL"
+                <FormInput
+                  control={control}
+                  name={`slack.${index}.url`}
                   label="Slack Webhook URL"
-                  className="w-full lg:col-span-9"
-                  hideEmptyHelperText
-                  error={!!errors?.slack?.[index]?.url}
-                  helperText={errors?.slack?.[index]?.url?.message}
-                  fullWidth
+                  placeholder="Enter Slack Webhook URL"
+                  containerClassName="w-full lg:col-span-9"
                   autoComplete="off"
                 />
 
-                <Input
-                  {...register(`slack.${index}.endpointURL`)}
-                  id={`${field.id}-endpointURL`}
-                  placeholder="Enter endpoint URL"
+                <FormInput
+                  control={control}
+                  name={`slack.${index}.endpointURL`}
                   label="Endpoint URL"
-                  className="w-full lg:col-span-9"
-                  hideEmptyHelperText
-                  error={!!errors?.slack?.[index]?.endpointURL}
-                  helperText={errors?.slack?.[index]?.endpointURL?.message}
-                  fullWidth
+                  placeholder="Enter endpoint URL"
+                  containerClassName="w-full lg:col-span-9"
                   autoComplete="off"
                 />
-              </Box>
+              </div>
 
               <Button
                 variant="ghost"
@@ -213,10 +173,10 @@ export default function SlackFormSection() {
               >
                 <TrashIcon className="h-6 w-4" />
               </Button>
-            </Box>
+            </div>
           ))}
-        </Box>
+        </div>
       ) : null}
-    </Box>
+    </div>
   );
 }

--- a/dashboard/src/features/orgs/projects/metrics/settings/components/WebhookFormSection/WebhookFormSection.tsx
+++ b/dashboard/src/features/orgs/projects/metrics/settings/components/WebhookFormSection/WebhookFormSection.tsx
@@ -1,18 +1,7 @@
-import {
-  EyeIcon,
-  EyeOffIcon,
-  InfoIcon,
-  PlusIcon,
-  Trash2 as TrashIcon,
-} from 'lucide-react';
-import { useState } from 'react';
+import { InfoIcon, PlusIcon, Trash2 as TrashIcon } from 'lucide-react';
 import { useFieldArray, useFormContext, useWatch } from 'react-hook-form';
-import { Box } from '@/components/ui/v2/Box';
-import { IconButton } from '@/components/ui/v2/IconButton';
-import { Input } from '@/components/ui/v2/Input';
-import { InputAdornment } from '@/components/ui/v2/InputAdornment';
-import { Text } from '@/components/ui/v2/Text';
-import { Tooltip } from '@/components/ui/v2/Tooltip';
+import { FormInput } from '@/components/form/FormInput';
+import { FormPasswordInput } from '@/components/form/FormPasswordInput';
 import { Button } from '@/components/ui/v3/button';
 import {
   Select,
@@ -21,45 +10,42 @@ import {
   SelectTrigger,
   SelectValue,
 } from '@/components/ui/v3/select';
+import {
+  Tooltip,
+  TooltipContent,
+  TooltipTrigger,
+} from '@/components/ui/v3/tooltip';
 import type { ContactPointsFormValues } from '@/features/orgs/projects/metrics/settings/components/ContactPointsSettings/ContactPointsSettingsTypes';
 import { HttpMethod } from './WebhookFormSectionTypes';
 
 export default function WebhookFormSection() {
-  const {
-    register,
-    formState: { errors },
-    setValue,
-    control,
-  } = useFormContext<ContactPointsFormValues>();
+  const { setValue, control } = useFormContext<ContactPointsFormValues>();
   const formValues = useWatch<ContactPointsFormValues>();
   const { fields, append, remove } = useFieldArray({
     control,
     name: 'webhook',
   });
 
-  const [showPassword, setShowPassword] = useState(false);
-
   const onChangeHttpMethod = (value: string | undefined, index: number) =>
     setValue(`webhook.${index}.httpMethod`, value as HttpMethod);
 
   return (
-    <Box className="flex flex-col gap-4 p-4">
-      <Box className="flex flex-row items-center justify-between">
-        <Box className="flex flex-row items-center space-x-2">
-          <Text variant="h4" className="font-semibold">
-            Webhook
-          </Text>
-          <Tooltip
-            title={
+    <div className="flex flex-col gap-4 p-4">
+      <div className="flex flex-row items-center justify-between">
+        <div className="flex flex-row items-center space-x-2">
+          <h3 className="font-semibold">Webhook</h3>
+          <Tooltip>
+            <TooltipTrigger asChild>
+              <InfoIcon aria-label="Info" className="h-4 w-4 text-primary" />
+            </TooltipTrigger>
+            <TooltipContent>
               <span>
                 Send information about a state change to an external service
                 over HTTP.
               </span>
-            }
-          >
-            <InfoIcon aria-label="Info" className="h-4 w-4 text-primary" />
+            </TooltipContent>
           </Tooltip>
-        </Box>
+        </div>
         <Button
           variant="ghost"
           size="icon"
@@ -78,23 +64,19 @@ export default function WebhookFormSection() {
         >
           <PlusIcon className="h-5 w-5" />
         </Button>
-      </Box>
+      </div>
 
       {fields?.length > 0 ? (
-        <Box className="flex flex-col gap-12">
+        <div className="flex flex-col gap-12">
           {fields.map((field, index) => (
-            <Box key={field.id} className="flex w-full items-center space-x-2">
-              <Box className="grid flex-grow gap-4 lg:grid-cols-9">
-                <Input
-                  {...register(`webhook.${index}.url`)}
-                  id={`${field.id}-url`}
-                  placeholder="Enter URL"
-                  className="w-full lg:col-span-7"
-                  hideEmptyHelperText
-                  error={!!errors?.webhook?.[index]?.url}
-                  helperText={errors?.webhook?.[index]?.url?.message}
-                  fullWidth
+            <div key={field.id} className="flex w-full items-center space-x-2">
+              <div className="grid flex-grow gap-4 lg:grid-cols-9">
+                <FormInput
+                  control={control}
+                  name={`webhook.${index}.url`}
                   label="URL"
+                  placeholder="Enter URL"
+                  containerClassName="w-full lg:col-span-7"
                   autoComplete="off"
                 />
 
@@ -122,93 +104,50 @@ export default function WebhookFormSection() {
                   </Select>
                 </div>
 
-                <Input
-                  {...register(`webhook.${index}.username`)}
-                  id={`${field.id}-username`}
-                  placeholder="Enter username"
+                <FormInput
+                  control={control}
+                  name={`webhook.${index}.username`}
                   label="Username"
-                  className="w-full lg:col-span-3"
-                  hideEmptyHelperText
-                  error={!!errors?.webhook?.[index]?.username}
-                  helperText={errors?.webhook?.[index]?.username?.message}
-                  fullWidth
+                  placeholder="Enter username"
+                  containerClassName="w-full lg:col-span-3"
                   autoComplete="off"
                 />
 
-                <Input
-                  {...register(`webhook.${index}.password`)}
-                  id={`${field.id}-password`}
-                  type={showPassword ? 'text' : 'password'}
-                  placeholder="Enter password"
+                <FormPasswordInput
+                  control={control}
+                  name={`webhook.${index}.password`}
                   label="Password"
-                  className="w-full lg:col-span-4"
-                  hideEmptyHelperText
-                  error={!!errors?.webhook?.[index]?.password}
-                  helperText={errors?.webhook?.[index]?.password?.message}
-                  fullWidth
+                  placeholder="Enter password"
+                  containerClassName="w-full lg:col-span-4"
                   autoComplete="off"
-                  endAdornment={
-                    <InputAdornment className="px-2" position="end">
-                      <IconButton
-                        variant="borderless"
-                        color="secondary"
-                        aria-label={
-                          showPassword ? 'Hide Password' : 'Show Password'
-                        }
-                        onClick={() => setShowPassword((show) => !show)}
-                      >
-                        {showPassword ? (
-                          <EyeOffIcon className="h-5 w-5" />
-                        ) : (
-                          <EyeIcon className="h-5 w-5" />
-                        )}
-                      </IconButton>
-                    </InputAdornment>
-                  }
                 />
-                <Input
-                  type="number"
-                  {...register(`webhook.${index}.maxAlerts`)}
-                  id={`${field.id}-maxAlerts`}
-                  placeholder="Enter max alerts"
+                <FormInput
+                  control={control}
+                  name={`webhook.${index}.maxAlerts`}
                   label="Max Alerts (0 means no limit)"
-                  className="w-full lg:col-span-2"
-                  hideEmptyHelperText
-                  error={!!errors?.webhook?.[index]?.maxAlerts}
-                  helperText={errors?.webhook?.[index]?.maxAlerts?.message}
-                  fullWidth
+                  placeholder="Enter max alerts"
+                  type="number"
+                  containerClassName="w-full lg:col-span-2"
                   autoComplete="off"
                 />
 
-                <Input
-                  {...register(`webhook.${index}.authorizationScheme`)}
-                  id={`${field.id}-authorizationScheme`}
-                  placeholder="Enter authorization scheme"
+                <FormInput
+                  control={control}
+                  name={`webhook.${index}.authorizationScheme`}
                   label="Authorization Scheme"
-                  className="w-full lg:col-span-3"
-                  hideEmptyHelperText
-                  error={!!errors?.webhook?.[index]?.authorizationScheme}
-                  helperText={
-                    errors?.webhook?.[index]?.authorizationScheme?.message
-                  }
-                  fullWidth
+                  placeholder="Enter authorization scheme"
+                  containerClassName="w-full lg:col-span-3"
                   autoComplete="off"
                 />
-                <Input
-                  {...register(`webhook.${index}.authorizationCredentials`)}
-                  id={`${field.id}-authorizationCredentials`}
-                  placeholder="Enter authorization credentials"
+                <FormInput
+                  control={control}
+                  name={`webhook.${index}.authorizationCredentials`}
                   label="Authorization Credentials"
-                  className="w-full lg:col-span-6"
-                  hideEmptyHelperText
-                  error={!!errors?.webhook?.[index]?.authorizationCredentials}
-                  helperText={
-                    errors?.webhook?.[index]?.authorizationCredentials?.message
-                  }
-                  fullWidth
+                  placeholder="Enter authorization credentials"
+                  containerClassName="w-full lg:col-span-6"
                   autoComplete="off"
                 />
-              </Box>
+              </div>
 
               <Button
                 variant="ghost"
@@ -218,10 +157,10 @@ export default function WebhookFormSection() {
               >
                 <TrashIcon className="h-6 w-4" />
               </Button>
-            </Box>
+            </div>
           ))}
-        </Box>
+        </div>
       ) : null}
-    </Box>
+    </div>
   );
 }

--- a/dashboard/src/pages/orgs/[orgSlug]/projects/[appSubdomain]/settings/metrics.tsx
+++ b/dashboard/src/pages/orgs/[orgSlug]/projects/[appSubdomain]/settings/metrics.tsx
@@ -1,5 +1,4 @@
 import type { ReactElement } from 'react';
-import { Container } from '@/components/layout/Container';
 import { Spinner } from '@/components/ui/v3/spinner';
 import { OrgLayout } from '@/features/orgs/layout/OrgLayout';
 import { SettingsLayout } from '@/features/orgs/layout/SettingsLayout';
@@ -35,29 +34,17 @@ export default function MetricsSettingsPage() {
   }
 
   return (
-    <Container
-      className="grid max-w-5xl grid-flow-row gap-y-6 bg-transparent"
-      rootClassName="bg-transparent"
-    >
+    <div className="grid grid-flow-row gap-y-6">
       <MetricsSettings />
-    </Container>
+    </div>
   );
 }
 
 MetricsSettingsPage.getLayout = function getLayout(page: ReactElement) {
   return (
-    <OrgLayout
-      mainContainerProps={{
-        className: 'flex h-full',
-      }}
-    >
+    <OrgLayout>
       <SettingsLayout>
-        <Container
-          sx={{ backgroundColor: 'background.default' }}
-          className="max-w-5xl"
-        >
-          {page}
-        </Container>
+        <div className="mx-auto w-full max-w-5xl px-5 py-4">{page}</div>
       </SettingsLayout>
     </OrgLayout>
   );


### PR DESCRIPTION
<!-- pi-reviewer:start -->
### **What this change solves**
Migrates the Metrics settings page and contact-point configuration UI to the new settings card and v3 form components. The change standardizes metrics settings layout, SMTP controls, and contact-point form sections.

___

### **Change Type**
Refactoring

___

### **Description**
- Replaces metrics settings `SettingsContainer` usage with `SettingsCard` headers, content, footers, and docs links.
- Migrates contact-point form sections from v2 layout/input/tooltip primitives to v3 form inputs, tooltips, and buttons.
- Simplifies the Metrics settings page wrapper under the shared settings layout.

___

<details> <summary><h3> File Walkthrough</h3></summary>

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody>
<tr><td><strong>Dashboard metrics</strong></td><td><details><summary>9 files</summary><table>
<tr><td><strong>dashboard/src/features/orgs/projects/metrics/settings/components/ContactPointsSettings/ContactPointsSettings.tsx</strong><dd><code>Migrates contact points settings card, separators, docs link, and save footer.</code></dd></td><td>+43/-27</td></tr>
<tr><td><strong>dashboard/src/features/orgs/projects/metrics/settings/components/DiscordFormSection/DiscordFormSection.tsx</strong><dd><code>Migrates Discord contact point fields to v3 FormInput, tooltip, and button controls.</code></dd></td><td>+34/-45</td></tr>
<tr><td><strong>dashboard/src/features/orgs/projects/metrics/settings/components/EmailsFormSection/EmailsFormSection.tsx</strong><dd><code>Migrates email contact point fields to v3 FormInput and button controls.</code></dd></td><td>+29/-36</td></tr>
<tr><td><strong>dashboard/src/features/orgs/projects/metrics/settings/components/MetricsSMTPSettings/MetricsSMTPSettings.tsx</strong><dd><code>Migrates SMTP settings to SettingsCard, v3 form inputs, switch, and footer controls.</code></dd></td><td>+75/-80</td></tr>
<tr><td><strong>dashboard/src/features/orgs/projects/metrics/settings/components/MetricsSettings/MetricsSettings.tsx</strong><dd><code>Migrates metrics enablement settings to SettingsCard and v3 switch/footer controls.</code></dd></td><td>+45/-17</td></tr>
<tr><td><strong>dashboard/src/features/orgs/projects/metrics/settings/components/PagerdutyFormSection/PagerdutyFormSection.tsx</strong><dd><code>Migrates PagerDuty contact point fields to v3 FormInput, tooltip, and button controls.</code></dd></td><td>+46/-68</td></tr>
<tr><td><strong>dashboard/src/features/orgs/projects/metrics/settings/components/SlackFormSection/SlackFormSection.tsx</strong><dd><code>Migrates Slack contact point fields to v3 FormInput, tooltip, and button controls.</code></dd></td><td>+77/-117</td></tr>
<tr><td><strong>dashboard/src/features/orgs/projects/metrics/settings/components/WebhookFormSection/WebhookFormSection.tsx</strong><dd><code>Migrates webhook contact point fields to v3 FormInput, tooltip, and button controls.</code></dd></td><td>+59/-120</td></tr>
<tr><td><strong>dashboard/src/pages/orgs/[orgSlug]/projects/[appSubdomain]/settings/metrics.tsx</strong><dd><code>Simplifies the Metrics settings page shell and content wrapper.</code></dd></td><td>+4/-17</td></tr>
</table></details></td></tr>
</tbody></table>

</details>

___

<!-- pi-reviewer:end -->
