### PR TITLE
fix(dashboard): migrate rate limiting settings page

### DIFF
--- a/dashboard/src/features/orgs/projects/rate-limiting/settings/components/AuthLimitingForm/AuthLimitingForm.tsx
+++ b/dashboard/src/features/orgs/projects/rate-limiting/settings/components/AuthLimitingForm/AuthLimitingForm.tsx
@@ -5,8 +5,13 @@ import * as Yup from 'yup';
 import { ApplyLocalSettingsDialog } from '@/components/common/ApplyLocalSettingsDialog';
 import { useDialog } from '@/components/common/DialogProvider';
 import { Form } from '@/components/form/Form';
-import { SettingsContainer } from '@/components/layout/SettingsContainer';
-import { Divider } from '@/components/ui/v2/Divider';
+import {
+  SettingsCard,
+  SettingsCardContent,
+  SettingsCardFooter,
+  SettingsCardHeader,
+} from '@/components/layout/SettingsCard';
+import { ButtonWithLoading } from '@/components/ui/v3/button';
 import { useIsPlatform } from '@/features/orgs/projects/common/hooks/useIsPlatform';
 import { useLocalMimirClient } from '@/features/orgs/projects/hooks/useLocalMimirClient';
 import { useProject } from '@/features/orgs/projects/hooks/useProject';
@@ -158,12 +163,7 @@ export default function AuthLimitingForm() {
     smsIntervalUnit,
   ]);
 
-  const {
-    register,
-    formState: { errors },
-    formState,
-    watch,
-  } = form;
+  const { formState, watch } = form;
 
   const enabled = watch('enabled');
 
@@ -232,57 +232,37 @@ export default function AuthLimitingForm() {
         onSubmit={handleSubmit}
         className="flex h-full flex-col overflow-hidden"
       >
-        <SettingsContainer
-          title="Auth"
-          slotProps={{
-            submitButton: {
-              disabled: !formState.isDirty,
-              loading: formState.isSubmitting,
-            },
-          }}
-          className="flex flex-col px-0"
-        >
-          <Divider />
-          <RateLimitField
-            disabled={!enabled}
-            register={register}
-            errors={errors.bruteForce}
-            id="bruteForce"
-            title="Brute Force"
-          />
-          <Divider />
-          <RateLimitField
-            disabled={!enabled}
-            register={register}
-            errors={errors.emails}
-            id="emails"
-            title="Emails"
-          />
-          <Divider />
-          <RateLimitField
-            disabled={!enabled}
-            register={register}
-            errors={errors.global}
-            id="global"
-            title="Global"
-          />
-          <Divider />
-          <RateLimitField
-            disabled={!enabled}
-            register={register}
-            errors={errors.signups}
-            id="signups"
-            title="Signups"
-          />
-          <Divider />
-          <RateLimitField
-            disabled={!enabled}
-            register={register}
-            errors={errors.sms}
-            id="sms"
-            title="SMS"
-          />
-        </SettingsContainer>
+        <SettingsCard>
+          <SettingsCardHeader title="Auth" />
+
+          <SettingsCardContent className="flex flex-col px-0">
+            <div className="border-t" />
+            <RateLimitField
+              disabled={!enabled}
+              id="bruteForce"
+              title="Brute Force"
+            />
+            <div className="border-t" />
+            <RateLimitField disabled={!enabled} id="emails" title="Emails" />
+            <div className="border-t" />
+            <RateLimitField disabled={!enabled} id="global" title="Global" />
+            <div className="border-t" />
+            <RateLimitField disabled={!enabled} id="signups" title="Signups" />
+            <div className="border-t" />
+            <RateLimitField disabled={!enabled} id="sms" title="SMS" />
+          </SettingsCardContent>
+
+          <SettingsCardFooter>
+            <ButtonWithLoading
+              type="submit"
+              disabled={!formState.isDirty}
+              loading={formState.isSubmitting}
+              className="w-full sm:w-auto"
+            >
+              Save
+            </ButtonWithLoading>
+          </SettingsCardFooter>
+        </SettingsCard>
       </Form>
     </FormProvider>
   );

--- a/dashboard/src/features/orgs/projects/rate-limiting/settings/components/RateLimitField/RateLimitField.tsx
+++ b/dashboard/src/features/orgs/projects/rate-limiting/settings/components/RateLimitField/RateLimitField.tsx
@@ -1,73 +1,47 @@
-import {
-  type FieldError,
-  type FieldErrorsImpl,
-  type Merge,
-  type UseFormRegister,
-  useFormContext,
-} from 'react-hook-form';
+import { useFormContext } from 'react-hook-form';
+import { FormInput } from '@/components/form/FormInput';
 import { FormSelect } from '@/components/form/FormSelect';
-import { Box } from '@/components/ui/v2/Box';
-import { Input } from '@/components/ui/v2/Input';
-import { Text } from '@/components/ui/v2/Text';
 import { SelectItem } from '@/components/ui/v3/select';
 import { intervalUnitOptions } from '@/features/orgs/projects/rate-limiting/settings/components/validationSchemas';
 
 interface RateLimitFieldProps {
-  // biome-ignore lint/suspicious/noExplicitAny: TODO
-  register: UseFormRegister<any>;
-  errors?: Merge<
-    FieldError,
-    FieldErrorsImpl<{
-      limit: number;
-      interval: number;
-      intervalUnit: string;
-    }>
-  >;
   disabled?: boolean;
   title?: string;
   id: string;
 }
 
 export default function RateLimitField({
-  register,
   disabled,
   id,
-  errors,
   title,
 }: RateLimitFieldProps) {
   const { control } = useFormContext();
 
   return (
-    <Box className="px-4">
-      {title ? <Text className="py-4 font-semibold">{title}</Text> : null}
+    <div className="px-4">
+      {title ? <p className="py-4 font-semibold">{title}</p> : null}
       <div className="flex flex-col gap-8 lg:flex-row">
         <div className="flex flex-row items-center gap-2">
-          <Text>Limit</Text>
-          <Input
-            {...register(`${id}.limit`)}
+          <span>Limit</span>
+          <FormInput
+            control={control}
+            name={`${id}.limit`}
             disabled={disabled}
-            id={`${id}.limit`}
             type="number"
             placeholder=""
-            className="max-w-60"
-            hideEmptyHelperText
-            error={!!errors?.limit}
-            helperText={errors?.limit?.message}
+            containerClassName="max-w-60"
             autoComplete="off"
           />
         </div>
         <div className="flex flex-row items-center gap-2">
-          <Text>Interval</Text>
-          <Input
-            {...register(`${id}.interval`)}
+          <span>Interval</span>
+          <FormInput
+            control={control}
+            name={`${id}.interval`}
             disabled={disabled}
-            id={`${id}.interval`}
             type="number"
             placeholder=""
-            hideEmptyHelperText
-            className="max-w-32"
-            error={!!errors?.interval}
-            helperText={errors?.interval?.message}
+            containerClassName="max-w-32"
             autoComplete="off"
           />
           <FormSelect
@@ -85,6 +59,6 @@ export default function RateLimitField({
           </FormSelect>
         </div>
       </div>
-    </Box>
+    </div>
   );
 }

--- a/dashboard/src/features/orgs/projects/rate-limiting/settings/components/RateLimitingForm/RateLimitingForm.tsx
+++ b/dashboard/src/features/orgs/projects/rate-limiting/settings/components/RateLimitingForm/RateLimitingForm.tsx
@@ -5,8 +5,14 @@ import * as Yup from 'yup';
 import { ApplyLocalSettingsDialog } from '@/components/common/ApplyLocalSettingsDialog';
 import { useDialog } from '@/components/common/DialogProvider';
 import { Form } from '@/components/form/Form';
-import { SettingsContainer } from '@/components/layout/SettingsContainer';
-import { Divider } from '@/components/ui/v2/Divider';
+import { FormSwitch } from '@/components/form/FormSwitch';
+import {
+  SettingsCard,
+  SettingsCardContent,
+  SettingsCardFooter,
+  SettingsCardHeader,
+} from '@/components/layout/SettingsCard';
+import { ButtonWithLoading } from '@/components/ui/v3/button';
 import { useIsPlatform } from '@/features/orgs/projects/common/hooks/useIsPlatform';
 import { useLocalMimirClient } from '@/features/orgs/projects/hooks/useLocalMimirClient';
 import { useProject } from '@/features/orgs/projects/hooks/useProject';
@@ -73,12 +79,7 @@ export default function RateLimitingForm({
     }
   }, [loading, defaultValues, form]);
 
-  const {
-    register,
-    formState: { errors },
-    formState,
-    watch,
-  } = form;
+  const { formState, watch } = form;
 
   const enabled = watch('enabled');
 
@@ -129,26 +130,36 @@ export default function RateLimitingForm({
         onSubmit={handleSubmit}
         className="flex h-full flex-col overflow-hidden"
       >
-        <SettingsContainer
-          title={title}
-          switchId="enabled"
-          showSwitch
-          slotProps={{
-            submitButton: {
-              disabled: !formState.isDirty,
-              loading: formState.isSubmitting,
-            },
-          }}
-          className="flex flex-col px-0"
-        >
-          <Divider />
-          <RateLimitField
-            disabled={!enabled}
-            register={register}
-            errors={errors.rateLimit}
-            id="rateLimit"
+        <SettingsCard>
+          <SettingsCardHeader
+            title={title}
+            control={
+              <FormSwitch
+                control={form.control}
+                name="enabled"
+                label={`Toggle ${title}`}
+                labelClassName="sr-only"
+                containerClassName="space-y-0"
+              />
+            }
           />
-        </SettingsContainer>
+
+          <SettingsCardContent className="flex flex-col px-0">
+            <div className="border-t" />
+            <RateLimitField disabled={!enabled} id="rateLimit" />
+          </SettingsCardContent>
+
+          <SettingsCardFooter>
+            <ButtonWithLoading
+              type="submit"
+              disabled={!formState.isDirty}
+              loading={formState.isSubmitting}
+              className="w-full sm:w-auto"
+            >
+              Save
+            </ButtonWithLoading>
+          </SettingsCardFooter>
+        </SettingsCard>
       </Form>
     </FormProvider>
   );

--- a/dashboard/src/features/orgs/projects/rate-limiting/settings/components/RunServiceLimitingForm/RunServiceLimitingForm.tsx
+++ b/dashboard/src/features/orgs/projects/rate-limiting/settings/components/RunServiceLimitingForm/RunServiceLimitingForm.tsx
@@ -5,8 +5,14 @@ import * as Yup from 'yup';
 import { ApplyLocalSettingsDialog } from '@/components/common/ApplyLocalSettingsDialog';
 import { useDialog } from '@/components/common/DialogProvider';
 import { Form } from '@/components/form/Form';
-import { SettingsContainer } from '@/components/layout/SettingsContainer';
-import { Divider } from '@/components/ui/v2/Divider';
+import { FormSwitch } from '@/components/form/FormSwitch';
+import {
+  SettingsCard,
+  SettingsCardContent,
+  SettingsCardFooter,
+  SettingsCardHeader,
+} from '@/components/layout/SettingsCard';
+import { ButtonWithLoading } from '@/components/ui/v3/button';
 import { useIsPlatform } from '@/features/orgs/projects/common/hooks/useIsPlatform';
 import { useLocalMimirClient } from '@/features/orgs/projects/hooks/useLocalMimirClient';
 import { useProject } from '@/features/orgs/projects/hooks/useProject';
@@ -83,12 +89,7 @@ export default function RunServiceLimitingForm({
     }
   }, [loading, enabledDefault, ports, form]);
 
-  const {
-    register,
-    formState: { errors },
-    formState,
-    watch,
-  } = form;
+  const { formState, watch } = form;
 
   const enabled = watch('enabled');
 
@@ -147,41 +148,54 @@ export default function RunServiceLimitingForm({
         onSubmit={handleSubmit}
         className="flex h-full flex-col overflow-hidden"
       >
-        <SettingsContainer
-          title={title}
-          switchId="enabled"
-          showSwitch
-          slotProps={{
-            submitButton: {
-              disabled: !formState.isDirty,
-              loading: formState.isSubmitting,
-            },
-          }}
-          className="flex flex-col px-0"
-        >
-          <Divider />
-          {(ports ?? []).map((port, index) => {
-            if (port?.type !== 'http' || !port?.publish) {
-              return null;
+        <SettingsCard>
+          <SettingsCardHeader
+            title={title}
+            control={
+              <FormSwitch
+                control={form.control}
+                name="enabled"
+                label={`Toggle ${title ?? 'Run service rate limiting'}`}
+                labelClassName="sr-only"
+                containerClassName="space-y-0"
+              />
             }
+          />
 
-            const fieldTitle = `${port.type} <-> ${port.port}`.toUpperCase();
-            const showDivider =
-              isNotEmptyValue(ports) && index < ports.length - 1;
-            return (
-              <div key={`ports.${port.port}`}>
-                <RateLimitField
-                  title={fieldTitle}
-                  disabled={!enabled}
-                  register={register}
-                  errors={errors.ports}
-                  id={`ports.${index}`}
-                />
-                {showDivider && <Divider />}
-              </div>
-            );
-          })}
-        </SettingsContainer>
+          <SettingsCardContent className="flex flex-col px-0">
+            <div className="border-t" />
+            {(ports ?? []).map((port, index) => {
+              if (port?.type !== 'http' || !port?.publish) {
+                return null;
+              }
+
+              const fieldTitle = `${port.type} <-> ${port.port}`.toUpperCase();
+              const showDivider =
+                isNotEmptyValue(ports) && index < ports.length - 1;
+              return (
+                <div key={`ports.${port.port}`}>
+                  <RateLimitField
+                    title={fieldTitle}
+                    disabled={!enabled}
+                    id={`ports.${index}`}
+                  />
+                  {showDivider && <div className="border-t" />}
+                </div>
+              );
+            })}
+          </SettingsCardContent>
+
+          <SettingsCardFooter>
+            <ButtonWithLoading
+              type="submit"
+              disabled={!formState.isDirty}
+              loading={formState.isSubmitting}
+              className="w-full sm:w-auto"
+            >
+              Save
+            </ButtonWithLoading>
+          </SettingsCardFooter>
+        </SettingsCard>
       </Form>
     </FormProvider>
   );

--- a/dashboard/src/pages/orgs/[orgSlug]/projects/[appSubdomain]/settings/rate-limiting.tsx
+++ b/dashboard/src/pages/orgs/[orgSlug]/projects/[appSubdomain]/settings/rate-limiting.tsx
@@ -1,9 +1,11 @@
 import type { ReactElement } from 'react';
-import { Container } from '@/components/layout/Container';
-import { Box } from '@/components/ui/v2/Box';
-import { Text } from '@/components/ui/v2/Text';
+import {
+  SettingsCard,
+  SettingsCardFooter,
+  SettingsCardHeader,
+  SettingsDocsLink,
+} from '@/components/layout/SettingsCard';
 import { Spinner } from '@/components/ui/v3/spinner';
-import { TextLink } from '@/components/ui/v3/text-link';
 import { OrgLayout } from '@/features/orgs/layout/OrgLayout';
 import { SettingsLayout } from '@/features/orgs/layout/SettingsLayout';
 import { useProject } from '@/features/orgs/projects/hooks/useProject';
@@ -36,26 +38,16 @@ export default function RateLimiting() {
   }
 
   return (
-    <Container
-      className="grid max-w-5xl grid-flow-row gap-6 bg-transparent"
-      rootClassName="bg-transparent"
-    >
-      <Box className="flex flex-row items-center gap-4 overflow-hidden rounded-lg border-1 p-4">
-        <div className="flex flex-col space-y-2">
-          <Text className="font-semibold text-lg">Rate Limiting</Text>
-
-          <Text color="secondary">
-            Learn more about
-            <TextLink
-              href="https://docs.nhost.io/platform/cloud/rate-limits"
-              external
-              className="ml-1 font-medium"
-            >
-              Rate Limiting
-            </TextLink>
-          </Text>
-        </div>
-      </Box>
+    <div className="grid grid-flow-row gap-6">
+      <SettingsCard>
+        <SettingsCardHeader title="Rate Limiting" />
+        <SettingsCardFooter>
+          <SettingsDocsLink
+            href="https://docs.nhost.io/platform/cloud/rate-limits"
+            title="Rate Limiting"
+          />
+        </SettingsCardFooter>
+      </SettingsCard>
       <AuthLimitingForm />
       <RateLimitingForm
         defaultValues={hasuraDefaultValues}
@@ -92,24 +84,15 @@ export default function RateLimiting() {
         }
         return null;
       })}
-    </Container>
+    </div>
   );
 }
 
 RateLimiting.getLayout = function getLayout(page: ReactElement) {
   return (
-    <OrgLayout
-      mainContainerProps={{
-        className: 'flex h-full overflow-auto',
-      }}
-    >
+    <OrgLayout>
       <SettingsLayout>
-        <Container
-          sx={{ backgroundColor: 'background.default' }}
-          className="max-w-5xl"
-        >
-          {page}
-        </Container>
+        <div className="mx-auto w-full max-w-5xl px-5 py-4">{page}</div>
       </SettingsLayout>
     </OrgLayout>
   );


### PR DESCRIPTION
<!-- pi-reviewer:start -->
### **What this change solves**
Migrates the dashboard rate limiting settings page and related forms from the legacy settings layout to the v3 card/button UI. The forms keep their existing validation and submit flows while aligning the page with the newer settings page structure.

___

### **Change Type**
Refactoring

___

### **Description**
- Replaces legacy settings containers and dividers with v3 settings cards on the rate limiting page.
- Updates Auth, Run service, and generic rate limit forms to render card headers, content, and footers consistently.
- Simplifies rate limit field wiring to use form context instead of passing registration/error props through each field.

___

<details> <summary><h3> File Walkthrough</h3></summary>

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody>
<tr><td><strong>Dashboard rate limiting settings</strong></td><td><details><summary>5 files</summary><table>
<tr>
  <td><strong>dashboard/src/features/orgs/projects/rate-limiting/settings/components/AuthLimitingForm/AuthLimitingForm.tsx</strong><dd><code>Migrates the auth rate limiting form to v3 settings cards and footer submit controls.</code></dd></td>
  <td>+39/-59</td>
</tr>
<tr>
  <td><strong>dashboard/src/features/orgs/projects/rate-limiting/settings/components/RateLimitField/RateLimitField.tsx</strong><dd><code>Updates reusable rate limit fields to read registration and errors from form context.</code></dd></td>
  <td>+15/-41</td>
</tr>
<tr>
  <td><strong>dashboard/src/features/orgs/projects/rate-limiting/settings/components/RateLimitingForm/RateLimitingForm.tsx</strong><dd><code>Moves the generic rate limiting form onto v3 settings cards and button controls.</code></dd></td>
  <td>+43/-27</td>
</tr>
<tr>
  <td><strong>dashboard/src/features/orgs/projects/rate-limiting/settings/components/RunServiceLimitingForm/RunServiceLimitingForm.tsx</strong><dd><code>Migrates Run service rate limiting settings to v3 card sections and submit footer.</code></dd></td>
  <td>+60/-41</td>
</tr>
<tr>
  <td><strong>dashboard/src/pages/orgs/[orgSlug]/projects/[appSubdomain]/settings/rate-limiting.tsx</strong><dd><code>Updates the settings page shell to the v3 layout used by migrated project settings pages.</code></dd></td>
  <td>+19/-36</td>
</tr>
</table></details></td></tr>
</tbody></table>

</details>

___

<!-- pi-reviewer:end -->
