### PR TITLE
fix(cli): SELinux bind mount label

### DIFF
--- a/cli/dockercompose/compose.go
+++ b/cli/dockercompose/compose.go
@@ -120,7 +120,7 @@ type Port struct {
 	Protocol  string `yaml:"protocol"`
 }
 
-//nolint:tagliatelle
+//nolint:tagliatelle,tagalign // golines tag order conflicts with golangci-lint tagalign
 type Volume struct {
 	Type     string       `yaml:"type"`
 	Source   string       `yaml:"source"`

--- a/cli/dockercompose/compose.go
+++ b/cli/dockercompose/compose.go
@@ -122,10 +122,19 @@ type Port struct {
 
 //nolint:tagliatelle
 type Volume struct {
-	Type     string `yaml:"type"`
-	Source   string `yaml:"source"`
-	Target   string `yaml:"target"`
-	ReadOnly *bool  `yaml:"read_only,omitempty"`
+	Type     string       `yaml:"type"`
+	Source   string       `yaml:"source"`
+	Target   string       `yaml:"target"`
+	ReadOnly *bool        `yaml:"read_only,omitempty"`
+	Bind     *BindOptions `exhaustruct:"optional"     yaml:"bind,omitempty"`
+}
+
+// BindOptions holds bind-mount-specific settings. SELinux carries the
+// relabel option ("z" for a shared label) so that on SELinux or Podman
+// hosts the container is granted access to the host source without the
+// user having to relax SELinux enforcement themselves.
+type BindOptions struct {
+	SELinux string `yaml:"selinux,omitempty"`
 }
 
 // extraHosts is the set of /etc/hosts entries injected into every bridge
@@ -309,6 +318,9 @@ func traefik(subdomain, projectName string, port uint, dotnhostfolder string) (*
 			Source:   dockerURL.Path,
 			Target:   "/var/run/docker.sock",
 			ReadOnly: new(true),
+			// Relabel the socket with a shared SELinux label so traefik can
+			// reach the docker daemon on SELinux/Podman hosts (no-op elsewhere).
+			Bind: &BindOptions{SELinux: "z"},
 		})
 		dockerEndpoint = "unix:///var/run/docker.sock"
 	}

--- a/cli/dockercompose/compose.go
+++ b/cli/dockercompose/compose.go
@@ -126,7 +126,7 @@ type Volume struct {
 	Source   string       `yaml:"source"`
 	Target   string       `yaml:"target"`
 	ReadOnly *bool        `yaml:"read_only,omitempty"`
-	Bind     *BindOptions `exhaustruct:"optional"     yaml:"bind,omitempty"`
+	Bind     *BindOptions `yaml:"bind,omitempty"      exhaustruct:"optional"`
 }
 
 // BindOptions holds bind-mount-specific settings. SELinux carries the

--- a/cli/dockercompose/compose_test.go
+++ b/cli/dockercompose/compose_test.go
@@ -58,3 +58,65 @@ restart: always
 		t.Errorf("source Environment map was mutated by marshal: %s", diff)
 	}
 }
+
+func TestVolumeSELinuxRelabel(t *testing.T) {
+	t.Parallel()
+
+	cases := []struct {
+		name     string
+		volume   dockercompose.Volume
+		expected string
+	}{
+		{
+			// A shared SELinux relabel ("z") is emitted as the long-form
+			// bind.selinux option so the docker socket is accessible on
+			// SELinux/Podman hosts.
+			name: "with selinux relabel",
+			volume: dockercompose.Volume{
+				Type:     "bind",
+				Source:   "/var/run/docker.sock",
+				Target:   "/var/run/docker.sock",
+				ReadOnly: new(true),
+				Bind:     &dockercompose.BindOptions{SELinux: "z"},
+			},
+			expected: `type: bind
+source: /var/run/docker.sock
+target: /var/run/docker.sock
+read_only: true
+bind:
+    selinux: z
+`,
+		},
+		{
+			// Without Bind, the bind mapping is omitted entirely so
+			// non-SELinux hosts see the unchanged output.
+			name: "without bind options",
+			volume: dockercompose.Volume{
+				Type:     "bind",
+				Source:   "/opt/traefik",
+				Target:   "/opt/traefik",
+				ReadOnly: new(true),
+			},
+			expected: `type: bind
+source: /opt/traefik
+target: /opt/traefik
+read_only: true
+`,
+		},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+
+			got, err := yaml.Marshal(tc.volume)
+			if err != nil {
+				t.Fatalf("marshal failed: %v", err)
+			}
+
+			if diff := cmp.Diff(tc.expected, string(got)); diff != "" {
+				t.Error(diff)
+			}
+		})
+	}
+}

--- a/cli/dockercompose/configserver.go
+++ b/cli/dockercompose/configserver.go
@@ -70,6 +70,9 @@ func configserver( //nolint: funlen
 			Source:   dockerURL.Path,
 			Target:   "/var/run/docker.sock",
 			ReadOnly: new(true),
+			// Relabel the socket with a shared SELinux label so the config
+			// server can reach the docker daemon on SELinux/Podman hosts.
+			Bind: &BindOptions{SELinux: "z"},
 		})
 		dockerEndpoint = "unix:///var/run/docker.sock"
 	}


### PR DESCRIPTION
### Checklist

- [x] No breaking changes
- [x] Tests pass
- [x] New features have new tests
- [ ] Documentation is updated (if applicable)
- [x] Title of the PR is in the correct format (see below)

Adds a bind mount label to generated docker-compose configuration so that mount works on SELinux-enabled host environments (e.g. Podman machine, Red Hat/Fedora-based systems)