### PR TITLE
feat(dashboard): Add warning|info|success variant to v3 alert

### DIFF
--- a/dashboard/src/components/ui/v3/alert.tsx
+++ b/dashboard/src/components/ui/v3/alert.tsx
@@ -4,13 +4,18 @@ import * as React from 'react';
 import { cn } from '@/lib/utils';
 
 const alertVariants = cva(
-  'relative w-full rounded-lg border p-4 [&>svg+div]:translate-y-[-3px] [&>svg]:absolute [&>svg]:top-4 [&>svg]:left-4 [&>svg]:text-foreground [&>svg~*]:pl-7',
+  'relative w-full rounded-lg border p-4 has-[>svg]:grid has-[>svg]:grid-cols-[auto_1fr] has-[>svg]:items-center has-[>svg]:gap-x-3 [&>svg]:shrink-0 [&>svg]:text-foreground',
   {
     variants: {
       variant: {
         default: 'bg-background text-foreground',
         destructive:
           'border-destructive/50 text-destructive dark:border-destructive [&>svg]:text-destructive',
+        warning:
+          'border-amber-500/30 bg-amber-500/10 text-foreground [&>svg]:text-amber-500',
+        success:
+          'border-emerald-500/30 bg-emerald-500/10 text-foreground [&>svg]:text-emerald-500',
+        info: 'border-blue-500/30 bg-blue-500/10 text-foreground [&>svg]:text-blue-500',
       },
     },
     defaultVariants: {
@@ -38,7 +43,10 @@ const AlertTitle = React.forwardRef<
 >(({ className, ...props }, ref) => (
   <h5
     ref={ref}
-    className={cn('mb-1 font-medium leading-none tracking-tight', className)}
+    className={cn(
+      'col-start-2 mb-1 font-medium leading-none tracking-tight',
+      className,
+    )}
     {...props}
   >
     {props.children}
@@ -52,7 +60,7 @@ const AlertDescription = React.forwardRef<
 >(({ className, ...props }, ref) => (
   <div
     ref={ref}
-    className={cn('text-sm [&_p]:leading-relaxed', className)}
+    className={cn('col-start-2 text-sm [&_p]:leading-relaxed', className)}
     {...props}
   />
 ));

--- a/dashboard/src/features/orgs/projects/database/dataGrid/components/ConfirmTrackAsQueryDialog/ConfirmTrackAsQueryDialog.tsx
+++ b/dashboard/src/features/orgs/projects/database/dataGrid/components/ConfirmTrackAsQueryDialog/ConfirmTrackAsQueryDialog.tsx
@@ -1,4 +1,5 @@
 import { TriangleAlert } from 'lucide-react';
+import { Alert, AlertDescription } from '@/components/ui/v3/alert';
 import { Button, ButtonWithLoading } from '@/components/ui/v3/button';
 import {
   Dialog,
@@ -32,16 +33,14 @@ export default function ConfirmTrackAsQueryDialog({
           </DialogDescription>
         </DialogHeader>
 
-        <div className="rounded-lg border border-amber-500/30 bg-amber-500/10 px-3 py-2">
-          <div className="flex items-center gap-2">
-            <TriangleAlert className="size-5 shrink-0 text-amber-500" />
-            <p className="text-pretty text-muted-foreground text-sm">
-              Queries should typically use STABLE or IMMUTABLE functions.
-              Tracking a VOLATILE function as a query may cause unexpected
-              behavior if the function has side effects.
-            </p>
-          </div>
-        </div>
+        <Alert variant="warning">
+          <TriangleAlert className="size-5" />
+          <AlertDescription className="text-pretty text-muted-foreground">
+            Queries should typically use STABLE or IMMUTABLE functions. Tracking
+            a VOLATILE function as a query may cause unexpected behavior if the
+            function has side effects.
+          </AlertDescription>
+        </Alert>
 
         <DialogFooter>
           <Button

--- a/dashboard/src/features/orgs/projects/graphql/metadata/components/ImportExportMetadataCard/sections/ExportMetadataSection/ExportMetadataSection.tsx
+++ b/dashboard/src/features/orgs/projects/graphql/metadata/components/ImportExportMetadataCard/sections/ExportMetadataSection/ExportMetadataSection.tsx
@@ -1,5 +1,6 @@
 import { Download, Info, Loader2 } from 'lucide-react';
 import { useState } from 'react';
+import { Alert, AlertDescription } from '@/components/ui/v3/alert';
 import { Button } from '@/components/ui/v3/button';
 import { fetchExportMetadata } from '@/features/orgs/projects/common/utils/fetchExportMetadata';
 import { generateAppServiceUrl } from '@/features/orgs/projects/common/utils/generateAppServiceUrl';
@@ -57,15 +58,13 @@ export default function ExportMetadataSection() {
         Download your current metadata as a JSON file for backup or version
         control.
       </p>
-      <div className="rounded-lg border border-primary/30 bg-primary/5 px-3 py-2">
-        <div className="flex items-center gap-2">
-          <Info className="size-5 shrink-0 text-primary" />
-          <p className="text-muted-foreground text-sm">
-            Includes tracked tables, relationships, permissions, event triggers,
-            and remote schemas.
-          </p>
-        </div>
-      </div>
+      <Alert variant="info">
+        <Info className="size-5" />
+        <AlertDescription className="text-muted-foreground">
+          Includes tracked tables, relationships, permissions, event triggers,
+          and remote schemas.
+        </AlertDescription>
+      </Alert>
       <Button
         onClick={handleExport}
         disabled={isExporting}

--- a/dashboard/src/features/orgs/projects/graphql/metadata/components/ImportExportMetadataCard/sections/ImportMetadataSection/ImportMetadataSection.tsx
+++ b/dashboard/src/features/orgs/projects/graphql/metadata/components/ImportExportMetadataCard/sections/ImportMetadataSection/ImportMetadataSection.tsx
@@ -1,4 +1,5 @@
 import { TriangleAlert, Upload } from 'lucide-react';
+import { Alert, AlertDescription } from '@/components/ui/v3/alert';
 import ImportMetadataDialog from '@/features/orgs/projects/graphql/metadata/components/ImportExportMetadataCard/sections/ImportMetadataSection/ImportMetadataDialog';
 
 export default function ImportMetadataSection() {
@@ -14,15 +15,13 @@ export default function ImportMetadataSection() {
         Replace your existing metadata with the contents of an uploaded JSON
         file.
       </p>
-      <div className="rounded-lg border border-amber-500/30 bg-amber-500/10 px-3 py-2">
-        <div className="flex items-center gap-2">
-          <TriangleAlert className="size-5 shrink-0 text-amber-500" />
-          <p className="text-muted-foreground text-sm">
-            Importing will overwrite all existing metadata. Make sure to export
-            a backup first.
-          </p>
-        </div>
-      </div>
+      <Alert variant="warning">
+        <TriangleAlert className="size-5" />
+        <AlertDescription className="text-muted-foreground">
+          Importing will overwrite all existing metadata. Make sure to export a
+          backup first.
+        </AlertDescription>
+      </Alert>
       <ImportMetadataDialog />
     </div>
   );

--- a/dashboard/src/features/orgs/projects/graphql/metadata/components/ResetMetadataCard/ResetMetadataCard.tsx
+++ b/dashboard/src/features/orgs/projects/graphql/metadata/components/ResetMetadataCard/ResetMetadataCard.tsx
@@ -1,4 +1,5 @@
 import { TriangleAlert } from 'lucide-react';
+import { Alert, AlertDescription } from '@/components/ui/v3/alert';
 import { ResetMetadataDialog } from '@/features/orgs/projects/graphql/metadata/components/ResetMetadataDialog';
 
 export default function ResetMetadataCard() {
@@ -12,15 +13,13 @@ export default function ResetMetadataCard() {
         engine.
       </p>
 
-      <div className="rounded-lg border border-amber-500/30 bg-amber-500/10 px-3 py-2">
-        <div className="flex items-center gap-2">
-          <TriangleAlert className="size-5 shrink-0 text-amber-500" />
-          <p className="text-pretty text-muted-foreground text-sm">
-            This action is irreversible. Make sure to export a backup before
-            resetting metadata.
-          </p>
-        </div>
-      </div>
+      <Alert variant="warning">
+        <TriangleAlert className="size-5" />
+        <AlertDescription className="text-pretty text-muted-foreground">
+          This action is irreversible. Make sure to export a backup before
+          resetting metadata.
+        </AlertDescription>
+      </Alert>
 
       <div className="mt-4 flex items-center justify-between gap-2">
         <ResetMetadataDialog />

--- a/dashboard/src/features/orgs/projects/resources/settings/components/CostEstimate/CostEstimate.tsx
+++ b/dashboard/src/features/orgs/projects/resources/settings/components/CostEstimate/CostEstimate.tsx
@@ -1,5 +1,6 @@
 import { AlertTriangle, Info } from 'lucide-react';
 import { useWatch } from 'react-hook-form';
+import { Alert, AlertDescription, AlertTitle } from '@/components/ui/v3/alert';
 import {
   Tooltip,
   TooltipContent,
@@ -97,24 +98,22 @@ export default function CostEstimate() {
       </div>
 
       {hasAutoscaler && (
-        <div className="flex items-start gap-2 rounded-md border border-amber-500/40 bg-amber-500/10 px-3 py-2 text-amber-900 text-xs dark:text-amber-200">
-          <AlertTriangle className="mt-0.5 h-3.5 w-3.5 shrink-0" />
-          <div className="flex flex-col gap-0.5">
-            <span className="font-medium">Autoscaler can vary the bill</span>
-            <span className="opacity-90">
-              Each extra replica is billed by the minute while it runs. Bursts
-              to max replicas can add up to{' '}
-              <span className="font-medium tabular-nums">
-                ${extraPerMinute.toFixed(4)}/min
-              </span>{' '}
-              (~
-              <span className="font-medium tabular-nums">
-                ${extraPerMonth.toFixed(2)}/mo
-              </span>
-              ) on top of the base cost.
+        <Alert variant="warning">
+          <AlertTriangle className="size-5" />
+          <AlertTitle>Autoscaler can vary the bill</AlertTitle>
+          <AlertDescription className="text-muted-foreground">
+            Each extra replica is billed by the minute while it runs. Bursts to
+            max replicas can add up to{' '}
+            <span className="font-medium tabular-nums">
+              ${extraPerMinute.toFixed(4)}/min
+            </span>{' '}
+            (~
+            <span className="font-medium tabular-nums">
+              ${extraPerMonth.toFixed(2)}/mo
             </span>
-          </div>
-        </div>
+            ) on top of the base cost.
+          </AlertDescription>
+        </Alert>
       )}
     </div>
   );

--- a/dashboard/src/features/orgs/projects/resources/settings/components/RatioBanner/RatioBanner.tsx
+++ b/dashboard/src/features/orgs/projects/resources/settings/components/RatioBanner/RatioBanner.tsx
@@ -1,8 +1,8 @@
 import { AlertTriangle, CheckCircle2 } from 'lucide-react';
 import { useWatch } from 'react-hook-form';
+import { Alert, AlertDescription, AlertTitle } from '@/components/ui/v3/alert';
 import { prettifyMemory } from '@/features/orgs/projects/resources/settings/utils/prettifyMemory';
 import type { ResourceSettingsFormValues } from '@/features/orgs/projects/resources/settings/utils/resourceSettingsValidationSchema';
-import { cn } from '@/lib/utils';
 import {
   RESOURCE_MEMORY_MULTIPLIER,
   RESOURCE_VCPU_MEMORY_RATIO,
@@ -41,47 +41,38 @@ export default function RatioBanner() {
   const balanced = delta === 0;
   const underAllocated = delta > 0;
 
+  if (balanced) {
+    return (
+      <Alert variant="success" role="status">
+        <CheckCircle2 className="size-5" />
+        <AlertDescription className="text-muted-foreground">
+          Total memory matches total vCPU at the 1:2 ratio.
+        </AlertDescription>
+      </Alert>
+    );
+  }
+
   return (
-    <div
-      role="status"
-      className={cn(
-        'flex items-start gap-3 rounded-lg border px-4 py-3 text-sm',
-        balanced
-          ? 'border-emerald-500/30 bg-emerald-500/10 text-emerald-900 dark:text-emerald-200'
-          : 'border-amber-500/40 bg-amber-500/10 text-amber-900 dark:text-amber-200',
-      )}
-    >
-      {balanced ? (
-        <CheckCircle2 className="mt-0.5 h-4 w-4 shrink-0" />
+    <Alert variant="warning" role="status">
+      <AlertTriangle className="size-9" />
+      {underAllocated ? (
+        <>
+          <AlertTitle>{prettifyMemory(delta)} of memory unallocated</AlertTitle>
+          <AlertDescription className="text-muted-foreground">
+            Total memory must equal 2× total vCPU. Add memory to a service or
+            reduce CPU.
+          </AlertDescription>
+        </>
       ) : (
-        <AlertTriangle className="mt-0.5 h-4 w-4 shrink-0" />
+        <>
+          <AlertTitle>
+            {prettifyMemory(-delta)} of memory over the 1:2 ratio
+          </AlertTitle>
+          <AlertDescription className="text-muted-foreground">
+            Reduce memory on a service or allocate more CPU.
+          </AlertDescription>
+        </>
       )}
-      <div className="flex flex-col gap-0.5">
-        {balanced && (
-          <span>Total memory matches total vCPU at the 1:2 ratio.</span>
-        )}
-        {underAllocated && (
-          <>
-            <span className="font-medium">
-              {prettifyMemory(delta)} of memory unallocated
-            </span>
-            <span className="text-xs opacity-90">
-              Total memory must equal 2× total vCPU. Add memory to a service or
-              reduce CPU.
-            </span>
-          </>
-        )}
-        {!balanced && !underAllocated && (
-          <>
-            <span className="font-medium">
-              {prettifyMemory(-delta)} of memory over the 1:2 ratio
-            </span>
-            <span className="text-xs opacity-90">
-              Reduce memory on a service or allocate more CPU.
-            </span>
-          </>
-        )}
-      </div>
-    </div>
+    </Alert>
   );
 }


### PR DESCRIPTION
### Checklist

- [x] No breaking changes
- [x] Tests pass
- [ ] New features have new tests
- [ ] Documentation is updated (if applicable)
- [x] Title of the PR is in the correct format (see below)

<!-- pi-reviewer:start -->
### **What this change solves**
The v3 `Alert` primitive only shipped `default` and `destructive` variants, so callers hand-rolled colored `<div>` boxes for warning/info/success callouts. This adds first-class `warning`, `info`, and `success` variants (plus a self-contained icon+content grid layout) and migrates five bespoke callouts onto the shared component.

___

### **Change Type**
Enhancement

___

### **Description**
- Add `warning`, `info`, and `success` variants to `alertVariants` in the v3 `Alert` component.
- Refactor the base `Alert` layout from absolute-positioned SVG to a `has-[>svg]:grid` two-column (icon + content) grid; `AlertTitle`/`AlertDescription` now pin to `col-start-2`.
- Replace five hand-rolled callout `<div>`s with `<Alert variant="…">` in the metadata cards, track-as-query dialog, cost estimate, and resource ratio banner.
- `RatioBanner` splits its single `role="status"` box into an early-return balanced (`success`) branch and a `warning` branch, dropping the `cn` conditional-class helper.

___

<details> <summary><h3> File Walkthrough</h3></summary>

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody>
<tr><td><strong>Component primitive</strong></td><td><details><summary>1 files</summary><table>
<tr>
  <td><strong>alert.tsx</strong><dd><code>Add warning/info/success variants and a has-[&gt;svg] grid layout</code></dd></td>
  <td>+11/-3</td>
</tr>
</table></details></td></tr>
<tr><td><strong>Consumers migrated to Alert</strong></td><td><details><summary>6 files</summary><table>
<tr>
  <td><strong>ConfirmTrackAsQueryDialog.tsx</strong><dd><code>Use Alert warning variant for the VOLATILE-function callout</code></dd></td>
  <td>+9/-10</td>
</tr>
<tr>
  <td><strong>ExportMetadataSection.tsx</strong><dd><code>Use Alert info variant for the export-contents note</code></dd></td>
  <td>+8/-9</td>
</tr>
<tr>
  <td><strong>ImportMetadataSection.tsx</strong><dd><code>Use Alert warning variant for the overwrite warning</code></dd></td>
  <td>+8/-9</td>
</tr>
<tr>
  <td><strong>ResetMetadataCard.tsx</strong><dd><code>Use Alert warning variant for the irreversible-reset warning</code></dd></td>
  <td>+8/-9</td>
</tr>
<tr>
  <td><strong>CostEstimate.tsx</strong><dd><code>Use Alert warning variant (title + description) for autoscaler note</code></dd></td>
  <td>+16/-17</td>
</tr>
<tr>
  <td><strong>RatioBanner.tsx</strong><dd><code>Split into success/warning Alert branches; drop cn conditional</code></dd></td>
  <td>+31/-40</td>
</tr>
</table></details></td></tr>
</tbody></table>

</details>

___

<!-- pi-reviewer:end -->
