### PR TITLE
fix(dashboard): use v2/query + v1/metadata instead of /apis/migrate when Constellation is enabled

### DIFF
--- a/dashboard/src/features/orgs/projects/common/hooks/useIsConstellationEnabled/index.ts
+++ b/dashboard/src/features/orgs/projects/common/hooks/useIsConstellationEnabled/index.ts
@@ -1,0 +1,1 @@
+export { default as useIsConstellationEnabled } from './useIsConstellationEnabled';

--- a/dashboard/src/features/orgs/projects/common/hooks/useIsConstellationEnabled/useIsConstellationEnabled.test.tsx
+++ b/dashboard/src/features/orgs/projects/common/hooks/useIsConstellationEnabled/useIsConstellationEnabled.test.tsx
@@ -1,0 +1,127 @@
+import { QueryClientProvider } from '@tanstack/react-query';
+import { HttpResponse, http } from 'msw';
+import { setupServer } from 'msw/node';
+import type { PropsWithChildren } from 'react';
+import { vi } from 'vitest';
+import { queryClient, renderHook, waitFor } from '@/tests/testUtils';
+import useIsConstellationEnabled from './useIsConstellationEnabled';
+
+const CONFIG_SERVER_URL =
+  'https://local.dashboard.local.nhost.run/v1/configserver/graphql';
+
+// useLocalMimirClient reads this at render time to build its Apollo client.
+process.env.NEXT_PUBLIC_NHOST_CONFIGSERVER_URL = CONFIG_SERVER_URL;
+
+const mocks = vi.hoisted(() => ({
+  useProject: vi.fn(),
+  useIsPlatform: vi.fn(),
+}));
+
+vi.mock('@/features/orgs/projects/hooks/useProject', () => ({
+  useProject: mocks.useProject,
+}));
+
+vi.mock('@/features/orgs/projects/common/hooks/useIsPlatform', () => ({
+  useIsPlatform: mocks.useIsPlatform,
+}));
+
+let constellationValue: { version: string } | null = null;
+let configRequests = 0;
+
+const server = setupServer(
+  http.post(CONFIG_SERVER_URL, async () => {
+    configRequests += 1;
+    return HttpResponse.json({
+      data: {
+        config: { experimental: { constellation: constellationValue } },
+      },
+    });
+  }),
+);
+
+function wrapper({ children }: PropsWithChildren) {
+  return (
+    <QueryClientProvider client={queryClient}>{children}</QueryClientProvider>
+  );
+}
+
+describe('useIsConstellationEnabled', () => {
+  beforeAll(() => server.listen());
+
+  beforeEach(() => {
+    server.resetHandlers();
+    queryClient.clear();
+    constellationValue = null;
+    configRequests = 0;
+    mocks.useProject.mockReturnValue({ project: { id: 'test-app-id' } });
+    mocks.useIsPlatform.mockReturnValue(false);
+  });
+
+  afterEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  afterAll(() => {
+    server.close();
+  });
+
+  it('returns true when the config exposes an experimental constellation block', async () => {
+    constellationValue = { version: '0.1.0' };
+
+    const { result } = renderHook(() => useIsConstellationEnabled(), {
+      wrapper,
+    });
+
+    await waitFor(() => expect(result.current.loading).toBe(false));
+    expect(result.current.isConstellationEnabled).toBe(true);
+  });
+
+  it('returns false when constellation is absent from the config', async () => {
+    constellationValue = null;
+
+    const { result } = renderHook(() => useIsConstellationEnabled(), {
+      wrapper,
+    });
+
+    await waitFor(() => expect(result.current.loading).toBe(false));
+    expect(result.current.isConstellationEnabled).toBe(false);
+  });
+
+  it('skips the config query on the platform', async () => {
+    mocks.useIsPlatform.mockReturnValue(true);
+
+    const { result } = renderHook(() => useIsConstellationEnabled(), {
+      wrapper,
+    });
+
+    await waitFor(() => expect(result.current.loading).toBe(false));
+    expect(result.current.isConstellationEnabled).toBe(false);
+    expect(configRequests).toBe(0);
+  });
+
+  it('skips the config query when no local project is selected', async () => {
+    mocks.useProject.mockReturnValue({ project: null });
+
+    const { result } = renderHook(() => useIsConstellationEnabled(), {
+      wrapper,
+    });
+
+    await waitFor(() => expect(result.current.loading).toBe(false));
+    expect(result.current.isConstellationEnabled).toBe(false);
+    expect(configRequests).toBe(0);
+  });
+
+  it('reports undefined (not false) while the config query is in flight', async () => {
+    constellationValue = { version: '0.1.0' };
+
+    const { result } = renderHook(() => useIsConstellationEnabled(), {
+      wrapper,
+    });
+
+    expect(result.current.loading).toBe(true);
+    expect(result.current.isConstellationEnabled).toBeUndefined();
+
+    await waitFor(() => expect(result.current.loading).toBe(false));
+    expect(result.current.isConstellationEnabled).toBe(true);
+  });
+});

--- a/dashboard/src/features/orgs/projects/common/hooks/useIsConstellationEnabled/useIsConstellationEnabled.ts
+++ b/dashboard/src/features/orgs/projects/common/hooks/useIsConstellationEnabled/useIsConstellationEnabled.ts
@@ -1,0 +1,65 @@
+import { gql, useQuery } from '@apollo/client';
+import { useIsPlatform } from '@/features/orgs/projects/common/hooks/useIsPlatform';
+import { useLocalMimirClient } from '@/features/orgs/projects/hooks/useLocalMimirClient';
+import { useProject } from '@/features/orgs/projects/hooks/useProject';
+import type { ConfigConfig } from '@/generated/graphql';
+
+const GET_CONFIG_CONSTELLATION = gql`
+  query getConfigConstellation($appId: uuid!) {
+    config(appID: $appId, resolve: true) {
+      experimental {
+        constellation {
+          version
+        }
+      }
+    }
+  }
+`;
+
+type GetConfigConstellationQuery = {
+  config?: Pick<ConfigConfig, 'experimental'> | null;
+};
+
+/**
+ * Returns `true` when the local project runs with the experimental
+ * Constellation engine enabled.
+ *
+ * Constellation replaces Hasura as the GraphQL engine and does not serve the
+ * hasura-cli migrations API (`/apis/migrate`). Callers use this to route
+ * schema/metadata mutations through the query and metadata APIs
+ * (`/v2/query`, `/v1/metadata`) instead — the same path the cloud platform
+ * already uses, where there is no hasura-cli console either.
+ *
+ * On the platform the query is skipped: `isPlatform` already selects the
+ * direct API path, so the value is unused there.
+ *
+ * While the config query is in flight, `isConstellationEnabled` is `undefined`
+ * rather than `false`, so callers cannot treat "not yet known" as "disabled"
+ * and mis-route an early mutation to the non-existent hasura-cli migrations
+ * API. The migration branch must only be taken once the value is definitively
+ * `false` (i.e. `isConstellationEnabled === false`).
+ */
+export default function useIsConstellationEnabled(): {
+  isConstellationEnabled: boolean | undefined;
+  loading: boolean;
+} {
+  const isPlatform = useIsPlatform();
+  const { project } = useProject();
+  const localMimirClient = useLocalMimirClient();
+
+  const { data, loading } = useQuery<GetConfigConstellationQuery>(
+    GET_CONFIG_CONSTELLATION,
+    {
+      variables: { appId: project?.id },
+      skip: isPlatform || !project,
+      client: localMimirClient,
+    },
+  );
+
+  return {
+    isConstellationEnabled: loading
+      ? undefined
+      : Boolean(data?.config?.experimental?.constellation),
+    loading,
+  };
+}

--- a/dashboard/src/features/orgs/projects/database/dataGrid/hooks/useComputedFieldMetadataMutation/useComputedFieldMetadataMutation.ts
+++ b/dashboard/src/features/orgs/projects/database/dataGrid/hooks/useComputedFieldMetadataMutation/useComputedFieldMetadataMutation.ts
@@ -2,6 +2,7 @@ import type { MutationOptions } from '@tanstack/react-query';
 import { useMutation, useQueryClient } from '@tanstack/react-query';
 import { EXPORT_METADATA_QUERY_KEY } from '@/features/orgs/projects/common/hooks/useExportMetadata';
 import { useGetMetadataResourceVersion } from '@/features/orgs/projects/common/hooks/useGetMetadataResourceVersion';
+import { useIsConstellationEnabled } from '@/features/orgs/projects/common/hooks/useIsConstellationEnabled';
 import { useIsPlatform } from '@/features/orgs/projects/common/hooks/useIsPlatform';
 import { generateAppServiceUrl } from '@/features/orgs/projects/common/utils/generateAppServiceUrl';
 import { useProject } from '@/features/orgs/projects/hooks/useProject';
@@ -56,6 +57,7 @@ export default function useComputedFieldMetadataMutation<
 >({ type, mutationOptions }: UseComputedFieldMetadataMutationOptions<T>) {
   const { project } = useProject();
   const isPlatform = useIsPlatform();
+  const { isConstellationEnabled } = useIsConstellationEnabled();
   const { refetch: refetchResourceVersion } = useGetMetadataResourceVersion();
   const queryClient = useQueryClient();
 
@@ -74,7 +76,7 @@ export default function useComputedFieldMetadataMutation<
         adminSecret: project!.config!.hasura.adminSecret,
       } as const;
 
-      if (isPlatform) {
+      if (isPlatform || isConstellationEnabled !== false) {
         const { data: latestResourceVersion } = await refetchResourceVersion();
         const resourceVersion = latestResourceVersion!;
 

--- a/dashboard/src/features/orgs/projects/database/dataGrid/hooks/useCreateColumnMutation/useCreateColumnMutation.ts
+++ b/dashboard/src/features/orgs/projects/database/dataGrid/hooks/useCreateColumnMutation/useCreateColumnMutation.ts
@@ -1,6 +1,7 @@
 import type { MutationOptions } from '@tanstack/react-query';
 import { useMutation } from '@tanstack/react-query';
 import { useRouter } from 'next/router';
+import { useIsConstellationEnabled } from '@/features/orgs/projects/common/hooks/useIsConstellationEnabled';
 import { useIsPlatform } from '@/features/orgs/projects/common/hooks/useIsPlatform';
 import { generateAppServiceUrl } from '@/features/orgs/projects/common/utils/generateAppServiceUrl';
 import { useProject } from '@/features/orgs/projects/hooks/useProject';
@@ -34,11 +35,15 @@ export default function useCreateColumnMutation({
   mutationOptions,
 }: UseCreateColumnMutationOptions = {}) {
   const isPlatform = useIsPlatform();
+  const { isConstellationEnabled } = useIsConstellationEnabled();
   const {
     query: { dataSourceSlug, schemaSlug, tableSlug },
   } = useRouter();
   const { project } = useProject();
-  const mutationFn = isPlatform ? createColumn : createColumnMigration;
+  const mutationFn =
+    isPlatform || isConstellationEnabled !== false
+      ? createColumn
+      : createColumnMigration;
 
   const mutation = useMutation((variables) => {
     const appUrl = generateAppServiceUrl(

--- a/dashboard/src/features/orgs/projects/database/dataGrid/hooks/useCreateTableMutation/useCreateTableMutation.test.tsx
+++ b/dashboard/src/features/orgs/projects/database/dataGrid/hooks/useCreateTableMutation/useCreateTableMutation.test.tsx
@@ -1,0 +1,168 @@
+import { QueryClientProvider } from '@tanstack/react-query';
+import { HttpResponse, http } from 'msw';
+import { setupServer } from 'msw/node';
+import type { PropsWithChildren } from 'react';
+import { vi } from 'vitest';
+import type { DatabaseTable } from '@/features/orgs/projects/database/dataGrid/types/dataBrowser';
+import { queryClient, renderHook } from '@/tests/testUtils';
+import { getHasuraMigrationsApiUrl } from '@/utils/env';
+import useCreateTableMutation from './useCreateTableMutation';
+
+// testUtils stubs NEXT_PUBLIC_NHOST_HASURA_MIGRATIONS_API_URL, so resolve the
+// migrations endpoint the same way the hook does.
+const MIGRATIONS_URL = getHasuraMigrationsApiUrl();
+
+const HASURA = 'https://local.hasura.local.nhost.run';
+
+const project = {
+  subdomain: 'test-app',
+  region: { name: 'us-east-1', domain: 'nhost.run' },
+  config: { hasura: { adminSecret: 'test-secret' } },
+};
+
+const table: DatabaseTable = {
+  name: 'test_table',
+  columns: [
+    { name: 'id', type: 'uuid' },
+    { name: 'name', type: 'text' },
+  ],
+  primaryKey: ['id'],
+};
+
+const mocks = vi.hoisted(() => ({
+  useProject: vi.fn(),
+  useIsPlatform: vi.fn(),
+  useIsConstellationEnabled: vi.fn(),
+  useRouter: vi.fn(),
+}));
+
+vi.mock('@/features/orgs/projects/hooks/useProject', () => ({
+  useProject: mocks.useProject,
+}));
+
+vi.mock('@/features/orgs/projects/common/hooks/useIsPlatform', () => ({
+  useIsPlatform: mocks.useIsPlatform,
+}));
+
+vi.mock(
+  '@/features/orgs/projects/common/hooks/useIsConstellationEnabled',
+  () => ({
+    useIsConstellationEnabled: mocks.useIsConstellationEnabled,
+  }),
+);
+
+vi.mock('next/router', () => ({
+  useRouter: mocks.useRouter,
+}));
+
+let queryBody: unknown = null;
+let migrationBody: unknown = null;
+
+const server = setupServer(
+  http.post(`${HASURA}/v2/query`, async ({ request }) => {
+    queryBody = await request.json();
+    return HttpResponse.json([
+      { affected_rows: 0 },
+      { result_type: 'CommandOk' },
+    ]);
+  }),
+  http.post(MIGRATIONS_URL, async ({ request }) => {
+    migrationBody = await request.json();
+    return HttpResponse.json({ message: 'success' });
+  }),
+);
+
+describe('useCreateTableMutation', () => {
+  beforeAll(() => server.listen());
+
+  beforeEach(() => {
+    server.resetHandlers();
+    queryClient.clear();
+    queryBody = null;
+    migrationBody = null;
+    mocks.useProject.mockReturnValue({ project });
+    mocks.useRouter.mockReturnValue({ query: {} });
+    mocks.useIsConstellationEnabled.mockReturnValue({
+      isConstellationEnabled: false,
+      loading: false,
+    });
+  });
+
+  afterEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  afterAll(() => {
+    server.close();
+  });
+
+  function wrapper({ children }: PropsWithChildren) {
+    return (
+      <QueryClientProvider client={queryClient}>{children}</QueryClientProvider>
+    );
+  }
+
+  it('routes through the migrations API on local (non-constellation) dev', async () => {
+    mocks.useIsPlatform.mockReturnValue(false);
+    mocks.useIsConstellationEnabled.mockReturnValue({
+      isConstellationEnabled: false,
+      loading: false,
+    });
+
+    const { result } = renderHook(
+      () => useCreateTableMutation({ dataSource: 'default', schema: 'public' }),
+      { wrapper },
+    );
+
+    await result.current.mutateAsync({ table });
+
+    expect(migrationBody).not.toBeNull();
+    expect(queryBody).toBeNull();
+  });
+
+  it('routes through the query API when constellation is enabled', async () => {
+    mocks.useIsPlatform.mockReturnValue(false);
+    mocks.useIsConstellationEnabled.mockReturnValue({
+      isConstellationEnabled: true,
+      loading: false,
+    });
+
+    const { result } = renderHook(
+      () => useCreateTableMutation({ dataSource: 'default', schema: 'public' }),
+      { wrapper },
+    );
+
+    await result.current.mutateAsync({ table });
+
+    expect(queryBody).toEqual({
+      type: 'bulk',
+      version: 1,
+      args: [
+        {
+          type: 'run_sql',
+          args: {
+            source: 'default',
+            sql: 'CREATE TABLE public.test_table (id uuid NOT NULL, name text NOT NULL, PRIMARY KEY (id));',
+            cascade: true,
+            read_only: false,
+          },
+        },
+      ],
+    });
+    expect(migrationBody).toBeNull();
+  });
+
+  it('routes through the query API on the platform', async () => {
+    mocks.useIsPlatform.mockReturnValue(true);
+
+    const { result } = renderHook(
+      () => useCreateTableMutation({ dataSource: 'default', schema: 'public' }),
+      { wrapper },
+    );
+
+    await result.current.mutateAsync({ table });
+
+    expect(queryBody).not.toBeNull();
+    expect(migrationBody).toBeNull();
+  });
+});

--- a/dashboard/src/features/orgs/projects/database/dataGrid/hooks/useCreateTableMutation/useCreateTableMutation.ts
+++ b/dashboard/src/features/orgs/projects/database/dataGrid/hooks/useCreateTableMutation/useCreateTableMutation.ts
@@ -1,6 +1,7 @@
 import type { MutationOptions } from '@tanstack/react-query';
 import { useMutation } from '@tanstack/react-query';
 import { useRouter } from 'next/router';
+import { useIsConstellationEnabled } from '@/features/orgs/projects/common/hooks/useIsConstellationEnabled';
 import { useIsPlatform } from '@/features/orgs/projects/common/hooks/useIsPlatform';
 import { generateAppServiceUrl } from '@/features/orgs/projects/common/utils/generateAppServiceUrl';
 import { useProject } from '@/features/orgs/projects/hooks/useProject';
@@ -31,13 +32,19 @@ export default function useCreateTableMutation({
   mutationOptions,
 }: UseCreateTableMutationOptions = {}) {
   const isPlatform = useIsPlatform();
+  const { isConstellationEnabled } = useIsConstellationEnabled();
   const {
     query: { dataSourceSlug, schemaSlug },
   } = useRouter();
 
   const { project } = useProject();
 
-  const mutationFn = isPlatform ? createTable : createTableMigration;
+  // Constellation replaces Hasura and does not serve the hasura-cli migrations
+  // API, so route through the query API directly (like the platform does).
+  const mutationFn =
+    isPlatform || isConstellationEnabled !== false
+      ? createTable
+      : createTableMigration;
 
   const mutation = useMutation((variables) => {
     const appUrl = generateAppServiceUrl(

--- a/dashboard/src/features/orgs/projects/database/dataGrid/hooks/useDeleteDatabaseObjectMutation/useDeleteDatabaseObjectMutation.ts
+++ b/dashboard/src/features/orgs/projects/database/dataGrid/hooks/useDeleteDatabaseObjectMutation/useDeleteDatabaseObjectMutation.ts
@@ -1,6 +1,7 @@
 import type { MutationOptions } from '@tanstack/react-query';
 import { useMutation } from '@tanstack/react-query';
 import { useRouter } from 'next/router';
+import { useIsConstellationEnabled } from '@/features/orgs/projects/common/hooks/useIsConstellationEnabled';
 import { useIsPlatform } from '@/features/orgs/projects/common/hooks/useIsPlatform';
 import { generateAppServiceUrl } from '@/features/orgs/projects/common/utils/generateAppServiceUrl';
 import fetchFunctionDefinition from '@/features/orgs/projects/database/dataGrid/hooks/useFunctionQuery/fetchFunctionDefinition';
@@ -47,13 +48,15 @@ export default function useDeleteDatabaseObjectMutation({
   mutationOptions,
 }: UseDeleteDatabaseObjectMutationOptions = {}) {
   const isPlatform = useIsPlatform();
+  const { isConstellationEnabled } = useIsConstellationEnabled();
   const {
     query: { dataSourceSlug },
   } = useRouter();
   const { project } = useProject();
-  const mutationFn = isPlatform
-    ? deleteDatabaseObject
-    : deleteDatabaseObjectMigration;
+  const mutationFn =
+    isPlatform || isConstellationEnabled !== false
+      ? deleteDatabaseObject
+      : deleteDatabaseObjectMigration;
 
   const mutation = useMutation(
     async (variables: UseDeleteDatabaseObjectVariables) => {

--- a/dashboard/src/features/orgs/projects/database/dataGrid/hooks/useManageFunctionPermissionMutation/useManageFunctionPermissionMutation.ts
+++ b/dashboard/src/features/orgs/projects/database/dataGrid/hooks/useManageFunctionPermissionMutation/useManageFunctionPermissionMutation.ts
@@ -1,6 +1,7 @@
 import type { MutationOptions } from '@tanstack/react-query';
 import { useMutation, useQueryClient } from '@tanstack/react-query';
 import { EXPORT_METADATA_QUERY_KEY } from '@/features/orgs/projects/common/hooks/useExportMetadata';
+import { useIsConstellationEnabled } from '@/features/orgs/projects/common/hooks/useIsConstellationEnabled';
 import { useIsPlatform } from '@/features/orgs/projects/common/hooks/useIsPlatform';
 import { generateAppServiceUrl } from '@/features/orgs/projects/common/utils/generateAppServiceUrl';
 import { useProject } from '@/features/orgs/projects/hooks/useProject';
@@ -34,6 +35,7 @@ export default function useManageFunctionPermissionMutation({
 }: UseManagePermissionMutationOptions = {}) {
   const { project } = useProject();
   const isPlatform = useIsPlatform();
+  const { isConstellationEnabled } = useIsConstellationEnabled();
   const queryClient = useQueryClient();
 
   const mutation = useMutation<
@@ -54,7 +56,7 @@ export default function useManageFunctionPermissionMutation({
         adminSecret: project!.config!.hasura.adminSecret,
       } as const;
 
-      if (isPlatform) {
+      if (isPlatform || isConstellationEnabled !== false) {
         return manageFunctionPermission({
           ...(variables as ManageFunctionPermissionVariables),
           ...base,

--- a/dashboard/src/features/orgs/projects/database/dataGrid/hooks/useManagePermissionMutation/useManagePermissionMutation.ts
+++ b/dashboard/src/features/orgs/projects/database/dataGrid/hooks/useManagePermissionMutation/useManagePermissionMutation.ts
@@ -1,6 +1,7 @@
 import type { MutationOptions } from '@tanstack/react-query';
 import { useMutation } from '@tanstack/react-query';
 import { useRouter } from 'next/router';
+import { useIsConstellationEnabled } from '@/features/orgs/projects/common/hooks/useIsConstellationEnabled';
 import { useIsPlatform } from '@/features/orgs/projects/common/hooks/useIsPlatform';
 import { generateAppServiceUrl } from '@/features/orgs/projects/common/utils/generateAppServiceUrl';
 import { useProject } from '@/features/orgs/projects/hooks/useProject';
@@ -37,12 +38,16 @@ export default function useManagePermissionMutation({
   mutationOptions,
 }: UseManagePermissionMutationOptions = {}) {
   const isPlatform = useIsPlatform();
+  const { isConstellationEnabled } = useIsConstellationEnabled();
   const {
     query: { dataSourceSlug, schemaSlug },
   } = useRouter();
   const { project } = useProject();
 
-  const mutationFn = isPlatform ? managePermission : managePermissionMigration;
+  const mutationFn =
+    isPlatform || isConstellationEnabled !== false
+      ? managePermission
+      : managePermissionMigration;
 
   const mutation = useMutation((variables) => {
     const appUrl = generateAppServiceUrl(

--- a/dashboard/src/features/orgs/projects/database/dataGrid/hooks/useRunSQL/useRunSQL.ts
+++ b/dashboard/src/features/orgs/projects/database/dataGrid/hooks/useRunSQL/useRunSQL.ts
@@ -3,6 +3,7 @@ import { useRouter } from 'next/router';
 import { useCallback, useState } from 'react';
 import toast from 'react-hot-toast';
 import { EXPORT_METADATA_QUERY_KEY } from '@/features/orgs/projects/common/hooks/useExportMetadata';
+import { useIsConstellationEnabled } from '@/features/orgs/projects/common/hooks/useIsConstellationEnabled';
 import { useIsPlatform } from '@/features/orgs/projects/common/hooks/useIsPlatform';
 import { generateAppServiceUrl } from '@/features/orgs/projects/common/utils/generateAppServiceUrl';
 import { useDatabaseQuery } from '@/features/orgs/projects/database/dataGrid/hooks/useDatabaseQuery';
@@ -22,6 +23,7 @@ export default function useRunSQL(
 ) {
   const { project } = useProject();
   const isPlatform = useIsPlatform();
+  const { isConstellationEnabled } = useIsConstellationEnabled();
   const queryClient = useQueryClient();
 
   const [loading, setLoading] = useState(false);
@@ -187,7 +189,10 @@ export default function useRunSQL(
 
   // biome-ignore lint/suspicious/noExplicitAny: TODO
   const trackAll = async (objects: any[]): Promise<Response[]> => {
-    const apiPath = isPlatform ? '/v1/metadata' : '/apis/migrate';
+    const apiPath =
+      isPlatform || isConstellationEnabled !== false
+        ? '/v1/metadata'
+        : '/apis/migrate';
     const responses: Response[] = await Promise.all(
       objects.map((object) =>
         fetch(`${appUrl}${apiPath}`, {
@@ -226,7 +231,7 @@ export default function useRunSQL(
     let trackTablesOrViews: any[] = [];
     // biome-ignore lint/suspicious/noExplicitAny: TODO
     let trackFunctions: any[] = [];
-    if (isPlatform) {
+    if (isPlatform || isConstellationEnabled !== false) {
       // use v2/query
       trackTablesOrViews = tablesOrViewEntities.map(({ name, schema }) => ({
         type: 'pg_track_table',
@@ -306,7 +311,10 @@ export default function useRunSQL(
     setCommandOk(false);
     setErrorMessage('');
 
-    if (isMigration) {
+    // Constellation has no hasura-cli migrations API, so migrations cannot be
+    // recorded. Fall back to running the SQL directly (like a non-migration
+    // run) instead of hitting a non-existent /apis/migrate endpoint.
+    if (isMigration && isConstellationEnabled === false) {
       const { error: createMigrationError } = await createMigration(
         sqlCode,
         migrationName,

--- a/dashboard/src/features/orgs/projects/database/dataGrid/hooks/useSetFunctionTrackingMutation/useSetFunctionTrackingMutation.ts
+++ b/dashboard/src/features/orgs/projects/database/dataGrid/hooks/useSetFunctionTrackingMutation/useSetFunctionTrackingMutation.ts
@@ -1,6 +1,7 @@
 import type { MutationOptions } from '@tanstack/react-query';
 import { useMutation, useQueryClient } from '@tanstack/react-query';
 import { EXPORT_METADATA_QUERY_KEY } from '@/features/orgs/projects/common/hooks/useExportMetadata';
+import { useIsConstellationEnabled } from '@/features/orgs/projects/common/hooks/useIsConstellationEnabled';
 import { useIsPlatform } from '@/features/orgs/projects/common/hooks/useIsPlatform';
 import { generateAppServiceUrl } from '@/features/orgs/projects/common/utils/generateAppServiceUrl';
 import { useProject } from '@/features/orgs/projects/hooks/useProject';
@@ -27,6 +28,7 @@ export default function useSetFunctionTrackingMutation(
 ) {
   const { project } = useProject();
   const isPlatform = useIsPlatform();
+  const { isConstellationEnabled } = useIsConstellationEnabled();
   const queryClient = useQueryClient();
 
   return useMutation<
@@ -47,7 +49,7 @@ export default function useSetFunctionTrackingMutation(
         adminSecret: project!.config!.hasura.adminSecret,
       } as const;
 
-      if (isPlatform) {
+      if (isPlatform || isConstellationEnabled !== false) {
         return setFunctionTracking({
           resourceVersion: resourceVersion!,
           ...commonParams,

--- a/dashboard/src/features/orgs/projects/database/dataGrid/hooks/useSetTableCustomizationMutation/useSetTableCustomizationMutation.ts
+++ b/dashboard/src/features/orgs/projects/database/dataGrid/hooks/useSetTableCustomizationMutation/useSetTableCustomizationMutation.ts
@@ -1,6 +1,7 @@
 import type { MutationOptions } from '@tanstack/react-query';
 import { useMutation, useQueryClient } from '@tanstack/react-query';
 import { EXPORT_METADATA_QUERY_KEY } from '@/features/orgs/projects/common/hooks/useExportMetadata';
+import { useIsConstellationEnabled } from '@/features/orgs/projects/common/hooks/useIsConstellationEnabled';
 import { useIsPlatform } from '@/features/orgs/projects/common/hooks/useIsPlatform';
 import { generateAppServiceUrl } from '@/features/orgs/projects/common/utils/generateAppServiceUrl';
 import { useProject } from '@/features/orgs/projects/hooks/useProject';
@@ -33,6 +34,7 @@ export default function useSetTableCustomizationMutation({
 }: UseSetTableCustomizationMutationOptions = {}) {
   const { project } = useProject();
   const isPlatform = useIsPlatform();
+  const { isConstellationEnabled } = useIsConstellationEnabled();
   const queryClient = useQueryClient();
 
   const mutation = useMutation<
@@ -52,7 +54,7 @@ export default function useSetTableCustomizationMutation({
         adminSecret: project!.config!.hasura.adminSecret,
       } as const;
 
-      if (isPlatform) {
+      if (isPlatform || isConstellationEnabled !== false) {
         return setTableCustomization({
           ...(variables as SetTableCustomizationVariables),
           ...base,

--- a/dashboard/src/features/orgs/projects/database/dataGrid/hooks/useSetTableIsEnumMutation/useSetTableIsEnumMutation.ts
+++ b/dashboard/src/features/orgs/projects/database/dataGrid/hooks/useSetTableIsEnumMutation/useSetTableIsEnumMutation.ts
@@ -1,6 +1,7 @@
 import type { MutationOptions } from '@tanstack/react-query';
 import { useMutation, useQueryClient } from '@tanstack/react-query';
 import { EXPORT_METADATA_QUERY_KEY } from '@/features/orgs/projects/common/hooks/useExportMetadata';
+import { useIsConstellationEnabled } from '@/features/orgs/projects/common/hooks/useIsConstellationEnabled';
 import { useIsPlatform } from '@/features/orgs/projects/common/hooks/useIsPlatform';
 import { generateAppServiceUrl } from '@/features/orgs/projects/common/utils/generateAppServiceUrl';
 import { useProject } from '@/features/orgs/projects/hooks/useProject';
@@ -33,6 +34,7 @@ export default function useSetTableIsEnumMutation({
 }: UseSetTableIsEnumMutationOptions = {}) {
   const { project } = useProject();
   const isPlatform = useIsPlatform();
+  const { isConstellationEnabled } = useIsConstellationEnabled();
   const queryClient = useQueryClient();
 
   const mutation = useMutation<
@@ -52,7 +54,7 @@ export default function useSetTableIsEnumMutation({
         adminSecret: project!.config!.hasura.adminSecret,
       } as const;
 
-      if (isPlatform) {
+      if (isPlatform || isConstellationEnabled !== false) {
         return setTableIsEnum({
           ...(variables as SetTableIsEnumVariables),
           ...commonParams,

--- a/dashboard/src/features/orgs/projects/database/dataGrid/hooks/useSetTableTrackingMutation/useSetTableTrackingMutation.ts
+++ b/dashboard/src/features/orgs/projects/database/dataGrid/hooks/useSetTableTrackingMutation/useSetTableTrackingMutation.ts
@@ -1,6 +1,7 @@
 import type { MutationOptions } from '@tanstack/react-query';
 import { useMutation, useQueryClient } from '@tanstack/react-query';
 import { EXPORT_METADATA_QUERY_KEY } from '@/features/orgs/projects/common/hooks/useExportMetadata';
+import { useIsConstellationEnabled } from '@/features/orgs/projects/common/hooks/useIsConstellationEnabled';
 import { useIsPlatform } from '@/features/orgs/projects/common/hooks/useIsPlatform';
 import { generateAppServiceUrl } from '@/features/orgs/projects/common/utils/generateAppServiceUrl';
 import { useProject } from '@/features/orgs/projects/hooks/useProject';
@@ -27,6 +28,7 @@ export default function useSetTableTrackingMutation(
 ) {
   const { project } = useProject();
   const isPlatform = useIsPlatform();
+  const { isConstellationEnabled } = useIsConstellationEnabled();
   const queryClient = useQueryClient();
 
   return useMutation<
@@ -47,7 +49,7 @@ export default function useSetTableTrackingMutation(
         adminSecret: project!.config!.hasura.adminSecret,
       } as const;
 
-      if (isPlatform) {
+      if (isPlatform || isConstellationEnabled !== false) {
         return setTableTracking({
           resourceVersion: resourceVersion!,
           ...commonParams,

--- a/dashboard/src/features/orgs/projects/database/dataGrid/hooks/useTrackForeignKeyRelationsMutation/useTrackForeignKeyRelationsMutation.ts
+++ b/dashboard/src/features/orgs/projects/database/dataGrid/hooks/useTrackForeignKeyRelationsMutation/useTrackForeignKeyRelationsMutation.ts
@@ -1,6 +1,7 @@
 import type { MutationOptions } from '@tanstack/react-query';
 import { useMutation } from '@tanstack/react-query';
 import { useRouter } from 'next/router';
+import { useIsConstellationEnabled } from '@/features/orgs/projects/common/hooks/useIsConstellationEnabled';
 import { useIsPlatform } from '@/features/orgs/projects/common/hooks/useIsPlatform';
 import { generateAppServiceUrl } from '@/features/orgs/projects/common/utils/generateAppServiceUrl';
 import { useProject } from '@/features/orgs/projects/hooks/useProject';
@@ -30,15 +31,17 @@ export default function useTrackForeignKeyRelationMutation({
   mutationOptions,
 }: UseTrackForeignKeyRelationsMutation = {}) {
   const isPlatform = useIsPlatform();
+  const { isConstellationEnabled } = useIsConstellationEnabled();
   const {
     query: { dataSourceSlug },
   } = useRouter();
 
   const { project } = useProject();
 
-  const mutationFn = isPlatform
-    ? trackForeignKeyRelations
-    : trackForeignKeyRelationsMigration;
+  const mutationFn =
+    isPlatform || isConstellationEnabled !== false
+      ? trackForeignKeyRelations
+      : trackForeignKeyRelationsMigration;
 
   const mutation = useMutation((variables) => {
     const appUrl = generateAppServiceUrl(

--- a/dashboard/src/features/orgs/projects/database/dataGrid/hooks/useUpdateColumnMutation/useUpdateColumnMutation.ts
+++ b/dashboard/src/features/orgs/projects/database/dataGrid/hooks/useUpdateColumnMutation/useUpdateColumnMutation.ts
@@ -1,6 +1,7 @@
 import type { MutationOptions } from '@tanstack/react-query';
 import { useMutation } from '@tanstack/react-query';
 import { useRouter } from 'next/router';
+import { useIsConstellationEnabled } from '@/features/orgs/projects/common/hooks/useIsConstellationEnabled';
 import { useIsPlatform } from '@/features/orgs/projects/common/hooks/useIsPlatform';
 import { generateAppServiceUrl } from '@/features/orgs/projects/common/utils/generateAppServiceUrl';
 import { useProject } from '@/features/orgs/projects/hooks/useProject';
@@ -35,13 +36,17 @@ export default function useUpdateColumnMutation({
   mutationOptions,
 }: UseUpdateColumnMutationOptions = {}) {
   const isPlatform = useIsPlatform();
+  const { isConstellationEnabled } = useIsConstellationEnabled();
   const {
     query: { dataSourceSlug, schemaSlug, tableSlug },
   } = useRouter();
 
   const { project } = useProject();
 
-  const mutationFn = isPlatform ? updateColumn : updateColumnMigration;
+  const mutationFn =
+    isPlatform || isConstellationEnabled !== false
+      ? updateColumn
+      : updateColumnMigration;
 
   const mutation = useMutation((variables) => {
     const appUrl = generateAppServiceUrl(

--- a/dashboard/src/features/orgs/projects/database/dataGrid/hooks/useUpdateTableMutation/useUpdateTableMutation.ts
+++ b/dashboard/src/features/orgs/projects/database/dataGrid/hooks/useUpdateTableMutation/useUpdateTableMutation.ts
@@ -1,6 +1,7 @@
 import type { MutationOptions } from '@tanstack/react-query';
 import { useMutation } from '@tanstack/react-query';
 import { useRouter } from 'next/router';
+import { useIsConstellationEnabled } from '@/features/orgs/projects/common/hooks/useIsConstellationEnabled';
 import { useIsPlatform } from '@/features/orgs/projects/common/hooks/useIsPlatform';
 import { generateAppServiceUrl } from '@/features/orgs/projects/common/utils/generateAppServiceUrl';
 import { useProject } from '@/features/orgs/projects/hooks/useProject';
@@ -31,12 +32,16 @@ export default function useUpdateTableMutation({
   mutationOptions,
 }: UseUpdateTableMutationOptions = {}) {
   const isPlatform = useIsPlatform();
+  const { isConstellationEnabled } = useIsConstellationEnabled();
   const {
     query: { dataSourceSlug, schemaSlug },
   } = useRouter();
   const { project } = useProject();
 
-  const mutationFn = isPlatform ? updateTable : updateTableMigration;
+  const mutationFn =
+    isPlatform || isConstellationEnabled !== false
+      ? updateTable
+      : updateTableMigration;
 
   const mutation = useMutation((variables) => {
     const appUrl = generateAppServiceUrl(

--- a/dashboard/src/features/orgs/projects/remote-schemas/hooks/useAddRemoteSchemaPermissionsMutation/useAddRemoteSchemaPermissionsMutation.test.tsx
+++ b/dashboard/src/features/orgs/projects/remote-schemas/hooks/useAddRemoteSchemaPermissionsMutation/useAddRemoteSchemaPermissionsMutation.test.tsx
@@ -1,0 +1,164 @@
+import { QueryClientProvider } from '@tanstack/react-query';
+import { HttpResponse, http } from 'msw';
+import { setupServer } from 'msw/node';
+import type { PropsWithChildren } from 'react';
+import { vi } from 'vitest';
+import { queryClient, renderHook } from '@/tests/testUtils';
+import useAddRemoteSchemaPermissionsMutation from './useAddRemoteSchemaPermissionsMutation';
+
+// testUtils stubs NEXT_PUBLIC_NHOST_HASURA_API_URL, so the hook's appUrl
+// resolves to this host for both the direct metadata and migration endpoints.
+const HASURA = 'https://local.hasura.local.nhost.run';
+
+const project = {
+  subdomain: 'test-app',
+  region: { name: 'us-east-1', domain: 'nhost.run' },
+  config: { hasura: { adminSecret: 'test-secret' } },
+};
+
+const variables = {
+  resourceVersion: 1,
+  args: {
+    remote_schema: 'test_schema',
+    role: 'user',
+    definition: { schema: 'schema { query: Query }' },
+  },
+};
+
+const mocks = vi.hoisted(() => ({
+  useProject: vi.fn(),
+  useIsPlatform: vi.fn(),
+  useIsConstellationEnabled: vi.fn(),
+}));
+
+vi.mock('@/features/orgs/projects/hooks/useProject', () => ({
+  useProject: mocks.useProject,
+}));
+
+vi.mock('@/features/orgs/projects/common/hooks/useIsPlatform', () => ({
+  useIsPlatform: mocks.useIsPlatform,
+}));
+
+vi.mock(
+  '@/features/orgs/projects/common/hooks/useIsConstellationEnabled',
+  () => ({
+    useIsConstellationEnabled: mocks.useIsConstellationEnabled,
+  }),
+);
+
+let metadataBody: unknown = null;
+let migrationBody: unknown = null;
+
+const server = setupServer(
+  http.post(`${HASURA}/v1/metadata`, async ({ request }) => {
+    metadataBody = await request.json();
+    return HttpResponse.json({});
+  }),
+  http.post(`${HASURA}/apis/migrate`, async ({ request }) => {
+    migrationBody = await request.json();
+    return HttpResponse.json({ message: 'success' });
+  }),
+);
+
+describe('useAddRemoteSchemaPermissionsMutation', () => {
+  beforeAll(() => server.listen());
+
+  beforeEach(() => {
+    server.resetHandlers();
+    queryClient.clear();
+    metadataBody = null;
+    migrationBody = null;
+    mocks.useProject.mockReturnValue({ project });
+    mocks.useIsPlatform.mockReturnValue(false);
+    mocks.useIsConstellationEnabled.mockReturnValue({
+      isConstellationEnabled: false,
+      loading: false,
+    });
+  });
+
+  afterEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  afterAll(() => {
+    server.close();
+  });
+
+  function wrapper({ children }: PropsWithChildren) {
+    return (
+      <QueryClientProvider client={queryClient}>{children}</QueryClientProvider>
+    );
+  }
+
+  it('routes through the migrations API when constellation is disabled (non-platform)', async () => {
+    mocks.useIsPlatform.mockReturnValue(false);
+    mocks.useIsConstellationEnabled.mockReturnValue({
+      isConstellationEnabled: false,
+      loading: false,
+    });
+
+    const { result } = renderHook(
+      () => useAddRemoteSchemaPermissionsMutation(),
+      { wrapper },
+    );
+
+    await result.current.mutateAsync(variables);
+
+    expect(migrationBody).not.toBeNull();
+    expect(metadataBody).toBeNull();
+  });
+
+  it('routes through the metadata API when constellation is enabled', async () => {
+    mocks.useIsPlatform.mockReturnValue(false);
+    mocks.useIsConstellationEnabled.mockReturnValue({
+      isConstellationEnabled: true,
+      loading: false,
+    });
+
+    const { result } = renderHook(
+      () => useAddRemoteSchemaPermissionsMutation(),
+      { wrapper },
+    );
+
+    await result.current.mutateAsync(variables);
+
+    expect(metadataBody).not.toBeNull();
+    expect(migrationBody).toBeNull();
+  });
+
+  it('routes through the metadata API while the constellation check is in-flight (undefined)', async () => {
+    mocks.useIsPlatform.mockReturnValue(false);
+    mocks.useIsConstellationEnabled.mockReturnValue({
+      isConstellationEnabled: undefined,
+      loading: true,
+    });
+
+    const { result } = renderHook(
+      () => useAddRemoteSchemaPermissionsMutation(),
+      { wrapper },
+    );
+
+    await result.current.mutateAsync(variables);
+
+    expect(metadataBody).not.toBeNull();
+    expect(migrationBody).toBeNull();
+  });
+
+  it('routes through the metadata API on the platform', async () => {
+    mocks.useIsPlatform.mockReturnValue(true);
+    mocks.useIsConstellationEnabled.mockReturnValue({
+      isConstellationEnabled: false,
+      loading: false,
+    });
+
+    const { result } = renderHook(
+      () => useAddRemoteSchemaPermissionsMutation(),
+      { wrapper },
+    );
+
+    await result.current.mutateAsync(variables);
+
+    expect(metadataBody).not.toBeNull();
+    expect(migrationBody).toBeNull();
+  });
+});

--- a/dashboard/src/features/orgs/projects/remote-schemas/hooks/useAddRemoteSchemaPermissionsMutation/useAddRemoteSchemaPermissionsMutation.ts
+++ b/dashboard/src/features/orgs/projects/remote-schemas/hooks/useAddRemoteSchemaPermissionsMutation/useAddRemoteSchemaPermissionsMutation.ts
@@ -1,5 +1,6 @@
 import type { MutationOptions } from '@tanstack/react-query';
 import { useMutation } from '@tanstack/react-query';
+import { useIsConstellationEnabled } from '@/features/orgs/projects/common/hooks/useIsConstellationEnabled';
 import { useIsPlatform } from '@/features/orgs/projects/common/hooks/useIsPlatform';
 import { generateAppServiceUrl } from '@/features/orgs/projects/common/utils/generateAppServiceUrl';
 import { useProject } from '@/features/orgs/projects/hooks/useProject';
@@ -33,6 +34,7 @@ export default function useAddRemoteSchemaPermissionsMutation({
 }: UseAddRemoteSchemaPermissionsMutationOptions = {}) {
   const { project } = useProject();
   const isPlatform = useIsPlatform();
+  const { isConstellationEnabled } = useIsConstellationEnabled();
 
   const mutation = useMutation<
     SuccessResponse | MetadataOperation200,
@@ -51,7 +53,7 @@ export default function useAddRemoteSchemaPermissionsMutation({
       adminSecret: project!.config!.hasura.adminSecret,
     } as const;
 
-    if (isPlatform) {
+    if (isPlatform || isConstellationEnabled !== false) {
       return addRemoteSchemaPermissions({
         ...(variables as AddRemoteSchemaPermissionsVariables),
         ...base,

--- a/dashboard/src/features/orgs/projects/remote-schemas/hooks/useRemoveRemoteSchemaMutation/useRemoveRemoteSchemaMutation.test.tsx
+++ b/dashboard/src/features/orgs/projects/remote-schemas/hooks/useRemoveRemoteSchemaMutation/useRemoveRemoteSchemaMutation.test.tsx
@@ -1,0 +1,159 @@
+import { QueryClientProvider } from '@tanstack/react-query';
+import { HttpResponse, http } from 'msw';
+import { setupServer } from 'msw/node';
+import type { PropsWithChildren } from 'react';
+import { vi } from 'vitest';
+import type { RemoteSchemaInfo } from '@/utils/hasura-api/generated/schemas';
+import { queryClient, renderHook } from '@/tests/testUtils';
+import useRemoveRemoteSchemaMutation from './useRemoveRemoteSchemaMutation';
+
+// testUtils stubs NEXT_PUBLIC_NHOST_HASURA_API_URL, so the hook's appUrl
+// resolves to this host for both the direct metadata and migration endpoints.
+const HASURA = 'https://local.hasura.local.nhost.run';
+
+const project = {
+  subdomain: 'test-app',
+  region: { name: 'us-east-1', domain: 'nhost.run' },
+  config: { hasura: { adminSecret: 'test-secret' } },
+};
+
+const remoteSchema: RemoteSchemaInfo = {
+  name: 'test_schema',
+  definition: { url: 'https://example.com/graphql' },
+};
+
+const variables = { remoteSchema };
+
+const mocks = vi.hoisted(() => ({
+  useProject: vi.fn(),
+  useIsPlatform: vi.fn(),
+  useIsConstellationEnabled: vi.fn(),
+}));
+
+vi.mock('@/features/orgs/projects/hooks/useProject', () => ({
+  useProject: mocks.useProject,
+}));
+
+vi.mock('@/features/orgs/projects/common/hooks/useIsPlatform', () => ({
+  useIsPlatform: mocks.useIsPlatform,
+}));
+
+vi.mock(
+  '@/features/orgs/projects/common/hooks/useIsConstellationEnabled',
+  () => ({
+    useIsConstellationEnabled: mocks.useIsConstellationEnabled,
+  }),
+);
+
+let metadataBody: unknown = null;
+let migrationBody: unknown = null;
+
+const server = setupServer(
+  http.post(`${HASURA}/v1/metadata`, async ({ request }) => {
+    metadataBody = await request.json();
+    return HttpResponse.json({});
+  }),
+  http.post(`${HASURA}/apis/migrate`, async ({ request }) => {
+    migrationBody = await request.json();
+    return HttpResponse.json({ message: 'success' });
+  }),
+);
+
+describe('useRemoveRemoteSchemaMutation', () => {
+  beforeAll(() => server.listen());
+
+  beforeEach(() => {
+    server.resetHandlers();
+    queryClient.clear();
+    metadataBody = null;
+    migrationBody = null;
+    mocks.useProject.mockReturnValue({ project });
+    mocks.useIsPlatform.mockReturnValue(false);
+    mocks.useIsConstellationEnabled.mockReturnValue({
+      isConstellationEnabled: false,
+      loading: false,
+    });
+  });
+
+  afterEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  afterAll(() => {
+    server.close();
+  });
+
+  function wrapper({ children }: PropsWithChildren) {
+    return (
+      <QueryClientProvider client={queryClient}>{children}</QueryClientProvider>
+    );
+  }
+
+  it('routes through the migrations API when constellation is disabled (non-platform)', async () => {
+    mocks.useIsPlatform.mockReturnValue(false);
+    mocks.useIsConstellationEnabled.mockReturnValue({
+      isConstellationEnabled: false,
+      loading: false,
+    });
+
+    const { result } = renderHook(() => useRemoveRemoteSchemaMutation(), {
+      wrapper,
+    });
+
+    await result.current.mutateAsync(variables);
+
+    expect(migrationBody).not.toBeNull();
+    expect(metadataBody).toBeNull();
+  });
+
+  it('routes through the metadata API when constellation is enabled', async () => {
+    mocks.useIsPlatform.mockReturnValue(false);
+    mocks.useIsConstellationEnabled.mockReturnValue({
+      isConstellationEnabled: true,
+      loading: false,
+    });
+
+    const { result } = renderHook(() => useRemoveRemoteSchemaMutation(), {
+      wrapper,
+    });
+
+    await result.current.mutateAsync(variables);
+
+    expect(metadataBody).not.toBeNull();
+    expect(migrationBody).toBeNull();
+  });
+
+  it('routes through the metadata API while the constellation check is in-flight (undefined)', async () => {
+    mocks.useIsPlatform.mockReturnValue(false);
+    mocks.useIsConstellationEnabled.mockReturnValue({
+      isConstellationEnabled: undefined,
+      loading: true,
+    });
+
+    const { result } = renderHook(() => useRemoveRemoteSchemaMutation(), {
+      wrapper,
+    });
+
+    await result.current.mutateAsync(variables);
+
+    expect(metadataBody).not.toBeNull();
+    expect(migrationBody).toBeNull();
+  });
+
+  it('routes through the metadata API on the platform', async () => {
+    mocks.useIsPlatform.mockReturnValue(true);
+    mocks.useIsConstellationEnabled.mockReturnValue({
+      isConstellationEnabled: false,
+      loading: false,
+    });
+
+    const { result } = renderHook(() => useRemoveRemoteSchemaMutation(), {
+      wrapper,
+    });
+
+    await result.current.mutateAsync(variables);
+
+    expect(metadataBody).not.toBeNull();
+    expect(migrationBody).toBeNull();
+  });
+});

--- a/dashboard/src/features/orgs/projects/remote-schemas/hooks/useRemoveRemoteSchemaMutation/useRemoveRemoteSchemaMutation.test.tsx
+++ b/dashboard/src/features/orgs/projects/remote-schemas/hooks/useRemoveRemoteSchemaMutation/useRemoveRemoteSchemaMutation.test.tsx
@@ -3,8 +3,8 @@ import { HttpResponse, http } from 'msw';
 import { setupServer } from 'msw/node';
 import type { PropsWithChildren } from 'react';
 import { vi } from 'vitest';
-import type { RemoteSchemaInfo } from '@/utils/hasura-api/generated/schemas';
 import { queryClient, renderHook } from '@/tests/testUtils';
+import type { RemoteSchemaInfo } from '@/utils/hasura-api/generated/schemas';
 import useRemoveRemoteSchemaMutation from './useRemoveRemoteSchemaMutation';
 
 // testUtils stubs NEXT_PUBLIC_NHOST_HASURA_API_URL, so the hook's appUrl

--- a/dashboard/src/features/orgs/projects/remote-schemas/hooks/useRemoveRemoteSchemaMutation/useRemoveRemoteSchemaMutation.ts
+++ b/dashboard/src/features/orgs/projects/remote-schemas/hooks/useRemoveRemoteSchemaMutation/useRemoveRemoteSchemaMutation.ts
@@ -1,5 +1,6 @@
 import type { MutationOptions } from '@tanstack/react-query';
 import { useMutation } from '@tanstack/react-query';
+import { useIsConstellationEnabled } from '@/features/orgs/projects/common/hooks/useIsConstellationEnabled';
 import { useIsPlatform } from '@/features/orgs/projects/common/hooks/useIsPlatform';
 import { generateAppServiceUrl } from '@/features/orgs/projects/common/utils/generateAppServiceUrl';
 import { useProject } from '@/features/orgs/projects/hooks/useProject';
@@ -33,6 +34,7 @@ export default function useRemoveRemoteSchemaMutation({
 }: UseRemoveRemoteSchemaMutationOptions = {}) {
   const { project } = useProject();
   const isPlatform = useIsPlatform();
+  const { isConstellationEnabled } = useIsConstellationEnabled();
 
   const mutation = useMutation<
     SuccessResponse | MetadataOperation200,
@@ -50,7 +52,7 @@ export default function useRemoveRemoteSchemaMutation({
       adminSecret: project!.config!.hasura.adminSecret,
     } as const;
 
-    if (isPlatform) {
+    if (isPlatform || isConstellationEnabled !== false) {
       return removeRemoteSchema({
         ...variables,
         ...base,

--- a/dashboard/src/features/orgs/projects/remote-schemas/hooks/useRemoveRemoteSchemaPermissionsMutation/useRemoveRemoteSchemaPermissionsMutation.test.tsx
+++ b/dashboard/src/features/orgs/projects/remote-schemas/hooks/useRemoveRemoteSchemaPermissionsMutation/useRemoveRemoteSchemaPermissionsMutation.test.tsx
@@ -1,0 +1,163 @@
+import { QueryClientProvider } from '@tanstack/react-query';
+import { HttpResponse, http } from 'msw';
+import { setupServer } from 'msw/node';
+import type { PropsWithChildren } from 'react';
+import { vi } from 'vitest';
+import { queryClient, renderHook } from '@/tests/testUtils';
+import useRemoveRemoteSchemaPermissionsMutation from './useRemoveRemoteSchemaPermissionsMutation';
+
+// testUtils stubs NEXT_PUBLIC_NHOST_HASURA_API_URL, so the hook's appUrl
+// resolves to this host for both the direct metadata and migration endpoints.
+const HASURA = 'https://local.hasura.local.nhost.run';
+
+const project = {
+  subdomain: 'test-app',
+  region: { name: 'us-east-1', domain: 'nhost.run' },
+  config: { hasura: { adminSecret: 'test-secret' } },
+};
+
+const variables = {
+  resourceVersion: 1,
+  args: {
+    remote_schema: 'test_schema',
+    role: 'user',
+  },
+};
+
+const mocks = vi.hoisted(() => ({
+  useProject: vi.fn(),
+  useIsPlatform: vi.fn(),
+  useIsConstellationEnabled: vi.fn(),
+}));
+
+vi.mock('@/features/orgs/projects/hooks/useProject', () => ({
+  useProject: mocks.useProject,
+}));
+
+vi.mock('@/features/orgs/projects/common/hooks/useIsPlatform', () => ({
+  useIsPlatform: mocks.useIsPlatform,
+}));
+
+vi.mock(
+  '@/features/orgs/projects/common/hooks/useIsConstellationEnabled',
+  () => ({
+    useIsConstellationEnabled: mocks.useIsConstellationEnabled,
+  }),
+);
+
+let metadataBody: unknown = null;
+let migrationBody: unknown = null;
+
+const server = setupServer(
+  http.post(`${HASURA}/v1/metadata`, async ({ request }) => {
+    metadataBody = await request.json();
+    return HttpResponse.json({});
+  }),
+  http.post(`${HASURA}/apis/migrate`, async ({ request }) => {
+    migrationBody = await request.json();
+    return HttpResponse.json({ message: 'success' });
+  }),
+);
+
+describe('useRemoveRemoteSchemaPermissionsMutation', () => {
+  beforeAll(() => server.listen());
+
+  beforeEach(() => {
+    server.resetHandlers();
+    queryClient.clear();
+    metadataBody = null;
+    migrationBody = null;
+    mocks.useProject.mockReturnValue({ project });
+    mocks.useIsPlatform.mockReturnValue(false);
+    mocks.useIsConstellationEnabled.mockReturnValue({
+      isConstellationEnabled: false,
+      loading: false,
+    });
+  });
+
+  afterEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  afterAll(() => {
+    server.close();
+  });
+
+  function wrapper({ children }: PropsWithChildren) {
+    return (
+      <QueryClientProvider client={queryClient}>{children}</QueryClientProvider>
+    );
+  }
+
+  it('routes through the migrations API when constellation is disabled (non-platform)', async () => {
+    mocks.useIsPlatform.mockReturnValue(false);
+    mocks.useIsConstellationEnabled.mockReturnValue({
+      isConstellationEnabled: false,
+      loading: false,
+    });
+
+    const { result } = renderHook(
+      () => useRemoveRemoteSchemaPermissionsMutation(),
+      { wrapper },
+    );
+
+    await result.current.mutateAsync(variables);
+
+    expect(migrationBody).not.toBeNull();
+    expect(metadataBody).toBeNull();
+  });
+
+  it('routes through the metadata API when constellation is enabled', async () => {
+    mocks.useIsPlatform.mockReturnValue(false);
+    mocks.useIsConstellationEnabled.mockReturnValue({
+      isConstellationEnabled: true,
+      loading: false,
+    });
+
+    const { result } = renderHook(
+      () => useRemoveRemoteSchemaPermissionsMutation(),
+      { wrapper },
+    );
+
+    await result.current.mutateAsync(variables);
+
+    expect(metadataBody).not.toBeNull();
+    expect(migrationBody).toBeNull();
+  });
+
+  it('routes through the metadata API while the constellation check is in-flight (undefined)', async () => {
+    mocks.useIsPlatform.mockReturnValue(false);
+    mocks.useIsConstellationEnabled.mockReturnValue({
+      isConstellationEnabled: undefined,
+      loading: true,
+    });
+
+    const { result } = renderHook(
+      () => useRemoveRemoteSchemaPermissionsMutation(),
+      { wrapper },
+    );
+
+    await result.current.mutateAsync(variables);
+
+    expect(metadataBody).not.toBeNull();
+    expect(migrationBody).toBeNull();
+  });
+
+  it('routes through the metadata API on the platform', async () => {
+    mocks.useIsPlatform.mockReturnValue(true);
+    mocks.useIsConstellationEnabled.mockReturnValue({
+      isConstellationEnabled: false,
+      loading: false,
+    });
+
+    const { result } = renderHook(
+      () => useRemoveRemoteSchemaPermissionsMutation(),
+      { wrapper },
+    );
+
+    await result.current.mutateAsync(variables);
+
+    expect(metadataBody).not.toBeNull();
+    expect(migrationBody).toBeNull();
+  });
+});

--- a/dashboard/src/features/orgs/projects/remote-schemas/hooks/useRemoveRemoteSchemaPermissionsMutation/useRemoveRemoteSchemaPermissionsMutation.ts
+++ b/dashboard/src/features/orgs/projects/remote-schemas/hooks/useRemoveRemoteSchemaPermissionsMutation/useRemoveRemoteSchemaPermissionsMutation.ts
@@ -1,5 +1,6 @@
 import type { MutationOptions } from '@tanstack/react-query';
 import { useMutation } from '@tanstack/react-query';
+import { useIsConstellationEnabled } from '@/features/orgs/projects/common/hooks/useIsConstellationEnabled';
 import { useIsPlatform } from '@/features/orgs/projects/common/hooks/useIsPlatform';
 import { generateAppServiceUrl } from '@/features/orgs/projects/common/utils/generateAppServiceUrl';
 import { useProject } from '@/features/orgs/projects/hooks/useProject';
@@ -33,6 +34,7 @@ export default function useRemoveRemoteSchemaPermissionsMutation({
 }: UseRemoveRemoteSchemaPermissionsMutationOptions = {}) {
   const { project } = useProject();
   const isPlatform = useIsPlatform();
+  const { isConstellationEnabled } = useIsConstellationEnabled();
 
   const mutation = useMutation<
     SuccessResponse | MetadataOperation200,
@@ -51,7 +53,7 @@ export default function useRemoveRemoteSchemaPermissionsMutation({
       adminSecret: project!.config!.hasura.adminSecret,
     } as const;
 
-    if (isPlatform) {
+    if (isPlatform || isConstellationEnabled !== false) {
       return removeRemoteSchemaPermissions({
         ...(variables as RemoveRemoteSchemaPermissionsVariables),
         ...base,

--- a/dashboard/src/features/orgs/projects/remote-schemas/hooks/useUpdateRemoteSchemaMutation/useUpdateRemoteSchemaMutation.test.tsx
+++ b/dashboard/src/features/orgs/projects/remote-schemas/hooks/useUpdateRemoteSchemaMutation/useUpdateRemoteSchemaMutation.test.tsx
@@ -3,8 +3,8 @@ import { HttpResponse, http } from 'msw';
 import { setupServer } from 'msw/node';
 import type { PropsWithChildren } from 'react';
 import { vi } from 'vitest';
-import type { RemoteSchemaInfo } from '@/utils/hasura-api/generated/schemas';
 import { queryClient, renderHook } from '@/tests/testUtils';
+import type { RemoteSchemaInfo } from '@/utils/hasura-api/generated/schemas';
 import useUpdateRemoteSchemaMutation from './useUpdateRemoteSchemaMutation';
 
 // testUtils stubs NEXT_PUBLIC_NHOST_HASURA_API_URL, so the hook's appUrl

--- a/dashboard/src/features/orgs/projects/remote-schemas/hooks/useUpdateRemoteSchemaMutation/useUpdateRemoteSchemaMutation.test.tsx
+++ b/dashboard/src/features/orgs/projects/remote-schemas/hooks/useUpdateRemoteSchemaMutation/useUpdateRemoteSchemaMutation.test.tsx
@@ -1,0 +1,165 @@
+import { QueryClientProvider } from '@tanstack/react-query';
+import { HttpResponse, http } from 'msw';
+import { setupServer } from 'msw/node';
+import type { PropsWithChildren } from 'react';
+import { vi } from 'vitest';
+import type { RemoteSchemaInfo } from '@/utils/hasura-api/generated/schemas';
+import { queryClient, renderHook } from '@/tests/testUtils';
+import useUpdateRemoteSchemaMutation from './useUpdateRemoteSchemaMutation';
+
+// testUtils stubs NEXT_PUBLIC_NHOST_HASURA_API_URL, so the hook's appUrl
+// resolves to this host for both the direct metadata and migration endpoints.
+const HASURA = 'https://local.hasura.local.nhost.run';
+
+const project = {
+  subdomain: 'test-app',
+  region: { name: 'us-east-1', domain: 'nhost.run' },
+  config: { hasura: { adminSecret: 'test-secret' } },
+};
+
+const remoteSchema: RemoteSchemaInfo = {
+  name: 'test_schema',
+  definition: { url: 'https://example.com/graphql' },
+};
+
+// Superset of the direct and migration variables so a single call satisfies
+// whichever path routing selects.
+const variables = {
+  updatedRemoteSchema: remoteSchema,
+  originalRemoteSchema: remoteSchema,
+  resourceVersion: 1,
+};
+
+const mocks = vi.hoisted(() => ({
+  useProject: vi.fn(),
+  useIsPlatform: vi.fn(),
+  useIsConstellationEnabled: vi.fn(),
+}));
+
+vi.mock('@/features/orgs/projects/hooks/useProject', () => ({
+  useProject: mocks.useProject,
+}));
+
+vi.mock('@/features/orgs/projects/common/hooks/useIsPlatform', () => ({
+  useIsPlatform: mocks.useIsPlatform,
+}));
+
+vi.mock(
+  '@/features/orgs/projects/common/hooks/useIsConstellationEnabled',
+  () => ({
+    useIsConstellationEnabled: mocks.useIsConstellationEnabled,
+  }),
+);
+
+let metadataBody: unknown = null;
+let migrationBody: unknown = null;
+
+const server = setupServer(
+  http.post(`${HASURA}/v1/metadata`, async ({ request }) => {
+    metadataBody = await request.json();
+    return HttpResponse.json({});
+  }),
+  http.post(`${HASURA}/apis/migrate`, async ({ request }) => {
+    migrationBody = await request.json();
+    return HttpResponse.json({ message: 'success' });
+  }),
+);
+
+describe('useUpdateRemoteSchemaMutation', () => {
+  beforeAll(() => server.listen());
+
+  beforeEach(() => {
+    server.resetHandlers();
+    queryClient.clear();
+    metadataBody = null;
+    migrationBody = null;
+    mocks.useProject.mockReturnValue({ project });
+    mocks.useIsPlatform.mockReturnValue(false);
+    mocks.useIsConstellationEnabled.mockReturnValue({
+      isConstellationEnabled: false,
+      loading: false,
+    });
+  });
+
+  afterEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  afterAll(() => {
+    server.close();
+  });
+
+  function wrapper({ children }: PropsWithChildren) {
+    return (
+      <QueryClientProvider client={queryClient}>{children}</QueryClientProvider>
+    );
+  }
+
+  it('routes through the migrations API when constellation is disabled (non-platform)', async () => {
+    mocks.useIsPlatform.mockReturnValue(false);
+    mocks.useIsConstellationEnabled.mockReturnValue({
+      isConstellationEnabled: false,
+      loading: false,
+    });
+
+    const { result } = renderHook(() => useUpdateRemoteSchemaMutation(), {
+      wrapper,
+    });
+
+    await result.current.mutateAsync(variables);
+
+    expect(migrationBody).not.toBeNull();
+    expect(metadataBody).toBeNull();
+  });
+
+  it('routes through the metadata API when constellation is enabled', async () => {
+    mocks.useIsPlatform.mockReturnValue(false);
+    mocks.useIsConstellationEnabled.mockReturnValue({
+      isConstellationEnabled: true,
+      loading: false,
+    });
+
+    const { result } = renderHook(() => useUpdateRemoteSchemaMutation(), {
+      wrapper,
+    });
+
+    await result.current.mutateAsync(variables);
+
+    expect(metadataBody).not.toBeNull();
+    expect(migrationBody).toBeNull();
+  });
+
+  it('routes through the metadata API while the constellation check is in-flight (undefined)', async () => {
+    mocks.useIsPlatform.mockReturnValue(false);
+    mocks.useIsConstellationEnabled.mockReturnValue({
+      isConstellationEnabled: undefined,
+      loading: true,
+    });
+
+    const { result } = renderHook(() => useUpdateRemoteSchemaMutation(), {
+      wrapper,
+    });
+
+    await result.current.mutateAsync(variables);
+
+    expect(metadataBody).not.toBeNull();
+    expect(migrationBody).toBeNull();
+  });
+
+  it('routes through the metadata API on the platform', async () => {
+    mocks.useIsPlatform.mockReturnValue(true);
+    mocks.useIsConstellationEnabled.mockReturnValue({
+      isConstellationEnabled: false,
+      loading: false,
+    });
+
+    const { result } = renderHook(() => useUpdateRemoteSchemaMutation(), {
+      wrapper,
+    });
+
+    await result.current.mutateAsync(variables);
+
+    expect(metadataBody).not.toBeNull();
+    expect(migrationBody).toBeNull();
+  });
+});

--- a/dashboard/src/features/orgs/projects/remote-schemas/hooks/useUpdateRemoteSchemaMutation/useUpdateRemoteSchemaMutation.ts
+++ b/dashboard/src/features/orgs/projects/remote-schemas/hooks/useUpdateRemoteSchemaMutation/useUpdateRemoteSchemaMutation.ts
@@ -1,5 +1,6 @@
 import type { MutationOptions } from '@tanstack/react-query';
 import { useMutation } from '@tanstack/react-query';
+import { useIsConstellationEnabled } from '@/features/orgs/projects/common/hooks/useIsConstellationEnabled';
 import { useIsPlatform } from '@/features/orgs/projects/common/hooks/useIsPlatform';
 import { generateAppServiceUrl } from '@/features/orgs/projects/common/utils/generateAppServiceUrl';
 import { useProject } from '@/features/orgs/projects/hooks/useProject';
@@ -32,6 +33,7 @@ export default function useUpdateRemoteSchemaMutation({
 }: UseUpdateRemoteSchemaMutationOptions = {}) {
   const { project } = useProject();
   const isPlatform = useIsPlatform();
+  const { isConstellationEnabled } = useIsConstellationEnabled();
 
   const mutation = useMutation<
     SuccessResponse | MetadataOperation200,
@@ -49,7 +51,7 @@ export default function useUpdateRemoteSchemaMutation({
       adminSecret: project!.config!.hasura.adminSecret,
     } as const;
 
-    if (isPlatform) {
+    if (isPlatform || isConstellationEnabled !== false) {
       return updateRemoteSchema({
         ...(variables as UpdateRemoteSchemaVariables),
         ...base,

--- a/dashboard/src/features/orgs/projects/remote-schemas/hooks/useUpdateRemoteSchemaPermissionsMutation/useUpdateRemoteSchemaPermissionsMutation.test.tsx
+++ b/dashboard/src/features/orgs/projects/remote-schemas/hooks/useUpdateRemoteSchemaPermissionsMutation/useUpdateRemoteSchemaPermissionsMutation.test.tsx
@@ -1,0 +1,165 @@
+import { QueryClientProvider } from '@tanstack/react-query';
+import { HttpResponse, http } from 'msw';
+import { setupServer } from 'msw/node';
+import type { PropsWithChildren } from 'react';
+import { vi } from 'vitest';
+import { queryClient, renderHook } from '@/tests/testUtils';
+import useUpdateRemoteSchemaPermissionsMutation from './useUpdateRemoteSchemaPermissionsMutation';
+
+// testUtils stubs NEXT_PUBLIC_NHOST_HASURA_API_URL, so the hook's appUrl
+// resolves to this host for both the direct metadata and migration endpoints.
+const HASURA = 'https://local.hasura.local.nhost.run';
+
+const project = {
+  subdomain: 'test-app',
+  region: { name: 'us-east-1', domain: 'nhost.run' },
+  config: { hasura: { adminSecret: 'test-secret' } },
+};
+
+// Superset of the direct and migration variables so a single call satisfies
+// whichever path routing selects.
+const variables = {
+  role: 'user',
+  remoteSchema: 'test_schema',
+  newPermissionSchema: 'schema { query: Query }',
+  originalPermissionSchema: 'schema { query: Query }',
+  resourceVersion: 1,
+};
+
+const mocks = vi.hoisted(() => ({
+  useProject: vi.fn(),
+  useIsPlatform: vi.fn(),
+  useIsConstellationEnabled: vi.fn(),
+}));
+
+vi.mock('@/features/orgs/projects/hooks/useProject', () => ({
+  useProject: mocks.useProject,
+}));
+
+vi.mock('@/features/orgs/projects/common/hooks/useIsPlatform', () => ({
+  useIsPlatform: mocks.useIsPlatform,
+}));
+
+vi.mock(
+  '@/features/orgs/projects/common/hooks/useIsConstellationEnabled',
+  () => ({
+    useIsConstellationEnabled: mocks.useIsConstellationEnabled,
+  }),
+);
+
+let metadataBody: unknown = null;
+let migrationBody: unknown = null;
+
+const server = setupServer(
+  http.post(`${HASURA}/v1/metadata`, async ({ request }) => {
+    metadataBody = await request.json();
+    return HttpResponse.json({});
+  }),
+  http.post(`${HASURA}/apis/migrate`, async ({ request }) => {
+    migrationBody = await request.json();
+    return HttpResponse.json({ message: 'success' });
+  }),
+);
+
+describe('useUpdateRemoteSchemaPermissionsMutation', () => {
+  beforeAll(() => server.listen());
+
+  beforeEach(() => {
+    server.resetHandlers();
+    queryClient.clear();
+    metadataBody = null;
+    migrationBody = null;
+    mocks.useProject.mockReturnValue({ project });
+    mocks.useIsPlatform.mockReturnValue(false);
+    mocks.useIsConstellationEnabled.mockReturnValue({
+      isConstellationEnabled: false,
+      loading: false,
+    });
+  });
+
+  afterEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  afterAll(() => {
+    server.close();
+  });
+
+  function wrapper({ children }: PropsWithChildren) {
+    return (
+      <QueryClientProvider client={queryClient}>{children}</QueryClientProvider>
+    );
+  }
+
+  it('routes through the migrations API when constellation is disabled (non-platform)', async () => {
+    mocks.useIsPlatform.mockReturnValue(false);
+    mocks.useIsConstellationEnabled.mockReturnValue({
+      isConstellationEnabled: false,
+      loading: false,
+    });
+
+    const { result } = renderHook(
+      () => useUpdateRemoteSchemaPermissionsMutation(),
+      { wrapper },
+    );
+
+    await result.current.mutateAsync(variables);
+
+    expect(migrationBody).not.toBeNull();
+    expect(metadataBody).toBeNull();
+  });
+
+  it('routes through the metadata API when constellation is enabled', async () => {
+    mocks.useIsPlatform.mockReturnValue(false);
+    mocks.useIsConstellationEnabled.mockReturnValue({
+      isConstellationEnabled: true,
+      loading: false,
+    });
+
+    const { result } = renderHook(
+      () => useUpdateRemoteSchemaPermissionsMutation(),
+      { wrapper },
+    );
+
+    await result.current.mutateAsync(variables);
+
+    expect(metadataBody).not.toBeNull();
+    expect(migrationBody).toBeNull();
+  });
+
+  it('routes through the metadata API while the constellation check is in-flight (undefined)', async () => {
+    mocks.useIsPlatform.mockReturnValue(false);
+    mocks.useIsConstellationEnabled.mockReturnValue({
+      isConstellationEnabled: undefined,
+      loading: true,
+    });
+
+    const { result } = renderHook(
+      () => useUpdateRemoteSchemaPermissionsMutation(),
+      { wrapper },
+    );
+
+    await result.current.mutateAsync(variables);
+
+    expect(metadataBody).not.toBeNull();
+    expect(migrationBody).toBeNull();
+  });
+
+  it('routes through the metadata API on the platform', async () => {
+    mocks.useIsPlatform.mockReturnValue(true);
+    mocks.useIsConstellationEnabled.mockReturnValue({
+      isConstellationEnabled: false,
+      loading: false,
+    });
+
+    const { result } = renderHook(
+      () => useUpdateRemoteSchemaPermissionsMutation(),
+      { wrapper },
+    );
+
+    await result.current.mutateAsync(variables);
+
+    expect(metadataBody).not.toBeNull();
+    expect(migrationBody).toBeNull();
+  });
+});

--- a/dashboard/src/features/orgs/projects/remote-schemas/hooks/useUpdateRemoteSchemaPermissionsMutation/useUpdateRemoteSchemaPermissionsMutation.ts
+++ b/dashboard/src/features/orgs/projects/remote-schemas/hooks/useUpdateRemoteSchemaPermissionsMutation/useUpdateRemoteSchemaPermissionsMutation.ts
@@ -1,5 +1,6 @@
 import type { MutationOptions } from '@tanstack/react-query';
 import { useMutation } from '@tanstack/react-query';
+import { useIsConstellationEnabled } from '@/features/orgs/projects/common/hooks/useIsConstellationEnabled';
 import { useIsPlatform } from '@/features/orgs/projects/common/hooks/useIsPlatform';
 import { generateAppServiceUrl } from '@/features/orgs/projects/common/utils/generateAppServiceUrl';
 import { useProject } from '@/features/orgs/projects/hooks/useProject';
@@ -34,6 +35,7 @@ export default function useUpdateRemoteSchemaPermissionsMutation({
 }: UseUpdateRemoteSchemaPermissionsMutationOptions = {}) {
   const { project } = useProject();
   const isPlatform = useIsPlatform();
+  const { isConstellationEnabled } = useIsConstellationEnabled();
 
   const mutation = useMutation<
     SuccessResponse | MetadataOperation200,
@@ -52,7 +54,7 @@ export default function useUpdateRemoteSchemaPermissionsMutation({
       adminSecret: project!.config!.hasura.adminSecret,
     } as const;
 
-    if (isPlatform) {
+    if (isPlatform || isConstellationEnabled !== false) {
       return updateRemoteSchemaPermissions({
         ...(variables as UpdateRemoteSchemaPermissionsVariables),
         ...base,


### PR DESCRIPTION
### Checklist

- [x] No breaking changes
- [x] Tests pass
- [x] New features have new tests
- [x] Documentation is updated (if applicable)
- [x] Title of the PR is in the correct format (see below)


<!-- pi-reviewer:start -->
## What this change solves

Under the experimental Constellation GraphQL engine there is no hasura-cli
migrations API (`/apis/migrate`), so dashboard database/metadata mutations that
assumed a local Hasura backend returned 404 (e.g. create-table). This routes
those mutations through the query/metadata APIs (`/v2/query`, `/v1/metadata`) —
the same path the cloud platform already uses — whenever Constellation is
detected.

## Change Type

Bug fix

## Description

- Add a new `useIsConstellationEnabled` hook that queries the local configserver
  (via `useLocalMimirClient`) for `config.experimental.constellation` and reports
  whether Constellation is enabled; the query is skipped on the platform.
- In every database dataGrid and remote-schema mutation hook that branched on
  `isPlatform` to choose between the direct API and the migrations API, extend
  the condition to `isPlatform || isConstellationEnabled`.
- In `useRunSQL`, additionally skip recording a migration when Constellation is
  enabled (no migrations API to record to) and fall back to running the SQL
  directly.
- Add unit tests for `useIsConstellationEnabled` and `useCreateTableMutation`.

## File Walkthrough

**New hook**
- `useIsConstellationEnabled/useIsConstellationEnabled.ts` — configserver query + boolean/loading result (+59)
- `useIsConstellationEnabled/index.ts` — barrel export (+1)
- `useIsConstellationEnabled/useIsConstellationEnabled.test.tsx` — MSW-backed unit tests (+101)

**Database dataGrid hooks (routing extended to Constellation)**
- `useCreateTableMutation.ts` (+6/-1), `useCreateTableMutation.test.tsx` (+168, new)
- `useRunSQL.ts` (+9/-3), `useDeleteDatabaseObjectMutation.ts` (+6/-3), `useTrackForeignKeyRelationsMutation.ts` (+6/-3)
- `useComputedFieldMetadataMutation.ts`, `useCreateColumnMutation.ts`, `useManageFunctionPermissionMutation.ts`, `useManagePermissionMutation.ts`, `useSetFunctionTrackingMutation.ts`, `useSetTableCustomizationMutation.ts`, `useSetTableIsEnumMutation.ts`, `useSetTableTrackingMutation.ts`, `useUpdateColumnMutation.ts`, `useUpdateTableMutation.ts` (each ~+3-6)

**Remote-schema hooks (routing extended to Constellation)**
- `useAddRemoteSchemaPermissionsMutation.ts`, `useRemoveRemoteSchemaMutation.ts`, `useRemoveRemoteSchemaPermissionsMutation.ts`, `useUpdateRemoteSchemaMutation.ts`, `useUpdateRemoteSchemaPermissionsMutation.ts` (each +3/-1)
<!-- pi-reviewer:end -->