### PR TITLE
fix(functions): populate /etc/passwd et al for node toolchains

### DIFF
--- a/services/functions/project.nix
+++ b/services/functions/project.nix
@@ -100,6 +100,7 @@ let
           copyToRoot = pkgs.buildEnv {
             name = "image";
             paths = [
+              pkgs.fakeNss
               serverFiles
               pkgs.busybox
               nodeRuntime


### PR DESCRIPTION
This change populates /etc/passwd so that environment variables such as HOME as well as writable environments are available for node tooling.

### Checklist

- [ ] No breaking changes
- [ ] Tests pass
- [ ] New features have new tests
- [ ] Documentation is updated (if applicable)
- [ ] Title of the PR is in the correct format (see below)
