### PR TITLE
fix(functions): update stale functions version ref in CLI docs and fix bump-refs sed pattern

### DIFF
--- a/docs/src/content/docs/reference/cli/commands.mdx
+++ b/docs/src/content/docs/reference/cli/commands.mdx
@@ -273,7 +273,7 @@ Start local development environment.
 | `--disable-tls` | Disable TLS. Env: `$NHOST_DISABLE_TLS`. |
 | `--down-on-error` | Skip confirmation. Env: `$NHOST_YES`. |
 | `--functions-port=""` | If specified, expose functions on this port. Not recommended. Default: `0`. |
-| `--functions-version=""` | Functions version to use. Default: `"2.1.0"`. Env: `$NHOST_FUNCTIONS_VERSION`. |
+| `--functions-version=""` | Functions version to use. Default: `"2.2.0"`. Env: `$NHOST_FUNCTIONS_VERSION`. |
 | `--hasura-console-port=""` | If specified, expose hasura console on this port. Not recommended. Default: `0`. |
 | `--hasura-port=""` | If specified, expose hasura on this port. Not recommended. Default: `0`. |
 | `--http-port=""` | HTTP port to listen on. Default: `443`. Env: `$NHOST_HTTP_PORT`. |

--- a/services/functions/Makefile
+++ b/services/functions/Makefile
@@ -42,4 +42,4 @@ _dev-env-down:
 .PHONY: changelog-bump-refs
 changelog-bump-refs:  ## Bump functions version ref in CLI source and docs
 	@sed -i 's|defaultFunctionsVersion = "[^"]*"|defaultFunctionsVersion = "$(BUMP_VERSION)"|' $(ROOT_DIR)/cli/cmd/dev/up.go
-	@sed -i 's|\(--functions-version\*\*.*(default: \)"[^"]*"|\1"$(BUMP_VERSION)"|' $(ROOT_DIR)/docs/src/content/docs/reference/cli/commands.mdx
+	@sed -i 's#\(--functions-version.*Default: `\)"[^"]*"#\1"$(BUMP_VERSION)"#' $(ROOT_DIR)/docs/src/content/docs/reference/cli/commands.mdx


### PR DESCRIPTION
The functions 2.2.0 bump-refs automation updated `defaultFunctionsVersion` in the CLI but silently failed to update the generated CLI docs: the sed pattern in `services/functions/Makefile` targets an old doc format that `cli gen-docs` no longer emits.

### Checklist

- [X] No breaking changes
- [X] Tests pass
- [X] New features have new tests
- [X] Documentation is updated (if applicable)
- [X] Title of the PR is in the correct format (see below)

<!-- pi-reviewer:start -->
### **What this change solves**
The `changelog-bump-refs` target for the functions service updated the CLI default version but its docs sed pattern matched a stale doc format, leaving `docs/src/content/docs/reference/cli/commands.mdx` showing `2.1.0` after the 2.2.0 release. This change fixes the stale doc reference and repairs the sed pattern so future bumps update the docs correctly.

___

### **Change Type**
Bug fix

___

### **Description**
- Update the `--functions-version` default shown in the CLI reference docs from `"2.1.0"` to `"2.2.0"` to match the released functions version
- Fix the `changelog-bump-refs` sed pattern in `services/functions/Makefile` to match the current docs table format (`` --functions-version ... Default: `"x.y.z"` ``) instead of the obsolete `**--functions-version** ... (default: ...)` format

___

<details> <summary><h3> File Walkthrough</h3></summary>

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody>
<tr><td><strong>Documentation</strong></td><td><details><summary>1 files</summary><table>
<tr>
  <td><strong>docs/src/content/docs/reference/cli/commands.mdx</strong><dd><code>Bump --functions-version default from 2.1.0 to 2.2.0</code></dd></td>
  <td>+1/-1</td>
</tr>
</table></details></td></tr>
<tr><td><strong>Build system</strong></td><td><details><summary>1 files</summary><table>
<tr>
  <td><strong>services/functions/Makefile</strong><dd><code>Fix changelog-bump-refs sed pattern to match current docs format</code></dd></td>
  <td>+1/-1</td>
</tr>
</table></details></td></tr>
</tbody></table>

</details>

___

<!-- pi-reviewer:end -->
