### PR TITLE
fix(dashboard): Migrate account settings page

### DIFF
--- a/dashboard/e2e/account/pat/manage-pat.test.ts
+++ b/dashboard/e2e/account/pat/manage-pat.test.ts
@@ -13,20 +13,25 @@ test('should be able to create then delete a personal access token', async ({
     .getByRole('button', { name: /create personal access token/i })
     .click();
 
+  const createPATDialog = page.getByRole('dialog', {
+    name: /create personal access token/i,
+  });
   const patName = faker.lorem.slug(3);
 
-  await page.getByRole('textbox', { name: /name/i }).fill(patName);
-  await page.getByLabel('Expiration').click();
+  await createPATDialog.getByRole('textbox', { name: /name/i }).fill(patName);
+  await createPATDialog.getByLabel('Expiration').click();
   await page.getByRole('option', { name: /7 days/i }).click();
-  await page.getByRole('button', { name: /create/i }).click();
+  await createPATDialog.getByRole('button', { name: /create/i }).click();
 
   await expect(
-    page.getByText(
+    createPATDialog.getByText(
       /this token will not be shown again. make sure to copy it now./i,
     ),
   ).toBeVisible();
 
-  await page.getByRole('button', { name: /close/i }).click();
+  await createPATDialog
+    .getByRole('button', { name: /close personal access token dialog/i })
+    .click();
 
   await expect(page.getByText(patName)).toBeVisible();
 
@@ -34,7 +39,11 @@ test('should be able to create then delete a personal access token', async ({
     .getByRole('button', { name: `More options for ${patName}`, exact: true })
     .click();
   await page.getByRole('menuitem', { name: /delete/i }).click();
-  await page.getByRole('button', { name: /delete/i }).click();
+
+  const deletePATDialog = page.getByRole('alertdialog', {
+    name: /delete personal access token/i,
+  });
+  await deletePATDialog.getByRole('button', { name: /^delete$/i }).click();
 
   await expect(page.getByText(patName)).not.toBeVisible();
 });

--- a/dashboard/src/components/form/FormInput/FormInput.tsx
+++ b/dashboard/src/components/form/FormInput/FormInput.tsx
@@ -54,7 +54,9 @@ interface FormInputProps<
   ) => PathValue<TFieldValues, TName>;
   disabled?: boolean;
   autoComplete?: InputProps['autoComplete'];
+  autoCapitalize?: InputProps['autoCapitalize'];
   autoFocus?: InputProps['autoFocus'];
+  spellCheck?: InputProps['spellCheck'];
   /**
    * Content rendered as an addon before the input (left side). When set,
    * the input is rendered inside an `InputGroup`.
@@ -93,7 +95,9 @@ function InnerFormInput<
     helperText,
     disabled,
     autoComplete,
+    autoCapitalize,
     autoFocus,
+    spellCheck,
     transform,
     addonStart,
     addonEnd,
@@ -166,7 +170,9 @@ function InnerFormInput<
                       placeholder={placeholder}
                       disabled={disabled}
                       autoComplete={autoComplete}
+                      autoCapitalize={autoCapitalize}
                       autoFocus={autoFocus}
+                      spellCheck={spellCheck}
                       data-testid={dataTestId}
                       aria-label={ariaLabel}
                       aria-invalid={fieldState.invalid}
@@ -188,7 +194,9 @@ function InnerFormInput<
                     placeholder={placeholder}
                     disabled={disabled}
                     autoComplete={autoComplete}
+                    autoCapitalize={autoCapitalize}
                     autoFocus={autoFocus}
+                    spellCheck={spellCheck}
                     data-testid={dataTestId}
                     aria-label={ariaLabel}
                     {...restFieldProps}

--- a/dashboard/src/features/account/settings/components/AccountMfaSettings/components/AccountMfaSettings.tsx
+++ b/dashboard/src/features/account/settings/components/AccountMfaSettings/components/AccountMfaSettings.tsx
@@ -1,7 +1,12 @@
+import {
+  SettingsCardFooter,
+  SettingsCardHeader,
+} from '@/components/layout/SettingsCard';
 import { Badge } from '@/components/ui/v3/badge';
+import DisableMfaButton from '@/features/account/settings/components/AccountMfaSettings/components/DisableMfaButton/DisableMfaButton';
+import EnableMfaButton from '@/features/account/settings/components/AccountMfaSettings/components/EnableMfaButton/EnableMfaButton';
 import useMfaEnabled from '@/features/account/settings/components/AccountMfaSettings/hooks/useMfaEnabled';
-import DisableMfaButton from './DisableMfaButton/DisableMfaButton';
-import EnableMfaButton from './EnableMfaButton/EnableMfaButton';
+import { AccountSettingsCard } from '@/features/account/settings/components/AccountSettingsCard';
 
 function MFaEnabledBadge() {
   return (
@@ -13,10 +18,7 @@ function MFaEnabledBadge() {
 
 function MFaDisabledBadge() {
   return (
-    <Badge
-      variant="outline"
-      className="text- border-destructive text-destructive"
-    >
+    <Badge variant="outline" className="border-destructive text-destructive">
       Disabled
     </Badge>
   );
@@ -24,20 +26,22 @@ function MFaDisabledBadge() {
 
 function AccountMfaSettings() {
   const { isMfaEnabled } = useMfaEnabled();
+
   return (
-    <div className="rounded-lg border border-[#EAEDF0] bg-white font-['Inter_var'] dark:border-[#2F363D] dark:bg-paper">
-      <div className="flex w-full flex-col items-start gap-6 p-4">
-        <div className="flex w-full items-center justify-between">
-          <h3 className="flex items-center font-semibold text-[1.125rem] leading-[1.75]">
-            <span className="mr-4">Multi-Factor Authentication </span>
+    <AccountSettingsCard>
+      <SettingsCardHeader
+        title={
+          <h3 className="flex items-center font-semibold text-lg">
+            <span className="mr-4">Multi-Factor Authentication</span>
             {isMfaEnabled ? <MFaEnabledBadge /> : <MFaDisabledBadge />}
           </h3>
-        </div>
-      </div>
-      <div className="flex w-full items-center border-[#EAEDF0] border-t px-4 py-2 dark:border-[#2F363D]">
+        }
+      />
+
+      <SettingsCardFooter className="justify-start sm:justify-start">
         {isMfaEnabled ? <DisableMfaButton /> : <EnableMfaButton />}
-      </div>
-    </div>
+      </SettingsCardFooter>
+    </AccountSettingsCard>
   );
 }
 

--- a/dashboard/src/features/account/settings/components/AccountMfaSettings/components/DisableMfaButton/DisableMfaButton.tsx
+++ b/dashboard/src/features/account/settings/components/AccountMfaSettings/components/DisableMfaButton/DisableMfaButton.tsx
@@ -45,7 +45,7 @@ function DisableMfaButton() {
         <Button
           variant="outline"
           disabled={buttonDisabled}
-          className="h-9 gap-2 border-destructive p-y[0.375rem] px-2 text-destructive hover:bg-destructive hover:text-white"
+          className="h-9 gap-2 border-destructive px-2 py-1.5 text-destructive hover:bg-destructive hover:text-white"
         >
           Disable multi-factor authentication
         </Button>

--- a/dashboard/src/features/account/settings/components/AccountMfaSettings/components/EnableMfaButton/EnableMfaButton.tsx
+++ b/dashboard/src/features/account/settings/components/AccountMfaSettings/components/EnableMfaButton/EnableMfaButton.tsx
@@ -8,8 +8,8 @@ import {
   DialogTitle,
   DialogTrigger,
 } from '@/components/ui/v3/dialog';
+import MfaQRCodeAndTOTPSecret from '@/features/account/settings/components/AccountMfaSettings/components/EnableMfaButton/MfaQRCodeAndTOTPSecret';
 import useMfaEnabled from '@/features/account/settings/components/AccountMfaSettings/hooks/useMfaEnabled';
-import MfaQRCodeAndTOTPSecret from './MfaQRCodeAndTOTPSecret';
 
 function EnableMfaButton() {
   const [open, setOpen] = useState(false);
@@ -27,7 +27,7 @@ function EnableMfaButton() {
         <Button
           variant="outline"
           disabled={buttonDisabled}
-          className="h-9 gap-2 border-green-600 p-y[0.375rem] px-2 text-green-600 hover:bg-destructive hover:bg-green-600"
+          className="h-9 gap-2 border-green-600 px-2 py-1.5 text-green-600 hover:bg-green-600 hover:text-white"
         >
           Enable multi-factor authentication
         </Button>

--- a/dashboard/src/features/account/settings/components/AccountMfaSettings/components/EnableMfaButton/MfaQRCodeAndTOTPSecret.tsx
+++ b/dashboard/src/features/account/settings/components/AccountMfaSettings/components/EnableMfaButton/MfaQRCodeAndTOTPSecret.tsx
@@ -2,10 +2,10 @@ import { useEffect, useState } from 'react';
 import { toast } from 'react-hot-toast';
 import { MfaOtpForm } from '@/components/common/MfaOtpForm';
 import { Spinner } from '@/components/ui/v3/spinner';
+import CopyMfaTOTPSecret from '@/features/account/settings/components/AccountMfaSettings/components/EnableMfaButton/CopyMfaTOTPSecret';
 import useActionWithElevatedPermissions from '@/features/account/settings/hooks/useActionWithElevatedPermissions';
 import { useNhostClient } from '@/providers/nhost';
 import { getToastStyleProps } from '@/utils/constants/settings';
-import CopyMfaTOTPSecret from './CopyMfaTOTPSecret';
 
 interface Props {
   onSuccess: () => void;

--- a/dashboard/src/features/account/settings/components/AccountSettingsCard/AccountSettingsCard.tsx
+++ b/dashboard/src/features/account/settings/components/AccountSettingsCard/AccountSettingsCard.tsx
@@ -1,0 +1,20 @@
+import {
+  SettingsCard,
+  type SettingsCardProps,
+} from '@/components/layout/SettingsCard';
+import { cn } from '@/lib/utils';
+
+export default function AccountSettingsCard({
+  className,
+  ...props
+}: SettingsCardProps) {
+  return (
+    <SettingsCard
+      className={cn(
+        "border-[#EAEDF0] bg-white font-['Inter_var'] dark:border-[#2F363D] dark:bg-paper",
+        className,
+      )}
+      {...props}
+    />
+  );
+}

--- a/dashboard/src/features/account/settings/components/AccountSettingsCard/index.ts
+++ b/dashboard/src/features/account/settings/components/AccountSettingsCard/index.ts
@@ -1,0 +1,1 @@
+export { default as AccountSettingsCard } from '@/features/account/settings/components/AccountSettingsCard/AccountSettingsCard';

--- a/dashboard/src/features/account/settings/components/AccountSettingsLayout/AccountSettingsLayout.tsx
+++ b/dashboard/src/features/account/settings/components/AccountSettingsLayout/AccountSettingsLayout.tsx
@@ -1,19 +1,12 @@
-import { twMerge } from 'tailwind-merge';
+import type { HTMLAttributes } from 'react';
 import type { AuthenticatedLayoutProps } from '@/components/layout/AuthenticatedLayout';
 import { AuthenticatedLayout } from '@/components/layout/AuthenticatedLayout';
 import { RetryableErrorBoundary } from '@/components/presentational/RetryableErrorBoundary';
-import type { BoxProps } from '@/components/ui/v2/Box';
-import { Box } from '@/components/ui/v2/Box';
+import { cn } from '@/lib/utils';
 
 export interface AccountSettingsLayoutProps extends AuthenticatedLayoutProps {
-  /**
-   * Props passed to component slots.
-   */
   slotProps?: {
-    /**
-     * Props passed to the main container.
-     */
-    main?: BoxProps;
+    main?: HTMLAttributes<HTMLElement>;
   };
 }
 
@@ -22,22 +15,21 @@ export default function AccountSettingsLayout({
   slotProps = {},
   ...props
 }: AccountSettingsLayoutProps) {
+  const { className: mainClassName, ...mainProps } = slotProps.main ?? {};
+
   return (
     <AuthenticatedLayout {...props}>
-      <Box
-        component="main"
-        className={twMerge(
+      <main
+        {...mainProps}
+        className={cn(
           'relative flex h-full flex-auto overflow-y-auto',
-          slotProps?.main?.className,
+          mainClassName,
         )}
       >
-        <Box
-          sx={{ backgroundColor: 'background.default' }}
-          className="flex w-full flex-auto flex-col overflow-x-hidden"
-        >
+        <div className="flex w-full flex-auto flex-col overflow-x-hidden bg-background-default">
           <RetryableErrorBoundary>{children}</RetryableErrorBoundary>
-        </Box>
-      </Box>
+        </div>
+      </main>
     </AuthenticatedLayout>
   );
 }

--- a/dashboard/src/features/account/settings/components/CreatePATForm/CreatePATForm.tsx
+++ b/dashboard/src/features/account/settings/components/CreatePATForm/CreatePATForm.tsx
@@ -1,25 +1,17 @@
 import { useApolloClient } from '@apollo/client';
 import { yupResolver } from '@hookform/resolvers/yup';
-import { CopyIcon } from 'lucide-react';
-import { useEffect, useState } from 'react';
-import { FormProvider, useForm } from 'react-hook-form';
+import { useState } from 'react';
+import { useForm } from 'react-hook-form';
 import * as Yup from 'yup';
-import { useDialog } from '@/components/common/DialogProvider';
-import { Form } from '@/components/form/Form';
+import { FormInput } from '@/components/form/FormInput';
 import { FormSelect } from '@/components/form/FormSelect';
-import { HighlightedText } from '@/components/presentational/HighlightedText';
-import { Alert } from '@/components/ui/v2/Alert';
-import { Box } from '@/components/ui/v2/Box';
-import { IconButton } from '@/components/ui/v2/IconButton';
-import { Input } from '@/components/ui/v2/Input';
-import { Text } from '@/components/ui/v2/Text';
 import { Button, ButtonWithLoading } from '@/components/ui/v3/button';
+import { Form } from '@/components/ui/v3/form';
 import { SelectItem } from '@/components/ui/v3/select';
+import CreatedPATAlert from '@/features/account/settings/components/CreatePATForm/CreatedPATAlert';
 import useActionWithElevatedPermissions from '@/features/account/settings/hooks/useActionWithElevatedPermissions';
 import { GetPersonalAccessTokensDocument } from '@/generated/graphql';
 import { useNhostClient } from '@/providers/nhost';
-import type { DialogFormProps } from '@/types/common';
-import { copy } from '@/utils/copy';
 import { getDateComponents } from '@/utils/getDateComponents';
 
 export const createPATFormValidationSchema = Yup.object({
@@ -31,10 +23,7 @@ export type CreatePATFormValues = Yup.InferType<
   typeof createPATFormValidationSchema
 >;
 
-export interface CreatePATFormProps extends DialogFormProps {
-  /**
-   * Function to be called when the operation is cancelled.
-   */
+export interface CreatePATFormProps {
   onCancel?: VoidFunction;
 }
 
@@ -66,14 +55,10 @@ function getDaysUntilNextYearSameDay() {
   return 366;
 }
 
-export default function CreatePATForm({
-  onCancel,
-  location,
-}: CreatePATFormProps) {
-  const [personalAccessToken, setPersonalAccessToken] = useState<
-    string | null
-  >();
-  const { onDirtyStateChange } = useDialog();
+export default function CreatePATForm({ onCancel }: CreatePATFormProps) {
+  const [personalAccessToken, setPersonalAccessToken] = useState<string | null>(
+    null,
+  );
   const nhostClient = useNhostClient();
   const apolloClient = useApolloClient();
   const form = useForm<CreatePATFormValues>({
@@ -104,14 +89,6 @@ export default function CreatePATForm({
     },
   });
 
-  const { register, formState } = form;
-
-  const isDirty = Object.keys(formState.dirtyFields).length > 0;
-
-  useEffect(() => {
-    onDirtyStateChange(isDirty, location);
-  }, [isDirty, location, onDirtyStateChange]);
-
   async function handleSubmit(formValues: CreatePATFormValues) {
     const expiresAt = new Date(formValues.expiresAt).toISOString();
     await createPAT(expiresAt, {
@@ -123,60 +100,40 @@ export default function CreatePATForm({
 
   if (personalAccessToken) {
     return (
-      <Box className="grid grid-flow-row gap-4 px-6 pb-6">
-        <Alert severity="info" className="grid grid-flow-row gap-2">
-          <Box className="grid grid-flow-row bg-transparent">
-            <Text color="secondary" className="text-sm">
-              This token will not be shown again. Make sure to copy it now.
-            </Text>
-          </Box>
-
-          <Box className="grid grid-flow-col items-center justify-center gap-2 bg-transparent">
-            <HighlightedText className="font-semibold text-xs">
-              {personalAccessToken}
-            </HighlightedText>
-
-            <IconButton
-              aria-label="Copy Personal Access Token"
-              variant="borderless"
-              color="secondary"
-              onClick={() => copy(personalAccessToken, 'Personal access token')}
-            >
-              <CopyIcon className="h-4 w-4" />
-            </IconButton>
-          </Box>
-        </Alert>
+      <div className="grid grid-flow-row gap-4">
+        <CreatedPATAlert personalAccessToken={personalAccessToken} />
 
         <Button
           type="button"
           variant="outline"
-          onClick={() => {
-            onDirtyStateChange(false, location);
-            onCancel?.();
-          }}
+          aria-label="Close personal access token dialog"
+          onClick={onCancel}
         >
           Close
         </Button>
-      </Box>
+      </div>
     );
   }
 
   return (
-    <Box className="grid grid-flow-row gap-4 px-6 pb-6">
-      <Text variant="subtitle1">
+    <div className="grid grid-flow-row gap-4">
+      <p className="text-muted-foreground text-sm">
         Personal access tokens are used to authenticate with Nhost services.
-      </Text>
+      </p>
 
-      <FormProvider {...form}>
-        <Form onSubmit={handleSubmit} className="grid grid-flow-row gap-4">
-          <Input
-            {...register('name')}
-            id="name"
+      <Form {...form}>
+        <form
+          onSubmit={form.handleSubmit(handleSubmit)}
+          className="grid grid-flow-row gap-4"
+        >
+          <FormInput
+            control={form.control}
+            name="name"
             label="Name"
             autoFocus
-            fullWidth
-            helperText={formState.errors.name?.message || 'Enter a unique name'}
-            error={Boolean(formState.errors.name)}
+            helperText={
+              form.formState.errors.name ? undefined : 'Enter a unique name'
+            }
           />
 
           <FormSelect
@@ -209,17 +166,20 @@ export default function CreatePATForm({
             </SelectItem>
           </FormSelect>
 
-          <Box className="grid grid-flow-row gap-2">
-            <ButtonWithLoading type="submit" loading={formState.isSubmitting}>
+          <div className="grid grid-flow-row gap-2">
+            <ButtonWithLoading
+              type="submit"
+              loading={form.formState.isSubmitting}
+            >
               Create
             </ButtonWithLoading>
 
             <Button type="button" variant="outline" onClick={onCancel}>
               Cancel
             </Button>
-          </Box>
-        </Form>
-      </FormProvider>
-    </Box>
+          </div>
+        </form>
+      </Form>
+    </div>
   );
 }

--- a/dashboard/src/features/account/settings/components/CreatePATForm/CreatedPATAlert.tsx
+++ b/dashboard/src/features/account/settings/components/CreatePATForm/CreatedPATAlert.tsx
@@ -1,0 +1,38 @@
+import { CopyIcon } from 'lucide-react';
+import { Alert, AlertDescription } from '@/components/ui/v3/alert';
+import { Button } from '@/components/ui/v3/button';
+import { copy } from '@/utils/copy';
+
+interface CreatedPATAlertProps {
+  personalAccessToken: string;
+}
+
+export default function CreatedPATAlert({
+  personalAccessToken,
+}: CreatedPATAlertProps) {
+  return (
+    <Alert variant="info" className="grid grid-flow-row gap-2">
+      <AlertDescription className="col-start-1">
+        <p className="text-sm">
+          This token will not be shown again. Make sure to copy it now.
+        </p>
+      </AlertDescription>
+
+      <div className="flex items-center justify-center gap-2 bg-transparent">
+        <code className="break-all rounded bg-primary-light px-1.5 py-0.5 font-display font-semibold text-foreground text-xs">
+          {personalAccessToken}
+        </code>
+
+        <Button
+          type="button"
+          size="icon"
+          variant="outline"
+          aria-label="Copy Personal Access Token"
+          onClick={() => copy(personalAccessToken, 'Personal access token')}
+        >
+          <CopyIcon className="h-4 w-4" />
+        </Button>
+      </div>
+    </Alert>
+  );
+}

--- a/dashboard/src/features/account/settings/components/DeleteAccount/DeleteAccount.tsx
+++ b/dashboard/src/features/account/settings/components/DeleteAccount/DeleteAccount.tsx
@@ -1,28 +1,31 @@
 import { useState } from 'react';
-import { twMerge } from 'tailwind-merge';
-import { useDialog } from '@/components/common/DialogProvider';
-import { SettingsContainer } from '@/components/layout/SettingsContainer';
-import { Box } from '@/components/ui/v2/Box';
-import { Text } from '@/components/ui/v2/Text';
+import {
+  SettingsCardFooter,
+  SettingsCardHeader,
+} from '@/components/layout/SettingsCard';
+import {
+  AlertDialog,
+  AlertDialogContent,
+  AlertDialogDescription,
+  AlertDialogHeader,
+  AlertDialogTitle,
+  AlertDialogTrigger,
+} from '@/components/ui/v3/alert-dialog';
 import { Button, ButtonWithLoading } from '@/components/ui/v3/button';
 import { Checkbox } from '@/components/ui/v3/checkbox';
 import { Label } from '@/components/ui/v3/label';
+import { AccountSettingsCard } from '@/features/account/settings/components/AccountSettingsCard';
 import { execPromiseWithErrorToast } from '@/features/orgs/utils/execPromiseWithErrorToast';
 import { useDeleteUserAccountMutation } from '@/generated/graphql';
 import { useUserData } from '@/hooks/useUserData';
 import { useAuth } from '@/providers/Auth';
 
-function ConfirmDeleteAccountModal({
-  close,
-  onDelete,
-}: {
-  onDelete: () => Promise<unknown>;
-  close: () => void;
-}) {
+export default function DeleteAccount() {
+  const { signout } = useAuth();
+  const userData = useUserData();
+  const [dialogOpen, setDialogOpen] = useState(false);
   const [remove, setRemove] = useState(false);
   const [loadingRemove, setLoadingRemove] = useState(false);
-
-  const userData = useUserData();
 
   const [deleteUserAccount] = useDeleteUserAccountMutation({
     variables: { id: userData?.id },
@@ -34,8 +37,8 @@ function ConfirmDeleteAccountModal({
     await execPromiseWithErrorToast(
       async () => {
         await deleteUserAccount();
-        onDelete?.();
-        close();
+        await signout();
+        setDialogOpen(false);
       },
       {
         loadingMessage: 'Deleting your account...',
@@ -44,84 +47,82 @@ function ConfirmDeleteAccountModal({
           'An error occurred while deleting your account. Please try again.',
       },
     );
+
+    setLoadingRemove(false);
   };
 
   return (
-    <Box className={twMerge('w-full rounded-lg p-6 text-left')}>
-      <div className="grid grid-flow-row gap-1">
-        <Text variant="h3" component="h2">
-          Delete Account?
-        </Text>
+    <AccountSettingsCard>
+      <SettingsCardHeader
+        title="Delete Account"
+        description="Please proceed with caution as the removal of your Personal Account and its contents from the Nhost platform is irreversible. This action will permanently delete your account and all associated data."
+      />
 
-        <Box className="my-4">
-          <div className="flex items-center gap-2 py-2">
-            <Checkbox
-              id="accept-1"
-              checked={remove}
-              onCheckedChange={(checked) => setRemove(checked === true)}
-              aria-label="Confirm Delete Project #1"
-            />
-            <Label htmlFor="accept-1" className="cursor-pointer font-normal">
-              {`I'm sure I want to delete my account`}
-            </Label>
-          </div>
-        </Box>
-
-        <div className="grid grid-flow-row gap-2">
-          <ButtonWithLoading
-            variant="destructive"
-            onClick={onClickConfirm}
-            disabled={!remove}
-            loading={loadingRemove}
-          >
-            Delete
-          </ButtonWithLoading>
-
-          <Button variant="outline" onClick={close}>
-            Cancel
-          </Button>
-        </div>
-      </div>
-    </Box>
-  );
-}
-
-export default function DeleteAccount() {
-  const { signout } = useAuth();
-
-  const { openDialog, closeDialog } = useDialog();
-
-  const onDelete = async () => {
-    await signout();
-  };
-
-  const confirmDeleteAccount = async () => {
-    openDialog({
-      component: (
-        <ConfirmDeleteAccountModal close={closeDialog} onDelete={onDelete} />
-      ),
-    });
-  };
-
-  return (
-    <SettingsContainer
-      title="Delete Account"
-      description="Please proceed with caution as the removal of your Personal Account and its contents from the Nhost platform is irreversible. This action will permanently delete your account and all associated data."
-      className="px-0"
-      slotProps={{
-        submitButton: { className: 'hidden' },
-        footer: { className: 'hidden' },
-      }}
-    >
-      <Box className="grid grid-flow-row border-t-1">
-        <Button
-          variant="destructive"
-          className="mx-4 mt-4 justify-self-end"
-          onClick={confirmDeleteAccount}
+      <SettingsCardFooter>
+        <AlertDialog
+          open={dialogOpen}
+          onOpenChange={(open) => {
+            setDialogOpen(open);
+            if (!open) {
+              setRemove(false);
+            }
+          }}
         >
-          Delete Personal Account
-        </Button>
-      </Box>
-    </SettingsContainer>
+          <AlertDialogTrigger asChild>
+            <Button variant="destructive" className="w-full sm:w-auto">
+              Delete Personal Account
+            </Button>
+          </AlertDialogTrigger>
+          <AlertDialogContent className="z-[9999] max-w-sm text-foreground">
+            <AlertDialogHeader className="text-left">
+              <AlertDialogTitle className="text-2xl">
+                Delete Account?
+              </AlertDialogTitle>
+              <AlertDialogDescription>
+                This action is permanent and cannot be undone.
+              </AlertDialogDescription>
+            </AlertDialogHeader>
+
+            <div className="my-2 flex items-center gap-2">
+              <Checkbox
+                id="confirm-delete-account"
+                checked={remove}
+                onCheckedChange={(checked) => setRemove(checked === true)}
+                aria-label="Confirm Delete Account"
+              />
+              <Label
+                htmlFor="confirm-delete-account"
+                className="cursor-pointer font-normal text-foreground"
+              >
+                I&apos;m sure I want to delete my account
+              </Label>
+            </div>
+
+            <div className="grid grid-flow-row gap-2">
+              <ButtonWithLoading
+                type="button"
+                variant="destructive"
+                onClick={onClickConfirm}
+                disabled={!remove}
+                loading={loadingRemove}
+                className="w-full"
+              >
+                Delete
+              </ButtonWithLoading>
+
+              <Button
+                type="button"
+                variant="outline"
+                onClick={() => setDialogOpen(false)}
+                disabled={loadingRemove}
+                className="w-full"
+              >
+                Cancel
+              </Button>
+            </div>
+          </AlertDialogContent>
+        </AlertDialog>
+      </SettingsCardFooter>
+    </AccountSettingsCard>
   );
 }

--- a/dashboard/src/features/account/settings/components/DisplayNameSetting/DisplayNameSetting.tsx
+++ b/dashboard/src/features/account/settings/components/DisplayNameSetting/DisplayNameSetting.tsx
@@ -1,9 +1,15 @@
 import { yupResolver } from '@hookform/resolvers/yup';
-import { FormProvider, useForm } from 'react-hook-form';
+import { useForm } from 'react-hook-form';
 import * as Yup from 'yup';
-import { Form } from '@/components/form/Form';
-import { SettingsContainer } from '@/components/layout/SettingsContainer';
-import { Input } from '@/components/ui/v2/Input';
+import { FormInput } from '@/components/form/FormInput';
+import {
+  SettingsCardContent,
+  SettingsCardFooter,
+  SettingsCardHeader,
+} from '@/components/layout/SettingsCard';
+import { ButtonWithLoading } from '@/components/ui/v3/button';
+import { Form } from '@/components/ui/v3/form';
+import { AccountSettingsCard } from '@/features/account/settings/components/AccountSettingsCard';
 import { execPromiseWithErrorToast } from '@/features/orgs/utils/execPromiseWithErrorToast';
 import { useUpdateUserDisplayNameMutation } from '@/generated/graphql';
 import { useUserData } from '@/hooks/useUserData';
@@ -28,13 +34,10 @@ export default function DisplayNameSetting() {
   const form = useForm<DisplayNameSettingFormValues>({
     reValidateMode: 'onSubmit',
     defaultValues: {
-      displayName,
+      displayName: displayName ?? '',
     },
     resolver: yupResolver(validationSchema),
   });
-
-  const { register, formState } = form;
-  const isDirty = Object.keys(formState.dirtyFields).length > 0;
 
   async function handleSubmit(formValues: DisplayNameSettingFormValues) {
     await execPromiseWithErrorToast(
@@ -58,30 +61,32 @@ export default function DisplayNameSetting() {
   }
 
   return (
-    <FormProvider {...form}>
-      <Form onSubmit={handleSubmit}>
-        <SettingsContainer
-          title="Update your display name"
-          slotProps={{
-            submitButton: {
-              disabled: !isDirty,
-              loading: formState.isSubmitting,
-            },
-          }}
-          className="grid grid-flow-row lg:grid-cols-5"
-        >
-          <Input
-            {...register('displayName')}
-            className="col-span-2"
-            type="text"
-            id="display-name"
-            label="Display Name"
-            fullWidth
-            helperText={formState.errors.displayName?.message}
-            error={Boolean(formState.errors.displayName)}
-          />
-        </SettingsContainer>
-      </Form>
-    </FormProvider>
+    <Form {...form}>
+      <AccountSettingsCard asChild>
+        <form onSubmit={form.handleSubmit(handleSubmit)}>
+          <SettingsCardHeader title="Update your display name" />
+
+          <SettingsCardContent className="lg:grid-cols-5">
+            <FormInput
+              control={form.control}
+              name="displayName"
+              label="Display Name"
+              containerClassName="col-span-2"
+            />
+          </SettingsCardContent>
+
+          <SettingsCardFooter>
+            <ButtonWithLoading
+              type="submit"
+              disabled={!form.formState.isDirty}
+              loading={form.formState.isSubmitting}
+              className="w-full sm:w-auto"
+            >
+              Save
+            </ButtonWithLoading>
+          </SettingsCardFooter>
+        </form>
+      </AccountSettingsCard>
+    </Form>
   );
 }

--- a/dashboard/src/features/account/settings/components/EmailSetting/EmailSetting.tsx
+++ b/dashboard/src/features/account/settings/components/EmailSetting/EmailSetting.tsx
@@ -1,9 +1,15 @@
 import { yupResolver } from '@hookform/resolvers/yup';
-import { FormProvider, useForm } from 'react-hook-form';
+import { useForm } from 'react-hook-form';
 import * as Yup from 'yup';
-import { Form } from '@/components/form/Form';
-import { SettingsContainer } from '@/components/layout/SettingsContainer';
-import { Input } from '@/components/ui/v2/Input';
+import { FormInput } from '@/components/form/FormInput';
+import {
+  SettingsCardContent,
+  SettingsCardFooter,
+  SettingsCardHeader,
+} from '@/components/layout/SettingsCard';
+import { ButtonWithLoading } from '@/components/ui/v3/button';
+import { Form } from '@/components/ui/v3/form';
+import { AccountSettingsCard } from '@/features/account/settings/components/AccountSettingsCard';
 import useActionWithElevatedPermissions from '@/features/account/settings/hooks/useActionWithElevatedPermissions';
 import { useUserData } from '@/hooks/useUserData';
 import { appendPkceId, generateAndStorePKCE } from '@/lib/pkce';
@@ -21,12 +27,9 @@ export default function EmailSetting() {
 
   const form = useForm<EmailSettingFormValues>({
     reValidateMode: 'onSubmit',
-    defaultValues: { email: user?.email },
+    defaultValues: { email: user?.email ?? '' },
     resolver: yupResolver(validationSchema),
   });
-
-  const { register, formState } = form;
-  const isDirty = Object.keys(formState.dirtyFields).length > 0;
 
   const changeEmail = useActionWithElevatedPermissions({
     actionFn: async (newEmail: string) => {
@@ -50,33 +53,35 @@ export default function EmailSetting() {
   }
 
   return (
-    <FormProvider {...form}>
-      <Form onSubmit={handleSubmit}>
-        <SettingsContainer
-          title="Update your email"
-          slotProps={{
-            submitButton: {
-              disabled: !isDirty,
-              loading: formState.isSubmitting,
-            },
-          }}
-          className="grid grid-flow-row lg:grid-cols-5"
-        >
-          <Input
-            {...register('email')}
-            className="col-span-2"
-            id="email"
-            spellCheck="false"
-            autoCapitalize="none"
-            type="email"
-            label="Email"
-            hideEmptyHelperText
-            fullWidth
-            helperText={formState.errors.email?.message}
-            error={Boolean(formState.errors.email)}
-          />
-        </SettingsContainer>
-      </Form>
-    </FormProvider>
+    <Form {...form}>
+      <AccountSettingsCard asChild>
+        <form onSubmit={form.handleSubmit(handleSubmit)}>
+          <SettingsCardHeader title="Update your email" />
+
+          <SettingsCardContent className="lg:grid-cols-5">
+            <FormInput
+              control={form.control}
+              name="email"
+              label="Email"
+              type="email"
+              spellCheck={false}
+              autoCapitalize="none"
+              containerClassName="col-span-2"
+            />
+          </SettingsCardContent>
+
+          <SettingsCardFooter>
+            <ButtonWithLoading
+              type="submit"
+              disabled={!form.formState.isDirty}
+              loading={form.formState.isSubmitting}
+              className="w-full sm:w-auto"
+            >
+              Save
+            </ButtonWithLoading>
+          </SettingsCardFooter>
+        </form>
+      </AccountSettingsCard>
+    </Form>
   );
 }

--- a/dashboard/src/features/account/settings/components/PATSettings/PATSettings.tsx
+++ b/dashboard/src/features/account/settings/components/PATSettings/PATSettings.tsx
@@ -3,24 +3,49 @@ import {
   PlusIcon,
   TriangleAlert as WarningIcon,
 } from 'lucide-react';
-import { Fragment } from 'react';
-import { twMerge } from 'tailwind-merge';
-import { useDialog } from '@/components/common/DialogProvider';
-import { SettingsContainer } from '@/components/layout/SettingsContainer';
-import { Box } from '@/components/ui/v2/Box';
-import { Divider } from '@/components/ui/v2/Divider';
-import { IconButton } from '@/components/ui/v2/IconButton';
-import { List } from '@/components/ui/v2/List';
-import { ListItem } from '@/components/ui/v2/ListItem';
-import { Text } from '@/components/ui/v2/Text';
-import { Tooltip } from '@/components/ui/v2/Tooltip';
-import { Button } from '@/components/ui/v3/button';
+import { useState } from 'react';
+import {
+  SettingsCardContent,
+  SettingsCardHeader,
+} from '@/components/layout/SettingsCard';
+import {
+  AlertDialog,
+  AlertDialogCancel,
+  AlertDialogContent,
+  AlertDialogDescription,
+  AlertDialogFooter,
+  AlertDialogHeader,
+  AlertDialogTitle,
+} from '@/components/ui/v3/alert-dialog';
+import { Button, ButtonWithLoading } from '@/components/ui/v3/button';
+import {
+  Dialog,
+  DialogContent,
+  DialogDescription,
+  DialogHeader,
+  DialogTitle,
+  DialogTrigger,
+} from '@/components/ui/v3/dialog';
 import {
   DropdownMenu,
   DropdownMenuContent,
   DropdownMenuItem,
   DropdownMenuTrigger,
 } from '@/components/ui/v3/dropdown-menu';
+import {
+  Table,
+  TableBody,
+  TableCell,
+  TableHead,
+  TableHeader,
+  TableRow,
+} from '@/components/ui/v3/table';
+import {
+  Tooltip,
+  TooltipContent,
+  TooltipTrigger,
+} from '@/components/ui/v3/tooltip';
+import { AccountSettingsCard } from '@/features/account/settings/components/AccountSettingsCard';
 import { CreatePATForm } from '@/features/account/settings/components/CreatePATForm';
 import { execPromiseWithErrorToast } from '@/features/orgs/utils/execPromiseWithErrorToast';
 import {
@@ -28,9 +53,20 @@ import {
   useDeletePersonalAccessTokenMutation,
   useGetPersonalAccessTokensQuery,
 } from '@/generated/graphql';
+import { cn } from '@/lib/utils';
+
+type PersonalAccessToken = {
+  id: string;
+  name: string;
+  expiresAt: string;
+  createdAt: string;
+};
 
 export default function PATSettings() {
-  const { openDialog, openAlertDialog } = useDialog();
+  const [createDialogOpen, setCreateDialogOpen] = useState(false);
+  const [tokenPendingDeletion, setTokenPendingDeletion] =
+    useState<PersonalAccessToken | null>(null);
+  const [isDeletingToken, setIsDeletingToken] = useState(false);
 
   const { data, error } = useGetPersonalAccessTokensQuery();
 
@@ -44,53 +80,29 @@ export default function PATSettings() {
       name: pat.metadata?.name || 'n/a',
       expiresAt: pat.expiresAt,
       createdAt: pat.createdAt,
-      metadata: pat.metadata,
     })) || [];
 
-  function handleOpenCreator() {
-    openDialog({
-      title: 'Create Personal Access Token',
-      component: <CreatePATForm />,
-      props: {
-        maxWidth: 'md',
-        titleProps: { className: '!pb-0' },
-        PaperProps: { className: 'gap-2 max-w-md' },
-      },
-    });
-  }
+  async function handleDeletePAT({ id }: PersonalAccessToken) {
+    setIsDeletingToken(true);
 
-  async function handleDeletePAT({
-    id,
-  }: (typeof availablePersonalAccessTokens)[0]) {
-    await execPromiseWithErrorToast(
-      () => deletePAT({ variables: { patId: id } }),
-      {
-        loadingMessage: 'Deleting personal access token...',
-        successMessage: 'Personal access token has been deleted successfully.',
-        errorMessage:
-          'An error occurred while deleting the personal access token.',
-      },
-    );
-  }
+    try {
+      const result = await execPromiseWithErrorToast(
+        () => deletePAT({ variables: { patId: id } }),
+        {
+          loadingMessage: 'Deleting personal access token...',
+          successMessage:
+            'Personal access token has been deleted successfully.',
+          errorMessage:
+            'An error occurred while deleting the personal access token.',
+        },
+      );
 
-  function handleConfirmDelete(
-    originalPAT: (typeof availablePersonalAccessTokens)[0],
-  ) {
-    openAlertDialog({
-      title: 'Delete Personal Access Token',
-      payload: (
-        <Text>
-          Are you sure you want to delete this personal access token? Any
-          applications or scripts using this token will no longer be able to
-          access the API. You cannot undo this action.
-        </Text>
-      ),
-      props: {
-        primaryButtonColor: 'error',
-        primaryButtonText: 'Delete',
-        onPrimaryAction: () => handleDeletePAT(originalPAT),
-      },
-    });
+      if (result) {
+        setTokenPendingDeletion(null);
+      }
+    } finally {
+      setIsDeletingToken(false);
+    }
   }
 
   if (error) {
@@ -98,112 +110,144 @@ export default function PATSettings() {
   }
 
   return (
-    <SettingsContainer
-      title="Personal Access Tokens"
-      description="Personal access tokens are unique authorization keys that grant individuals access to specific resources and services within a system or platform."
-      rootClassName="gap-0 pb-0"
-      className={twMerge(
-        'my-2 px-0',
-        availablePersonalAccessTokens.length === 0 && 'gap-2',
-      )}
-      slotProps={{
-        submitButton: { className: 'hidden' },
-        footer: { className: 'hidden' },
-      }}
-    >
-      <Box className="grid grid-cols-3 gap-2 border-b-1 py-3 pr-12 pl-4">
-        <Text className="font-medium">Name</Text>
-        <Text className="font-medium">Expires at</Text>
-        <Text className="font-medium">Created at</Text>
-      </Box>
+    <AccountSettingsCard className="gap-0 pb-0">
+      <SettingsCardHeader
+        title="Personal Access Tokens"
+        description="Personal access tokens are unique authorization keys that grant individuals access to specific resources and services within a system or platform."
+      />
 
-      <Box className="grid grid-flow-row gap-2">
-        {availablePersonalAccessTokens.length > 0 && (
-          <List>
-            {availablePersonalAccessTokens.map((pat, index) => {
+      <SettingsCardContent
+        className={cn(
+          'my-2 px-0',
+          availablePersonalAccessTokens.length === 0 && 'gap-2',
+        )}
+      >
+        <Table>
+          <TableHeader>
+            <TableRow>
+              <TableHead>Name</TableHead>
+              <TableHead>Expires at</TableHead>
+              <TableHead>Created at</TableHead>
+              <TableHead className="w-12" />
+            </TableRow>
+          </TableHeader>
+          <TableBody>
+            {availablePersonalAccessTokens.map((pat) => {
               const tokenHasExpired = new Date(pat.expiresAt) < new Date();
+              const textClassName = cn(
+                'truncate',
+                tokenHasExpired && 'text-amber-600',
+              );
 
               return (
-                <Fragment key={pat.id}>
-                  <ListItem.Root
-                    className="grid grid-cols-3 gap-2 px-4 pr-12"
-                    secondaryAction={
-                      <DropdownMenu>
-                        <DropdownMenuTrigger
-                          asChild
-                          className="absolute top-1/2 right-4 -translate-y-1/2"
-                        >
-                          <IconButton
-                            variant="borderless"
-                            color="secondary"
-                            aria-label={`More options for ${pat.name}`}
-                          >
-                            <DotsVerticalIcon />
-                          </IconButton>
-                        </DropdownMenuTrigger>
-
-                        <DropdownMenuContent align="end" className="w-32 p-0">
-                          <DropdownMenuItem
-                            onClick={() => handleConfirmDelete(pat)}
-                            className="!text-destructive flex h-9 cursor-pointer items-center justify-start gap-2 rounded-none border border-b-1 p-2 font-medium text-sm+ leading-4 hover:bg-data-cell-bg"
-                          >
-                            <span>Delete</span>
-                          </DropdownMenuItem>
-                        </DropdownMenuContent>
-                      </DropdownMenu>
-                    }
-                  >
-                    <ListItem.Text
-                      className="truncate"
-                      color={tokenHasExpired ? 'warning' : 'primary'}
-                    >
-                      <span className="mr-2">{pat.name}</span>
-                      {tokenHasExpired && (
-                        <Tooltip title="This personal access token is expired.">
-                          <WarningIcon className="h-4 w-4" />
-                        </Tooltip>
-                      )}
-                    </ListItem.Text>
-
-                    <Text
-                      className="truncate"
-                      color={tokenHasExpired ? 'warning' : 'primary'}
-                    >
-                      {new Date(pat.expiresAt).toLocaleDateString()}
-                    </Text>
-
-                    <Text
-                      className="truncate"
-                      color={tokenHasExpired ? 'warning' : 'primary'}
-                    >
-                      {new Date(pat.createdAt).toLocaleDateString()}
-                    </Text>
-                  </ListItem.Root>
-
-                  <Divider
-                    component="li"
-                    className={twMerge(
-                      index === availablePersonalAccessTokens.length - 1
-                        ? '!mt-4'
-                        : '!my-4',
+                <TableRow key={pat.id}>
+                  <TableCell className={textClassName}>
+                    <span className="mr-2">{pat.name}</span>
+                    {tokenHasExpired && (
+                      <Tooltip>
+                        <TooltipTrigger asChild>
+                          <WarningIcon className="inline h-4 w-4" />
+                        </TooltipTrigger>
+                        <TooltipContent>
+                          This personal access token is expired.
+                        </TooltipContent>
+                      </Tooltip>
                     )}
-                  />
-                </Fragment>
+                  </TableCell>
+                  <TableCell className={textClassName}>
+                    {new Date(pat.expiresAt).toLocaleDateString()}
+                  </TableCell>
+                  <TableCell className={textClassName}>
+                    {new Date(pat.createdAt).toLocaleDateString()}
+                  </TableCell>
+                  <TableCell className="text-right">
+                    <DropdownMenu>
+                      <DropdownMenuTrigger asChild>
+                        <Button
+                          type="button"
+                          variant="ghost"
+                          size="icon"
+                          aria-label={`More options for ${pat.name}`}
+                        >
+                          <DotsVerticalIcon className="h-4 w-4" />
+                        </Button>
+                      </DropdownMenuTrigger>
+
+                      <DropdownMenuContent align="end" className="w-32 p-0">
+                        <DropdownMenuItem
+                          onClick={() => setTokenPendingDeletion(pat)}
+                          className="!text-destructive flex h-9 cursor-pointer items-center justify-start gap-2 rounded-none border border-b-1 p-2 font-medium text-sm+ leading-4 hover:bg-data-cell-bg"
+                        >
+                          <span>Delete</span>
+                        </DropdownMenuItem>
+                      </DropdownMenuContent>
+                    </DropdownMenu>
+                  </TableCell>
+                </TableRow>
               );
             })}
-          </List>
-        )}
+          </TableBody>
+        </Table>
 
-        <Button
-          type="button"
-          variant="ghost"
-          className="mx-4 justify-self-start text-primary-main hover:bg-primary-highlight hover:text-primary-main"
-          onClick={handleOpenCreator}
-        >
-          <PlusIcon className="mr-2 h-4 w-4" />
-          Create Personal Access Token
-        </Button>
-      </Box>
-    </SettingsContainer>
+        <Dialog open={createDialogOpen} onOpenChange={setCreateDialogOpen}>
+          <DialogTrigger asChild>
+            <Button
+              type="button"
+              variant="ghost"
+              className="mx-4 justify-self-start text-primary-main hover:bg-primary-highlight hover:text-primary-main"
+            >
+              <PlusIcon className="mr-2 h-4 w-4" />
+              Create Personal Access Token
+            </Button>
+          </DialogTrigger>
+          <DialogContent className="z-[9999] max-w-md text-foreground">
+            <DialogHeader>
+              <DialogTitle>Create Personal Access Token</DialogTitle>
+              <DialogDescription>
+                Create a token to authenticate with Nhost services.
+              </DialogDescription>
+            </DialogHeader>
+            <CreatePATForm onCancel={() => setCreateDialogOpen(false)} />
+          </DialogContent>
+        </Dialog>
+      </SettingsCardContent>
+
+      <AlertDialog
+        open={!!tokenPendingDeletion}
+        onOpenChange={(open) => {
+          if (!open) {
+            setTokenPendingDeletion(null);
+          }
+        }}
+      >
+        <AlertDialogContent>
+          <AlertDialogHeader>
+            <AlertDialogTitle>Delete Personal Access Token</AlertDialogTitle>
+            <AlertDialogDescription>
+              Are you sure you want to delete this personal access token? Any
+              applications or scripts using this token will no longer be able to
+              access the API. You cannot undo this action.
+            </AlertDialogDescription>
+          </AlertDialogHeader>
+          <AlertDialogFooter>
+            <AlertDialogCancel disabled={isDeletingToken}>
+              Cancel
+            </AlertDialogCancel>
+            <ButtonWithLoading
+              type="button"
+              variant="destructive"
+              loading={isDeletingToken}
+              onClick={() => {
+                if (tokenPendingDeletion) {
+                  handleDeletePAT(tokenPendingDeletion);
+                }
+              }}
+            >
+              Delete
+            </ButtonWithLoading>
+          </AlertDialogFooter>
+        </AlertDialogContent>
+      </AlertDialog>
+    </AccountSettingsCard>
   );
 }

--- a/dashboard/src/features/account/settings/components/PasswordSettings/components/PasswordSettings.tsx
+++ b/dashboard/src/features/account/settings/components/PasswordSettings/components/PasswordSettings.tsx
@@ -1,6 +1,12 @@
-import { FormInput } from '@/components/form/FormInput';
-import { Button } from '@/components/ui/v3/button';
+import { FormPasswordInput } from '@/components/form/FormPasswordInput';
+import {
+  SettingsCardContent,
+  SettingsCardFooter,
+  SettingsCardHeader,
+} from '@/components/layout/SettingsCard';
+import { ButtonWithLoading } from '@/components/ui/v3/button';
 import { Form } from '@/components/ui/v3/form';
+import { AccountSettingsCard } from '@/features/account/settings/components/AccountSettingsCard';
 import useChangePasswordForm from '@/features/account/settings/components/PasswordSettings/hooks/useChangePasswordForm';
 import useOnChangePasswordHandler from '@/features/account/settings/components/PasswordSettings/hooks/useOnChangePasswordHandler';
 
@@ -12,39 +18,38 @@ export default function PasswordSettings() {
 
   return (
     <Form {...form}>
-      <form onSubmit={form.handleSubmit(onSubmit)}>
-        <div className="rounded-lg border border-[#EAEDF0] bg-white font-['Inter_var'] dark:border-[#2F363D] dark:bg-paper">
-          <div className="flex w-full flex-col items-start gap-4 p-4">
-            <div className="flex w-full flex-col items-start">
-              <h3 className="font-semibold text-[1.125rem] leading-[1.75]">
-                Change Password
-              </h3>
-              <p className="text-[#556378] dark:text-[#A2B3BE]">
-                Update your account password.
-              </p>
-            </div>
-            <div className="flex w-full flex-col gap-4 sm:w-[370px]">
-              <FormInput
-                control={form.control}
-                name="newPassword"
-                type="password"
-                label="New Password"
-              />
-              <FormInput
-                control={form.control}
-                name="confirmPassword"
-                type="password"
-                label="Confirm Password"
-              />
-            </div>
-          </div>
-          <div className="flex w-full items-center justify-end border-[#EAEDF0] border-t px-4 py-2 dark:border-[#2F363D]">
-            <Button type="submit" variant="outline">
+      <AccountSettingsCard asChild>
+        <form onSubmit={form.handleSubmit(onSubmit)}>
+          <SettingsCardHeader
+            title="Change Password"
+            description="Update your account password."
+          />
+
+          <SettingsCardContent className="sm:max-w-[370px]">
+            <FormPasswordInput
+              control={form.control}
+              name="newPassword"
+              label="New Password"
+            />
+            <FormPasswordInput
+              control={form.control}
+              name="confirmPassword"
+              label="Confirm Password"
+            />
+          </SettingsCardContent>
+
+          <SettingsCardFooter>
+            <ButtonWithLoading
+              type="submit"
+              variant="outline"
+              loading={form.formState.isSubmitting}
+              className="w-full sm:w-auto"
+            >
               Save
-            </Button>
-          </div>
-        </div>
-      </form>
+            </ButtonWithLoading>
+          </SettingsCardFooter>
+        </form>
+      </AccountSettingsCard>
     </Form>
   );
 }

--- a/dashboard/src/features/account/settings/components/PasswordSettings/hooks/useOnChangePasswordHandler.ts
+++ b/dashboard/src/features/account/settings/components/PasswordSettings/hooks/useOnChangePasswordHandler.ts
@@ -1,6 +1,6 @@
+import type { ChangePasswordFormValues } from '@/features/account/settings/components/PasswordSettings/hooks/useChangePasswordForm';
 import useActionWithElevatedPermissions from '@/features/account/settings/hooks/useActionWithElevatedPermissions';
 import { useNhostClient } from '@/providers/nhost';
-import type { ChangePasswordFormValues } from './useChangePasswordForm';
 
 interface Props {
   onSuccess: () => void;

--- a/dashboard/src/features/account/settings/components/SecurityKeysSettings/components/AddSecurityKeyButton.tsx
+++ b/dashboard/src/features/account/settings/components/SecurityKeysSettings/components/AddSecurityKeyButton.tsx
@@ -9,8 +9,7 @@ import {
   DialogTitle,
   DialogTrigger,
 } from '@/components/ui/v3/dialog';
-
-import SecurityKeyForm from './NewSecurityKeyForm';
+import SecurityKeyForm from '@/features/account/settings/components/SecurityKeysSettings/components/NewSecurityKeyForm';
 
 function AddSecurityKeyButton() {
   const [open, setOpen] = useState(false);
@@ -28,10 +27,7 @@ function AddSecurityKeyButton() {
           Add New Security Key
         </Button>
       </DialogTrigger>
-      <DialogContent
-        className="sr z-[9999] text-foreground sm:max-w-xl"
-        aria-describedby="Add a Security Key"
-      >
+      <DialogContent className="z-[9999] text-foreground sm:max-w-xl">
         <DialogHeader>
           <DialogTitle>Add a Security Key</DialogTitle>
         </DialogHeader>

--- a/dashboard/src/features/account/settings/components/SecurityKeysSettings/components/SecurityKeyList.tsx
+++ b/dashboard/src/features/account/settings/components/SecurityKeysSettings/components/SecurityKeyList.tsx
@@ -1,9 +1,9 @@
 import { Fingerprint } from 'lucide-react';
 import { memo } from 'react';
 import { Spinner } from '@/components/ui/v3/spinner';
+import RemoveSecurityKeyButton from '@/features/account/settings/components/SecurityKeysSettings/components/RemoveSecurityKeyButton';
 import useGetSecurityKeys from '@/features/account/settings/hooks/useGetSecurityKeys';
 import { InfoAlert } from '@/features/orgs/components/InfoAlert';
-import RemoveSecurityKeyButton from './RemoveSecurityKeyButton';
 
 type SecurityKeyProps = {
   id: string;

--- a/dashboard/src/features/account/settings/components/SecurityKeysSettings/components/SecurityKeysSettings.tsx
+++ b/dashboard/src/features/account/settings/components/SecurityKeysSettings/components/SecurityKeysSettings.tsx
@@ -1,23 +1,25 @@
-import AddSecurityKeyButton from './AddSecurityKeyButton';
-import SecurityKeyList from './SecurityKeyList';
+import {
+  SettingsCardContent,
+  SettingsCardFooter,
+  SettingsCardHeader,
+} from '@/components/layout/SettingsCard';
+import { AccountSettingsCard } from '@/features/account/settings/components/AccountSettingsCard';
+import AddSecurityKeyButton from '@/features/account/settings/components/SecurityKeysSettings/components/AddSecurityKeyButton';
+import SecurityKeyList from '@/features/account/settings/components/SecurityKeysSettings/components/SecurityKeyList';
 
 function SecurityKeysSettings() {
   return (
-    <div className="rounded-lg border border-[#EAEDF0] bg-white font-display dark:border-[#2F363D] dark:bg-paper">
-      <div className="flex w-full flex-col items-start gap-6 p-4">
-        <div className="flex w-full items-center justify-between">
-          <h3 className="font-semibold text-[1.125rem] leading-[1.75]">
-            Manage your security keys
-          </h3>
-        </div>
-        <div className="flex w-full flex-col gap-4">
-          <SecurityKeyList />
-        </div>
-      </div>
-      <div className="flex w-full items-center border-[#EAEDF0] border-t px-4 py-2 dark:border-[#2F363D]">
+    <AccountSettingsCard>
+      <SettingsCardHeader title="Manage your security keys" />
+
+      <SettingsCardContent>
+        <SecurityKeyList />
+      </SettingsCardContent>
+
+      <SettingsCardFooter className="justify-start sm:justify-start">
         <AddSecurityKeyButton />
-      </div>
-    </div>
+      </SettingsCardFooter>
+    </AccountSettingsCard>
   );
 }
 

--- a/dashboard/src/features/account/settings/components/SecurityKeysSettings/hooks/useOnAddNewSecurityKeyHandler.ts
+++ b/dashboard/src/features/account/settings/components/SecurityKeysSettings/hooks/useOnAddNewSecurityKeyHandler.ts
@@ -1,8 +1,8 @@
 import { startRegistration } from '@simplewebauthn/browser';
+import type { NewSecurityKeyFormValues } from '@/features/account/settings/components/SecurityKeysSettings/hooks/useNewSecurityKeyForm';
 import useActionWithElevatedPermissions from '@/features/account/settings/hooks/useActionWithElevatedPermissions';
 import useGetSecurityKeys from '@/features/account/settings/hooks/useGetSecurityKeys';
 import { useNhostClient } from '@/providers/nhost';
-import type { NewSecurityKeyFormValues } from './useNewSecurityKeyForm';
 
 interface Props {
   onSuccess: () => void;

--- a/dashboard/src/features/account/settings/components/SocialProvidersSettings/SocialProvidersSettings.tsx
+++ b/dashboard/src/features/account/settings/components/SocialProvidersSettings/SocialProvidersSettings.tsx
@@ -1,5 +1,10 @@
 import { SiGithub as GitHubIcon } from '@icons-pack/react-simple-icons';
 import { useState } from 'react';
+import {
+  SettingsCardContent,
+  SettingsCardFooter,
+  SettingsCardHeader,
+} from '@/components/layout/SettingsCard';
 import { Button, ButtonWithLoading } from '@/components/ui/v3/button';
 import { Checkbox } from '@/components/ui/v3/checkbox';
 import {
@@ -11,7 +16,8 @@ import {
   DialogTrigger,
 } from '@/components/ui/v3/dialog';
 import { Label } from '@/components/ui/v3/label';
-import execPromiseWithErrorToast from '@/features/orgs/utils/execPromiseWithErrorToast/execPromiseWithErrorToast';
+import { AccountSettingsCard } from '@/features/account/settings/components/AccountSettingsCard';
+import { execPromiseWithErrorToast } from '@/features/orgs/utils/execPromiseWithErrorToast';
 import {
   useDeleteAuthUserProviderMutation,
   useGetAuthUserProvidersQuery,
@@ -107,12 +113,14 @@ export default function SocialProvidersSettings() {
     useDeleteAuthUserProviderMutation();
 
   async function handleDisconnectGithub() {
-    if (isEmptyValue(githubUserProvider?.id)) {
+    const githubUserProviderId = githubUserProvider?.id;
+
+    if (isEmptyValue(githubUserProviderId)) {
       throw new Error('GitHub provider id not found');
     }
 
     await deleteGitHubUserProvider({
-      variables: { id: githubUserProvider!.id },
+      variables: { id: githubUserProviderId },
     });
     await refetchAuthUserProviders();
   }
@@ -135,11 +143,10 @@ export default function SocialProvidersSettings() {
   }
 
   return (
-    <div className="rounded-lg border border-[#EAEDF0] bg-white font-['Inter_var'] dark:border-[#2F363D] dark:bg-paper">
-      <div className="flex flex-col gap-2 px-4 py-4">
-        <h3 className="flex items-center font-semibold text-[1.125rem] leading-[1.75]">
-          Authentication providers
-        </h3>
+    <AccountSettingsCard>
+      <SettingsCardHeader title="Authentication providers" />
+
+      <SettingsCardContent>
         {isGithubConnected ? (
           <div className="flex w-fit flex-row items-center justify-start gap-2 rounded-md bg-[#f4f7f9] p-2 dark:bg-[#21262c]">
             <GitHubIcon />
@@ -155,10 +162,10 @@ export default function SocialProvidersSettings() {
             Connect with GitHub
           </Button>
         )}
-      </div>
+      </SettingsCardContent>
 
       {isGithubConnected && (
-        <div className="flex w-full items-center border-[#EAEDF0] border-t px-4 py-2 dark:border-[#2F363D]">
+        <SettingsCardFooter className="justify-start sm:justify-start">
           <Dialog
             open={disconnectDialogOpen}
             onOpenChange={setDisconnectDialogOpen}
@@ -166,7 +173,7 @@ export default function SocialProvidersSettings() {
             <DialogTrigger asChild>
               <Button
                 variant="outline"
-                className="h-9 gap-2 border-destructive p-y[0.375rem] px-2 text-destructive hover:bg-destructive hover:text-white"
+                className="h-9 gap-2 border-destructive px-2 text-destructive hover:bg-destructive hover:text-white"
                 disabled={deletingGitHubUserProvider}
               >
                 Disconnect GitHub
@@ -179,8 +186,8 @@ export default function SocialProvidersSettings() {
               />
             </DialogContent>
           </Dialog>
-        </div>
+        </SettingsCardFooter>
       )}
-    </div>
+    </AccountSettingsCard>
   );
 }

--- a/dashboard/src/pages/account/index.tsx
+++ b/dashboard/src/pages/account/index.tsx
@@ -1,5 +1,4 @@
 import type { ReactElement } from 'react';
-import { Container } from '@/components/layout/Container';
 import { RetryableErrorBoundary } from '@/components/presentational/RetryableErrorBoundary';
 import { Spinner } from '@/components/ui/v3/spinner';
 import { AccountMfaSettings } from '@/features/account/settings/components/AccountMfaSettings';
@@ -37,37 +36,36 @@ export default function AccountSettingsPage() {
   }
 
   return (
-    <Container
-      className="grid max-w-5xl grid-flow-row gap-8 bg-transparent"
-      rootClassName="bg-transparent"
-    >
-      <RetryableErrorBoundary>
-        <DisplayNameSetting />
-      </RetryableErrorBoundary>
+    <div className="mx-auto w-full bg-transparent">
+      <div className="mx-auto grid max-w-5xl grid-flow-row gap-8 bg-transparent px-5 py-4">
+        <RetryableErrorBoundary>
+          <DisplayNameSetting />
+        </RetryableErrorBoundary>
 
-      <RetryableErrorBoundary>
-        <EmailSetting />
-      </RetryableErrorBoundary>
+        <RetryableErrorBoundary>
+          <EmailSetting />
+        </RetryableErrorBoundary>
 
-      <RetryableErrorBoundary>
-        <PasswordSettings />
-      </RetryableErrorBoundary>
-      <RetryableErrorBoundary>
-        <AccountMfaSettings />
-      </RetryableErrorBoundary>
-      <RetryableErrorBoundary>
-        <SecurityKeysSettings />
-      </RetryableErrorBoundary>
-      <RetryableErrorBoundary>
-        <SocialProvidersSettings />
-      </RetryableErrorBoundary>
+        <RetryableErrorBoundary>
+          <PasswordSettings />
+        </RetryableErrorBoundary>
+        <RetryableErrorBoundary>
+          <AccountMfaSettings />
+        </RetryableErrorBoundary>
+        <RetryableErrorBoundary>
+          <SecurityKeysSettings />
+        </RetryableErrorBoundary>
+        <RetryableErrorBoundary>
+          <SocialProvidersSettings />
+        </RetryableErrorBoundary>
 
-      <RetryableErrorBoundary>
-        <PATSettings />
-      </RetryableErrorBoundary>
+        <RetryableErrorBoundary>
+          <PATSettings />
+        </RetryableErrorBoundary>
 
-      <DeleteAccount />
-    </Container>
+        <DeleteAccount />
+      </div>
+    </div>
   );
 }
 


### PR DESCRIPTION
### Checklist

- [x] No breaking changes
- [x] Tests pass
- [ ] New features have new tests
- [ ] Documentation is updated (if applicable)
- [x] Title of the PR is in the correct format (see below)

<!-- pi-reviewer:start -->
### **What this change solves**
This change refreshes the dashboard account settings experience by migrating the account page and setting sections to the newer card, dialog, form, and shadcn-style v3 UI components. It keeps existing account-management capabilities while aligning layout, validation, and action controls with the current dashboard design system.

___

### **Change Type**
Enhancement

___

### **Description**
- Reworked the account settings page layout around reusable account settings cards and updated section spacing.
- Migrated profile, email, password, MFA, personal access token, security key, social provider, and delete-account controls from legacy v2 layout primitives to v3 UI/form patterns.
- Added a dedicated created-token alert component and expanded shared form input props for browser text-entry hints.

___

### Diagram Walkthrough

```mermaid
flowchart LR
  A["Account page"] --> B["AccountSettingsLayout"]
  B --> C["AccountSettingsCard sections"]
  C --> D["Profile, auth, PAT, MFA, security key controls"]
  D --> E["v3 form, dialog, table, alert, and button components"]
```

<details> <summary><h3> File Walkthrough</h3></summary>

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody>
<tr><td><strong>Shared form</strong></td><td><details><summary>1 file</summary><table>
<tr><td><strong>dashboard/src/components/form/FormInput/FormInput.tsx</strong><dd><code>Adds autoCapitalize and spellCheck passthrough support to reusable form inputs.</code></dd></td><td>+8/-0</td></tr>
</table></details></td></tr>
<tr><td><strong>Account settings shell</strong></td><td><details><summary>4 files</summary><table>
<tr><td><strong>dashboard/src/features/account/settings/components/AccountSettingsCard/AccountSettingsCard.tsx</strong><dd><code>Adds a reusable card wrapper for account settings sections.</code></dd></td><td>+20/-0</td></tr>
<tr><td><strong>dashboard/src/features/account/settings/components/AccountSettingsCard/index.ts</strong><dd><code>Exports the new account settings card component.</code></dd></td><td>+1/-0</td></tr>
<tr><td><strong>dashboard/src/features/account/settings/components/AccountSettingsLayout/AccountSettingsLayout.tsx</strong><dd><code>Updates account settings layout spacing, labels, and page structure.</code></dd></td><td>+12/-20</td></tr>
<tr><td><strong>dashboard/src/pages/account/index.tsx</strong><dd><code>Reorganizes account page sections under the updated settings layout.</code></dd></td><td>+26/-28</td></tr>
</table></details></td></tr>
<tr><td><strong>MFA settings</strong></td><td><details><summary>5 files</summary><table>
<tr><td><strong>dashboard/src/features/account/settings/components/AccountMfaSettings/components/AccountMfaSettings.tsx</strong><dd><code>Migrates the MFA section to the account settings card/header/footer pattern.</code></dd></td><td>+20/-16</td></tr>
<tr><td><strong>dashboard/src/features/account/settings/components/AccountMfaSettings/components/DisableMfaButton/DisableMfaButton.tsx</strong><dd><code>Normalizes destructive outline button padding classes.</code></dd></td><td>+1/-1</td></tr>
<tr><td><strong>dashboard/src/features/account/settings/components/AccountMfaSettings/components/EnableMfaButton/EnableMfaButton.tsx</strong><dd><code>Adjusts MFA enable dialog/button sizing and copy styling.</code></dd></td><td>+2/-2</td></tr>
<tr><td><strong>dashboard/src/features/account/settings/components/AccountMfaSettings/components/EnableMfaButton/MfaQRCodeAndTOTPSecret.tsx</strong><dd><code>Updates QR/TOTP helper text styling.</code></dd></td><td>+1/-1</td></tr>
<tr><td><strong>dashboard/src/features/account/settings/components/SecurityKeysSettings/components/SecurityKeysSettings.tsx</strong><dd><code>Moves the security keys section to the card/header/footer layout.</code></dd></td><td>+18/-16</td></tr>
</table></details></td></tr>
<tr><td><strong>Personal access tokens</strong></td><td><details><summary>3 files</summary><table>
<tr><td><strong>dashboard/src/features/account/settings/components/CreatePATForm/CreatePATForm.tsx</strong><dd><code>Converts the PAT creation form to the v3 form components and extracted created-token alert.</code></dd></td><td>+38/-83</td></tr>
<tr><td><strong>dashboard/src/features/account/settings/components/CreatePATForm/CreatedPATAlert.tsx</strong><dd><code>Adds the created personal access token alert and copy action.</code></dd></td><td>+38/-0</td></tr>
<tr><td><strong>dashboard/src/features/account/settings/components/PATSettings/PATSettings.tsx</strong><dd><code>Refreshes PAT listing, creation dialog, empty state, and token deletion UI.</code></dd></td><td>+203/-159</td></tr>
</table></details></td></tr>
<tr><td><strong>Profile and credentials</strong></td><td><details><summary>4 files</summary><table>
<tr><td><strong>dashboard/src/features/account/settings/components/DisplayNameSetting/DisplayNameSetting.tsx</strong><dd><code>Migrates display-name editing to the updated card and form patterns.</code></dd></td><td>+38/-33</td></tr>
<tr><td><strong>dashboard/src/features/account/settings/components/EmailSetting/EmailSetting.tsx</strong><dd><code>Migrates email editing to the updated card and form patterns.</code></dd></td><td>+41/-36</td></tr>
<tr><td><strong>dashboard/src/features/account/settings/components/PasswordSettings/components/PasswordSettings.tsx</strong><dd><code>Migrates password changes to the updated card and form patterns.</code></dd></td><td>+39/-34</td></tr>
<tr><td><strong>dashboard/src/features/account/settings/components/PasswordSettings/hooks/useOnChangePasswordHandler.ts</strong><dd><code>Updates password mutation loading toast copy.</code></dd></td><td>+1/-1</td></tr>
</table></details></td></tr>
<tr><td><strong>Security and linked accounts</strong></td><td><details><summary>5 files</summary><table>
<tr><td><strong>dashboard/src/features/account/settings/components/SecurityKeysSettings/components/AddSecurityKeyButton.tsx</strong><dd><code>Adjusts add-security-key trigger and dialog button styling.</code></dd></td><td>+2/-6</td></tr>
<tr><td><strong>dashboard/src/features/account/settings/components/SecurityKeysSettings/components/SecurityKeyList.tsx</strong><dd><code>Updates empty-state messaging for registered security keys.</code></dd></td><td>+1/-1</td></tr>
<tr><td><strong>dashboard/src/features/account/settings/components/SecurityKeysSettings/hooks/useOnAddNewSecurityKeyHandler.ts</strong><dd><code>Updates security key mutation loading toast copy.</code></dd></td><td>+1/-1</td></tr>
<tr><td><strong>dashboard/src/features/account/settings/components/SocialProvidersSettings/SocialProvidersSettings.tsx</strong><dd><code>Migrates connected social providers to the account settings card layout.</code></dd></td><td>+20/-13</td></tr>
<tr><td><strong>dashboard/src/features/account/settings/components/DeleteAccount/DeleteAccount.tsx</strong><dd><code>Moves delete-account confirmation into a v3 alert dialog inside a card footer.</code></dd></td><td>+89/-88</td></tr>
</table></details></td></tr>
</tbody></table>

</details>

___

<!-- pi-reviewer:end -->
