### PR TITLE
fix(dashboard): migrate run service page

### DIFF
--- a/dashboard/src/features/orgs/projects/common/components/DeleteServiceModal/DeleteServiceModal.tsx
+++ b/dashboard/src/features/orgs/projects/common/components/DeleteServiceModal/DeleteServiceModal.tsx
@@ -1,8 +1,5 @@
 import { useState } from 'react';
-import { twMerge } from 'tailwind-merge';
-import { Box } from '@/components/ui/v2/Box';
-import { Button } from '@/components/ui/v2/Button';
-import { Text } from '@/components/ui/v2/Text';
+import { Button, ButtonWithLoading } from '@/components/ui/v3/button';
 import { Checkbox } from '@/components/ui/v3/checkbox';
 import { Label } from '@/components/ui/v3/label';
 import type { RunService } from '@/features/orgs/projects/common/hooks/useRunServices';
@@ -42,34 +39,34 @@ export default function DeleteServiceModal({
   async function handleClick() {
     setLoadingRemove(true);
 
-    await execPromiseWithErrorToast(() => deleteServiceAndConfig(), {
-      loadingMessage: 'Deleting the service...',
-      successMessage: 'The service has been deleted successfully.',
-      errorMessage:
-        'An error occurred while deleting the service. Please try again.',
-    });
+    try {
+      await execPromiseWithErrorToast(() => deleteServiceAndConfig(), {
+        loadingMessage: 'Deleting the service...',
+        successMessage: 'The service has been deleted successfully.',
+        errorMessage:
+          'An error occurred while deleting the service. Please try again.',
+      });
+    } finally {
+      setLoadingRemove(false);
+    }
   }
 
   return (
-    <Box className={twMerge('w-full rounded-lg p-6 text-left')}>
+    <div className="w-full rounded-lg p-6 text-left">
       <div className="grid grid-flow-row gap-1">
-        <Text variant="h3" component="h2">
+        <h2 className="font-medium text-lg">
           Delete Service {service?.config?.name}
-        </Text>
+        </h2>
 
-        <Text variant="subtitle2">
+        <p className="text-muted-foreground text-sm">
           Are you sure you want to delete this service?
-        </Text>
+        </p>
 
-        <Text
-          variant="subtitle2"
-          className="font-bold"
-          sx={{ color: (theme) => `${theme.palette.error.main} !important` }}
-        >
+        <p className="font-bold text-destructive text-sm">
           This cannot be undone.
-        </Text>
+        </p>
 
-        <Box className="my-4">
+        <div className="my-4">
           <div className="flex items-center gap-2 py-2">
             <Checkbox
               id="accept-1"
@@ -81,23 +78,23 @@ export default function DeleteServiceModal({
               {`I'm sure I want to delete ${service?.config?.name}`}
             </Label>
           </div>
-        </Box>
+        </div>
 
         <div className="grid grid-flow-row gap-2">
-          <Button
-            color="error"
+          <ButtonWithLoading
+            variant="destructive"
             onClick={handleClick}
             disabled={!remove}
             loading={loadingRemove}
           >
             Delete Service
-          </Button>
+          </ButtonWithLoading>
 
-          <Button variant="outlined" color="secondary" onClick={close}>
+          <Button variant="outline" onClick={close}>
             Cancel
           </Button>
         </div>
       </div>
-    </Box>
+    </div>
   );
 }

--- a/dashboard/src/features/orgs/projects/services/components/ServiceDrawerTitle/ServiceDrawerTitle.tsx
+++ b/dashboard/src/features/orgs/projects/services/components/ServiceDrawerTitle/ServiceDrawerTitle.tsx
@@ -1,0 +1,17 @@
+import { BoxIcon } from 'lucide-react';
+import type { ReactNode } from 'react';
+
+interface ServiceDrawerTitleProps {
+  children: ReactNode;
+}
+
+export default function ServiceDrawerTitle({
+  children,
+}: ServiceDrawerTitleProps) {
+  return (
+    <div className="flex flex-row items-center space-x-2">
+      <BoxIcon className="h-5 w-5" />
+      <span>{children}</span>
+    </div>
+  );
+}

--- a/dashboard/src/features/orgs/projects/services/components/ServiceDrawerTitle/index.ts
+++ b/dashboard/src/features/orgs/projects/services/components/ServiceDrawerTitle/index.ts
@@ -1,0 +1,1 @@
+export { default as ServiceDrawerTitle } from './ServiceDrawerTitle';

--- a/dashboard/src/features/orgs/projects/services/components/ServiceForm/ServiceForm.tsx
+++ b/dashboard/src/features/orgs/projects/services/components/ServiceForm/ServiceForm.tsx
@@ -1,25 +1,37 @@
 import { yupResolver } from '@hookform/resolvers/yup';
 import { CopyIcon, InfoIcon, PlusIcon, RefreshCwIcon } from 'lucide-react';
-import { useEffect, useMemo, useState } from 'react';
+import {
+  type KeyboardEvent,
+  useEffect,
+  useMemo,
+  useRef,
+  useState,
+} from 'react';
 import { FormProvider, useForm } from 'react-hook-form';
 import { ApplyLocalSettingsDialog } from '@/components/common/ApplyLocalSettingsDialog';
 import { useDialog } from '@/components/common/DialogProvider';
-import { Form } from '@/components/form/Form';
-import { Alert } from '@/components/ui/v2/Alert';
-import { Box } from '@/components/ui/v2/Box';
-import { Input } from '@/components/ui/v2/Input';
-import { Text } from '@/components/ui/v2/Text';
-import { Tooltip } from '@/components/ui/v2/Tooltip';
+import { Alert } from '@/components/ui/v3/alert';
 import { Button } from '@/components/ui/v3/button';
+import { Input } from '@/components/ui/v3/input';
+import { Label } from '@/components/ui/v3/label';
+import {
+  Tooltip,
+  TooltipContent,
+  TooltipTrigger,
+} from '@/components/ui/v3/tooltip';
 import { useHostName } from '@/features/orgs/projects/common/hooks/useHostName';
 import { useIsPlatform } from '@/features/orgs/projects/common/hooks/useIsPlatform';
 import { useLocalMimirClient } from '@/features/orgs/projects/hooks/useLocalMimirClient';
 import { useProject } from '@/features/orgs/projects/hooks/useProject';
 import { COST_PER_VCPU } from '@/features/orgs/projects/resources/settings/utils/resourceSettingsValidationSchema';
+import { CommandFormSection } from '@/features/orgs/projects/services/components/ServiceForm/components/CommandFormSection';
 import { ComputeFormSection } from '@/features/orgs/projects/services/components/ServiceForm/components/ComputeFormSection';
 import { EnvironmentFormSection } from '@/features/orgs/projects/services/components/ServiceForm/components/EnvironmentFormSection';
+import { HealthCheckFormSection } from '@/features/orgs/projects/services/components/ServiceForm/components/HealthCheckFormSection';
+import { ImageFormSection } from '@/features/orgs/projects/services/components/ServiceForm/components/ImageFormSection';
 import { PortsFormSection } from '@/features/orgs/projects/services/components/ServiceForm/components/PortsFormSection';
 import { ReplicasFormSection } from '@/features/orgs/projects/services/components/ServiceForm/components/ReplicasFormSection';
+import { ServiceConfirmationDialog } from '@/features/orgs/projects/services/components/ServiceForm/components/ServiceConfirmationDialog';
 import { StorageFormSection } from '@/features/orgs/projects/services/components/ServiceForm/components/StorageFormSection';
 import {
   defaultServiceFormValues,
@@ -33,12 +45,9 @@ import {
   useInsertRunServiceConfigMutation,
   useReplaceRunServiceConfigMutation,
 } from '@/generated/graphql';
+import { cn } from '@/lib/utils';
 import { RESOURCE_VCPU_MULTIPLIER } from '@/utils/constants/common';
 import { copy } from '@/utils/copy';
-import { CommandFormSection } from './components/CommandFormSection';
-import { HealthCheckFormSection } from './components/HealthCheckFormSection';
-import { ImageFormSection } from './components/ImageFormSection';
-import { ServiceConfirmationDialog } from './components/ServiceConfirmationDialog';
 
 export default function ServiceForm({
   serviceID,
@@ -47,6 +56,7 @@ export default function ServiceForm({
   onCancel,
   location,
 }: ServiceFormProps) {
+  const formRef = useRef<HTMLFormElement | null>(null);
   const hostName = useHostName();
   const isPlatform = useIsPlatform();
   const localMimirClient = useLocalMimirClient();
@@ -71,6 +81,7 @@ export default function ServiceForm({
   const {
     watch,
     register,
+    handleSubmit: handleFormSubmit,
     formState: { errors, isSubmitting, dirtyFields },
     reset,
   } = form;
@@ -208,6 +219,26 @@ export default function ServiceForm({
     });
   };
 
+  const handleKeyDown = (event: KeyboardEvent<HTMLFormElement>) => {
+    const isModifierEnter =
+      event.key === 'Enter' && (event.ctrlKey || event.metaKey);
+
+    if (!isModifierEnter || isSubmitting) {
+      return;
+    }
+
+    const submitButton = Array.from(
+      formRef.current!.getElementsByTagName('button'),
+    ).find((item) => item.type === 'submit');
+
+    if (submitButton?.disabled) {
+      return;
+    }
+
+    event.preventDefault();
+    handleFormSubmit(handleConfirm)(event);
+  };
+
   const pricingExplanation = () => {
     const vCPUs = `${formValues.compute.cpu / RESOURCE_VCPU_MULTIPLIER} vCPUs`;
     const mem = `${formValues.compute.memory} MiB Mem`;
@@ -235,35 +266,45 @@ export default function ServiceForm({
 
   return (
     <FormProvider {...form}>
-      <Form
-        onSubmit={handleConfirm}
+      <form
+        ref={formRef}
+        onSubmit={handleFormSubmit(handleConfirm)}
+        onKeyDown={handleKeyDown}
         className="grid grid-flow-row gap-4 px-6 pb-6"
       >
-        <Input
-          {...register('name')}
-          id="name"
-          label={
-            <Box className="flex flex-row items-center space-x-2">
-              <Text>Name</Text>
-              <Tooltip title="Name of the service, must be unique per project.">
-                <InfoIcon aria-label="Info" className="h-4 w-4 text-primary" />
-              </Tooltip>
-            </Box>
-          }
-          placeholder="Service name"
-          hideEmptyHelperText
-          error={!!errors.name}
-          helperText={errors?.name?.message}
-          fullWidth
-          autoComplete="off"
-          autoFocus
-        />
+        <div className="space-y-2">
+          <div className="flex flex-row items-center space-x-2">
+            <Label htmlFor="name">Name</Label>
+            <Tooltip>
+              <TooltipTrigger asChild>
+                <button type="button" aria-label="Info" className="flex">
+                  <InfoIcon className="h-4 w-4 text-primary" />
+                </button>
+              </TooltipTrigger>
+              <TooltipContent>
+                Name of the service, must be unique per project.
+              </TooltipContent>
+            </Tooltip>
+          </div>
+          <Input
+            {...register('name')}
+            id="name"
+            placeholder="Service name"
+            className={cn({ 'border-destructive': errors.name })}
+            aria-invalid={!!errors.name}
+            autoComplete="off"
+            autoFocus
+          />
+          {errors.name?.message && (
+            <p className="text-destructive text-sm">{errors.name.message}</p>
+          )}
+        </div>
 
         <CommandFormSection />
 
         {isPlatform ? (
           <Alert
-            severity="info"
+            variant="info"
             className="flex items-center justify-between space-x-2"
           >
             <span>{pricingExplanation()}</span>
@@ -301,14 +342,15 @@ export default function ServiceForm({
 
         {createServiceFormError && (
           <Alert
-            severity="error"
-            className="grid grid-flow-col items-center justify-between px-4 py-3"
+            variant="destructive"
+            className="flex items-center justify-between px-4 py-3"
           >
             <span className="text-left">
               <strong>Error:</strong> {createServiceFormError.message}
             </span>
 
             <Button
+              type="button"
               variant="ghost"
               size="sm"
               className="text-destructive hover:text-destructive"
@@ -331,6 +373,7 @@ export default function ServiceForm({
               {serviceID ? 'Update' : 'Create'}
             </Button>
             <Button
+              type="button"
               variant="outline"
               disabled={isSubmitting}
               onClick={copyConfig}
@@ -340,11 +383,11 @@ export default function ServiceForm({
             </Button>
           </div>
 
-          <Button variant="outline" onClick={onCancel}>
+          <Button type="button" variant="outline" onClick={onCancel}>
             Cancel
           </Button>
         </div>
-      </Form>
+      </form>
     </FormProvider>
   );
 }

--- a/dashboard/src/features/orgs/projects/services/components/ServiceForm/components/CommandFormSection/CommandFormSection.tsx
+++ b/dashboard/src/features/orgs/projects/services/components/ServiceForm/components/CommandFormSection/CommandFormSection.tsx
@@ -1,18 +1,26 @@
 import debounce from 'lodash.debounce';
 import { InfoIcon, PlusIcon, Trash2 as TrashIcon } from 'lucide-react';
 import { useFieldArray, useFormContext } from 'react-hook-form';
-import { Alert } from '@/components/ui/v2/Alert';
-import { Box } from '@/components/ui/v2/Box';
-import { Input } from '@/components/ui/v2/Input';
-import { Text } from '@/components/ui/v2/Text';
-import { Tooltip } from '@/components/ui/v2/Tooltip';
+import { Alert } from '@/components/ui/v3/alert';
 import { Button } from '@/components/ui/v3/button';
+import { Input } from '@/components/ui/v3/input';
+import {
+  Tooltip,
+  TooltipContent,
+  TooltipTrigger,
+} from '@/components/ui/v3/tooltip';
 import type { ServiceFormValues } from '@/features/orgs/projects/services/components/ServiceForm/ServiceFormTypes';
+import { cn } from '@/lib/utils';
 
 function CommandTooltip() {
   return (
-    <Tooltip
-      title={
+    <Tooltip>
+      <TooltipTrigger asChild>
+        <button type="button" aria-label="Info" className="flex">
+          <InfoIcon className="h-4 w-4 text-primary" />
+        </button>
+      </TooltipTrigger>
+      <TooltipContent className="max-w-sm">
         <div className="flex flex-col gap-2">
           <p>Specify the command and its arguments to run the service.</p>
           <p>
@@ -26,9 +34,7 @@ function CommandTooltip() {
             <li>--port=3000</li>
           </ul>
         </div>
-      }
-    >
-      <InfoIcon aria-label="Info" className="h-4 w-4 text-primary" />
+      </TooltipContent>
     </Tooltip>
   );
 }
@@ -61,14 +67,12 @@ export default function CommandFormSection() {
   });
 
   return (
-    <Box className="space-y-4 rounded border-1 p-4">
-      <Box className="flex flex-row items-center justify-between">
-        <Box className="flex flex-row items-center space-x-2">
-          <Text variant="h4" className="font-semibold">
-            Command
-          </Text>
+    <div className="space-y-4 rounded border-1 p-4">
+      <div className="flex flex-row items-center justify-between">
+        <div className="flex flex-row items-center space-x-2">
+          <h4 className="font-semibold">Command</h4>
           <CommandTooltip />
-        </Box>
+        </div>
         <Button
           variant="ghost"
           size="icon"
@@ -77,52 +81,58 @@ export default function CommandFormSection() {
         >
           <PlusIcon className="h-5 w-5" />
         </Button>
-      </Box>
+      </div>
 
-      <Box className="flex flex-col space-y-4">
-        {fields.map((field, index) => (
-          <Box key={field.id} className="flex w-full items-center space-x-2">
-            <Input
-              {...register(`command.${index}.argument`)}
-              onChange={(event) =>
-                handleCommandChange(event.target.value, index)
-              }
-              id={`command-${index}`}
-              placeholder={index === 0 ? 'mycmd' : '--myflag'}
-              className="w-full"
-              hideEmptyHelperText
-              error={!!errors.command?.[index]}
-              helperText={errors.command?.[index]?.message}
-              fullWidth
-              autoComplete="off"
-            />
-            <Button
-              variant="ghost"
-              size="icon"
-              className="text-destructive hover:text-destructive"
-              aria-label="Remove command argument"
-              onClick={() => remove(index)}
-            >
-              <TrashIcon className="h-6 w-4" />
-            </Button>
-          </Box>
-        ))}
+      <div className="flex flex-col space-y-4">
+        {fields.map((field, index) => {
+          const errorMessage = errors.command?.[index]?.argument?.message;
+
+          return (
+            <div key={field.id} className="flex w-full items-start space-x-2">
+              <div className="w-full space-y-1">
+                <Input
+                  {...register(`command.${index}.argument`)}
+                  onChange={(event) =>
+                    handleCommandChange(event.target.value, index)
+                  }
+                  id={`command-${index}`}
+                  placeholder={index === 0 ? 'mycmd' : '--myflag'}
+                  className={cn({ 'border-destructive': errorMessage })}
+                  aria-invalid={!!errorMessage}
+                  autoComplete="off"
+                />
+                {errorMessage && (
+                  <p className="text-destructive text-sm">{errorMessage}</p>
+                )}
+              </div>
+              <Button
+                variant="ghost"
+                size="icon"
+                className="text-destructive hover:text-destructive"
+                aria-label="Remove command argument"
+                onClick={() => remove(index)}
+              >
+                <TrashIcon className="h-6 w-4" />
+              </Button>
+            </div>
+          );
+        })}
         {hasSpaceInCommand && (
-          <Alert severity="warning" className="flex flex-col gap-3 text-left">
+          <Alert variant="warning" className="flex flex-col gap-3 text-left">
             <div className="flex flex-col gap-2 lg:flex-row lg:justify-between">
-              <Text className="flex items-start gap-1 font-semibold">
+              <p className="flex items-start gap-1 font-semibold">
                 <span>⚠</span> Warning: Space in command
-              </Text>
+              </p>
             </div>
             <div>
-              <Text>
+              <p>
                 A space was detected, make sure it is intended, check the
                 tooltip for details
-              </Text>
+              </p>
             </div>
           </Alert>
         )}
-      </Box>
-    </Box>
+      </div>
+    </div>
   );
 }

--- a/dashboard/src/features/orgs/projects/services/components/ServiceForm/components/ComputeFormSection/ComputeFormSection.tsx
+++ b/dashboard/src/features/orgs/projects/services/components/ServiceForm/components/ComputeFormSection/ComputeFormSection.tsx
@@ -1,10 +1,8 @@
-import { ArrowLeftIcon, ArrowRightIcon, InfoIcon } from 'lucide-react';
+import { ArrowLeftIcon, ArrowRightIcon } from 'lucide-react';
 import { useFormContext, useWatch } from 'react-hook-form';
-import { Box } from '@/components/ui/v2/Box';
-import { Slider } from '@/components/ui/v2/Slider';
-import { Text } from '@/components/ui/v2/Text';
-import { Tooltip } from '@/components/ui/v2/Tooltip';
 import { Button } from '@/components/ui/v3/button';
+import { TextLink } from '@/components/ui/v3/text-link';
+import { InfoTooltip } from '@/features/orgs/projects/common/components/InfoTooltip';
 import {
   MAX_SERVICES_MEM,
   MEM_CPU_RATIO,
@@ -24,6 +22,20 @@ export default function ComputeFormSection({
 
   const formValues = useWatch<ServiceFormValues>();
 
+  const updateMemory = (memory: number) => {
+    const boundedMemory = Math.min(
+      Math.max(memory, MIN_SERVICES_MEM),
+      MAX_SERVICES_MEM,
+    );
+
+    setValue('compute.memory', Math.floor(boundedMemory), {
+      shouldDirty: true,
+    });
+    setValue('compute.cpu', Math.floor(boundedMemory / MEM_CPU_RATIO), {
+      shouldDirty: true,
+    });
+  };
+
   const handleSliderUpdate = (value: string) => {
     const updatedMem = parseFloat(value);
 
@@ -31,65 +43,49 @@ export default function ComputeFormSection({
       return;
     }
 
-    setValue('compute.memory', Math.floor(updatedMem), { shouldDirty: true });
-    setValue('compute.cpu', Math.floor(updatedMem / MEM_CPU_RATIO), {
-      shouldDirty: true,
-    });
+    updateMemory(updatedMem);
   };
 
   const incrementCompute = () => {
     const memory = formValues.compute?.memory;
     if (isNotEmptyValue(memory)) {
-      const newMemoryValue = memory + 128;
-      setValue('compute.memory', newMemoryValue, { shouldDirty: true });
-      setValue('compute.cpu', Math.floor(newMemoryValue / MEM_CPU_RATIO), {
-        shouldDirty: true,
-      });
+      updateMemory(memory + 128);
     }
   };
 
   const decrementCompute = () => {
     const memory = formValues.compute?.memory;
     if (isNotEmptyValue(memory)) {
-      const newMemoryValue = memory - 128;
-      setValue('compute.memory', newMemoryValue, { shouldDirty: true });
-      setValue('compute.cpu', Math.floor(newMemoryValue / MEM_CPU_RATIO), {
-        shouldDirty: true,
-      });
+      updateMemory(memory - 128);
     }
   };
 
+  const memoryValue = Number(formValues.compute?.memory ?? MIN_SERVICES_MEM);
+
   return (
-    <Box className="space-y-4 rounded border-1 p-4">
-      <Box className="flex flex-row items-center space-x-2">
-        <Text variant="h4" className="font-semibold">
+    <div className="space-y-4 rounded border-1 p-4">
+      <div className="flex flex-row items-center space-x-2">
+        <h4 className="font-semibold">
           vCPUs: {(formValues.compute?.cpu ?? 0) / 1000} / Memory:{' '}
           {formValues.compute?.memory ?? ''}
-        </Text>
+        </h4>
 
         {showTooltip && (
-          <Tooltip
-            title={
-              <span>
-                Compute resources dedicated for the service. Refer to{' '}
-                <a
-                  target="_blank"
-                  rel="noopener noreferrer"
-                  href="https://docs.nhost.io/products/run/resources#compute"
-                  className="underline"
-                >
-                  resources
-                </a>{' '}
-                for more information.
-              </span>
-            }
-          >
-            <InfoIcon aria-label="Info" className="h-4 w-4 text-primary" />
-          </Tooltip>
+          <InfoTooltip>
+            Compute resources dedicated for the service. Refer to{' '}
+            <TextLink
+              href="https://docs.nhost.io/products/run/resources#compute"
+              external
+              className="font-medium"
+            >
+              resources
+            </TextLink>{' '}
+            for more information.
+          </InfoTooltip>
         )}
-      </Box>
+      </div>
 
-      <Box className="flex flex-row items-center justify-between space-x-4">
+      <div className="flex flex-row items-center justify-between space-x-4">
         <Button
           disabled={
             isNotEmptyValue(formValues.compute?.memory) &&
@@ -103,14 +99,15 @@ export default function ComputeFormSection({
           <ArrowLeftIcon className="h-4 w-4" />
         </Button>
 
-        <Slider
-          value={Number(formValues.compute?.memory)}
-          onChange={(_event, value) => handleSliderUpdate(value.toString())}
+        <input
+          type="range"
+          value={memoryValue}
+          onChange={(event) => handleSliderUpdate(event.target.value)}
           max={MAX_SERVICES_MEM}
           min={MIN_SERVICES_MEM}
           step={256}
           aria-label="Compute resources"
-          marks
+          className="h-2 w-full cursor-pointer accent-primary"
         />
         <Button
           disabled={
@@ -124,7 +121,7 @@ export default function ComputeFormSection({
         >
           <ArrowRightIcon className="h-4 w-4" />
         </Button>
-      </Box>
-    </Box>
+      </div>
+    </div>
   );
 }

--- a/dashboard/src/features/orgs/projects/services/components/ServiceForm/components/EnvironmentFormSection/EnvironmentFormSection.tsx
+++ b/dashboard/src/features/orgs/projects/services/components/ServiceForm/components/EnvironmentFormSection/EnvironmentFormSection.tsx
@@ -1,12 +1,16 @@
 import { InfoIcon, PlusIcon, Trash2 as TrashIcon } from 'lucide-react';
 import { useState } from 'react';
 import { useFieldArray, useFormContext } from 'react-hook-form';
-import { Box } from '@/components/ui/v2/Box';
-import { Input } from '@/components/ui/v2/Input';
-import { Text } from '@/components/ui/v2/Text';
-import { Tooltip } from '@/components/ui/v2/Tooltip';
 import { Button } from '@/components/ui/v3/button';
+import { Input } from '@/components/ui/v3/input';
+import { Textarea } from '@/components/ui/v3/textarea';
+import {
+  Tooltip,
+  TooltipContent,
+  TooltipTrigger,
+} from '@/components/ui/v3/tooltip';
 import type { ServiceFormValues } from '@/features/orgs/projects/services/components/ServiceForm/ServiceFormTypes';
+import { cn } from '@/lib/utils';
 
 export default function EnvironmentFormSection() {
   const {
@@ -21,25 +25,23 @@ export default function EnvironmentFormSection() {
   });
 
   return (
-    <Box className="space-y-4 rounded border-1 p-4">
-      <Box className="flex flex-row items-center justify-between">
-        <Box className="flex flex-row items-center space-x-2">
-          <Text variant="h4" className="font-semibold">
-            Environment
-          </Text>
-          <Tooltip
-            title={
-              <span>
-                Environment variables to add to the service. Other than the ones
-                specified here only <code>NHOST_SUBDOMAIN</code> and{' '}
-                <code>NHOST_REGION</code> are added automatically to the
-                service.
-              </span>
-            }
-          >
-            <InfoIcon aria-label="Info" className="h-4 w-4 text-primary" />
+    <div className="space-y-4 rounded border-1 p-4">
+      <div className="flex flex-row items-center justify-between">
+        <div className="flex flex-row items-center space-x-2">
+          <h4 className="font-semibold">Environment</h4>
+          <Tooltip>
+            <TooltipTrigger asChild>
+              <button type="button" aria-label="Info" className="flex">
+                <InfoIcon className="h-4 w-4 text-primary" />
+              </button>
+            </TooltipTrigger>
+            <TooltipContent className="max-w-xs">
+              Environment variables to add to the service. Other than the ones
+              specified here only NHOST_SUBDOMAIN and NHOST_REGION are added
+              automatically to the service.
+            </TooltipContent>
           </Tooltip>
-        </Box>
+        </div>
         <Button
           variant="ghost"
           size="icon"
@@ -48,51 +50,62 @@ export default function EnvironmentFormSection() {
         >
           <PlusIcon className="h-5 w-5" />
         </Button>
-      </Box>
+      </div>
 
-      <Box className="flex flex-col space-y-4">
-        {fields.map((field, index) => (
-          <Box key={field.id} className="flex w-full items-center space-x-2">
-            <div className="flex w-full flex-col space-y-2">
-              <Input
-                {...register(`environment.${index}.name`)}
-                id={`${field.id}-name`}
-                placeholder={`Key ${index}`}
-                className="w-full"
-                hideEmptyHelperText
-                error={!!errors?.environment?.at?.(index)}
-                helperText={errors?.environment?.at?.(index)?.message}
-                fullWidth
-                autoComplete="off"
-              />
-              <Input
-                {...register(`environment.${index}.value`)}
-                id={`${field.id}-value`}
-                placeholder={`Value ${index}`}
-                className="w-full"
-                hideEmptyHelperText
-                error={!!errors?.environment?.at?.(index)}
-                helperText={errors?.environment?.at?.(index)?.message}
-                fullWidth
-                autoComplete="off"
-                multiline
-                maxRows={focusedInput === `${field.id}-value` ? 1000 : 1}
-                onFocusCapture={() => setFocusedInput(`${field.id}-value`)}
-                onBlurCapture={() => setFocusedInput(null)}
-              />
+      <div className="flex flex-col space-y-4">
+        {fields.map((field, index) => {
+          const fieldErrors = errors.environment?.[index];
+          const nameError = fieldErrors?.name?.message;
+          const valueError = fieldErrors?.value?.message;
+
+          return (
+            <div key={field.id} className="flex w-full items-start space-x-2">
+              <div className="flex w-full flex-col space-y-2">
+                <div className="space-y-1">
+                  <Input
+                    {...register(`environment.${index}.name`)}
+                    id={`${field.id}-name`}
+                    placeholder={`Key ${index}`}
+                    className={cn({ 'border-destructive': nameError })}
+                    aria-invalid={!!nameError}
+                    autoComplete="off"
+                  />
+                  {nameError && (
+                    <p className="text-destructive text-sm">{nameError}</p>
+                  )}
+                </div>
+                <div className="space-y-1">
+                  <Textarea
+                    {...register(`environment.${index}.value`)}
+                    id={`${field.id}-value`}
+                    placeholder={`Value ${index}`}
+                    className={cn('min-h-10 resize-y', {
+                      'border-destructive': valueError,
+                    })}
+                    aria-invalid={!!valueError}
+                    autoComplete="off"
+                    rows={focusedInput === `${field.id}-value` ? 8 : 1}
+                    onFocusCapture={() => setFocusedInput(`${field.id}-value`)}
+                    onBlurCapture={() => setFocusedInput(null)}
+                  />
+                  {valueError && (
+                    <p className="text-destructive text-sm">{valueError}</p>
+                  )}
+                </div>
+              </div>
+              <Button
+                variant="ghost"
+                size="icon"
+                className="text-destructive hover:text-destructive"
+                aria-label="Remove environment variable"
+                onClick={() => remove(index)}
+              >
+                <TrashIcon className="h-6 w-4" />
+              </Button>
             </div>
-            <Button
-              variant="ghost"
-              size="icon"
-              className="text-destructive hover:text-destructive"
-              aria-label="Remove environment variable"
-              onClick={() => remove(index)}
-            >
-              <TrashIcon className="h-6 w-4" />
-            </Button>
-          </Box>
-        ))}
-      </Box>
-    </Box>
+          );
+        })}
+      </div>
+    </div>
   );
 }

--- a/dashboard/src/features/orgs/projects/services/components/ServiceForm/components/HealthCheckFormSection/HealthCheckFormSection.tsx
+++ b/dashboard/src/features/orgs/projects/services/components/ServiceForm/components/HealthCheckFormSection/HealthCheckFormSection.tsx
@@ -1,12 +1,12 @@
-import { InfoIcon } from 'lucide-react';
 import { useState } from 'react';
 import { useFormContext } from 'react-hook-form';
-import { Box } from '@/components/ui/v2/Box';
-import { Input } from '@/components/ui/v2/Input';
-import { Switch } from '@/components/ui/v2/Switch';
-import { Text } from '@/components/ui/v2/Text';
-import { Tooltip } from '@/components/ui/v2/Tooltip';
+import { Input } from '@/components/ui/v3/input';
+import { Label } from '@/components/ui/v3/label';
+import { Switch } from '@/components/ui/v3/switch';
+import { TextLink } from '@/components/ui/v3/text-link';
+import { InfoTooltip } from '@/features/orgs/projects/common/components/InfoTooltip';
 import type { ServiceFormValues } from '@/features/orgs/projects/services/components/ServiceForm/ServiceFormTypes';
+import { cn } from '@/lib/utils';
 
 export default function HealthCheckFormSection() {
   const {
@@ -19,7 +19,7 @@ export default function HealthCheckFormSection() {
   const healthCheck = watch('healthCheck');
   const [healthCheckEnabled, setHealthCheckEnabled] = useState(!!healthCheck);
 
-  const toggleHealthCheckEnabled = async (enabled: boolean) => {
+  const toggleHealthCheckEnabled = (enabled: boolean) => {
     setHealthCheckEnabled(enabled);
 
     if (!enabled) {
@@ -28,85 +28,98 @@ export default function HealthCheckFormSection() {
   };
 
   return (
-    <Box className="space-y-4 rounded border-1 p-4">
-      <Box className="flex flex-row items-center justify-between">
-        <Box className="flex flex-row items-center space-x-2">
-          <Text variant="h4" className="font-semibold">
-            Health Check
-          </Text>
+    <div className="space-y-4 rounded border-1 p-4">
+      <div className="flex flex-row items-center justify-between">
+        <div className="flex flex-row items-center space-x-2">
+          <h4 className="font-semibold">Health Check</h4>
 
-          <Tooltip
-            title={
-              <span>
-                Monitor the health and availability of a service. Refer to{' '}
-                <a
-                  target="_blank"
-                  rel="noopener noreferrer"
-                  href="https://docs.nhost.io/products/run/health-checks"
-                  className="underline"
-                >
-                  Health Check
-                </a>{' '}
-                for more information.
-              </span>
-            }
-          >
-            <InfoIcon aria-label="Info" className="h-4 w-4 text-primary" />
-          </Tooltip>
-        </Box>
+          <InfoTooltip>
+            Monitor the health and availability of a service. Refer to{' '}
+            <TextLink
+              href="https://docs.nhost.io/products/run/health-checks"
+              external
+              className="font-medium"
+            >
+              Health Check
+            </TextLink>{' '}
+            for more information.
+          </InfoTooltip>
+        </div>
 
         <Switch
           checked={healthCheckEnabled}
-          onChange={(e) => toggleHealthCheckEnabled(e.target.checked)}
+          onCheckedChange={toggleHealthCheckEnabled}
           className="self-center"
         />
-      </Box>
+      </div>
 
       {healthCheckEnabled && (
-        <Box className="flex flex-col space-y-4">
-          <Input
-            {...register(`healthCheck.port`)}
-            id="healthCheck.port"
-            label="Port"
-            placeholder="3000"
-            className="w-full"
-            hideEmptyHelperText
-            error={!!errors?.healthCheck?.port}
-            helperText={errors?.healthCheck?.port?.message}
-            fullWidth
-            autoComplete="off"
-            type="number"
-          />
+        <div className="flex flex-col space-y-4">
+          <div className="space-y-2">
+            <Label htmlFor="healthCheck.port">Port</Label>
+            <Input
+              {...register('healthCheck.port')}
+              id="healthCheck.port"
+              placeholder="3000"
+              className={cn({
+                'border-destructive': errors.healthCheck?.port,
+              })}
+              aria-invalid={!!errors.healthCheck?.port}
+              autoComplete="off"
+              type="number"
+            />
+            {errors.healthCheck?.port?.message && (
+              <p className="text-destructive text-sm">
+                {errors.healthCheck.port.message}
+              </p>
+            )}
+          </div>
 
-          <Input
-            {...register(`healthCheck.initialDelaySeconds`)}
-            id="healthCheck.initialDelaySeconds"
-            label="Initial delay seconds"
-            placeholder="30"
-            className="w-full"
-            hideEmptyHelperText
-            error={!!errors?.healthCheck?.initialDelaySeconds}
-            helperText={errors?.healthCheck?.initialDelaySeconds?.message}
-            fullWidth
-            autoComplete="off"
-            type="number"
-          />
+          <div className="space-y-2">
+            <Label htmlFor="healthCheck.initialDelaySeconds">
+              Initial delay seconds
+            </Label>
+            <Input
+              {...register('healthCheck.initialDelaySeconds')}
+              id="healthCheck.initialDelaySeconds"
+              placeholder="30"
+              className={cn({
+                'border-destructive': errors.healthCheck?.initialDelaySeconds,
+              })}
+              aria-invalid={!!errors.healthCheck?.initialDelaySeconds}
+              autoComplete="off"
+              type="number"
+            />
+            {errors.healthCheck?.initialDelaySeconds?.message && (
+              <p className="text-destructive text-sm">
+                {errors.healthCheck.initialDelaySeconds.message}
+              </p>
+            )}
+          </div>
 
-          <Input
-            {...register(`healthCheck.probePeriodSeconds`)}
-            id="healthCheck.probePeriodSeconds"
-            label="Probe period seconds"
-            placeholder="60"
-            className="w-full"
-            hideEmptyHelperText
-            error={!!errors?.healthCheck?.probePeriodSeconds}
-            helperText={errors?.healthCheck?.probePeriodSeconds?.message}
-            fullWidth
-            autoComplete="off"
-            type="number"
-          />
-        </Box>
+          <div className="space-y-2">
+            <Label htmlFor="healthCheck.probePeriodSeconds">
+              Probe period seconds
+            </Label>
+            <Input
+              {...register('healthCheck.probePeriodSeconds')}
+              id="healthCheck.probePeriodSeconds"
+              placeholder="60"
+              className={cn({
+                'border-destructive': errors.healthCheck?.probePeriodSeconds,
+              })}
+              aria-invalid={!!errors.healthCheck?.probePeriodSeconds}
+              autoComplete="off"
+              type="number"
+            />
+            {errors.healthCheck?.probePeriodSeconds?.message && (
+              <p className="text-destructive text-sm">
+                {errors.healthCheck.probePeriodSeconds.message}
+              </p>
+            )}
+          </div>
+        </div>
       )}
-    </Box>
+    </div>
   );
 }

--- a/dashboard/src/features/orgs/projects/services/components/ServiceForm/components/ImageField/ImageField.tsx
+++ b/dashboard/src/features/orgs/projects/services/components/ServiceForm/components/ImageField/ImageField.tsx
@@ -1,14 +1,21 @@
-import { inputBaseClasses } from '@mui/material';
-import { useTheme } from '@mui/system';
 import { InfoIcon } from 'lucide-react';
 import { useEffect, useState } from 'react';
 import { useFormContext } from 'react-hook-form';
-import { Box } from '@/components/ui/v2/Box';
-import { Input } from '@/components/ui/v2/Input';
-import { Text } from '@/components/ui/v2/Text';
-import { Tooltip } from '@/components/ui/v2/Tooltip';
+import { Input } from '@/components/ui/v3/input';
+import {
+  InputGroup,
+  InputGroupAddon,
+  InputGroupInput,
+} from '@/components/ui/v3/input-group';
+import { Label } from '@/components/ui/v3/label';
 import { TextLink } from '@/components/ui/v3/text-link';
+import {
+  Tooltip,
+  TooltipContent,
+  TooltipTrigger,
+} from '@/components/ui/v3/tooltip';
 import type { ServiceFormValues } from '@/features/orgs/projects/services/components/ServiceForm/ServiceFormTypes';
+import { cn } from '@/lib/utils';
 
 interface ImageFieldProps {
   privateRegistryImage: string;
@@ -27,8 +34,6 @@ export default function ImageField({
     setValue,
   } = useFormContext<ServiceFormValues>();
 
-  const theme = useTheme();
-
   const [imageTag, setImageTag] = useState(initialImageTag || '');
 
   useEffect(() => {
@@ -44,45 +49,35 @@ export default function ImageField({
     return (
       <>
         <div className="flex flex-col gap-1">
-          <Box className="flex flex-row items-center space-x-2">
-            <Text>Image</Text>
-          </Box>
+          <Label htmlFor="imageTagField">Image</Label>
 
-          <Box className="flex flex-col gap-1 md:flex-row md:gap-0">
-            <Text
-              as="span"
-              className="mt-0 py-2 pr-1 pl-[10px] md:whitespace-nowrap"
-              sx={{
-                color: theme.palette.grey[600],
-                borderColor: theme.palette.grey[400],
-                backgroundColor: theme.palette.grey[200],
-                borderTopLeftRadius: theme.shape.borderRadius,
-                borderBottomLeftRadius: theme.shape.borderRadius,
-              }}
+          <InputGroup
+            className={cn({
+              'border-destructive': errors.image,
+            })}
+          >
+            <InputGroupAddon
+              align="inline-start"
+              className="max-w-[70%] justify-start truncate font-normal"
             >
-              {privateRegistryImage}:
-            </Text>
-            <Input
+              <span className="truncate">{privateRegistryImage}:</span>
+            </InputGroupAddon>
+            <InputGroupInput
               value={imageTag}
-              onChange={(e) => setImageTag(e.target.value)}
+              onChange={(event) => setImageTag(event.target.value)}
               id="imageTagField"
-              className="pl-0"
-              sx={{
-                [`& .${inputBaseClasses.input}`]: {
-                  paddingLeft: '4px',
-                },
-              }}
               placeholder="latest"
-              hideEmptyHelperText
-              error={!!errors.image}
-              fullWidth
+              aria-invalid={!!errors.image}
               autoComplete="off"
             />
-          </Box>
+          </InputGroup>
+          {errors.image?.message && (
+            <p className="text-destructive text-sm">{errors.image.message}</p>
+          )}
         </div>
 
         <div className="grid w-full grid-flow-col justify-start gap-x-1 self-center align-middle">
-          <Text>
+          <p className="text-sm">
             Learn more about{' '}
             <TextLink
               href="https://docs.nhost.io/products/run/registry#creating-a-private-repository-for-your-image"
@@ -91,7 +86,7 @@ export default function ImageField({
             >
               using Nhost registry for images
             </TextLink>
-          </Text>
+          </p>
         </div>
       </>
     );
@@ -100,52 +95,54 @@ export default function ImageField({
   if (imageType === 'private') {
     return (
       <>
-        <Input
-          {...register('image')}
-          id="image"
-          className="pl-0"
-          label={
-            <Box className="flex flex-row items-center space-x-2">
-              <Text>Image</Text>
-            </Box>
-          }
-          placeholder="myprivaterepo/myservice:1.0.1"
-          hideEmptyHelperText
-          error={!!errors.image}
-          helperText={errors?.image?.message}
-          fullWidth
-          autoComplete="off"
-        />
+        <div className="space-y-2">
+          <Label htmlFor="image">Image</Label>
+          <Input
+            {...register('image')}
+            id="image"
+            placeholder="myprivaterepo/myservice:1.0.1"
+            className={cn({ 'border-destructive': errors.image })}
+            aria-invalid={!!errors.image}
+            autoComplete="off"
+          />
+          {errors.image?.message && (
+            <p className="text-destructive text-sm">{errors.image.message}</p>
+          )}
+        </div>
 
-        <Input
-          {...register('pullCredentials')}
-          id="pullCredentials"
-          label={
-            <Box className="flex flex-row items-center space-x-2">
-              <Text>Pull credentials</Text>
-              <Tooltip
-                title={
-                  <span>
-                    If you are publishing your images in your own private
-                    registry you can add pull credentials to your Run
-                    configuration so the image can be pulled successfully.
-                  </span>
-                }
-              >
-                <InfoIcon aria-label="Info" className="h-4 w-4 text-primary" />
-              </Tooltip>
-            </Box>
-          }
-          placeholder="Enter your pull credentials here"
-          hideEmptyHelperText
-          error={!!errors.pullCredentials}
-          helperText={errors?.pullCredentials?.message}
-          fullWidth
-          autoComplete="off"
-        />
+        <div className="space-y-2">
+          <div className="flex flex-row items-center space-x-2">
+            <Label htmlFor="pullCredentials">Pull credentials</Label>
+            <Tooltip>
+              <TooltipTrigger asChild>
+                <button type="button" aria-label="Info" className="flex">
+                  <InfoIcon className="h-4 w-4 text-primary" />
+                </button>
+              </TooltipTrigger>
+              <TooltipContent className="max-w-xs">
+                If you are publishing your images in your own private registry
+                you can add pull credentials to your Run configuration so the
+                image can be pulled successfully.
+              </TooltipContent>
+            </Tooltip>
+          </div>
+          <Input
+            {...register('pullCredentials')}
+            id="pullCredentials"
+            placeholder="Enter your pull credentials here"
+            className={cn({ 'border-destructive': errors.pullCredentials })}
+            aria-invalid={!!errors.pullCredentials}
+            autoComplete="off"
+          />
+          {errors.pullCredentials?.message && (
+            <p className="text-destructive text-sm">
+              {errors.pullCredentials.message}
+            </p>
+          )}
+        </div>
 
         <div className="grid w-full grid-flow-col justify-start gap-x-1 self-center align-middle">
-          <Text>
+          <p className="text-sm">
             Learn more about{' '}
             <TextLink
               href="https://docs.nhost.io/products/run/registry#using-your-own-private-registry"
@@ -154,29 +151,28 @@ export default function ImageField({
             >
               using your own private registry for images
             </TextLink>
-          </Text>
+          </p>
         </div>
       </>
     );
   }
+
   if (imageType === 'public') {
     return (
-      <Input
-        {...register('image')}
-        id="image"
-        className="pl-0"
-        label={
-          <Box className="flex flex-row items-center space-x-2">
-            <Text>Image</Text>
-          </Box>
-        }
-        placeholder="myimage:1.0.1"
-        hideEmptyHelperText
-        error={!!errors.image}
-        helperText={errors?.image?.message}
-        fullWidth
-        autoComplete="off"
-      />
+      <div className="space-y-2">
+        <Label htmlFor="image">Image</Label>
+        <Input
+          {...register('image')}
+          id="image"
+          placeholder="myimage:1.0.1"
+          className={cn({ 'border-destructive': errors.image })}
+          aria-invalid={!!errors.image}
+          autoComplete="off"
+        />
+        {errors.image?.message && (
+          <p className="text-destructive text-sm">{errors.image.message}</p>
+        )}
+      </div>
     );
   }
   return null;

--- a/dashboard/src/features/orgs/projects/services/components/ServiceForm/components/ImageFormSection/ImageFormSection.tsx
+++ b/dashboard/src/features/orgs/projects/services/components/ServiceForm/components/ImageFormSection/ImageFormSection.tsx
@@ -1,5 +1,3 @@
-import { Box } from '@/components/ui/v2/Box';
-import { Text } from '@/components/ui/v2/Text';
 import { Label } from '@/components/ui/v3/label';
 import { RadioGroup, RadioGroupItem } from '@/components/ui/v3/radio-group';
 import { ImageField } from '@/features/orgs/projects/services/components/ServiceForm/components/ImageField';
@@ -18,12 +16,10 @@ export default function ImageFormSection({
   initialImageTag,
 }: ImageFormSectionProps) {
   return (
-    <Box className="space-y-4 rounded border-1 p-4">
-      <Box className="flex flex-row items-center space-x-2">
-        <Text variant="h4" className="font-semibold">
-          Image
-        </Text>
-      </Box>
+    <div className="space-y-4 rounded border-1 p-4">
+      <div className="flex flex-row items-center space-x-2">
+        <h4 className="font-semibold">Image</h4>
+      </div>
       <RadioGroup
         className="flex flex-row space-x-2"
         defaultValue="public"
@@ -48,6 +44,6 @@ export default function ImageFormSection({
         imageType={imageType}
         initialImageTag={initialImageTag}
       />
-    </Box>
+    </div>
   );
 }

--- a/dashboard/src/features/orgs/projects/services/components/ServiceForm/components/PortsFormSection/PortsFormSection.tsx
+++ b/dashboard/src/features/orgs/projects/services/components/ServiceForm/components/PortsFormSection/PortsFormSection.tsx
@@ -1,11 +1,8 @@
-import { InfoIcon, PlusIcon, Trash2 as TrashIcon } from 'lucide-react';
+import { CopyIcon, PlusIcon, Trash2 as TrashIcon } from 'lucide-react';
 import { useFieldArray, useFormContext, useWatch } from 'react-hook-form';
-import { ControlledSwitch } from '@/components/form/ControlledSwitch';
-import { Box } from '@/components/ui/v2/Box';
-import { Input } from '@/components/ui/v2/Input';
-import { Text } from '@/components/ui/v2/Text';
-import { Tooltip } from '@/components/ui/v2/Tooltip';
 import { Button } from '@/components/ui/v3/button';
+import { Input } from '@/components/ui/v3/input';
+import { Label } from '@/components/ui/v3/label';
 import {
   Select,
   SelectContent,
@@ -13,15 +10,18 @@ import {
   SelectTrigger,
   SelectValue,
 } from '@/components/ui/v3/select';
+import { Switch } from '@/components/ui/v3/switch';
+import { TextLink } from '@/components/ui/v3/text-link';
+import { InfoTooltip } from '@/features/orgs/projects/common/components/InfoTooltip';
 import { useProject } from '@/features/orgs/projects/hooks/useProject';
-import { InfoCard } from '@/features/orgs/projects/overview/components/InfoCard';
 import {
   isPublishablePortType,
   type PortTypes,
 } from '@/features/orgs/projects/services/components/ServiceForm/components/PortsFormSection/PortsFormSectionTypes';
 import type { ServiceFormValues } from '@/features/orgs/projects/services/components/ServiceForm/ServiceFormTypes';
 import type { ConfigRunServicePort } from '@/generated/graphql';
-import { isNotEmptyValue } from '@/lib/utils';
+import { cn, isNotEmptyValue } from '@/lib/utils';
+import { copy } from '@/utils/copy';
 import { getRunServicePortURL } from '@/utils/helpers';
 
 export default function PortsFormSection() {
@@ -42,9 +42,9 @@ export default function PortsFormSection() {
   const formValues = useWatch<ServiceFormValues & { subdomain: string }>();
 
   const onChangePortType = (value: string | undefined, index: number) => {
-    setValue(`ports.${index}.type`, value as PortTypes);
+    setValue(`ports.${index}.type`, value as PortTypes, { shouldDirty: true });
     if (!isPublishablePortType(value)) {
-      setValue(`ports.${index}.publish`, false);
+      setValue(`ports.${index}.publish`, false, { shouldDirty: true });
     }
   };
 
@@ -55,31 +55,22 @@ export default function PortsFormSection() {
     formValues.ports?.[index]?.publish;
 
   return (
-    <Box className="space-y-4 rounded border-1 p-4">
-      <Box className="flex flex-row items-center justify-between">
-        <Box className="flex flex-row items-center space-x-2">
-          <Text variant="h4" className="font-semibold">
-            Ports
-          </Text>
-          <Tooltip
-            title={
-              <span>
-                Network ports to configure for the service. Refer to{' '}
-                <a
-                  target="_blank"
-                  rel="noopener noreferrer"
-                  href="https://docs.nhost.io/products/run/networking"
-                  className="underline"
-                >
-                  Networking
-                </a>{' '}
-                for more information.
-              </span>
-            }
-          >
-            <InfoIcon aria-label="Info" className="h-4 w-4 text-primary" />
-          </Tooltip>
-        </Box>
+    <div className="space-y-4 rounded border-1 p-4">
+      <div className="flex flex-row items-center justify-between">
+        <div className="flex flex-row items-center space-x-2">
+          <h4 className="font-semibold">Ports</h4>
+          <InfoTooltip>
+            Network ports to configure for the service. Refer to{' '}
+            <TextLink
+              href="https://docs.nhost.io/products/run/networking"
+              external
+              className="font-medium"
+            >
+              Networking
+            </TextLink>{' '}
+            for more information.
+          </InfoTooltip>
+        </div>
         <Button
           variant="ghost"
           size="icon"
@@ -88,77 +79,103 @@ export default function PortsFormSection() {
         >
           <PlusIcon className="h-5 w-5" />
         </Button>
-      </Box>
+      </div>
 
-      <Box className="flex flex-col space-y-4">
-        {fields.map((field, index) => (
-          <Box key={field.id} className="flex flex-col space-y-2">
-            <Box className="flex w-full xs+:flex-row flex-col xs+:space-x-2 space-y-2 xs+:space-y-0">
-              <Input
-                {...register(`ports.${index}.port`)}
-                id={`${field.id}-port`}
-                placeholder="Port"
-                className="w-full"
-                hideEmptyHelperText
-                error={!!errors?.ports?.at?.(index)}
-                helperText={errors?.ports?.at?.(index)?.message}
-                fullWidth
-                autoComplete="off"
-              />
+      <div className="flex flex-col space-y-4">
+        {fields.map((field, index) => {
+          const portError = errors.ports?.[index];
+          const errorMessage =
+            portError?.port?.message ?? portError?.type?.message;
+          const url = showURL(index)
+            ? getRunServicePortURL(
+                formValues.subdomain!,
+                project!.region.name!,
+                project!.region.domain!,
+                formValues.ports![index] as ConfigRunServicePort,
+              )
+            : null;
 
-              <Select
-                value={formValues.ports?.at?.(index)?.type || ''}
-                onValueChange={(value) => onChangePortType(value, index)}
-              >
-                <SelectTrigger className="w-full">
-                  <SelectValue placeholder="Select port type" />
-                </SelectTrigger>
-                <SelectContent className="z-[10000] w-[270px] min-w-0">
-                  {['http', 'tcp', 'udp', 'grpc']?.map((portType) => (
-                    <SelectItem key={portType} value={portType}>
-                      {portType}
-                    </SelectItem>
-                  ))}
-                </SelectContent>
-              </Select>
+          return (
+            <div key={field.id} className="flex flex-col space-y-2">
+              <div className="flex w-full xs+:flex-row flex-col xs+:space-x-2 space-y-2 xs+:space-y-0">
+                <div className="w-full space-y-1">
+                  <Input
+                    {...register(`ports.${index}.port`)}
+                    id={`${field.id}-port`}
+                    type="number"
+                    placeholder="Port"
+                    className={cn({ 'border-destructive': errorMessage })}
+                    aria-invalid={!!errorMessage}
+                    autoComplete="off"
+                  />
+                  {errorMessage && (
+                    <p className="text-destructive text-sm">{errorMessage}</p>
+                  )}
+                </div>
 
-              <ControlledSwitch
-                {...register(`ports.${index}.publish`)}
-                disabled={
-                  !isPublishablePortType(formValues.ports?.at?.(index)?.type)
-                }
-                label={
-                  <Text variant="subtitle1" component="span">
-                    Publish
-                  </Text>
-                }
-              />
-              <Button
-                variant="ghost"
-                size="icon"
-                className="text-destructive hover:text-destructive"
-                aria-label="Remove port"
-                onClick={() => remove(index)}
-              >
-                <TrashIcon className="h-4 w-4" />
-              </Button>
-            </Box>
+                <Select
+                  value={formValues.ports?.[index]?.type || ''}
+                  onValueChange={(value) => onChangePortType(value, index)}
+                >
+                  <SelectTrigger className="w-full">
+                    <SelectValue placeholder="Select port type" />
+                  </SelectTrigger>
+                  <SelectContent className="z-[10000] w-[270px] min-w-0">
+                    {['http', 'tcp', 'udp', 'grpc']?.map((portType) => (
+                      <SelectItem key={portType} value={portType}>
+                        {portType}
+                      </SelectItem>
+                    ))}
+                  </SelectContent>
+                </Select>
 
-            {/* project and formValues are present */}
-            {showURL(index) && (
-              <InfoCard
-                title="URL"
-                value={getRunServicePortURL(
-                  formValues.subdomain!,
-                  project!.region.name!,
-                  project!.region.domain!,
-                  formValues.ports![index] as ConfigRunServicePort,
-                )}
-              />
-            )}
-          </Box>
-        ))}
-      </Box>
-    </Box>
+                <div className="flex items-center gap-2">
+                  <Switch
+                    id={`${field.id}-publish`}
+                    checked={!!formValues.ports?.[index]?.publish}
+                    onCheckedChange={(checked) =>
+                      setValue(`ports.${index}.publish`, checked, {
+                        shouldDirty: true,
+                      })
+                    }
+                    disabled={
+                      !isPublishablePortType(formValues.ports?.[index]?.type)
+                    }
+                  />
+                  <Label htmlFor={`${field.id}-publish`}>Publish</Label>
+                </div>
+                <Button
+                  variant="ghost"
+                  size="icon"
+                  className="text-destructive hover:text-destructive"
+                  aria-label="Remove port"
+                  onClick={() => remove(index)}
+                >
+                  <TrashIcon className="h-4 w-4" />
+                </Button>
+              </div>
+
+              {url && (
+                <div className="flex items-center justify-between gap-2 rounded-lg bg-muted p-3">
+                  <div className="min-w-0">
+                    <p className="text-muted-foreground text-xs">URL</p>
+                    <p className="truncate font-mono text-sm">{url}</p>
+                  </div>
+                  <Button
+                    type="button"
+                    variant="ghost"
+                    size="icon"
+                    aria-label="Copy URL"
+                    onClick={() => copy(url, 'URL')}
+                  >
+                    <CopyIcon className="h-4 w-4" />
+                  </Button>
+                </div>
+              )}
+            </div>
+          );
+        })}
+      </div>
+    </div>
   );
 }

--- a/dashboard/src/features/orgs/projects/services/components/ServiceForm/components/ReplicasFormSection/ReplicasFormSection.tsx
+++ b/dashboard/src/features/orgs/projects/services/components/ServiceForm/components/ReplicasFormSection/ReplicasFormSection.tsx
@@ -1,23 +1,24 @@
-import { InfoIcon } from 'lucide-react';
 import { useState } from 'react';
 import { useFormContext, useWatch } from 'react-hook-form';
-import { Box } from '@/components/ui/v2/Box';
-import { Input } from '@/components/ui/v2/Input';
-import { Switch } from '@/components/ui/v2/Switch';
-import { Text } from '@/components/ui/v2/Text';
-import { Tooltip } from '@/components/ui/v2/Tooltip';
+import { Input } from '@/components/ui/v3/input';
+import { Label } from '@/components/ui/v3/label';
+import { Switch } from '@/components/ui/v3/switch';
+import { TextLink } from '@/components/ui/v3/text-link';
+import { InfoTooltip } from '@/features/orgs/projects/common/components/InfoTooltip';
 import type { ServiceFormValues } from '@/features/orgs/projects/services/components/ServiceForm/ServiceFormTypes';
+import { cn } from '@/lib/utils';
 
 export default function ReplicasFormSection() {
   const {
     register,
     setValue,
     trigger: triggerValidation,
+    formState: { errors },
   } = useFormContext<ServiceFormValues>();
   const { replicas, autoscaler } = useWatch<ServiceFormValues>();
   const [autoscalerEnabled, setAutoscalerEnabled] = useState(!!autoscaler);
 
-  const toggleAutoscalerEnabled = async (enabled: boolean) => {
+  const toggleAutoscalerEnabled = (enabled: boolean) => {
     setAutoscalerEnabled(enabled);
 
     if (!enabled) {
@@ -44,86 +45,95 @@ export default function ReplicasFormSection() {
   };
 
   return (
-    <Box className="space-y-4 rounded border-1 p-4">
-      <Box className="flex flex-row items-center space-x-2">
-        <Text variant="h4" className="font-semibold">
-          Replicas ({replicas})
-        </Text>
-        <Tooltip
-          title={
-            <Text className="text-white">
-              Learn more about{' '}
-              <a
-                target="_blank"
-                rel="noopener noreferrer"
-                href="https://docs.nhost.io/platform/cloud/service-replicas"
-                className="underline"
-              >
-                Service Replicas
-              </a>
-            </Text>
-          }
-        >
-          <InfoIcon aria-label="Info" className="h-4 w-4 text-primary" />
-        </Tooltip>
-      </Box>
+    <div className="space-y-4 rounded border-1 p-4">
+      <div className="flex flex-row items-center space-x-2">
+        <h4 className="font-semibold">Replicas ({replicas})</h4>
+        <InfoTooltip>
+          Learn more about{' '}
+          <TextLink
+            href="https://docs.nhost.io/platform/cloud/service-replicas"
+            external
+            className="font-medium"
+          >
+            Service Replicas
+          </TextLink>
+        </InfoTooltip>
+      </div>
 
-      <Box className="flex flex-col justify-between gap-4 lg:flex-row">
-        <Box className="flex flex-col gap-4 lg:flex-row lg:gap-8">
-          <Box className="flex flex-row items-center gap-2">
-            <Text className="w-28 lg:w-auto">Replicas</Text>
-            <Input
-              {...register('replicas')}
-              onChange={(event) => handleReplicasChange(event.target.value)}
-              type="number"
-              id="replicas"
-              placeholder="Replicas"
-              className="max-w-28"
-              hideEmptyHelperText
-              fullWidth
-              onWheel={(e) => (e.target as HTMLInputElement).blur()}
-              autoComplete="off"
-              slotProps={{
-                inputRoot: {
-                  min: 0,
-                },
-              }}
-            />
-          </Box>
-          <Box className="flex flex-row items-center gap-2">
-            <Text className="w-28 text-nowrap lg:w-auto">Max Replicas</Text>
-            <Input
-              value={autoscaler?.maxReplicas}
-              onChange={(event) => handleMaxReplicasChange(event.target.value)}
-              type="number"
-              id="maxReplicas"
-              placeholder="10"
-              disabled={!autoscalerEnabled}
-              className="max-w-28"
-              hideEmptyHelperText
-              fullWidth
-              onWheel={(e) => (e.target as HTMLInputElement).blur()}
-              autoComplete="off"
-              slotProps={{
-                inputRoot: {
-                  min: 0,
-                },
-              }}
-            />
-          </Box>
-        </Box>
-        <Box className="flex flex-row items-center gap-3">
+      <div className="flex flex-col justify-between gap-4 lg:flex-row">
+        <div className="flex flex-col gap-4 lg:flex-row lg:gap-8">
+          <div className="flex flex-row items-start gap-2">
+            <Label htmlFor="replicas" className="mt-2 w-28 lg:w-auto">
+              Replicas
+            </Label>
+            <div className="space-y-1">
+              <Input
+                {...register('replicas')}
+                onChange={(event) => handleReplicasChange(event.target.value)}
+                type="number"
+                id="replicas"
+                placeholder="Replicas"
+                className={cn('max-w-28', {
+                  'border-destructive': errors.replicas,
+                })}
+                aria-invalid={!!errors.replicas}
+                onWheel={(event) => (event.target as HTMLInputElement).blur()}
+                autoComplete="off"
+                min={0}
+              />
+              {errors.replicas?.message && (
+                <p className="text-destructive text-sm">
+                  {errors.replicas.message}
+                </p>
+              )}
+            </div>
+          </div>
+          <div className="flex flex-row items-start gap-2">
+            <Label
+              htmlFor="maxReplicas"
+              className="mt-2 w-28 text-nowrap lg:w-auto"
+            >
+              Max Replicas
+            </Label>
+            <div className="space-y-1">
+              <Input
+                value={autoscaler?.maxReplicas ?? ''}
+                onChange={(event) =>
+                  handleMaxReplicasChange(event.target.value)
+                }
+                type="number"
+                id="maxReplicas"
+                placeholder="10"
+                disabled={!autoscalerEnabled}
+                className={cn('max-w-28', {
+                  'border-destructive': errors.autoscaler?.maxReplicas,
+                })}
+                aria-invalid={!!errors.autoscaler?.maxReplicas}
+                onWheel={(event) => (event.target as HTMLInputElement).blur()}
+                autoComplete="off"
+                min={0}
+              />
+              {errors.autoscaler?.maxReplicas?.message && (
+                <p className="text-destructive text-sm">
+                  {errors.autoscaler.maxReplicas.message}
+                </p>
+              )}
+            </div>
+          </div>
+        </div>
+        <div className="flex flex-row items-center gap-3">
           <Switch
             checked={autoscalerEnabled}
-            onChange={(e) => toggleAutoscalerEnabled(e.target.checked)}
+            onCheckedChange={toggleAutoscalerEnabled}
             className="self-center"
           />
-          <Text>Autoscaler</Text>
-          <Tooltip title="Enable autoscaler to automatically provision extra run service replicas when needed.">
-            <InfoIcon className="h-4 w-4" />
-          </Tooltip>
-        </Box>
-      </Box>
-    </Box>
+          <span>Autoscaler</span>
+          <InfoTooltip>
+            Enable autoscaler to automatically provision extra run service
+            replicas when needed.
+          </InfoTooltip>
+        </div>
+      </div>
+    </div>
   );
 }

--- a/dashboard/src/features/orgs/projects/services/components/ServiceForm/components/ServiceConfirmationDialog/ServiceConfirmationDialog.tsx
+++ b/dashboard/src/features/orgs/projects/services/components/ServiceForm/components/ServiceConfirmationDialog/ServiceConfirmationDialog.tsx
@@ -1,10 +1,12 @@
 import { InfoIcon } from 'lucide-react';
 import { useState } from 'react';
-import { Box } from '@/components/ui/v2/Box';
-import { Divider } from '@/components/ui/v2/Divider';
-import { Text } from '@/components/ui/v2/Text';
-import { Tooltip } from '@/components/ui/v2/Tooltip';
 import { Button, ButtonWithLoading } from '@/components/ui/v3/button';
+import { Separator } from '@/components/ui/v3/separator';
+import {
+  Tooltip,
+  TooltipContent,
+  TooltipTrigger,
+} from '@/components/ui/v3/tooltip';
 import { COST_PER_VCPU } from '@/features/orgs/projects/resources/settings/utils/resourceSettingsValidationSchema';
 import type { ServiceFormValues } from '@/features/orgs/projects/services/components/ServiceForm/ServiceFormTypes';
 import { RESOURCE_VCPU_MULTIPLIER } from '@/utils/constants/common';
@@ -46,46 +48,47 @@ export default function ServiceConfirmationDialog({
 
   return (
     <div className="grid grid-flow-row gap-6 px-6 pb-6">
-      <Box className="grid grid-flow-row gap-4">
-        <Box className="grid grid-flow-row gap-1.5">
-          <Box className="grid grid-flow-col items-center justify-between gap-2">
-            <Box className="grid grid-flow-row gap-0.5">
-              <Text color="secondary">vCPUs</Text>
-            </Box>
-            <Text>{formValues.compute.cpu / RESOURCE_VCPU_MULTIPLIER}</Text>
-          </Box>
+      <div className="grid grid-flow-row gap-4">
+        <div className="grid grid-flow-row gap-1.5">
+          <div className="grid grid-flow-col items-center justify-between gap-2">
+            <p className="text-muted-foreground">vCPUs</p>
+            <p>{formValues.compute.cpu / RESOURCE_VCPU_MULTIPLIER}</p>
+          </div>
 
-          <Box className="grid grid-flow-col items-center justify-between gap-2">
-            <Box className="grid grid-flow-row gap-0.5">
-              <Text color="secondary">Memory</Text>
-            </Box>
-            <Text>{formValues.compute.memory} MiB</Text>
-          </Box>
+          <div className="grid grid-flow-col items-center justify-between gap-2">
+            <p className="text-muted-foreground">Memory</p>
+            <p>{formValues.compute.memory} MiB</p>
+          </div>
 
-          <Box className="grid grid-flow-col items-center justify-between gap-2">
-            <Box className="grid grid-flow-row gap-0.5">
-              <Text color="secondary">Replicas</Text>
-            </Box>
-            <Text>{formValues.replicas}</Text>
-          </Box>
-        </Box>
+          <div className="grid grid-flow-col items-center justify-between gap-2">
+            <p className="text-muted-foreground">Replicas</p>
+            <p>{formValues.replicas}</p>
+          </div>
+        </div>
 
-        <Divider />
+        <Separator />
 
-        <Box className="grid grid-flow-col justify-between gap-2">
-          <Box className="grid grid-flow-col items-center gap-1.5">
-            <Text className="font-medium">Approximate Cost</Text>
+        <div className="grid grid-flow-col justify-between gap-2">
+          <div className="grid grid-flow-col items-center gap-1.5">
+            <p className="font-medium">Approximate Cost</p>
 
-            <Tooltip title="$0.0012/minute for every 1 vCPU and 2 GiB of RAM">
-              <InfoIcon aria-label="Info" className="h-4 w-4 text-primary" />
+            <Tooltip>
+              <TooltipTrigger asChild>
+                <button type="button" aria-label="Info" className="flex">
+                  <InfoIcon className="h-4 w-4 text-primary" />
+                </button>
+              </TooltipTrigger>
+              <TooltipContent>
+                $0.0012/minute for every 1 vCPU and 2 GiB of RAM
+              </TooltipContent>
             </Tooltip>
-          </Box>
+          </div>
 
-          <Text>${approximatePriceForService}/mo</Text>
-        </Box>
-      </Box>
+          <p>${approximatePriceForService}/mo</p>
+        </div>
+      </div>
 
-      <Box className="grid grid-flow-row gap-2">
+      <div className="grid grid-flow-row gap-2">
         <ButtonWithLoading
           loading={isSubmitting}
           onClick={handleSubmit}
@@ -97,7 +100,7 @@ export default function ServiceConfirmationDialog({
         <Button variant="ghost" onClick={onCancel}>
           Cancel
         </Button>
-      </Box>
+      </div>
     </div>
   );
 }

--- a/dashboard/src/features/orgs/projects/services/components/ServiceForm/components/StorageFormSection/StorageFormSection.tsx
+++ b/dashboard/src/features/orgs/projects/services/components/ServiceForm/components/StorageFormSection/StorageFormSection.tsx
@@ -1,15 +1,21 @@
-import { InfoIcon, PlusIcon, Trash2 as TrashIcon } from 'lucide-react';
+import { PlusIcon, Trash2 as TrashIcon } from 'lucide-react';
 import { useFieldArray, useFormContext } from 'react-hook-form';
-import { Box } from '@/components/ui/v2/Box';
-import { Input } from '@/components/ui/v2/Input';
-import { Text } from '@/components/ui/v2/Text';
-import { Tooltip } from '@/components/ui/v2/Tooltip';
 import { Button } from '@/components/ui/v3/button';
+import { Input } from '@/components/ui/v3/input';
+import {
+  InputGroup,
+  InputGroupAddon,
+  InputGroupInput,
+} from '@/components/ui/v3/input-group';
+import { Label } from '@/components/ui/v3/label';
+import { TextLink } from '@/components/ui/v3/text-link';
+import { InfoTooltip } from '@/features/orgs/projects/common/components/InfoTooltip';
 import {
   MAX_STORAGE_CAPACITY,
   MIN_STORAGE_CAPACITY,
 } from '@/features/orgs/projects/resources/settings/utils/resourceSettingsValidationSchema';
 import type { ServiceFormValues } from '@/features/orgs/projects/services/components/ServiceForm/ServiceFormTypes';
+import { cn } from '@/lib/utils';
 
 export default function StorageFormSection() {
   const {
@@ -39,35 +45,25 @@ export default function StorageFormSection() {
   };
 
   return (
-    <Box className="space-y-4 rounded border-1 p-4">
-      <Box className="flex flex-row items-center justify-between">
-        <Box className="flex flex-row items-center space-x-2">
-          <Text variant="h4" className="font-semibold">
-            Storage
-          </Text>
+    <div className="space-y-4 rounded border-1 p-4">
+      <div className="flex flex-row items-center justify-between">
+        <div className="flex flex-row items-center space-x-2">
+          <h4 className="font-semibold">Storage</h4>
 
-          <Tooltip
-            title={
-              <span>
-                By default, services do not have persistent storage. You can add
-                SSD disks to the service here. It is important to note that
-                capacity can not be decreased after creation, only expanded.
-                Refer to{' '}
-                <a
-                  target="_blank"
-                  rel="noopener noreferrer"
-                  href="https://docs.nhost.io/products/run/resources#storage"
-                  className="underline"
-                >
-                  Storage
-                </a>{' '}
-                for more information.
-              </span>
-            }
-          >
-            <InfoIcon aria-label="Info" className="h-4 w-4 text-primary" />
-          </Tooltip>
-        </Box>
+          <InfoTooltip>
+            By default, services do not have persistent storage. You can add SSD
+            disks to the service here. It is important to note that capacity can
+            not be decreased after creation, only expanded. Refer to{' '}
+            <TextLink
+              href="https://docs.nhost.io/products/run/resources#storage"
+              external
+              className="font-medium"
+            >
+              Storage
+            </TextLink>{' '}
+            for more information.
+          </InfoTooltip>
+        </div>
 
         <Button
           variant="ghost"
@@ -77,73 +73,91 @@ export default function StorageFormSection() {
         >
           <PlusIcon className="h-5 w-5" />
         </Button>
-      </Box>
+      </div>
 
-      <Box className="flex flex-col space-y-4">
-        {fields.map((field, index) => (
-          <Box
-            key={field.id}
-            className="flex w-full xs+:flex-row flex-col xs+:space-x-2 space-y-2 xs+:space-y-0"
-          >
-            <Input
-              {...register(`storage.${index}.name`)}
-              id={`${field.id}-name`}
-              label={!index && 'Name'}
-              placeholder="Name"
-              className="w-full"
-              hideEmptyHelperText
-              error={!!errors?.storage?.at?.(index)}
-              helperText={errors?.storage?.at?.(index)?.message}
-              fullWidth
-              autoComplete="off"
-            />
+      <div className="flex flex-col space-y-4">
+        {fields.map((field, index) => {
+          const storageErrors = errors.storage?.[index];
+          const nameError = storageErrors?.name?.message;
+          const capacityError = storageErrors?.capacity?.message;
+          const pathError = storageErrors?.path?.message;
 
-            <Input
-              {...register(`storage.${index}.capacity`, {
-                onBlur: (event) => checkBounds(event.target.value, index),
-              })}
-              id={`${field.id}-capacity`}
-              label={!index && 'Capacity'}
-              type="number"
-              placeholder="Capacity"
-              className="w-full"
-              hideEmptyHelperText
-              error={!!errors?.storage?.at?.(index)}
-              helperText={errors?.storage?.at?.(index)?.message}
-              fullWidth
-              autoComplete="off"
-              endAdornment={
-                <Text sx={{ color: 'grey.500' }} className="pr-2">
-                  GiB
-                </Text>
-              }
-            />
-
-            <Input
-              {...register(`storage.${index}.path`)}
-              id={`${field.id}-path`}
-              label={!index && 'Path'}
-              placeholder="Path"
-              className="w-full"
-              hideEmptyHelperText
-              error={!!errors?.storage?.at?.(index)}
-              helperText={errors?.storage?.at?.(index)?.message}
-              fullWidth
-              autoComplete="off"
-            />
-
-            <Button
-              variant="ghost"
-              size="icon"
-              className="text-destructive hover:text-destructive"
-              aria-label="Remove storage"
-              onClick={() => remove(index)}
+          return (
+            <div
+              key={field.id}
+              className="flex w-full xs+:flex-row flex-col xs+:space-x-2 space-y-2 xs+:space-y-0"
             >
-              <TrashIcon className="h-4 w-4" />
-            </Button>
-          </Box>
-        ))}
-      </Box>
-    </Box>
+              <div className="w-full space-y-1">
+                {index === 0 && (
+                  <Label htmlFor={`${field.id}-name`}>Name</Label>
+                )}
+                <Input
+                  {...register(`storage.${index}.name`)}
+                  id={`${field.id}-name`}
+                  placeholder="Name"
+                  className={cn({ 'border-destructive': nameError })}
+                  aria-invalid={!!nameError}
+                  autoComplete="off"
+                />
+                {nameError && (
+                  <p className="text-destructive text-sm">{nameError}</p>
+                )}
+              </div>
+
+              <div className="w-full space-y-1">
+                {index === 0 && (
+                  <Label htmlFor={`${field.id}-capacity`}>Capacity</Label>
+                )}
+                <InputGroup
+                  className={cn({ 'border-destructive': capacityError })}
+                >
+                  <InputGroupInput
+                    {...register(`storage.${index}.capacity`, {
+                      onBlur: (event) => checkBounds(event.target.value, index),
+                    })}
+                    id={`${field.id}-capacity`}
+                    type="number"
+                    placeholder="Capacity"
+                    aria-invalid={!!capacityError}
+                    autoComplete="off"
+                  />
+                  <InputGroupAddon align="inline-end">GiB</InputGroupAddon>
+                </InputGroup>
+                {capacityError && (
+                  <p className="text-destructive text-sm">{capacityError}</p>
+                )}
+              </div>
+
+              <div className="w-full space-y-1">
+                {index === 0 && (
+                  <Label htmlFor={`${field.id}-path`}>Path</Label>
+                )}
+                <Input
+                  {...register(`storage.${index}.path`)}
+                  id={`${field.id}-path`}
+                  placeholder="Path"
+                  className={cn({ 'border-destructive': pathError })}
+                  aria-invalid={!!pathError}
+                  autoComplete="off"
+                />
+                {pathError && (
+                  <p className="text-destructive text-sm">{pathError}</p>
+                )}
+              </div>
+
+              <Button
+                variant="ghost"
+                size="icon"
+                className="text-destructive hover:text-destructive"
+                aria-label="Remove storage"
+                onClick={() => remove(index)}
+              >
+                <TrashIcon className="h-4 w-4" />
+              </Button>
+            </div>
+          );
+        })}
+      </div>
+    </div>
   );
 }

--- a/dashboard/src/features/orgs/projects/services/components/ServicesList/ServicesList.tsx
+++ b/dashboard/src/features/orgs/projects/services/components/ServicesList/ServicesList.tsx
@@ -7,19 +7,22 @@ import {
   Trash2 as TrashIcon,
 } from 'lucide-react';
 import { useDialog } from '@/components/common/DialogProvider';
-import { Box } from '@/components/ui/v2/Box';
-import { IconButton } from '@/components/ui/v2/IconButton';
-import { Text } from '@/components/ui/v2/Text';
-import { Tooltip } from '@/components/ui/v2/Tooltip';
+import { Button } from '@/components/ui/v3/button';
 import {
   DropdownMenu,
   DropdownMenuContent,
   DropdownMenuItem,
   DropdownMenuTrigger,
 } from '@/components/ui/v3/dropdown-menu';
+import {
+  Tooltip,
+  TooltipContent,
+  TooltipTrigger,
+} from '@/components/ui/v3/tooltip';
 import { DeleteServiceModal } from '@/features/orgs/projects/common/components/DeleteServiceModal';
 import { useIsPlatform } from '@/features/orgs/projects/common/hooks/useIsPlatform';
 import type { RunService } from '@/features/orgs/projects/common/hooks/useRunServices';
+import { ServiceDrawerTitle } from '@/features/orgs/projects/services/components/ServiceDrawerTitle';
 import { ServiceForm } from '@/features/orgs/projects/services/components/ServiceForm';
 import type { PortTypes } from '@/features/orgs/projects/services/components/ServiceForm/components/PortsFormSection/PortsFormSectionTypes';
 import {
@@ -56,10 +59,9 @@ export default function ServicesList({
   const viewService = async (service: RunService) => {
     openDrawer({
       title: (
-        <Box className="flex flex-row items-center space-x-2">
-          <BoxIcon className="h-5 w-5" />
-          <Text>Edit {service.config?.name ?? 'unset'}</Text>
-        </Box>
+        <ServiceDrawerTitle>
+          Edit {service.config?.name ?? 'unset'}
+        </ServiceDrawerTitle>
       ),
       component: (
         <ServiceForm
@@ -111,93 +113,84 @@ export default function ServicesList({
   };
 
   return (
-    <Box className="flex flex-col">
-      {services.map((service) => (
-        <Box
-          key={service.id ?? service.serviceID}
-          className="flex h-[64px] w-full cursor-pointer items-center justify-between space-x-4 border-b-1 px-4 py-2 transition-colors"
-          sx={{
-            [`&:hover`]: {
-              backgroundColor: 'action.hover',
-            },
-          }}
-          onClick={() => viewService(service)}
-        >
-          <Box
-            className="flex w-full flex-row justify-between"
-            sx={{
-              backgroundColor: 'transparent',
-            }}
+    <div className="flex flex-col">
+      {services.map((service) => {
+        const serviceID = service.id ?? service.serviceID;
+        const serviceName = service.config?.name ?? 'unset';
+
+        return (
+          <div
+            key={serviceID}
+            className="flex h-16 w-full items-center justify-between space-x-4 border-b-1 px-4 py-2"
           >
-            <div className="flex flex-1 flex-row items-center space-x-4">
-              <BoxIcon className="h-5 w-5" />
-              <div className="flex flex-col">
-                <Text variant="h4" className="font-semibold">
-                  {service.config?.name ?? 'unset'}
-                </Text>
-                {isPlatform ? (
-                  <Tooltip title={service.updatedAt}>
-                    <span className="xs+:flex hidden cursor-pointer text-slate-500 text-sm">
-                      Deployed{' '}
-                      {formatDistanceToNow(new Date(service.updatedAt!))} ago
-                    </span>
-                  </Tooltip>
-                ) : null}
+            <div className="flex w-full flex-row justify-between bg-transparent">
+              <div className="flex flex-1 flex-row items-center space-x-4">
+                <BoxIcon className="h-5 w-5" />
+                <div className="flex flex-col">
+                  <h4 className="font-semibold text-sm+">{serviceName}</h4>
+                  {isPlatform ? (
+                    <Tooltip>
+                      <TooltipTrigger asChild>
+                        <span className="xs+:flex hidden text-muted-foreground text-sm">
+                          Deployed{' '}
+                          {service.updatedAt
+                            ? formatDistanceToNow(new Date(service.updatedAt))
+                            : 'unknown time'}{' '}
+                          ago
+                        </span>
+                      </TooltipTrigger>
+                      <TooltipContent>{service.updatedAt}</TooltipContent>
+                    </Tooltip>
+                  ) : null}
+                </div>
+              </div>
+
+              <div className="hidden flex-row items-center space-x-2 md:flex">
+                <span className="font-mono text-muted-foreground text-xs">
+                  {serviceID}
+                </span>
+                <Button
+                  variant="ghost"
+                  size="icon"
+                  onClick={() => copy(serviceID!, 'Service Id')}
+                  aria-label="Service Id"
+                >
+                  <CopyIcon className="h-4 w-4" />
+                </Button>
               </div>
             </div>
 
-            <div className="hidden flex-row items-center space-x-2 md:flex">
-              <Text variant="subtitle1" className="font-mono text-xs">
-                {service.id ?? service.serviceID}
-              </Text>
-              <IconButton
-                variant="borderless"
-                color="secondary"
-                onClick={(event) => {
-                  copy(service.id ?? service.serviceID!, 'Service Id');
-                  event.stopPropagation();
-                }}
-                aria-label="Service Id"
-              >
-                <CopyIcon className="h-4 w-4" />
-              </IconButton>
-            </div>
-          </Box>
-
-          <DropdownMenu>
-            <DropdownMenuTrigger asChild>
-              <IconButton
-                variant="borderless"
-                color="secondary"
-                aria-label={`More options for ${service.config?.name ?? 'unset'}`}
-                onClick={(event) => event.stopPropagation()}
-              >
-                <DotsHorizontalIcon />
-              </IconButton>
-            </DropdownMenuTrigger>
-            <DropdownMenuContent align="end" className="w-52 p-0">
-              <DropdownMenuItem
-                onClick={() => viewService(service)}
-                className="flex h-9 cursor-pointer items-center justify-start gap-2 rounded-none border border-b-1 p-2 font-medium text-sm+ leading-4 hover:bg-data-cell-bg"
-              >
-                <EyeIcon className="h-4 w-4" />
-                <span>View Service</span>
-              </DropdownMenuItem>
-              <DropdownMenuItem
-                className="!text-destructive flex h-9 cursor-pointer items-center justify-start gap-2 rounded-none border border-b-1 p-2 font-medium text-sm+ leading-4 hover:bg-data-cell-bg"
-                onClick={(event) => {
-                  event.stopPropagation();
-                  deleteService(service);
-                }}
-                disabled={!isPlatform}
-              >
-                <TrashIcon className="h-4 w-4" />
-                <span>Delete Service</span>
-              </DropdownMenuItem>
-            </DropdownMenuContent>
-          </DropdownMenu>
-        </Box>
-      ))}
-    </Box>
+            <DropdownMenu>
+              <DropdownMenuTrigger asChild>
+                <Button
+                  variant="ghost"
+                  size="icon"
+                  aria-label={`More options for ${serviceName}`}
+                >
+                  <DotsHorizontalIcon />
+                </Button>
+              </DropdownMenuTrigger>
+              <DropdownMenuContent align="end" className="w-52 p-0">
+                <DropdownMenuItem
+                  onClick={() => viewService(service)}
+                  className="flex h-9 cursor-pointer items-center justify-start gap-2 rounded-none border border-b-1 p-2 font-medium text-sm+ leading-4 hover:bg-data-cell-bg"
+                >
+                  <EyeIcon className="h-4 w-4" />
+                  <span>View Service</span>
+                </DropdownMenuItem>
+                <DropdownMenuItem
+                  className="!text-destructive flex h-9 cursor-pointer items-center justify-start gap-2 rounded-none border border-b-1 p-2 font-medium text-sm+ leading-4 hover:bg-data-cell-bg"
+                  onClick={() => deleteService(service)}
+                  disabled={!isPlatform}
+                >
+                  <TrashIcon className="h-4 w-4" />
+                  <span>Delete Service</span>
+                </DropdownMenuItem>
+              </DropdownMenuContent>
+            </DropdownMenu>
+          </div>
+        );
+      })}
+    </div>
   );
 }

--- a/dashboard/src/features/orgs/projects/services/utils/parseConfigFromInstallLink/parseConfigFromInstallLink.ts
+++ b/dashboard/src/features/orgs/projects/services/utils/parseConfigFromInstallLink/parseConfigFromInstallLink.ts
@@ -8,9 +8,16 @@ import {
 export default function parseConfigFromInstallLink(
   base64Config: string,
 ): ServiceFormInitialData {
-  const decodedConfig = atob(base64Config);
-  const parsedConfig: RunServiceConfig = JSON.parse(decodedConfig);
-  const initialData = {
+  let parsedConfig: RunServiceConfig;
+
+  try {
+    const decodedConfig = atob(base64Config);
+    parsedConfig = JSON.parse(decodedConfig);
+  } catch {
+    throw new Error('Invalid service configuration');
+  }
+
+  return {
     ...parsedConfig,
     autoscaler:
       parsedConfig?.resources?.autoscaler ??
@@ -43,6 +50,4 @@ export default function parseConfigFromInstallLink(
     replicas: parsedConfig?.resources?.replicas,
     storage: parsedConfig?.resources?.storage ?? undefined,
   };
-
-  return initialData;
 }

--- a/dashboard/src/pages/orgs/[orgSlug]/projects/[appSubdomain]/run.tsx
+++ b/dashboard/src/pages/orgs/[orgSlug]/projects/[appSubdomain]/run.tsx
@@ -1,20 +1,19 @@
-import { SiDocker as ServicesIcon } from '@icons-pack/react-simple-icons';
-import { BoxIcon, PlusIcon } from 'lucide-react';
+import { PlusIcon } from 'lucide-react';
 import { useRouter } from 'next/router';
 import { type ReactElement, useCallback, useEffect } from 'react';
 import { useDialog } from '@/components/common/DialogProvider';
 import { Pagination } from '@/components/common/Pagination';
 import { UpgradeToProBanner } from '@/components/common/UpgradeToProBanner';
 import { Container } from '@/components/layout/Container';
-import { Box } from '@/components/ui/v2/Box';
-import { Text } from '@/components/ui/v2/Text';
 import { Button } from '@/components/ui/v3/button';
+import { ServicesOutlinedIcon } from '@/components/ui/v3/icons/ServicesOutlinedIcon';
 import { Spinner } from '@/components/ui/v3/spinner';
 import { OrgLayout } from '@/features/orgs/layout/OrgLayout';
 import { useIsPlatform } from '@/features/orgs/projects/common/hooks/useIsPlatform';
 import { useRunServices } from '@/features/orgs/projects/common/hooks/useRunServices';
 import { useCurrentOrg } from '@/features/orgs/projects/hooks/useCurrentOrg';
 import { useProject } from '@/features/orgs/projects/hooks/useProject';
+import { ServiceDrawerTitle } from '@/features/orgs/projects/services/components/ServiceDrawerTitle';
 import { ServiceForm } from '@/features/orgs/projects/services/components/ServiceForm';
 import { ServicesList } from '@/features/orgs/projects/services/components/ServicesList';
 import { parseConfigFromInstallLink } from '@/features/orgs/projects/services/utils/parseConfigFromInstallLink';
@@ -41,31 +40,30 @@ export default function RunPage() {
 
   const checkConfigFromQuery = useCallback(
     (base64Config: string) => {
-      if (router.query?.config) {
-        try {
-          const initialData = parseConfigFromInstallLink(base64Config);
+      if (!router.query?.config) {
+        return;
+      }
 
-          openDrawer({
-            title: (
-              <Box className="flex flex-row items-center space-x-2">
-                <BoxIcon className="h-5 w-5" />
-                <Text>Create a new run service</Text>
-              </Box>
-            ),
-            component: (
-              <ServiceForm initialData={initialData} onSubmit={refetch} />
-            ),
-          });
-        } catch {
-          openAlertDialog({
-            title: 'Configuration not set properly',
-            payload: 'The service configuration was not properly encoded',
-            props: {
-              primaryButtonText: 'Ok',
-              hideSecondaryAction: true,
-            },
-          });
-        }
+      try {
+        const initialData = parseConfigFromInstallLink(base64Config);
+
+        openDrawer({
+          title: (
+            <ServiceDrawerTitle>Create a new run service</ServiceDrawerTitle>
+          ),
+          component: (
+            <ServiceForm initialData={initialData} onSubmit={refetch} />
+          ),
+        });
+      } catch {
+        openAlertDialog({
+          title: 'Configuration not set properly',
+          payload: 'The service configuration was not properly encoded',
+          props: {
+            primaryButtonText: 'Ok',
+            hideSecondaryAction: true,
+          },
+        });
       }
     },
     [router.query.config, openDrawer, refetch, openAlertDialog],
@@ -73,7 +71,7 @@ export default function RunPage() {
 
   useEffect(() => {
     if (router.query?.config) {
-      checkConfigFromQuery(router.query?.config as string);
+      checkConfigFromQuery(router.query.config as string);
     }
   }, [checkConfigFromQuery, router.query]);
 
@@ -84,12 +82,7 @@ export default function RunPage() {
     }
 
     openDrawer({
-      title: (
-        <Box className="flex flex-row items-center space-x-2">
-          <BoxIcon className="h-5 w-5" />
-          <Text>Create a new service</Text>
-        </Box>
-      ),
+      title: <ServiceDrawerTitle>Create a new service</ServiceDrawerTitle>,
       component: <ServiceForm onSubmit={refetch} />,
     });
   };
@@ -126,15 +119,15 @@ export default function RunPage() {
           </Button>
         </div>
 
-        <Box className="flex flex-col items-center justify-center space-y-5 rounded-lg border px-48 py-12 shadow-sm">
-          <ServicesIcon className="h-10 w-10" />
+        <div className="flex flex-col items-center justify-center space-y-5 rounded-lg border px-48 py-12 shadow-sm">
+          <ServicesOutlinedIcon className="h-10 w-10" />
           <div className="flex flex-col space-y-1">
-            <Text className="text-center font-medium" variant="h3">
+            <h3 className="text-center font-medium text-lg">
               No custom services are available
-            </Text>
-            <Text variant="subtitle1" className="text-center">
+            </h3>
+            <p className="text-center text-muted-foreground text-sm">
               All your project&apos;s custom services will be listed here.
-            </Text>
+            </p>
           </div>
           {isPlatform ? (
             <div className="flex flex-row place-content-between rounded-lg">
@@ -144,20 +137,20 @@ export default function RunPage() {
               </Button>
             </div>
           ) : null}
-        </Box>
+        </div>
       </Container>
     );
   }
 
   return (
     <div className="flex flex-col">
-      <Box className="flex flex-row place-content-end border-b-1 p-4">
+      <div className="flex flex-row place-content-end border-b-1 p-4">
         <Button onClick={openCreateServiceDialog} disabled={!isPlatform}>
           <PlusIcon className="mr-2 h-4 w-4" />
           Add service
         </Button>
-      </Box>
-      <Box className="space-y-4">
+      </div>
+      <div className="space-y-4">
         <ServicesList
           services={services}
           onDelete={() => refetch()}
@@ -194,7 +187,7 @@ export default function RunPage() {
             }}
           />
         ) : null}
-      </Box>
+      </div>
     </div>
   );
 }

--- a/dashboard/src/pages/run-one-click-install.tsx
+++ b/dashboard/src/pages/run-one-click-install.tsx
@@ -1,22 +1,16 @@
-import { Divider } from '@mui/material';
 import debounce from 'lodash.debounce';
 import Image from 'next/image';
 import { useRouter } from 'next/router';
 import type { ChangeEvent, ReactElement } from 'react';
-import { Fragment, useCallback, useEffect, useMemo, useState } from 'react';
+import { useCallback, useEffect, useMemo, useState } from 'react';
 import { useDialog } from '@/components/common/DialogProvider';
 import { AuthenticatedLayout } from '@/components/layout/AuthenticatedLayout';
 import { RetryableErrorBoundary } from '@/components/presentational/RetryableErrorBoundary';
-import { Box } from '@/components/ui/v2/Box';
-import { Input } from '@/components/ui/v2/Input';
-import { List } from '@/components/ui/v2/List';
-import { ListItem } from '@/components/ui/v2/ListItem';
-import { Text } from '@/components/ui/v2/Text';
 import { Badge } from '@/components/ui/v3/badge';
 import { Button } from '@/components/ui/v3/button';
+import { Input } from '@/components/ui/v3/input';
 import { Spinner } from '@/components/ui/v3/spinner';
 import { useOrgs } from '@/features/orgs/projects/hooks/useOrgs';
-import { InfoCard } from '@/features/orgs/projects/overview/components/InfoCard';
 import { cn } from '@/lib/utils';
 
 interface ProjectSelectorOption {
@@ -82,7 +76,7 @@ export default function SelectOrganizationAndProject() {
     const config = router.query?.config as string;
 
     if (config) {
-      checkConfigFromQuery(router.query?.config as string);
+      checkConfigFromQuery(config);
     }
   }, [checkConfigFromQuery, router.query]);
 
@@ -138,73 +132,73 @@ export default function SelectOrganizationAndProject() {
       <div className="mx-auto flex h-full w-full max-w-[760px] flex-col gap-4 py-6 sm:py-14">
         <h1 className="font-medium text-2xl">New Run Service</h1>
 
-        <InfoCard
-          title="Please select the project where you want to create the service"
-          disableCopy
-          value=""
-        />
+        <div className="rounded-lg bg-muted p-3 shadow-sm">
+          <p className="font-medium text-sm+">
+            Please select the project where you want to create the service
+          </p>
+        </div>
 
         <div>
           <div className="mb-2 flex w-full">
             <Input
               placeholder="Search..."
               onChange={handleFilterChange}
-              fullWidth
+              wrapperClassName="w-full"
               autoFocus
             />
           </div>
           <RetryableErrorBoundary>
             {projectsToDisplay.length === 0 ? (
-              <Box className="h-import py-2">
-                <Text variant="subtitle2">No results found.</Text>
-              </Box>
+              <div className="h-import py-2">
+                <p className="text-muted-foreground text-sm">
+                  No results found.
+                </p>
+              </div>
             ) : (
-              <List className="flex h-import flex-col gap-2 overflow-y-auto">
+              <ul className="flex h-import flex-col overflow-y-auto rounded-md border">
                 {projectsToDisplay.map((project, index) => (
-                  <Fragment key={project.projectPathDescriptor}>
-                    <ListItem.Root
-                      className="flex flex-row items-center justify-center gap-4"
-                      secondaryAction={
-                        <Button
-                          variant="ghost"
-                          onClick={() => goToServices(project)}
-                        >
-                          Proceed
-                        </Button>
-                      }
-                    >
-                      <ListItem.Avatar className="flex h-full items-center justify-center">
-                        <Image
-                          src="/logos/new.svg"
-                          alt="Nhost Logo"
-                          className="h-10 w-10 rounded-md"
-                          width={38}
-                          height={38}
-                        />
-                      </ListItem.Avatar>
-                      <ListItem.Text
-                        primary={
-                          <div className="flex items-center">
-                            <span>{project.projectName}</span>
-                            <Badge
-                              variant={project.isFree ? 'outline' : 'default'}
-                              className={cn(
-                                'hover:none ml-2 h-5 px-[6px] text-[10px]',
-                                project.isFree && 'bg-muted',
-                              )}
-                            >
-                              {project.plan}
-                            </Badge>
-                          </div>
-                        }
-                        secondary={project.projectPathDescriptor}
+                  <li
+                    key={project.projectPathDescriptor}
+                    className={cn(
+                      'flex flex-row items-center justify-center gap-4 p-3',
+                      index < projectsToDisplay.length - 1 && 'border-b',
+                    )}
+                  >
+                    <div className="flex h-full items-center justify-center">
+                      <Image
+                        src="/logos/new.svg"
+                        alt="Nhost Logo"
+                        className="h-10 w-10 rounded-md"
+                        width={38}
+                        height={38}
                       />
-                    </ListItem.Root>
-
-                    {index < projects.length - 1 && <Divider component="li" />}
-                  </Fragment>
+                    </div>
+                    <div className="min-w-0 flex-1">
+                      <div className="flex items-center">
+                        <span className="truncate">{project.projectName}</span>
+                        <Badge
+                          variant={project.isFree ? 'outline' : 'default'}
+                          className={cn(
+                            'hover:none ml-2 h-5 px-[6px] text-[10px]',
+                            project.isFree && 'bg-muted',
+                          )}
+                        >
+                          {project.plan}
+                        </Badge>
+                      </div>
+                      <p className="truncate text-muted-foreground text-sm">
+                        {project.projectPathDescriptor}
+                      </p>
+                    </div>
+                    <Button
+                      variant="ghost"
+                      onClick={() => goToServices(project)}
+                    >
+                      Proceed
+                    </Button>
+                  </li>
                 ))}
-              </List>
+              </ul>
             )}
           </RetryableErrorBoundary>
         </div>


### PR DESCRIPTION
### Checklist

- [x] No breaking changes
- [x] Tests pass
- [ ] New features have new tests
- [ ] Documentation is updated (if applicable)
- [x] Title of the PR is in the correct format (see below)

<!-- pi-reviewer:start -->
### **What this change solves**
This change migrates the dashboard run service management screens from legacy v2 UI primitives to v3/Shadcn-style components. It keeps the service create/edit, listing, deletion, and one-click install flows aligned with the newer dashboard UI system.

___

### **Change Type**
Refactoring

___

### **Description**
- Migrates run service forms, modals, lists, and page wrappers away from legacy v2 components toward v3 dashboard primitives.
- Reworks form field rendering, labels, helper/error text, and loading button behavior across service configuration sections.
- Updates run service list, delete confirmation, install-link parsing, and run page entrypoints to match the migrated components.

___

<details> <summary><h3> File Walkthrough</h3></summary>

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody>
<tr><td><strong>Service lifecycle UI</strong></td><td><details><summary>2 files</summary><table>
<tr>
  <td><strong>dashboard/src/features/orgs/projects/common/components/DeleteServiceModal/DeleteServiceModal.tsx</strong><dd><code>Migrates the delete service confirmation modal to v3 buttons, checkbox styling, and native layout elements.</code></dd></td>
  <td>+25/-28</td>
</tr>
<tr>
  <td><strong>dashboard/src/features/orgs/projects/services/components/ServicesList/ServicesList.tsx</strong><dd><code>Updates the services list presentation and actions to the v3 UI stack.</code></dd></td>
  <td>+93/-91</td>
</tr>
</table></details></td></tr>
<tr><td><strong>Service form</strong></td><td><details><summary>10 files</summary><table>
<tr>
  <td><strong>dashboard/src/features/orgs/projects/services/components/ServiceForm/ServiceForm.tsx</strong><dd><code>Refactors the main service form shell, submit flow, labels, alerts, and tooltip usage for v3 components.</code></dd></td>
  <td>+80/-37</td>
</tr>
<tr>
  <td><strong>dashboard/src/features/orgs/projects/services/components/ServiceForm/components/CommandFormSection/CommandFormSection.tsx</strong><dd><code>Migrates command/entrypoint fields to v3 inputs, labels, and validation display.</code></dd></td>
  <td>+63/-53</td>
</tr>
<tr>
  <td><strong>dashboard/src/features/orgs/projects/services/components/ServiceForm/components/ComputeFormSection/ComputeFormSection.tsx</strong><dd><code>Updates compute resource controls and tooltip presentation with v3 primitives.</code></dd></td>
  <td>+47/-47</td>
</tr>
<tr>
  <td><strong>dashboard/src/features/orgs/projects/services/components/ServiceForm/components/EnvironmentFormSection/EnvironmentFormSection.tsx</strong><dd><code>Reworks environment variable editing rows and controls using v3 inputs and buttons.</code></dd></td>
  <td>+79/-66</td>
</tr>
<tr>
  <td><strong>dashboard/src/features/orgs/projects/services/components/ServiceForm/components/HealthCheckFormSection/HealthCheckFormSection.tsx</strong><dd><code>Migrates health-check controls, switches, and error states to the v3 component set.</code></dd></td>
  <td>+91/-74</td>
</tr>
<tr>
  <td><strong>dashboard/src/features/orgs/projects/services/components/ServiceForm/components/ImageField/ImageField.tsx</strong><dd><code>Updates image input behavior, popovers, and validation presentation for the new UI primitives.</code></dd></td>
  <td>+94/-98</td>
</tr>
<tr>
  <td><strong>dashboard/src/features/orgs/projects/services/components/ServiceForm/components/ImageFormSection/ImageFormSection.tsx</strong><dd><code>Simplifies the image section wrapper after the field migration.</code></dd></td>
  <td>+5/-9</td>
</tr>
<tr>
  <td><strong>dashboard/src/features/orgs/projects/services/components/ServiceForm/components/PortsFormSection/PortsFormSection.tsx</strong><dd><code>Replaces port configuration rows, selects, switches, URL display, and copy actions with v3 equivalents.</code></dd></td>
  <td>+127/-102</td>
</tr>
<tr>
  <td><strong>dashboard/src/features/orgs/projects/services/components/ServiceForm/components/ReplicasFormSection/ReplicasFormSection.tsx</strong><dd><code>Migrates replicas and autoscaler controls with explicit labels, tooltip content, and validation styles.</code></dd></td>
  <td>+106/-80</td>
</tr>
<tr>
  <td><strong>dashboard/src/features/orgs/projects/services/components/ServiceForm/components/StorageFormSection/StorageFormSection.tsx</strong><dd><code>Updates storage configuration rows, mount fields, and validation rendering to v3 UI elements.</code></dd></td>
  <td>+112/-95</td>
</tr>
</table></details></td></tr>
<tr><td><strong>Dialogs and pages</strong></td><td><details><summary>3 files</summary><table>
<tr>
  <td><strong>dashboard/src/features/orgs/projects/services/components/ServiceForm/components/ServiceConfirmationDialog/ServiceConfirmationDialog.tsx</strong><dd><code>Migrates service confirmation dialog layout and actions to v3 styling.</code></dd></td>
  <td>+40/-37</td>
</tr>
<tr>
  <td><strong>dashboard/src/pages/orgs/[orgSlug]/projects/[appSubdomain]/run.tsx</strong><dd><code>Updates the run services page layout and actions for the migrated components.</code></dd></td>
  <td>+47/-46</td>
</tr>
<tr>
  <td><strong>dashboard/src/pages/run-one-click-install.tsx</strong><dd><code>Migrates the one-click install page presentation and action controls to the new UI stack.</code></dd></td>
  <td>+54/-60</td>
</tr>
</table></details></td></tr>
<tr><td><strong>Utilities</strong></td><td><details><summary>1 file</summary><table>
<tr>
  <td><strong>dashboard/src/features/orgs/projects/services/utils/parseConfigFromInstallLink/parseConfigFromInstallLink.ts</strong><dd><code>Adjusts install-link parsing defaults and normalization for service configuration input.</code></dd></td>
  <td>+10/-5</td>
</tr>
</table></details></td></tr>
</tbody></table>

</details>

___

<!-- pi-reviewer:end -->
