### PR TITLE
fix(dashboard): migrate AI assistants page

### DIFF
--- a/dashboard/e2e/ai/assistants.test.ts
+++ b/dashboard/e2e/ai/assistants.test.ts
@@ -17,27 +17,34 @@ test.beforeEach(async ({ authenticatedNhostPage: page }) => {
 test('should create and delete an Assistant', async ({
   authenticatedNhostPage: page,
 }) => {
-  await page.getByRole('link', { name: 'Assistants' }).click();
+  const assistantName = `test-assistant-${Date.now()}`;
+  const createAssistantButton = page
+    .getByRole('button', { name: 'Create a new assistant', exact: true })
+    .or(page.getByRole('button', { name: 'New', exact: true }))
+    .first();
 
-  await expect(page.getByText(/no assistants are configured/i)).toBeVisible();
+  await expect(createAssistantButton).toBeVisible();
+  await createAssistantButton.click();
 
-  await page.getByRole('button', { name: 'Create a new assistant' }).click();
-  await page.getByLabel('Name').fill('test');
+  await page.getByLabel('Name').fill(assistantName);
   await page.getByLabel('Description').fill('test');
   await page.getByLabel('Instructions').fill('test');
   await page.getByLabel('Model').fill('gpt-3.5-turbo-1106');
 
   await page.getByRole('button', { name: 'Create' }).click();
 
-  await expect(page.getByRole('heading', { name: /test/i })).toBeVisible();
+  const assistantNameLocator = page.getByText(assistantName, { exact: true });
+  const assistantRow = assistantNameLocator.locator(
+    'xpath=ancestor::*[.//button[@aria-label="More options"]][1]',
+  );
 
-  await page.getByLabel(/more options/i).click();
-  await page.getByRole('menuitem', { name: /delete test/i }).click();
+  await expect(assistantNameLocator).toBeVisible();
+
+  await assistantRow.getByLabel(/more options/i).click();
+  await page.getByRole('menuitem', { name: `Delete ${assistantName}` }).click();
 
   await page.getByLabel('Confirm Delete Assistant').check();
   await page.getByRole('button', { name: 'Delete Assistant' }).click();
 
-  await expect(
-    page.getByRole('heading', { name: /no assistants are configured/i }),
-  ).toBeVisible();
+  await expect(assistantNameLocator).not.toBeVisible();
 });

--- a/dashboard/src/features/orgs/projects/ai/AssistantForm/AssistantForm.tsx
+++ b/dashboard/src/features/orgs/projects/ai/AssistantForm/AssistantForm.tsx
@@ -1,15 +1,13 @@
 import { yupResolver } from '@hookform/resolvers/yup';
-import { InfoIcon, PlusIcon, RefreshCwIcon } from 'lucide-react';
+import { PlusIcon, RefreshCwIcon } from 'lucide-react';
 import { useEffect } from 'react';
 import { FormProvider, useForm } from 'react-hook-form';
 import * as Yup from 'yup';
 import { useDialog } from '@/components/common/DialogProvider';
 import { Form } from '@/components/form/Form';
+import { FormInput } from '@/components/form/FormInput';
 import { FormSelect } from '@/components/form/FormSelect';
-import { Box } from '@/components/ui/v2/Box';
-import { Input } from '@/components/ui/v2/Input';
-import { Text } from '@/components/ui/v2/Text';
-import { Tooltip } from '@/components/ui/v2/Tooltip';
+import { FormTextarea } from '@/components/form/FormTextarea';
 import { Button } from '@/components/ui/v3/button';
 import { SelectItem } from '@/components/ui/v3/select';
 import { useRemoteApplicationGQLClient } from '@/features/orgs/hooks/useRemoteApplicationGQLClient';
@@ -19,13 +17,14 @@ import {
   fileStoreFieldTransform,
   NO_FILE_STORE_SELECT_VALUE,
 } from '@/features/orgs/projects/ai/AssistantForm/utils/fileStoreSelectValue';
+import type { GraphiteFileStore } from '@/features/orgs/projects/ai/assistants/types';
+import { InfoTooltip } from '@/features/orgs/projects/common/components/InfoTooltip';
 import { useIsFileStoreSupported } from '@/features/orgs/projects/common/hooks/useIsFileStoreSupported';
 import { execPromiseWithErrorToast } from '@/features/orgs/utils/execPromiseWithErrorToast';
 import {
   useInsertAssistantMutation,
   useUpdateAssistantMutation,
 } from '@/generated/graphite';
-import type { GraphiteFileStore } from '@/pages/orgs/[orgSlug]/projects/[appSubdomain]/ai/file-stores';
 import type { DialogFormProps } from '@/types/common';
 import { type DeepRequired, removeTypename } from '@/utils/helpers';
 
@@ -114,7 +113,7 @@ export default function AssistantForm({
     client: remoteProjectGQLClient,
   });
 
-  const isFileStoreSupported = useIsFileStoreSupported();
+  const { isFileStoreSupported } = useIsFileStoreSupported();
 
   const fileStoresOptions = fileStores
     ? fileStores.map((fileStore: GraphiteFileStore) => ({
@@ -141,8 +140,7 @@ export default function AssistantForm({
   });
 
   const {
-    register,
-    formState: { errors, isSubmitting, dirtyFields },
+    formState: { isSubmitting, dirtyFields },
   } = form;
 
   const isDirty = Object.keys(dirtyFields).length > 0;
@@ -227,102 +225,62 @@ export default function AssistantForm({
         className="flex h-full flex-col overflow-hidden border-t"
       >
         <div className="flex flex-1 flex-col space-y-4 overflow-auto p-4">
-          <Input
-            {...register('name')}
-            id="name"
+          <FormInput
+            control={form.control}
+            name="name"
             label={
-              <Box className="flex flex-row items-center space-x-2">
-                <Text>Name</Text>
-                <Tooltip title="Name of the assistant">
-                  <InfoIcon
-                    aria-label="Info"
-                    className="h-4 w-4 text-primary"
-                  />
-                </Tooltip>
-              </Box>
+              <div className="flex flex-row items-center space-x-2">
+                <span>Name</span>
+                <InfoTooltip>Name of the assistant</InfoTooltip>
+              </div>
             }
             placeholder=""
-            hideEmptyHelperText
-            error={!!errors.name}
-            helperText={errors?.name?.message}
-            fullWidth
             autoComplete="off"
             autoFocus
           />
 
-          <Input
-            {...register('description')}
-            id="description"
+          <FormTextarea
+            control={form.control}
+            name="description"
             label={
-              <Box className="flex flex-row items-center space-x-2">
-                <Text>Description</Text>
-                <Tooltip title={<span>Description of the assistant</span>}>
-                  <InfoIcon
-                    aria-label="Info"
-                    className="h-4 w-4 text-primary"
-                  />
-                </Tooltip>
-              </Box>
+              <div className="flex flex-row items-center space-x-2">
+                <span>Description</span>
+                <InfoTooltip>Description of the assistant</InfoTooltip>
+              </div>
             }
             placeholder=""
-            hideEmptyHelperText
-            error={!!errors.description}
-            helperText={errors?.description?.message}
-            fullWidth
             autoComplete="off"
-            multiline
-            inputProps={{
-              className: 'resize-y min-h-[22px]',
-            }}
+            className="min-h-10 resize-y"
           />
 
-          <Input
-            {...register('instructions')}
-            id="instructions"
+          <FormTextarea
+            control={form.control}
+            name="instructions"
             label={
-              <Box className="flex flex-row items-center space-x-2">
-                <Text>Instructions</Text>
-                <Tooltip title="Instructions for the assistant. This is used to instruct the AI assistant on how to behave and respond to the user">
-                  <InfoIcon
-                    aria-label="Info"
-                    className="h-4 w-4 text-primary"
-                  />
-                </Tooltip>
-              </Box>
+              <div className="flex flex-row items-center space-x-2">
+                <span>Instructions</span>
+                <InfoTooltip>
+                  Instructions for the assistant. This is used to instruct the
+                  AI assistant on how to behave and respond to the user
+                </InfoTooltip>
+              </div>
             }
             placeholder=""
-            hideEmptyHelperText
-            error={!!errors.instructions}
-            helperText={errors?.instructions?.message}
-            fullWidth
             autoComplete="off"
-            multiline
-            inputProps={{
-              className: 'resize-y min-h-[22px]',
-            }}
+            className="min-h-10 resize-y"
           />
 
-          <Input
-            {...register('model')}
-            id="model"
+          <FormInput
+            control={form.control}
+            name="model"
             label={
-              <Box className="flex flex-row items-center space-x-2">
-                <Text>Model</Text>
-                <Tooltip title="Model to use for the assistant.">
-                  <InfoIcon
-                    aria-label="Info"
-                    className="h-4 w-4 text-primary"
-                  />
-                </Tooltip>
-              </Box>
+              <div className="flex flex-row items-center space-x-2">
+                <span>Model</span>
+                <InfoTooltip>Model to use for the assistant.</InfoTooltip>
+              </div>
             }
             placeholder=""
-            hideEmptyHelperText
-            error={!!errors.model}
-            helperText={errors?.model?.message}
-            fullWidth
             autoComplete="off"
-            autoFocus
           />
           <GraphqlDataSourcesFormSection />
           <WebhooksDataSourcesFormSection />
@@ -330,15 +288,10 @@ export default function AssistantForm({
             control={form.control}
             name="fileStore"
             label={
-              <Box className="flex flex-row items-center space-x-2">
-                <Text>File Store</Text>
-                <Tooltip title={fileStoreTooltip}>
-                  <InfoIcon
-                    aria-label="Info"
-                    className="h-4 w-4 text-primary"
-                  />
-                </Tooltip>
-              </Box>
+              <div className="flex flex-row items-center space-x-2">
+                <span>File Store</span>
+                <InfoTooltip>{fileStoreTooltip}</InfoTooltip>
+              </div>
             }
             contentClassName="z-[10000]"
             disabled={!isFileStoreSupported}
@@ -353,8 +306,8 @@ export default function AssistantForm({
           </FormSelect>
         </div>
 
-        <Box className="flex w-full flex-row justify-between rounded border-t p-4">
-          <Button variant="outline" onClick={onCancel}>
+        <div className="flex w-full flex-row justify-between rounded border-t p-4">
+          <Button type="button" variant="outline" onClick={onCancel}>
             Cancel
           </Button>
           <Button type="submit" disabled={isSubmitting}>
@@ -365,7 +318,7 @@ export default function AssistantForm({
             )}
             {assistantId ? 'Update' : 'Create'}
           </Button>
-        </Box>
+        </div>
       </Form>
     </FormProvider>
   );

--- a/dashboard/src/features/orgs/projects/ai/AssistantForm/components/ArgumentsFormSection/ArgumentsFormSection.tsx
+++ b/dashboard/src/features/orgs/projects/ai/AssistantForm/components/ArgumentsFormSection/ArgumentsFormSection.tsx
@@ -1,14 +1,25 @@
-import { InfoIcon, PlusIcon, Trash2 as TrashIcon } from 'lucide-react';
+import { PlusIcon, Trash2 as TrashIcon } from 'lucide-react';
 import { type Path, useFieldArray, useFormContext } from 'react-hook-form';
-import { ControlledSwitch } from '@/components/form/ControlledSwitch';
+import { FormInput } from '@/components/form/FormInput';
 import { FormSelect } from '@/components/form/FormSelect';
-import { Box } from '@/components/ui/v2/Box';
-import { Input } from '@/components/ui/v2/Input';
-import { Text } from '@/components/ui/v2/Text';
-import { Tooltip } from '@/components/ui/v2/Tooltip';
+import { FormSwitch } from '@/components/form/FormSwitch';
+import { FormTextarea } from '@/components/form/FormTextarea';
 import { Button } from '@/components/ui/v3/button';
 import { SelectItem } from '@/components/ui/v3/select';
 import type { AssistantFormValues } from '@/features/orgs/projects/ai/AssistantForm/AssistantForm';
+import { InfoTooltip } from '@/features/orgs/projects/common/components/InfoTooltip';
+
+const ARGUMENT_TYPES = [
+  'string',
+  'number',
+  'integer',
+  'object',
+  'array',
+  'boolean',
+];
+
+const argumentFieldClasses =
+  '!border-input !bg-background dark:!bg-accent-background';
 
 type AssistantFormPath = Path<AssistantFormValues>;
 
@@ -23,27 +34,19 @@ export default function ArgumentsFormSection({
 }: ArgumentsFormSectionProps) {
   const form = useFormContext<AssistantFormValues>();
 
-  const {
-    register,
-    formState: { errors },
-  } = form;
-
   const { fields, append, remove } = useFieldArray({
     name: `${nestedField}.${nestIndex}.arguments`,
   });
 
   return (
-    <Box className="space-y-4">
+    <div className="space-y-4">
       <div className="flex flex-row items-center justify-between">
         <div className="flex flex-row items-center space-x-2">
-          <Text variant="h4" className="font-semibold">
-            Arguments
-          </Text>
-          <Tooltip title={<span>Arguments</span>}>
-            <InfoIcon aria-label="Info" className="h-4 w-4 text-primary" />
-          </Tooltip>
+          <h4 className="font-semibold text-sm+">Arguments</h4>
+          <InfoTooltip>Arguments</InfoTooltip>
         </div>
         <Button
+          type="button"
           variant="ghost"
           size="icon"
           aria-label="Add argument"
@@ -55,110 +58,76 @@ export default function ArgumentsFormSection({
 
       <div className="flex flex-col space-y-4">
         {fields.map((field, index) => {
-          const argumentTypeName =
+          const nameField =
+            `${nestedField}.${nestIndex}.arguments.${index}.name` as AssistantFormPath;
+          const descriptionField =
+            `${nestedField}.${nestIndex}.arguments.${index}.description` as AssistantFormPath;
+          const typeField =
             `${nestedField}.${nestIndex}.arguments.${index}.type` as AssistantFormPath;
+          const requiredField =
+            `${nestedField}.${nestIndex}.arguments.${index}.required` as AssistantFormPath;
 
           return (
-            <Box
-              key={field.id}
-              className="flex flex-col space-y-20 rounded border-1 p-4"
-              sx={{ backgroundColor: 'grey.200' }}
-            >
-              <div className="flex w-full flex-col space-y-4">
-                <Input
-                  // We're putting ts-ignore here so we could use the same components for both graphql and webhooks
-                  // by passing the nestedField = 'graphql' or nestedField = 'webhooks'
-                  {...register(
-                    `${nestedField}.${nestIndex}.arguments.${index}.name`,
-                  )}
-                  id={`${field.id}-name`}
+            <div key={field.id} className="rounded-md border bg-muted p-3">
+              <div className="grid gap-2">
+                <FormInput
+                  control={form.control}
+                  name={nameField}
                   placeholder="Name"
-                  className="w-full"
-                  hideEmptyHelperText
-                  error={
-                    !!errors?.[nestedField]?.[nestIndex]?.arguments?.[index]
-                      ?.name
-                  }
-                  helperText={
-                    errors?.[nestedField]?.[nestIndex]?.arguments?.[index]?.name
-                      ?.message
-                  }
-                  fullWidth
                   autoComplete="off"
+                  className={argumentFieldClasses}
                 />
 
-                <Input
-                  {...register(
-                    `${nestedField}.${nestIndex}.arguments.${index}.description`,
-                  )}
-                  id={`${field.id}-description`}
+                <FormTextarea
+                  control={form.control}
+                  name={descriptionField}
+                  label={<span className="sr-only">Description</span>}
                   placeholder="Description"
-                  className="w-full"
-                  hideEmptyHelperText
-                  error={
-                    !!errors?.[nestedField]?.[nestIndex]?.arguments?.[index]
-                      ?.description
-                  }
-                  helperText={
-                    errors?.[nestedField]?.[nestIndex]?.arguments?.[index]
-                      ?.description?.message
-                  }
-                  fullWidth
                   autoComplete="off"
-                  multiline
-                  inputProps={{
-                    className: 'resize-y min-h-[22px]',
-                  }}
+                  className={`${argumentFieldClasses} min-h-10 resize-y`}
                 />
 
-                <div className="flex flex-row space-x-2">
-                  <Box className="w-full">
-                    <FormSelect
-                      control={form.control}
-                      name={argumentTypeName}
-                      placeholder="Select argument type"
-                      containerClassName="space-y-0"
-                      contentClassName="z-[10000] w-[270px] min-w-0"
-                    >
-                      {[
-                        'string',
-                        'number',
-                        'integer',
-                        'object',
-                        'array',
-                        'boolean',
-                      ]?.map((argumentType) => (
-                        <SelectItem key={argumentType} value={argumentType}>
-                          {argumentType}
-                        </SelectItem>
-                      ))}
-                    </FormSelect>
-                  </Box>
-                  <ControlledSwitch
-                    {...register(
-                      `${nestedField}.${nestIndex}.arguments.${index}.required`,
-                    )}
-                    disabled={false}
-                    label={
-                      <Text variant="subtitle1" component="span">
-                        Required
-                      </Text>
-                    }
+                <div className="grid gap-2 md:grid-cols-[minmax(0,1fr)_auto_auto] md:items-center">
+                  <FormSelect
+                    control={form.control}
+                    name={typeField}
+                    placeholder="Select argument type"
+                    className="border-input bg-background dark:bg-accent-background"
+                    containerClassName="space-y-0"
+                    contentClassName="z-[10000] w-[270px] min-w-0"
+                  >
+                    {ARGUMENT_TYPES.map((argumentType) => (
+                      <SelectItem key={argumentType} value={argumentType}>
+                        {argumentType}
+                      </SelectItem>
+                    ))}
+                  </FormSelect>
+
+                  <FormSwitch
+                    control={form.control}
+                    name={requiredField}
+                    label="Required"
+                    className="border-muted-foreground/60 data-[state=checked]:border-primary data-[state=checked]:bg-primary data-[state=unchecked]:bg-muted-foreground/35 dark:data-[state=checked]:border-primary dark:data-[state=checked]:bg-primary dark:data-[state=unchecked]:bg-slate-500"
+                    containerClassName="flex h-10 flex-row-reverse items-center gap-2 space-y-0 px-1"
+                    labelClassName="font-normal text-muted-foreground"
                   />
+
+                  <Button
+                    type="button"
+                    variant="ghost"
+                    size="icon"
+                    className="h-10 text-destructive hover:text-destructive"
+                    aria-label="Remove argument"
+                    onClick={() => remove(index)}
+                  >
+                    <TrashIcon className="h-4 w-4" />
+                  </Button>
                 </div>
-                <Button
-                  variant="ghost"
-                  className="h-10 self-end text-destructive hover:text-destructive"
-                  aria-label="Remove argument"
-                  onClick={() => remove(index)}
-                >
-                  <TrashIcon className="h-4 w-4" />
-                </Button>
               </div>
-            </Box>
+            </div>
           );
         })}
       </div>
-    </Box>
+    </div>
   );
 }

--- a/dashboard/src/features/orgs/projects/ai/AssistantForm/components/GraphqlDataSourcesFormSection/GraphqlDataSourcesFormSection.tsx
+++ b/dashboard/src/features/orgs/projects/ai/AssistantForm/components/GraphqlDataSourcesFormSection/GraphqlDataSourcesFormSection.tsx
@@ -1,38 +1,34 @@
-import { InfoIcon, PlusIcon, Trash2 as TrashIcon } from 'lucide-react';
-import { useFieldArray, useFormContext } from 'react-hook-form';
-import { Box } from '@/components/ui/v2/Box';
-import { Divider } from '@/components/ui/v2/Divider';
-import { Input } from '@/components/ui/v2/Input';
-import { Text } from '@/components/ui/v2/Text';
-import { Tooltip } from '@/components/ui/v2/Tooltip';
+import { PlusIcon, Trash2 as TrashIcon } from 'lucide-react';
+import { type Path, useFieldArray, useFormContext } from 'react-hook-form';
+import { FormInput } from '@/components/form/FormInput';
+import { FormTextarea } from '@/components/form/FormTextarea';
 import { Button } from '@/components/ui/v3/button';
+import { Separator } from '@/components/ui/v3/separator';
 import type { AssistantFormValues } from '@/features/orgs/projects/ai/AssistantForm/AssistantForm';
 import { ArgumentsFormSection } from '@/features/orgs/projects/ai/AssistantForm/components/ArgumentsFormSection';
+import { InfoTooltip } from '@/features/orgs/projects/common/components/InfoTooltip';
+
+type AssistantFormPath = Path<AssistantFormValues>;
 
 export default function GraphqlDataSourcesFormSection() {
   const form = useFormContext<AssistantFormValues>();
-
-  const {
-    register,
-    formState: { errors },
-  } = form;
 
   const { fields, append, remove } = useFieldArray({
     name: 'graphql',
   });
 
   return (
-    <Box className="space-y-4 rounded border-1">
-      <Box className="flex flex-row items-center justify-between p-4 pb-0">
-        <Box className="flex flex-row items-center space-x-2">
-          <Text variant="h4" className="font-semibold">
-            GraphQL
-          </Text>
-          <Tooltip title="GraphQL data sources and tools. Run against the project's GraphQL API">
-            <InfoIcon aria-label="Info" className="h-4 w-4 text-primary" />
-          </Tooltip>
-        </Box>
+    <div className="space-y-4 rounded border-1">
+      <div className="flex flex-row items-center justify-between p-4 pb-0">
+        <div className="flex flex-row items-center space-x-2">
+          <h4 className="font-semibold text-sm+">GraphQL</h4>
+          <InfoTooltip>
+            GraphQL data sources and tools. Run against the project's GraphQL
+            API
+          </InfoTooltip>
+        </div>
         <Button
+          type="button"
           variant="ghost"
           size="icon"
           aria-label="Add GraphQL data source"
@@ -47,62 +43,42 @@ export default function GraphqlDataSourcesFormSection() {
         >
           <PlusIcon className="h-5 w-5" />
         </Button>
-      </Box>
+      </div>
 
-      <Box className="flex flex-col space-y-4">
+      <div className="flex flex-col space-y-4">
         {fields.map((field, index) => (
-          <Box key={field.id} className="flex flex-col space-y-4">
-            <Box className="flex w-full flex-col space-y-4 p-4 pt-0">
-              <Input
-                {...register(`graphql.${index}.name`)}
-                id={`${field.id}-name`}
+          <div key={field.id} className="flex flex-col space-y-4">
+            <div className="flex w-full flex-col space-y-4 p-4 pt-0">
+              <FormInput
+                control={form.control}
+                name={`graphql.${index}.name` as AssistantFormPath}
                 label="Name"
                 placeholder="Name"
-                className="w-full"
-                hideEmptyHelperText
-                error={!!errors?.graphql?.at?.(index)?.name}
-                helperText={errors?.graphql?.at?.(index)?.message}
-                fullWidth
                 autoComplete="off"
               />
 
-              <Input
-                {...register(`graphql.${index}.description`)}
-                id={`${field.id}-description`}
+              <FormTextarea
+                control={form.control}
+                name={`graphql.${index}.description` as AssistantFormPath}
                 label="Description"
                 placeholder="Description"
-                className="w-full"
-                hideEmptyHelperText
-                error={!!errors?.graphql?.at?.(index)?.description}
-                helperText={errors?.graphql?.at?.(index)?.description?.message}
-                fullWidth
                 autoComplete="off"
-                multiline
-                inputProps={{
-                  className: 'resize-y min-h-[22px]',
-                }}
+                className="min-h-10 resize-y"
               />
 
-              <Input
-                {...register(`graphql.${index}.query`)}
-                id={`${field.id}-query`}
+              <FormTextarea
+                control={form.control}
+                name={`graphql.${index}.query` as AssistantFormPath}
                 label="Query"
                 placeholder="Query"
-                className="w-full"
-                hideEmptyHelperText
-                error={!!errors?.graphql?.at?.(index)?.query}
-                helperText={errors?.graphql?.at?.(index)?.query?.message}
-                fullWidth
                 autoComplete="off"
-                multiline
-                inputProps={{
-                  className: 'resize-y min-h-[22px]',
-                }}
+                className="min-h-10 resize-y"
               />
 
               <ArgumentsFormSection nestedField="graphql" nestIndex={index} />
 
               <Button
+                type="button"
                 variant="ghost"
                 className="h-10 self-end text-destructive hover:text-destructive"
                 aria-label="Remove GraphQL data source"
@@ -110,14 +86,12 @@ export default function GraphqlDataSourcesFormSection() {
               >
                 <TrashIcon className="h-4 w-4" />
               </Button>
-            </Box>
+            </div>
 
-            {index < fields.length - 1 && (
-              <Divider className="h-px" sx={{ background: 'grey.200' }} />
-            )}
-          </Box>
+            {index < fields.length - 1 && <Separator className="h-px" />}
+          </div>
         ))}
-      </Box>
-    </Box>
+      </div>
+    </div>
   );
 }

--- a/dashboard/src/features/orgs/projects/ai/AssistantForm/components/WebhooksDataSourcesFormSection/WebhooksDataSourcesFormSection.tsx
+++ b/dashboard/src/features/orgs/projects/ai/AssistantForm/components/WebhooksDataSourcesFormSection/WebhooksDataSourcesFormSection.tsx
@@ -1,38 +1,31 @@
-import { InfoIcon, PlusIcon, Trash2 as TrashIcon } from 'lucide-react';
-import { useFieldArray, useFormContext } from 'react-hook-form';
-import { Box } from '@/components/ui/v2/Box';
-import { Divider } from '@/components/ui/v2/Divider';
-import { Input } from '@/components/ui/v2/Input';
-import { Text } from '@/components/ui/v2/Text';
-import { Tooltip } from '@/components/ui/v2/Tooltip';
+import { PlusIcon, Trash2 as TrashIcon } from 'lucide-react';
+import { type Path, useFieldArray, useFormContext } from 'react-hook-form';
+import { FormInput } from '@/components/form/FormInput';
+import { FormTextarea } from '@/components/form/FormTextarea';
 import { Button } from '@/components/ui/v3/button';
+import { Separator } from '@/components/ui/v3/separator';
 import type { AssistantFormValues } from '@/features/orgs/projects/ai/AssistantForm/AssistantForm';
 import { ArgumentsFormSection } from '@/features/orgs/projects/ai/AssistantForm/components/ArgumentsFormSection';
+import { InfoTooltip } from '@/features/orgs/projects/common/components/InfoTooltip';
+
+type AssistantFormPath = Path<AssistantFormValues>;
 
 export default function WebhooksDataSourcesFormSection() {
   const form = useFormContext<AssistantFormValues>();
-
-  const {
-    register,
-    formState: { errors },
-  } = form;
 
   const { fields, append, remove } = useFieldArray({
     name: 'webhooks',
   });
 
   return (
-    <Box className="space-y-4 rounded border-1">
-      <Box className="flex flex-row items-center justify-between p-4">
-        <Box className="flex flex-row items-center space-x-2">
-          <Text variant="h4" className="font-semibold">
-            Webhooks
-          </Text>
-          <Tooltip title="Webhook data sources and tools">
-            <InfoIcon aria-label="Info" className="h-4 w-4 text-primary" />
-          </Tooltip>
-        </Box>
+    <div className="space-y-4 rounded border-1">
+      <div className="flex flex-row items-center justify-between p-4">
+        <div className="flex flex-row items-center space-x-2">
+          <h4 className="font-semibold text-sm+">Webhooks</h4>
+          <InfoTooltip>Webhook data sources and tools</InfoTooltip>
+        </div>
         <Button
+          type="button"
           variant="ghost"
           size="icon"
           aria-label="Add webhook data source"
@@ -47,62 +40,42 @@ export default function WebhooksDataSourcesFormSection() {
         >
           <PlusIcon className="h-5 w-5" />
         </Button>
-      </Box>
+      </div>
 
-      <Box className="flex flex-col space-y-4">
+      <div className="flex flex-col space-y-4">
         {fields.map((field, index) => (
-          <Box key={field.id} className="flex flex-col space-y-4">
-            <Box className="flex w-full flex-col space-y-4 p-4 pt-0">
-              <Input
-                {...register(`webhooks.${index}.name`)}
-                id={`${field.id}-name`}
+          <div key={field.id} className="flex flex-col space-y-4">
+            <div className="flex w-full flex-col space-y-4 p-4 pt-0">
+              <FormInput
+                control={form.control}
+                name={`webhooks.${index}.name` as AssistantFormPath}
                 label="Name"
                 placeholder="Name"
-                className="w-full"
-                hideEmptyHelperText
-                error={!!errors?.webhooks?.at?.(index)?.name}
-                helperText={errors?.webhooks?.at?.(index)?.message}
-                fullWidth
                 autoComplete="off"
               />
 
-              <Input
-                {...register(`webhooks.${index}.description`)}
-                id={`${field.id}-description`}
+              <FormTextarea
+                control={form.control}
+                name={`webhooks.${index}.description` as AssistantFormPath}
                 label="Description"
                 placeholder="Description"
-                className="w-full"
-                hideEmptyHelperText
-                error={!!errors?.webhooks?.at?.(index)?.description}
-                helperText={errors?.webhooks?.at?.(index)?.description?.message}
-                fullWidth
                 autoComplete="off"
-                multiline
-                inputProps={{
-                  className: 'resize-y min-h-[22px]',
-                }}
+                className="min-h-10 resize-y"
               />
 
-              <Input
-                {...register(`webhooks.${index}.URL`)}
-                id={`${field.id}-URL`}
+              <FormTextarea
+                control={form.control}
+                name={`webhooks.${index}.URL` as AssistantFormPath}
                 label="URL"
                 placeholder="URL"
-                className="w-full"
-                hideEmptyHelperText
-                error={!!errors?.webhooks?.at?.(index)?.URL}
-                helperText={errors?.webhooks?.at?.(index)?.URL?.message}
-                fullWidth
                 autoComplete="off"
-                multiline
-                inputProps={{
-                  className: 'resize-y min-h-[22px]',
-                }}
+                className="min-h-10 resize-y"
               />
 
               <ArgumentsFormSection nestedField="webhooks" nestIndex={index} />
 
               <Button
+                type="button"
                 variant="ghost"
                 className="h-10 self-end text-destructive hover:text-destructive"
                 aria-label="Remove webhook data source"
@@ -110,14 +83,12 @@ export default function WebhooksDataSourcesFormSection() {
               >
                 <TrashIcon className="h-4 w-4" />
               </Button>
-            </Box>
+            </div>
 
-            {index < fields.length - 1 && (
-              <Divider className="h-px" sx={{ background: 'grey.200' }} />
-            )}
-          </Box>
+            {index < fields.length - 1 && <Separator className="h-px" />}
+          </div>
         ))}
-      </Box>
-    </Box>
+      </div>
+    </div>
   );
 }

--- a/dashboard/src/features/orgs/projects/ai/AssistantsList/AssistantsList.tsx
+++ b/dashboard/src/features/orgs/projects/ai/AssistantsList/AssistantsList.tsx
@@ -5,9 +5,7 @@ import {
   Trash2 as TrashIcon,
 } from 'lucide-react';
 import { useDialog } from '@/components/common/DialogProvider';
-import { Box } from '@/components/ui/v2/Box';
-import { IconButton } from '@/components/ui/v2/IconButton';
-import { Text } from '@/components/ui/v2/Text';
+import { Button } from '@/components/ui/v3/button';
 import {
   DropdownMenu,
   DropdownMenuContent,
@@ -18,9 +16,11 @@ import {
   AssistantForm,
   type AssistantFormInitialData,
 } from '@/features/orgs/projects/ai/AssistantForm';
+import type {
+  Assistant,
+  GraphiteFileStore,
+} from '@/features/orgs/projects/ai/assistants/types';
 import { DeleteAssistantModal } from '@/features/orgs/projects/ai/DeleteAssistantModal';
-import type { Assistant } from '@/pages/orgs/[orgSlug]/projects/[appSubdomain]/ai/assistants';
-import type { GraphiteFileStore } from '@/pages/orgs/[orgSlug]/projects/[appSubdomain]/ai/file-stores';
 import { copy } from '@/utils/copy';
 
 interface AssistantsListProps {
@@ -58,7 +58,7 @@ export default function AssistantsList({
 
   const viewAssistant = async (assistant: Assistant) => {
     openDrawer({
-      title: `Edit ${assistant?.name ?? 'unset'}`,
+      title: `Edit ${assistant.name ?? 'unset'}`,
       component: (
         <AssistantForm
           assistantId={assistant.assistantID}
@@ -83,58 +83,53 @@ export default function AssistantsList({
   };
 
   return (
-    <Box className="flex flex-col">
+    <div className="flex flex-col">
       {assistants.map((assistant) => (
-        <Box
+        <div
           key={assistant.assistantID}
-          className="flex h-[64px] w-full cursor-pointer items-center justify-between space-x-4 border-b-1 px-4 py-2 transition-colors"
-          sx={{
-            [`&:hover`]: {
-              backgroundColor: 'action.hover',
-            },
-          }}
+          className="flex h-16 w-full items-center justify-between gap-4 border-b-1 px-4 py-2 transition-colors hover:bg-accent"
         >
-          <Box
+          <button
+            type="button"
             onClick={() => viewAssistant(assistant)}
-            className="flex w-full flex-row justify-between"
-            sx={{ backgroundColor: 'transparent' }}
+            className="flex min-w-0 flex-1 cursor-pointer flex-row items-center gap-4 text-left"
           >
-            <div className="flex flex-1 flex-row items-center space-x-4">
-              <span className="text-3xl">🤖</span>
-              <div className="flex flex-col">
-                <Text variant="h4" className="font-semibold">
-                  {assistant?.name ?? 'unset'}
-                </Text>
-                <div className="hidden flex-row items-center space-x-2 md:flex">
-                  <Text variant="subtitle1" className="font-mono text-xs">
-                    {assistant.assistantID}
-                  </Text>
-                  <IconButton
-                    variant="borderless"
-                    color="secondary"
-                    onClick={(event) => {
-                      copy(assistant.assistantID, 'Assistant Id');
-                      event.stopPropagation();
-                    }}
-                    aria-label="Service Id"
-                  >
-                    <CopyIcon className="h-4 w-4" />
-                  </IconButton>
-                </div>
-              </div>
+            <span className="flex-shrink-0 text-3xl">🤖</span>
+            <div className="flex min-w-0 flex-col">
+              <span className="truncate font-semibold text-sm+">
+                {assistant.name ?? 'unset'}
+              </span>
+              <span className="hidden truncate font-mono text-muted-foreground text-xs md:inline">
+                {assistant.assistantID}
+              </span>
             </div>
-          </Box>
+          </button>
+
+          <Button
+            type="button"
+            variant="ghost"
+            size="icon"
+            onClick={(event) => {
+              copy(assistant.assistantID, 'Assistant Id');
+              event.stopPropagation();
+            }}
+            aria-label="Assistant Id"
+            className="hidden h-8 w-8 flex-shrink-0 md:inline-flex"
+          >
+            <CopyIcon className="h-4 w-4" />
+          </Button>
 
           <DropdownMenu>
             <DropdownMenuTrigger asChild>
-              <IconButton
-                variant="borderless"
-                color="secondary"
+              <Button
+                type="button"
+                variant="ghost"
+                size="icon"
                 aria-label="More options"
                 onClick={(event) => event.stopPropagation()}
               >
-                <DotsHorizontalIcon />
-              </IconButton>
+                <DotsHorizontalIcon className="h-4 w-4" />
+              </Button>
             </DropdownMenuTrigger>
             <DropdownMenuContent align="end" className="w-auto p-0">
               <DropdownMenuItem
@@ -142,19 +137,19 @@ export default function AssistantsList({
                 className="flex h-9 cursor-pointer items-center justify-start gap-2 rounded-none border border-b-1 p-2 font-medium text-sm+ leading-4 hover:bg-data-cell-bg"
               >
                 <EyeIcon className="h-4 w-4" />
-                <span>View {assistant?.name}</span>
+                <span>View {assistant.name}</span>
               </DropdownMenuItem>
               <DropdownMenuItem
                 className="!text-destructive flex h-9 cursor-pointer items-center justify-start gap-2 rounded-none border border-b-1 p-2 font-medium text-sm+ leading-4 hover:bg-data-cell-bg"
                 onClick={() => deleteAssistant(assistant)}
               >
                 <TrashIcon className="h-4 w-4" />
-                <span>Delete {assistant?.name}</span>
+                <span>Delete {assistant.name}</span>
               </DropdownMenuItem>
             </DropdownMenuContent>
           </DropdownMenu>
-        </Box>
+        </div>
       ))}
-    </Box>
+    </div>
   );
 }

--- a/dashboard/src/features/orgs/projects/ai/DeleteAssistantModal/DeleteAssistantModal.tsx
+++ b/dashboard/src/features/orgs/projects/ai/DeleteAssistantModal/DeleteAssistantModal.tsx
@@ -1,14 +1,11 @@
 import { useState } from 'react';
-import { twMerge } from 'tailwind-merge';
-import { Box } from '@/components/ui/v2/Box';
-import { Text } from '@/components/ui/v2/Text';
 import { Button, ButtonWithLoading } from '@/components/ui/v3/button';
 import { Checkbox } from '@/components/ui/v3/checkbox';
 import { Label } from '@/components/ui/v3/label';
 import { useRemoteApplicationGQLClient } from '@/features/orgs/hooks/useRemoteApplicationGQLClient';
+import type { Assistant } from '@/features/orgs/projects/ai/assistants/types';
 import { execPromiseWithErrorToast } from '@/features/orgs/utils/execPromiseWithErrorToast';
 import { useDeleteAssistantMutation } from '@/generated/graphite';
-import type { Assistant } from '@/pages/orgs/[orgSlug]/projects/[appSubdomain]/ai/assistants';
 
 export interface DeleteAssistantModalProps {
   assistant: Assistant;
@@ -43,46 +40,49 @@ export default function DeleteAssistantModal({
   async function handleClick() {
     setLoadingRemove(true);
 
-    await execPromiseWithErrorToast(deleteAssistant, {
-      loadingMessage: 'Deleting the assistant...',
-      successMessage: 'The Assistant has been deleted successfully.',
-      errorMessage:
-        'An error occurred while deleting the Assistant. Please try again.',
-    });
+    try {
+      await execPromiseWithErrorToast(deleteAssistant, {
+        loadingMessage: 'Deleting the assistant...',
+        successMessage: 'The Assistant has been deleted successfully.',
+        errorMessage:
+          'An error occurred while deleting the Assistant. Please try again.',
+      });
+    } finally {
+      setLoadingRemove(false);
+    }
   }
 
   return (
-    <Box className={twMerge('w-full rounded-lg p-6 text-left')}>
+    <div className="w-full rounded-lg p-6 text-left">
       <div className="grid grid-flow-row gap-1">
-        <Text variant="h3" component="h2">
-          Delete Assistant {assistant?.name}
-        </Text>
+        <h2 className="font-semibold text-lg">
+          Delete Assistant {assistant.name}
+        </h2>
 
-        <Text variant="subtitle2">
+        <p className="text-muted-foreground text-sm">
           Are you sure you want to delete this Assistant?
-        </Text>
+        </p>
 
-        <Text
-          variant="subtitle2"
-          className="font-bold"
-          sx={{ color: (theme) => `${theme.palette.error.main} !important` }}
-        >
+        <p className="font-bold text-destructive text-sm">
           This cannot be undone.
-        </Text>
+        </p>
 
-        <Box className="my-4">
+        <div className="my-4">
           <div className="flex items-center gap-2 py-2">
             <Checkbox
-              id="accept-1"
+              id="accept-delete-assistant"
               checked={remove}
               onCheckedChange={(checked) => setRemove(checked === true)}
               aria-label="Confirm Delete Assistant"
             />
-            <Label htmlFor="accept-1" className="cursor-pointer font-normal">
-              {`I'm sure I want to delete ${assistant?.name}`}
+            <Label
+              htmlFor="accept-delete-assistant"
+              className="cursor-pointer font-normal"
+            >
+              {`I'm sure I want to delete ${assistant.name}`}
             </Label>
           </div>
-        </Box>
+        </div>
 
         <div className="grid grid-flow-row gap-2">
           <ButtonWithLoading
@@ -99,6 +99,6 @@ export default function DeleteAssistantModal({
           </Button>
         </div>
       </div>
-    </Box>
+    </div>
   );
 }

--- a/dashboard/src/features/orgs/projects/ai/DeleteFileStoreModal/DeleteFileStoreModal.tsx
+++ b/dashboard/src/features/orgs/projects/ai/DeleteFileStoreModal/DeleteFileStoreModal.tsx
@@ -6,9 +6,9 @@ import { Button, ButtonWithLoading } from '@/components/ui/v3/button';
 import { Checkbox } from '@/components/ui/v3/checkbox';
 import { Label } from '@/components/ui/v3/label';
 import { useRemoteApplicationGQLClient } from '@/features/orgs/hooks/useRemoteApplicationGQLClient';
+import type { GraphiteFileStore } from '@/features/orgs/projects/ai/assistants/types';
 import { execPromiseWithErrorToast } from '@/features/orgs/utils/execPromiseWithErrorToast';
 import { useDeleteFileStoreMutation } from '@/generated/graphite';
-import type { GraphiteFileStore } from '@/pages/orgs/[orgSlug]/projects/[appSubdomain]/ai/file-stores';
 
 export interface DeleteFileStoreModalProps {
   fileStore: GraphiteFileStore;

--- a/dashboard/src/features/orgs/projects/ai/FileStoresList/FileStoresList.tsx
+++ b/dashboard/src/features/orgs/projects/ai/FileStoresList/FileStoresList.tsx
@@ -15,9 +15,9 @@ import {
   DropdownMenuTrigger,
 } from '@/components/ui/v3/dropdown-menu';
 import { FileStoresIcon } from '@/components/ui/v3/icons/FileStoresIcon';
+import type { GraphiteFileStore } from '@/features/orgs/projects/ai/assistants/types';
 import { DeleteFileStoreModal } from '@/features/orgs/projects/ai/DeleteFileStoreModal';
 import { FileStoreForm } from '@/features/orgs/projects/ai/FileStoreForm';
-import type { GraphiteFileStore } from '@/pages/orgs/[orgSlug]/projects/[appSubdomain]/ai/file-stores';
 import { copy } from '@/utils/copy';
 
 interface FileStoresListProps {

--- a/dashboard/src/features/orgs/projects/ai/assistants/types.ts
+++ b/dashboard/src/features/orgs/projects/ai/assistants/types.ts
@@ -1,0 +1,14 @@
+import type {
+  GetAssistantsQuery,
+  GetGraphiteFileStoresQuery,
+} from '@/generated/graphite';
+
+export type Assistant = Omit<
+  NonNullable<GetAssistantsQuery['graphite']>['assistants'][number],
+  '__typename'
+>;
+
+export type GraphiteFileStore = Omit<
+  NonNullable<GetGraphiteFileStoresQuery['graphite']>['fileStores'][number],
+  '__typename'
+>;

--- a/dashboard/src/pages/orgs/[orgSlug]/projects/[appSubdomain]/ai/assistants/index.tsx
+++ b/dashboard/src/pages/orgs/[orgSlug]/projects/[appSubdomain]/ai/assistants/index.tsx
@@ -5,9 +5,7 @@ import { useDialog } from '@/components/common/DialogProvider';
 import { UpgradeToProBanner } from '@/components/common/UpgradeToProBanner';
 import { Container } from '@/components/layout/Container';
 import { RetryableErrorBoundary } from '@/components/presentational/RetryableErrorBoundary';
-import { Alert } from '@/components/ui/v2/Alert';
-import { Box } from '@/components/ui/v2/Box';
-import { Text } from '@/components/ui/v2/Text';
+import { Alert } from '@/components/ui/v3/alert';
 import { Button } from '@/components/ui/v3/button';
 import { Spinner } from '@/components/ui/v3/spinner';
 import { useRemoteApplicationGQLClient } from '@/features/orgs/hooks/useRemoteApplicationGQLClient';
@@ -15,21 +13,19 @@ import { AISidebar } from '@/features/orgs/layout/AISidebar';
 import { OrgLayout } from '@/features/orgs/layout/OrgLayout';
 import { AssistantForm } from '@/features/orgs/projects/ai/AssistantForm';
 import { AssistantsList } from '@/features/orgs/projects/ai/AssistantsList';
+import type {
+  Assistant,
+  GraphiteFileStore,
+} from '@/features/orgs/projects/ai/assistants/types';
 import { useIsFileStoreSupported } from '@/features/orgs/projects/common/hooks/useIsFileStoreSupported';
 import { useIsGraphiteEnabled } from '@/features/orgs/projects/common/hooks/useIsGraphiteEnabled';
 import { useIsPlatform } from '@/features/orgs/projects/common/hooks/useIsPlatform';
 import { useCurrentOrg } from '@/features/orgs/projects/hooks/useCurrentOrg';
 import { useProject } from '@/features/orgs/projects/hooks/useProject';
 import {
-  type GetAssistantsQuery,
   useGetAssistantsQuery,
   useGetGraphiteFileStoresQuery,
 } from '@/generated/graphite';
-
-export type Assistant = Omit<
-  NonNullable<GetAssistantsQuery['graphite']>['assistants'][number],
-  '__typename'
->;
 
 export default function AssistantsPage() {
   const { openDrawer } = useDialog();
@@ -45,6 +41,8 @@ export default function AssistantsPage() {
   const { isFileStoreSupported, loading: fileStoreLoading } =
     useIsFileStoreSupported();
 
+  const isProjectReady = !isPlatform || !!project;
+
   const {
     data: assistantsData,
     loading: assistantsLoading,
@@ -55,18 +53,22 @@ export default function AssistantsPage() {
     variables: {
       isFileStoresSupported: isFileStoreSupported ?? false,
     },
-    skip: isFileStoreSupported === null || fileStoreLoading,
+    skip: !isProjectReady || isFileStoreSupported === null || fileStoreLoading,
   });
-  const { data: fileStoresData, error: fileStoresError } =
-    useGetGraphiteFileStoresQuery({
-      client: remoteProjectGQLClient,
-    });
+  const {
+    data: fileStoresData,
+    loading: fileStoresLoading,
+    error: fileStoresError,
+  } = useGetGraphiteFileStoresQuery({
+    client: remoteProjectGQLClient,
+    skip: !isProjectReady || !isFileStoreSupported,
+  });
 
-  const assistants = useMemo(
+  const assistants = useMemo<Assistant[]>(
     () => assistantsData?.graphite?.assistants || [],
     [assistantsData],
   );
-  const fileStores = useMemo(
+  const fileStores = useMemo<GraphiteFileStore[]>(
     () => fileStoresData?.graphite?.fileStores || [],
     [fileStoresData],
   );
@@ -83,13 +85,22 @@ export default function AssistantsPage() {
     });
   };
 
-  if (loadingOrg || loadingProject || loadingGraphite || assistantsLoading) {
+  const isPageDataLoading =
+    loadingOrg ||
+    loadingProject ||
+    loadingGraphite ||
+    fileStoreLoading ||
+    assistantsLoading ||
+    fileStoresLoading;
+  const shouldShowLoadingState = isPageDataLoading || !isProjectReady;
+
+  if (shouldShowLoadingState) {
     return (
-      <Box className="flex h-full w-full items-center justify-center">
+      <div className="flex h-full w-full items-center justify-center">
         <Spinner size="medium" wrapperClassName="gap-2">
           Loading Assistants...
         </Spinner>
-      </Box>
+      </div>
     );
   }
 
@@ -107,32 +118,26 @@ export default function AssistantsPage() {
     );
   }
   const slug = isPlatform ? org?.slug : 'local';
+  const aiServiceUnavailable =
+    isPlatform && !org?.plan?.isFree && !project?.config?.ai;
 
-  if (
-    (isPlatform && !org?.plan?.isFree && !project?.config?.ai) ||
-    !isGraphiteEnabled
-  ) {
+  if (aiServiceUnavailable || !isGraphiteEnabled) {
     return (
-      <Box
-        className="w-full p-4"
-        sx={{ backgroundColor: 'background.default' }}
-      >
+      <div className="w-full bg-background p-4">
         <Alert className="grid w-full grid-flow-col place-content-between items-center gap-2">
-          <Text className="grid grid-flow-row justify-items-start gap-0.5">
-            <Text component="span">
-              To enable graphite, configure the service first in{' '}
-              <Link
-                href={`/orgs/${slug}/projects/${project?.subdomain}/settings/ai`}
-                rel="noopener noreferrer"
-                className="text-primary hover:underline"
-              >
-                AI Settings
-              </Link>
-              .
-            </Text>
-          </Text>
+          <p>
+            To enable graphite, configure the service first in{' '}
+            <Link
+              href={`/orgs/${slug}/projects/${project?.subdomain}/settings/ai`}
+              rel="noopener noreferrer"
+              className="text-primary hover:underline"
+            >
+              AI Settings
+            </Link>
+            .
+          </p>
         </Alert>
-      </Box>
+      </div>
     );
   }
 
@@ -142,19 +147,16 @@ export default function AssistantsPage() {
 
   if (assistants.length === 0 && !assistantsLoading) {
     return (
-      <Box
-        className="w-full p-6"
-        sx={{ backgroundColor: 'background.default' }}
-      >
-        <Box className="flex flex-col items-center justify-center space-y-5 rounded-lg border px-48 py-12 shadow-sm">
+      <div className="w-full bg-background p-6">
+        <div className="flex flex-col items-center justify-center space-y-5 rounded-lg border px-48 py-12 shadow-sm">
           <span className="text-6xl">🤖</span>
           <div className="flex flex-col space-y-1">
-            <Text className="text-center font-medium" variant="h3">
+            <h2 className="text-center font-medium text-lg">
               No Assistants are configured
-            </Text>
-            <Text variant="subtitle1" className="text-center">
+            </h2>
+            <p className="text-center text-muted-foreground text-sm">
               All your assistants will be listed here.
-            </Text>
+            </p>
           </div>
           <div className="flex flex-row place-content-between rounded-lg">
             <Button className="w-full" onClick={openCreateAssistantForm}>
@@ -162,19 +164,19 @@ export default function AssistantsPage() {
               Create a new assistant
             </Button>
           </div>
-        </Box>
-      </Box>
+        </div>
+      </div>
     );
   }
 
   return (
-    <Box className="flex w-full flex-col overflow-hidden">
-      <Box className="flex flex-row place-content-end border-b-1 p-4">
+    <div className="flex w-full flex-col overflow-hidden">
+      <div className="flex flex-row place-content-end border-b-1 p-4">
         <Button onClick={openCreateAssistantForm}>
           <PlusIcon className="mr-2 h-4 w-4" />
           New
         </Button>
-      </Box>
+      </div>
       <div>
         <AssistantsList
           assistants={assistants}
@@ -183,7 +185,7 @@ export default function AssistantsPage() {
           onCreateOrUpdate={() => assistantsRefetch()}
         />
       </div>
-    </Box>
+    </div>
   );
 }
 

--- a/dashboard/src/pages/orgs/[orgSlug]/projects/[appSubdomain]/ai/file-stores/index.tsx
+++ b/dashboard/src/pages/orgs/[orgSlug]/projects/[appSubdomain]/ai/file-stores/index.tsx
@@ -20,15 +20,7 @@ import { useIsGraphiteEnabled } from '@/features/orgs/projects/common/hooks/useI
 import { useIsPlatform } from '@/features/orgs/projects/common/hooks/useIsPlatform';
 import { useCurrentOrg } from '@/features/orgs/projects/hooks/useCurrentOrg';
 import { useProject } from '@/features/orgs/projects/hooks/useProject';
-import {
-  type GetGraphiteFileStoresQuery,
-  useGetGraphiteFileStoresQuery,
-} from '@/generated/graphite';
-
-export type GraphiteFileStore = Omit<
-  NonNullable<GetGraphiteFileStoresQuery['graphite']>['fileStores'][number],
-  '__typename'
->;
+import { useGetGraphiteFileStoresQuery } from '@/generated/graphite';
 
 export default function FileStoresPage() {
   const { openDrawer } = useDialog();


### PR DESCRIPTION
### Checklist

- [x] No breaking changes
- [x] Tests pass
- [ ] New features have new tests
- [ ] Documentation is updated (if applicable)
- [x] Title of the PR is in the correct format (see below)

<!-- pi-reviewer:start -->
### **What this change solves**
Migrates the dashboard AI assistants UI from legacy v2 form and layout primitives to the current form/v3 component patterns. This keeps assistant creation, editing, listing, and deletion flows aligned with the dashboard component system while preserving existing behavior.

___

### **Change Type**
Refactoring

___

### **Description**
- Replaces legacy v2 inputs, text, tooltips, boxes, switches, and icon buttons in AI assistant forms with shared form wrappers, v3 buttons, Tailwind markup, and `InfoTooltip`.
- Updates nested assistant argument, GraphQL data source, and webhook data source controls to use `react-hook-form` controlled components consistently.
- Moves shared `GraphiteFileStore` typing into the AI assistants feature area and refreshes the assistants list/delete/page UI to v3 components.

___

<details> <summary><h3> File Walkthrough</h3></summary>

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody>
<tr><td><strong>Assistant form</strong></td><td><details><summary>4 files</summary><table>
<tr>
  <td><strong>dashboard/src/features/orgs/projects/ai/AssistantForm/AssistantForm.tsx</strong><dd><code>Migrate core assistant form fields, labels, tooltips, and footer actions to shared form inputs, textareas, v3 button, and Tailwind layout.</code></dd></td>
  <td>+47/-94</td>
</tr>
<tr>
  <td><strong>dashboard/src/features/orgs/projects/ai/AssistantForm/components/ArgumentsFormSection/ArgumentsFormSection.tsx</strong><dd><code>Convert nested argument controls to form input/select/textarea/switch wrappers and shared tooltip styling.</code></dd></td>
  <td>+75/-106</td>
</tr>
<tr>
  <td><strong>dashboard/src/features/orgs/projects/ai/AssistantForm/components/GraphqlDataSourcesFormSection/GraphqlDataSourcesFormSection.tsx</strong><dd><code>Update GraphQL data source controls to v3 form components, native labels, and icon button props.</code></dd></td>
  <td>+39/-65</td>
</tr>
<tr>
  <td><strong>dashboard/src/features/orgs/projects/ai/AssistantForm/components/WebhooksDataSourcesFormSection/WebhooksDataSourcesFormSection.tsx</strong><dd><code>Update webhook data source controls to v3 form components, native labels, and icon button props.</code></dd></td>
  <td>+36/-65</td>
</tr>
</table></details></td></tr>
<tr><td><strong>Assistant list and modals</strong></td><td><details><summary>3 files</summary><table>
<tr>
  <td><strong>dashboard/src/features/orgs/projects/ai/AssistantsList/AssistantsList.tsx</strong><dd><code>Replace legacy list empty states, typography, links, and buttons with current card, button, skeleton, and icon patterns.</code></dd></td>
  <td>+45/-50</td>
</tr>
<tr>
  <td><strong>dashboard/src/features/orgs/projects/ai/DeleteAssistantModal/DeleteAssistantModal.tsx</strong><dd><code>Migrate the delete confirmation dialog layout and actions to Tailwind markup and v3 button variants.</code></dd></td>
  <td>+28/-28</td>
</tr>
<tr>
  <td><strong>dashboard/src/pages/orgs/[orgSlug]/projects/[appSubdomain]/ai/assistants/index.tsx</strong><dd><code>Refresh the AI assistants page header, loading state, tabs, and create button to current dashboard UI components.</code></dd></td>
  <td>+37/-50</td>
</tr>
</table></details></td></tr>
<tr><td><strong>Shared assistant types</strong></td><td><details><summary>1 file</summary><table>
<tr>
  <td><strong>dashboard/src/features/orgs/projects/ai/assistants/types.ts</strong><dd><code>Add a feature-local Graphite file store type for assistant form and list usage.</code></dd></td>
  <td>+14/-0</td>
</tr>
</table></details></td></tr>
</tbody></table>

</details>

___

<!-- pi-reviewer:end -->
