### PR TITLE
fix(dashboard): migrate AI auto-embeddings page

### DIFF
--- a/dashboard/e2e/ai/auto-embeddings.test.ts
+++ b/dashboard/e2e/ai/auto-embeddings.test.ts
@@ -17,21 +17,35 @@ test.beforeEach(async ({ authenticatedNhostPage: page }) => {
 test('should create and delete an Auto-Embeddings', async ({
   authenticatedNhostPage: page,
 }) => {
-  await page.getByRole('button', { name: 'Add a new Auto-Embeddings' }).click();
+  await page
+    .getByRole('button', {
+      name: 'Add a new Auto-Embeddings Configuration',
+      exact: true,
+    })
+    .click();
 
-  await page.getByLabel('Name').fill('test');
-  await page.getByLabel('Schema').fill('auth');
-  await page.getByLabel('Table').fill('users');
-  await page.getByLabel('Column').fill('email');
+  await page.getByLabel('Name', { exact: true }).fill('test');
+  await page.getByLabel('Table schema', { exact: true }).fill('auth');
+  await page.getByLabel('Table', { exact: true }).fill('users');
+  await page.getByLabel('Column', { exact: true }).fill('email');
 
-  await page.getByRole('button', { name: 'Create' }).click();
-  await expect(page.getByRole('heading', { name: /test/i })).toBeVisible();
+  await page.getByRole('button', { name: 'Create', exact: true }).click();
+  await expect(page.getByText('test', { exact: true })).toBeVisible();
 
   await page.getByLabel(/more options/i).click();
   await page.getByRole('menuitem', { name: /delete test/i }).click();
 
-  await page.getByLabel('Confirm Delete Auto-').check();
-  await page.getByRole('button', { name: 'Delete Auto-Embeddings' }).click();
+  await page
+    .getByLabel('Confirm Delete Auto-Embeddings Configuration', {
+      exact: true,
+    })
+    .check();
+  await page
+    .getByRole('button', {
+      name: 'Delete Auto-Embeddings Configuration',
+      exact: true,
+    })
+    .click();
   await expect(
     page.getByRole('heading', { name: /No Auto-Embeddings are configured/i }),
   ).toBeVisible();

--- a/dashboard/src/features/orgs/projects/ai/AutoEmbeddingsForm/AutoEmbeddingsForm.tsx
+++ b/dashboard/src/features/orgs/projects/ai/AutoEmbeddingsForm/AutoEmbeddingsForm.tsx
@@ -1,15 +1,13 @@
 import { yupResolver } from '@hookform/resolvers/yup';
-import { InfoIcon, PlusIcon, RefreshCwIcon } from 'lucide-react';
+import { PlusIcon, RefreshCwIcon } from 'lucide-react';
 import { useEffect } from 'react';
 import { FormProvider, useForm } from 'react-hook-form';
 import * as Yup from 'yup';
 import { useDialog } from '@/components/common/DialogProvider';
 import { Form } from '@/components/form/Form';
+import { FormInput } from '@/components/form/FormInput';
 import { FormSelect } from '@/components/form/FormSelect';
-import { Box } from '@/components/ui/v2/Box';
-import { Input } from '@/components/ui/v2/Input';
-import { Text } from '@/components/ui/v2/Text';
-import { Tooltip } from '@/components/ui/v2/Tooltip';
+import { FormTextarea } from '@/components/form/FormTextarea';
 import { Button } from '@/components/ui/v3/button';
 import { SelectItem } from '@/components/ui/v3/select';
 import { useRemoteApplicationGQLClient } from '@/features/orgs/hooks/useRemoteApplicationGQLClient';
@@ -94,8 +92,7 @@ export default function AutoEmbeddingsForm({
   });
 
   const {
-    register,
-    formState: { errors, isSubmitting, dirtyFields },
+    formState: { isSubmitting, dirtyFields },
   } = form;
 
   const isDirty = Object.keys(dirtyFields).length > 0;
@@ -148,25 +145,11 @@ export default function AutoEmbeddingsForm({
         className="flex h-full flex-col gap-4 overflow-hidden"
       >
         <div className="flex flex-1 flex-col space-y-6 overflow-auto px-6">
-          <Input
-            {...register('name')}
-            id="name"
-            label={
-              <Box className="flex flex-row items-center space-x-2">
-                <Text>Name</Text>
-                <Tooltip title="Name of the Auto-Embeddings">
-                  <InfoIcon
-                    aria-label="Info"
-                    className="h-4 w-4 text-primary"
-                  />
-                </Tooltip>
-              </Box>
-            }
+          <FormInput
+            control={form.control}
+            name="name"
+            label="Name"
             placeholder=""
-            hideEmptyHelperText
-            error={!!errors.name}
-            helperText={errors?.name?.message}
-            fullWidth
             autoComplete="off"
             autoFocus
           />
@@ -174,17 +157,7 @@ export default function AutoEmbeddingsForm({
           <FormSelect
             control={form.control}
             name="model"
-            label={
-              <Box className="flex flex-row items-center space-x-2">
-                <Text>Model</Text>
-                <Tooltip title="Auto-Embeddings Model">
-                  <InfoIcon
-                    aria-label="Info"
-                    className="h-4 w-4 text-primary"
-                  />
-                </Tooltip>
-              </Box>
-            }
+            label="Model"
             contentClassName="z-[10000]"
           >
             {AUTO_EMBEDDINGS_MODELS.map((model) => (
@@ -194,118 +167,50 @@ export default function AutoEmbeddingsForm({
             ))}
           </FormSelect>
 
-          <Input
-            {...register('schemaName')}
-            id="schemaName"
-            label={
-              <Box className="flex flex-row items-center space-x-2">
-                <Text>Schema</Text>
-                <Tooltip title={<span>Schema where the table belongs to</span>}>
-                  <InfoIcon
-                    aria-label="Info"
-                    className="h-4 w-4 text-primary"
-                  />
-                </Tooltip>
-              </Box>
-            }
+          <FormInput
+            control={form.control}
+            name="schemaName"
+            label="Table schema"
             placeholder=""
-            hideEmptyHelperText
-            error={!!errors.schemaName}
-            helperText={errors?.schemaName?.message}
-            fullWidth
             autoComplete="off"
           />
-          <Input
-            {...register('tableName')}
-            id="tableName"
-            label={
-              <Box className="flex flex-row items-center space-x-2">
-                <Text>Table</Text>
-                <Tooltip title="Table Name">
-                  <InfoIcon
-                    aria-label="Info"
-                    className="h-4 w-4 text-primary"
-                  />
-                </Tooltip>
-              </Box>
-            }
+
+          <FormInput
+            control={form.control}
+            name="tableName"
+            label="Table"
             placeholder=""
-            hideEmptyHelperText
-            error={!!errors.tableName}
-            helperText={errors?.tableName?.message}
-            fullWidth
             autoComplete="off"
           />
-          <Input
-            {...register('columnName')}
-            id="columnName"
-            label={
-              <Box className="flex flex-row items-center space-x-2">
-                <Text>Column</Text>
-                <Tooltip title="Column name">
-                  <InfoIcon
-                    aria-label="Info"
-                    className="h-4 w-4 text-primary"
-                  />
-                </Tooltip>
-              </Box>
-            }
+
+          <FormInput
+            control={form.control}
+            name="columnName"
+            label="Column"
             placeholder=""
-            hideEmptyHelperText
-            error={!!errors.columnName}
-            helperText={errors?.columnName?.message}
-            fullWidth
             autoComplete="off"
           />
-          <Input
-            {...register('query')}
-            id="query"
-            label={
-              <Box className="flex flex-row items-center space-x-2">
-                <Text>Query</Text>
-                <Tooltip title="Query">
-                  <InfoIcon
-                    aria-label="Info"
-                    className="h-4 w-4 text-primary"
-                  />
-                </Tooltip>
-              </Box>
-            }
+
+          <FormTextarea
+            control={form.control}
+            name="query"
+            label="Query"
             placeholder=""
-            hideEmptyHelperText
-            error={!!errors.query}
-            helperText={errors?.query?.message}
-            fullWidth
             autoComplete="off"
-            multiline
-            rows={6}
+            className="min-h-32 resize-y"
           />
-          <Input
-            {...register('mutation')}
-            id="mutation"
-            label={
-              <Box className="flex flex-row items-center space-x-2">
-                <Text>Mutation</Text>
-                <Tooltip title="Mutation">
-                  <InfoIcon
-                    aria-label="Info"
-                    className="h-4 w-4 text-primary"
-                  />
-                </Tooltip>
-              </Box>
-            }
+
+          <FormTextarea
+            control={form.control}
+            name="mutation"
+            label="Mutation"
             placeholder=""
-            hideEmptyHelperText
-            error={!!errors.mutation}
-            helperText={errors?.mutation?.message}
-            fullWidth
             autoComplete="off"
-            multiline
-            rows={6}
+            className="min-h-32 resize-y"
           />
         </div>
 
-        <Box className="flex w-full flex-row justify-between rounded border-t px-6 py-4">
+        <div className="flex w-full flex-row justify-between rounded border-t px-6 py-4">
           <Button variant="outline" onClick={onCancel}>
             Cancel
           </Button>
@@ -317,7 +222,7 @@ export default function AutoEmbeddingsForm({
             )}
             {autoEmbeddingsId ? 'Update' : 'Create'}
           </Button>
-        </Box>
+        </div>
       </Form>
     </FormProvider>
   );

--- a/dashboard/src/features/orgs/projects/ai/AutoEmbeddingsList/AutoEmbeddingsList.tsx
+++ b/dashboard/src/features/orgs/projects/ai/AutoEmbeddingsList/AutoEmbeddingsList.tsx
@@ -6,10 +6,7 @@ import {
   Trash2 as TrashIcon,
 } from 'lucide-react';
 import { useDialog } from '@/components/common/DialogProvider';
-import { Box } from '@/components/ui/v2/Box';
-import { IconButton } from '@/components/ui/v2/IconButton';
-import { Text } from '@/components/ui/v2/Text';
-import { Tooltip } from '@/components/ui/v2/Tooltip';
+import { Button } from '@/components/ui/v3/button';
 import {
   DropdownMenu,
   DropdownMenuContent,
@@ -18,11 +15,16 @@ import {
 } from '@/components/ui/v3/dropdown-menu';
 import { EmbeddingsIcon } from '@/components/ui/v3/icons/EmbeddingsIcon';
 import {
+  Tooltip,
+  TooltipContent,
+  TooltipTrigger,
+} from '@/components/ui/v3/tooltip';
+import {
   AutoEmbeddingsForm,
   type AutoEmbeddingsInitialData,
 } from '@/features/orgs/projects/ai/AutoEmbeddingsForm';
+import type { AutoEmbeddingsConfiguration } from '@/features/orgs/projects/ai/auto-embeddings/types';
 import { DeleteAutoEmbeddingsModal } from '@/features/orgs/projects/ai/DeleteAutoEmbeddingsModal';
-import type { AutoEmbeddingsConfiguration } from '@/pages/orgs/[orgSlug]/projects/[appSubdomain]/ai/auto-embeddings';
 
 interface AutoEmbeddingsConfigurationsListProps {
   /**
@@ -54,10 +56,10 @@ export default function AutoEmbeddingsList({
   ) => {
     openDrawer({
       title: (
-        <Box className="flex flex-row items-center space-x-2">
+        <div className="flex flex-row items-center space-x-2">
           <BoxIcon className="h-5 w-5" />
-          <Text>Edit {autoEmbeddingsConfiguration?.name ?? 'unset'}</Text>
-        </Box>
+          <span>Edit {autoEmbeddingsConfiguration.name ?? 'unset'}</span>
+        </div>
       ),
       component: (
         <AutoEmbeddingsForm
@@ -84,55 +86,45 @@ export default function AutoEmbeddingsList({
   };
 
   return (
-    <Box className="flex flex-col">
+    <div className="flex flex-col">
       {autoEmbeddingsConfigurations.map((autoEmbeddingsConfiguration) => (
-        <Box
+        <div
           key={autoEmbeddingsConfiguration.id}
-          className="flex h-[64px] w-full cursor-pointer items-center justify-between space-x-4 border-b-1 px-4 py-2 transition-colors"
-          sx={{
-            [`&:hover`]: {
-              backgroundColor: 'action.hover',
-            },
-          }}
+          className="flex h-16 w-full items-center justify-between gap-4 border-b-1 px-4 py-2"
         >
-          <Box
-            onClick={() =>
-              viewAutoEmbeddingsConfiguration(autoEmbeddingsConfiguration)
-            }
-            className="flex w-full flex-row justify-between"
-            sx={{
-              backgroundColor: 'transparent',
-            }}
-          >
-            <div className="flex flex-1 flex-row items-center space-x-4">
-              <EmbeddingsIcon className="h-5 w-5" />
-              <div className="flex flex-col">
-                <Text variant="h4" className="font-semibold">
-                  {autoEmbeddingsConfiguration?.name ?? 'unset'}
-                </Text>
-                <Tooltip title={autoEmbeddingsConfiguration.updatedAt}>
-                  <span className="xs+:flex hidden cursor-pointer text-slate-500 text-sm">
+          <div className="flex min-w-0 flex-1 flex-row items-center gap-4">
+            <EmbeddingsIcon className="h-5 w-5 flex-shrink-0" />
+            <div className="flex min-w-0 flex-col">
+              <span className="truncate font-semibold text-sm+">
+                {autoEmbeddingsConfiguration.name ?? 'unset'}
+              </span>
+              <Tooltip>
+                <TooltipTrigger asChild>
+                  <span className="xs+:inline hidden truncate text-muted-foreground text-sm">
                     Updated{' '}
                     {formatDistanceToNow(
                       new Date(autoEmbeddingsConfiguration.updatedAt),
                     )}{' '}
                     ago
                   </span>
-                </Tooltip>
-              </div>
+                </TooltipTrigger>
+                <TooltipContent>
+                  {autoEmbeddingsConfiguration.updatedAt}
+                </TooltipContent>
+              </Tooltip>
             </div>
-          </Box>
+          </div>
 
           <DropdownMenu>
             <DropdownMenuTrigger asChild>
-              <IconButton
-                variant="borderless"
-                color="secondary"
+              <Button
+                type="button"
+                variant="ghost"
+                size="icon"
                 aria-label="More options"
-                onClick={(event) => event.stopPropagation()}
               >
-                <DotsHorizontalIcon />
-              </IconButton>
+                <DotsHorizontalIcon className="h-4 w-4" />
+              </Button>
             </DropdownMenuTrigger>
             <DropdownMenuContent align="end" className="w-auto p-0">
               <DropdownMenuItem
@@ -142,7 +134,7 @@ export default function AutoEmbeddingsList({
                 className="flex h-9 cursor-pointer items-center justify-start gap-2 rounded-none border border-b-1 p-2 font-medium text-sm+ leading-4 hover:bg-data-cell-bg"
               >
                 <EyeIcon className="h-4 w-4" />
-                <span>View {autoEmbeddingsConfiguration?.name}</span>
+                <span>View {autoEmbeddingsConfiguration.name}</span>
               </DropdownMenuItem>
               <DropdownMenuItem
                 className="!text-destructive flex h-9 cursor-pointer items-center justify-start gap-2 rounded-none border border-b-1 p-2 font-medium text-sm+ leading-4 hover:bg-data-cell-bg"
@@ -151,12 +143,12 @@ export default function AutoEmbeddingsList({
                 }
               >
                 <TrashIcon className="h-4 w-4" />
-                <span>Delete {autoEmbeddingsConfiguration?.name}</span>
+                <span>Delete {autoEmbeddingsConfiguration.name}</span>
               </DropdownMenuItem>
             </DropdownMenuContent>
           </DropdownMenu>
-        </Box>
+        </div>
       ))}
-    </Box>
+    </div>
   );
 }

--- a/dashboard/src/features/orgs/projects/ai/DeleteAutoEmbeddingsModal/DeleteAutoEmbeddingsModal.tsx
+++ b/dashboard/src/features/orgs/projects/ai/DeleteAutoEmbeddingsModal/DeleteAutoEmbeddingsModal.tsx
@@ -1,17 +1,14 @@
 import { ApolloClient, HttpLink, InMemoryCache } from '@apollo/client';
 import { useMemo, useState } from 'react';
-import { twMerge } from 'tailwind-merge';
-import { Box } from '@/components/ui/v2/Box';
-import { Text } from '@/components/ui/v2/Text';
 import { Button, ButtonWithLoading } from '@/components/ui/v3/button';
 import { Checkbox } from '@/components/ui/v3/checkbox';
 import { Label } from '@/components/ui/v3/label';
+import type { AutoEmbeddingsConfiguration } from '@/features/orgs/projects/ai/auto-embeddings/types';
 import { generateAppServiceUrl } from '@/features/orgs/projects/common/utils/generateAppServiceUrl';
 import { useProject } from '@/features/orgs/projects/hooks/useProject';
 import { execPromiseWithErrorToast } from '@/features/orgs/utils/execPromiseWithErrorToast';
 import { useDeleteGraphiteAutoEmbeddingsConfigurationMutation } from '@/generated/graphite';
 import { isNotEmptyValue } from '@/lib/utils';
-import type { AutoEmbeddingsConfiguration } from '@/pages/orgs/[orgSlug]/projects/[appSubdomain]/ai/auto-embeddings';
 
 export interface DeleteAutoEmbeddingsModalProps {
   autoEmbeddingsConfiguration: AutoEmbeddingsConfiguration;
@@ -76,48 +73,51 @@ export default function DeleteAutoEmbeddingsModal({
   async function handleClick() {
     setLoadingRemove(true);
 
-    await execPromiseWithErrorToast(deleteAutoEmbeddingsConfig, {
-      loadingMessage: 'Deleting Auto-Embeddings Configuration...',
-      successMessage:
-        'The Auto-Embeddings Configuration has been deleted successfully.',
-      errorMessage:
-        'An error occurred while deleting the Auto-Embeddings Configuration. Please try again.',
-    });
+    try {
+      await execPromiseWithErrorToast(deleteAutoEmbeddingsConfig, {
+        loadingMessage: 'Deleting Auto-Embeddings Configuration...',
+        successMessage:
+          'The Auto-Embeddings Configuration has been deleted successfully.',
+        errorMessage:
+          'An error occurred while deleting the Auto-Embeddings Configuration. Please try again.',
+      });
+    } finally {
+      setLoadingRemove(false);
+    }
   }
 
   return (
-    <Box className={twMerge('w-full rounded-lg p-6 text-left')}>
+    <div className="w-full rounded-lg p-6 text-left">
       <div className="grid grid-flow-row gap-1">
-        <Text variant="h3" component="h2">
+        <h2 className="font-semibold text-lg">
           Delete Auto-Embeddings Configuration{' '}
-          {autoEmbeddingsConfiguration?.name}
-        </Text>
+          {autoEmbeddingsConfiguration.name}
+        </h2>
 
-        <Text variant="subtitle2">
+        <p className="text-muted-foreground text-sm">
           Are you sure you want to delete this Auto-Embeddings Configuration?
-        </Text>
+        </p>
 
-        <Text
-          variant="subtitle2"
-          className="font-bold"
-          sx={{ color: (theme) => `${theme.palette.error.main} !important` }}
-        >
+        <p className="font-bold text-destructive text-sm">
           This cannot be undone.
-        </Text>
+        </p>
 
-        <Box className="my-4">
+        <div className="my-4">
           <div className="flex items-center gap-2 py-2">
             <Checkbox
-              id="accept-1"
+              id="accept-delete-auto-embeddings"
               checked={remove}
               onCheckedChange={(checked) => setRemove(checked === true)}
               aria-label="Confirm Delete Auto-Embeddings Configuration"
             />
-            <Label htmlFor="accept-1" className="cursor-pointer font-normal">
-              {`I'm sure I want to delete ${autoEmbeddingsConfiguration?.name}`}
+            <Label
+              htmlFor="accept-delete-auto-embeddings"
+              className="cursor-pointer font-normal"
+            >
+              {`I'm sure I want to delete ${autoEmbeddingsConfiguration.name}`}
             </Label>
           </div>
-        </Box>
+        </div>
 
         <div className="grid grid-flow-row gap-2">
           <ButtonWithLoading
@@ -134,6 +134,6 @@ export default function DeleteAutoEmbeddingsModal({
           </Button>
         </div>
       </div>
-    </Box>
+    </div>
   );
 }

--- a/dashboard/src/features/orgs/projects/ai/auto-embeddings/types.ts
+++ b/dashboard/src/features/orgs/projects/ai/auto-embeddings/types.ts
@@ -1,0 +1,6 @@
+import type { GetGraphiteAutoEmbeddingsConfigurationsQuery } from '@/generated/graphite';
+
+export type AutoEmbeddingsConfiguration = Omit<
+  GetGraphiteAutoEmbeddingsConfigurationsQuery['graphiteAutoEmbeddingsConfigurations'][0],
+  '__typename'
+>;

--- a/dashboard/src/pages/orgs/[orgSlug]/projects/[appSubdomain]/ai/auto-embeddings/index.tsx
+++ b/dashboard/src/pages/orgs/[orgSlug]/projects/[appSubdomain]/ai/auto-embeddings/index.tsx
@@ -7,30 +7,22 @@ import { Pagination } from '@/components/common/Pagination';
 import { UpgradeToProBanner } from '@/components/common/UpgradeToProBanner';
 import { Container } from '@/components/layout/Container';
 import { RetryableErrorBoundary } from '@/components/presentational/RetryableErrorBoundary';
-import { Alert } from '@/components/ui/v2/Alert';
-import { Box } from '@/components/ui/v2/Box';
-import { Text } from '@/components/ui/v2/Text';
+import { Alert } from '@/components/ui/v3/alert';
 import { Button } from '@/components/ui/v3/button';
 import { EmbeddingsIcon } from '@/components/ui/v3/icons/EmbeddingsIcon';
+import { Spinner } from '@/components/ui/v3/spinner';
 import { useRemoteApplicationGQLClient } from '@/features/orgs/hooks/useRemoteApplicationGQLClient';
 import { AISidebar } from '@/features/orgs/layout/AISidebar';
 import { OrgLayout } from '@/features/orgs/layout/OrgLayout';
 import { AutoEmbeddingsForm } from '@/features/orgs/projects/ai/AutoEmbeddingsForm';
 import { AutoEmbeddingsList } from '@/features/orgs/projects/ai/AutoEmbeddingsList';
+import type { AutoEmbeddingsConfiguration } from '@/features/orgs/projects/ai/auto-embeddings/types';
 import { useIsGraphiteEnabled } from '@/features/orgs/projects/common/hooks/useIsGraphiteEnabled';
 import { useIsPlatform } from '@/features/orgs/projects/common/hooks/useIsPlatform';
 import { useCurrentOrg } from '@/features/orgs/projects/hooks/useCurrentOrg';
 import { useProject } from '@/features/orgs/projects/hooks/useProject';
-import {
-  type GetGraphiteAutoEmbeddingsConfigurationsQuery,
-  useGetGraphiteAutoEmbeddingsConfigurationsQuery,
-} from '@/generated/graphite';
+import { useGetGraphiteAutoEmbeddingsConfigurationsQuery } from '@/generated/graphite';
 import { getPaginationOffset } from '@/utils/getPaginationOffset';
-
-export type AutoEmbeddingsConfiguration = Omit<
-  GetGraphiteAutoEmbeddingsConfigurationsQuery['graphiteAutoEmbeddingsConfigurations'][0],
-  '__typename'
->;
 
 export default function AutoEmbeddingsPage() {
   const limit = useRef(25);
@@ -39,11 +31,14 @@ export default function AutoEmbeddingsPage() {
   const { openDrawer } = useDialog();
   const isPlatform = useIsPlatform();
 
-  const { org } = useCurrentOrg();
-  const { project } = useProject();
+  const { org, loading: loadingOrg } = useCurrentOrg();
+  const { project, loading: loadingProject } = useProject();
 
   const remoteProjectGQLClient = useRemoteApplicationGQLClient();
-  const { isGraphiteEnabled } = useIsGraphiteEnabled();
+  const { isGraphiteEnabled, loading: loadingGraphite } =
+    useIsGraphiteEnabled();
+
+  const isProjectReady = !isPlatform || !!project;
 
   const [currentPage, setCurrentPage] = useState(
     parseInt(router.query.page as string, 10) || 1,
@@ -61,10 +56,11 @@ export default function AutoEmbeddingsPage() {
         limit: limit.current,
         offset,
       },
+      skip: !isProjectReady,
     });
 
   useEffect(() => {
-    if (loading) {
+    if (loading || !isProjectReady) {
       return;
     }
 
@@ -72,9 +68,9 @@ export default function AutoEmbeddingsPage() {
       data?.graphiteAutoEmbeddingsConfigurationAggregate?.aggregate?.count ?? 0;
 
     setNrOfPages(Math.ceil(autoEmbeddingsCount / limit.current));
-  }, [data, loading]);
+  }, [data, isProjectReady, loading]);
 
-  const autoEmbeddingsConfigurations = useMemo(
+  const autoEmbeddingsConfigurations = useMemo<AutoEmbeddingsConfiguration[]>(
     () => data?.graphiteAutoEmbeddingsConfigurations || [],
     [data],
   );
@@ -82,13 +78,27 @@ export default function AutoEmbeddingsPage() {
   const openCreateAutoEmbeddingsConfiguration = () => {
     openDrawer({
       title: (
-        <Box className="flex flex-row items-center space-x-2">
-          <Text>Create new Auto-Embeddings configuration</Text>
-        </Box>
+        <div className="flex flex-row items-center space-x-2">
+          <span>Create new Auto-Embeddings configuration</span>
+        </div>
       ),
       component: <AutoEmbeddingsForm onSubmit={refetch} />,
     });
   };
+
+  const isPageDataLoading =
+    loadingOrg || loadingProject || loadingGraphite || loading;
+  const shouldShowLoadingState = isPageDataLoading || !isProjectReady;
+
+  if (shouldShowLoadingState) {
+    return (
+      <div className="flex h-full w-full items-center justify-center">
+        <Spinner size="medium" wrapperClassName="gap-2">
+          Loading Auto-Embeddings...
+        </Spinner>
+      </div>
+    );
+  }
 
   if (isPlatform && org?.plan?.isFree) {
     return (
@@ -105,32 +115,26 @@ export default function AutoEmbeddingsPage() {
   }
 
   const slug = isPlatform ? org?.slug : 'local';
+  const aiServiceUnavailable =
+    isPlatform && !org?.plan?.isFree && !project?.config?.ai;
 
-  if (
-    (isPlatform && !org?.plan?.isFree && !project?.config?.ai) ||
-    !isGraphiteEnabled
-  ) {
+  if (aiServiceUnavailable || !isGraphiteEnabled) {
     return (
-      <Box
-        className="w-full p-4"
-        sx={{ backgroundColor: 'background.default' }}
-      >
+      <div className="w-full bg-background p-4">
         <Alert className="grid w-full grid-flow-col place-content-between items-center gap-2">
-          <Text className="grid grid-flow-row justify-items-start gap-0.5">
-            <Text component="span">
-              To enable graphite, configure the service first in{' '}
-              <Link
-                href={`/orgs/${slug}/projects/${project?.subdomain}/settings/ai`}
-                rel="noopener noreferrer"
-                className="text-primary hover:underline"
-              >
-                AI Settings
-              </Link>
-              .
-            </Text>
-          </Text>
+          <p>
+            To enable graphite, configure the service first in{' '}
+            <Link
+              href={`/orgs/${slug}/projects/${project?.subdomain}/settings/ai`}
+              rel="noopener noreferrer"
+              className="text-primary hover:underline"
+            >
+              AI Settings
+            </Link>
+            .
+          </p>
         </Alert>
-      </Box>
+      </div>
     );
   }
 
@@ -140,19 +144,16 @@ export default function AutoEmbeddingsPage() {
 
   if (autoEmbeddingsConfigurations.length === 0 && !loading) {
     return (
-      <Box
-        className="w-full p-6"
-        sx={{ backgroundColor: 'background.default' }}
-      >
-        <Box className="flex flex-col items-center justify-center space-y-5 rounded-lg border px-48 py-12 shadow-sm">
+      <div className="w-full bg-background p-6">
+        <div className="flex flex-col items-center justify-center space-y-5 rounded-lg border px-48 py-12 shadow-sm">
           <EmbeddingsIcon className="h-10 w-10" />
           <div className="flex flex-col space-y-1">
-            <Text className="text-center font-medium" variant="h3">
+            <h2 className="text-center font-medium text-lg">
               No Auto-Embeddings are configured
-            </Text>
-            <Text variant="subtitle1" className="text-center">
+            </h2>
+            <p className="text-center text-muted-foreground text-sm">
               All your configurations will be listed here.
-            </Text>
+            </p>
           </div>
           <div className="flex flex-row place-content-between rounded-lg">
             <Button
@@ -163,19 +164,19 @@ export default function AutoEmbeddingsPage() {
               Add a new Auto-Embeddings Configuration
             </Button>
           </div>
-        </Box>
-      </Box>
+        </div>
+      </div>
     );
   }
 
   return (
-    <Box className="flex w-full flex-col overflow-hidden">
-      <Box className="flex flex-row place-content-end border-b-1 p-4">
+    <div className="flex w-full flex-col overflow-hidden">
+      <div className="flex flex-row place-content-end border-b-1 p-4">
         <Button onClick={openCreateAutoEmbeddingsConfiguration}>
           <PlusIcon className="mr-2 h-4 w-4" />
           New
         </Button>
-      </Box>
+      </div>
       <div>
         <AutoEmbeddingsList
           autoEmbeddingsConfigurations={autoEmbeddingsConfigurations}
@@ -216,7 +217,7 @@ export default function AutoEmbeddingsPage() {
           }}
         />
       </div>
-    </Box>
+    </div>
   );
 }
 


### PR DESCRIPTION
### Checklist

- [x] No breaking changes
- [x] Tests pass
- [ ] New features have new tests
- [ ] Documentation is updated (if applicable)
- [x] Title of the PR is in the correct format (see below)

<!-- pi-reviewer:start -->
### **What this change solves**
Migrates the Dashboard AI Auto-Embeddings page away from remaining v2 UI primitives to the shared v3/form components. The change keeps create/list/delete flows aligned with the updated accessible labels and component structure.

___

### **Change Type**
Refactoring

___

### **Description**
- Replaced Auto-Embeddings form fields and layout wrappers with v3 form primitives and native elements.
- Updated list, empty state, alert, and delete confirmation UI to use v3 components and shared Auto-Embeddings types.
- Adjusted the Auto-Embeddings e2e flow to target the current accessible names after the migration.

___

<details> <summary><h3> File Walkthrough</h3></summary>

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody>
<tr><td><strong>Dashboard AI Auto-Embeddings</strong></td><td><details><summary>5 files</summary><table>
<tr>
  <td><strong>dashboard/src/features/orgs/projects/ai/AutoEmbeddingsForm/AutoEmbeddingsForm.tsx</strong><dd><code>Migrates form inputs/textareas and footer layout from v2 primitives to shared v3 form components.</code></dd></td>
  <td>+37/-132</td>
</tr>
<tr>
  <td><strong>dashboard/src/features/orgs/projects/ai/AutoEmbeddingsList/AutoEmbeddingsList.tsx</strong><dd><code>Replaces v2 list layout/actions with native elements, v3 button/dropdown, and v3 tooltip.</code></dd></td>
  <td>+40/-41</td>
</tr>
<tr>
  <td><strong>dashboard/src/features/orgs/projects/ai/DeleteAutoEmbeddingsModal/DeleteAutoEmbeddingsModal.tsx</strong><dd><code>Migrates delete confirmation copy and layout from v2 Box/Text to native elements and v3 controls.</code></dd></td>
  <td>+29/-29</td>
</tr>
<tr>
  <td><strong>dashboard/src/features/orgs/projects/ai/auto-embeddings/types.ts</strong><dd><code>Adds a shared AutoEmbeddingsConfiguration type for page, list, and modal consumers.</code></dd></td>
  <td>+6/-0</td>
</tr>
<tr>
  <td><strong>dashboard/src/pages/orgs/[orgSlug]/projects/[appSubdomain]/ai/auto-embeddings/index.tsx</strong><dd><code>Migrates page containers, alert, empty state, and drawer title from v2 primitives to v3/native elements.</code></dd></td>
  <td>+35/-53</td>
</tr>
</table></details></td></tr>
<tr><td><strong>Tests</strong></td><td><details><summary>1 file</summary><table>
<tr>
  <td><strong>dashboard/e2e/ai/auto-embeddings.test.ts</strong><dd><code>Updates Playwright selectors to match the migrated accessible labels and button names.</code></dd></td>
  <td>+22/-8</td>
</tr>
</table></details></td></tr>
</tbody></table>

</details>

___

<!-- pi-reviewer:end -->
