### PR TITLE
fix(dashboard): migrate AI file stores page

### DIFF
--- a/dashboard/src/features/orgs/layout/AISidebar/AISidebar.tsx
+++ b/dashboard/src/features/orgs/layout/AISidebar/AISidebar.tsx
@@ -1,17 +1,18 @@
 import { useRouter } from 'next/router';
+import type { ReactNode } from 'react';
 import { ListNavLink } from '@/components/common/NavLink';
 import { FeatureSidebar } from '@/components/layout/FeatureSidebar';
-import { List } from '@/components/ui/v2/List';
-import type { ListItemButtonProps } from '@/components/ui/v2/ListItem';
-import { ListItem } from '@/components/ui/v2/ListItem';
 import { useProject } from '@/features/orgs/projects/hooks/useProject';
+import { cn } from '@/lib/utils';
 
-interface AINavLinkProps extends ListItemButtonProps {
+interface AINavLinkProps {
+  children: ReactNode;
   href: string;
   exact?: boolean;
+  onClick?: VoidFunction;
 }
 
-function AINavLink({ exact = true, href, children, ...props }: AINavLinkProps) {
+function AINavLink({ exact = true, href, children, onClick }: AINavLinkProps) {
   const router = useRouter();
 
   const {
@@ -26,17 +27,17 @@ function AINavLink({ exact = true, href, children, ...props }: AINavLinkProps) {
     : router.asPath.startsWith(finalUrl);
 
   return (
-    <ListItem.Root>
-      <ListItem.Button
-        dense
-        href={finalUrl}
-        component={ListNavLink}
-        selected={active}
-        {...props}
-      >
-        <ListItem.Text>{children}</ListItem.Text>
-      </ListItem.Button>
-    </ListItem.Root>
+    <ListNavLink
+      href={finalUrl}
+      underline="none"
+      onClick={onClick}
+      className={cn(
+        'rounded-md px-3 text-foreground text-sm+',
+        active && 'bg-table-selected text-primary-main hover:text-primary-main',
+      )}
+    >
+      {children}
+    </ListNavLink>
   );
 }
 
@@ -54,18 +55,16 @@ export default function AISidebar() {
       className="px-2"
     >
       {(collapse) => (
-        <nav aria-label="Settings navigation">
-          <List className="grid gap-2">
-            <AINavLink href="/auto-embeddings" exact={false} onClick={collapse}>
-              Auto-Embeddings
-            </AINavLink>
-            <AINavLink href="/assistants" exact={false} onClick={collapse}>
-              Assistants
-            </AINavLink>
-            <AINavLink href="/file-stores" exact={false} onClick={collapse}>
-              File Stores
-            </AINavLink>
-          </List>
+        <nav aria-label="AI navigation" className="grid gap-2">
+          <AINavLink href="/auto-embeddings" exact={false} onClick={collapse}>
+            Auto-Embeddings
+          </AINavLink>
+          <AINavLink href="/assistants" exact={false} onClick={collapse}>
+            Assistants
+          </AINavLink>
+          <AINavLink href="/file-stores" exact={false} onClick={collapse}>
+            File Stores
+          </AINavLink>
         </nav>
       )}
     </FeatureSidebar>

--- a/dashboard/src/features/orgs/projects/ai/AssistantForm/AssistantForm.tsx
+++ b/dashboard/src/features/orgs/projects/ai/AssistantForm/AssistantForm.tsx
@@ -17,7 +17,7 @@ import {
   fileStoreFieldTransform,
   NO_FILE_STORE_SELECT_VALUE,
 } from '@/features/orgs/projects/ai/AssistantForm/utils/fileStoreSelectValue';
-import type { GraphiteFileStore } from '@/features/orgs/projects/ai/assistants/types';
+import type { GraphiteFileStore } from '@/features/orgs/projects/ai/file-stores/types';
 import { InfoTooltip } from '@/features/orgs/projects/common/components/InfoTooltip';
 import { useIsFileStoreSupported } from '@/features/orgs/projects/common/hooks/useIsFileStoreSupported';
 import { execPromiseWithErrorToast } from '@/features/orgs/utils/execPromiseWithErrorToast';

--- a/dashboard/src/features/orgs/projects/ai/AssistantsList/AssistantsList.tsx
+++ b/dashboard/src/features/orgs/projects/ai/AssistantsList/AssistantsList.tsx
@@ -16,11 +16,9 @@ import {
   AssistantForm,
   type AssistantFormInitialData,
 } from '@/features/orgs/projects/ai/AssistantForm';
-import type {
-  Assistant,
-  GraphiteFileStore,
-} from '@/features/orgs/projects/ai/assistants/types';
+import type { Assistant } from '@/features/orgs/projects/ai/assistants/types';
 import { DeleteAssistantModal } from '@/features/orgs/projects/ai/DeleteAssistantModal';
+import type { GraphiteFileStore } from '@/features/orgs/projects/ai/file-stores/types';
 import { copy } from '@/utils/copy';
 
 interface AssistantsListProps {

--- a/dashboard/src/features/orgs/projects/ai/DeleteFileStoreModal/DeleteFileStoreModal.tsx
+++ b/dashboard/src/features/orgs/projects/ai/DeleteFileStoreModal/DeleteFileStoreModal.tsx
@@ -1,12 +1,9 @@
 import { useState } from 'react';
-import { twMerge } from 'tailwind-merge';
-import { Box } from '@/components/ui/v2/Box';
-import { Text } from '@/components/ui/v2/Text';
 import { Button, ButtonWithLoading } from '@/components/ui/v3/button';
 import { Checkbox } from '@/components/ui/v3/checkbox';
 import { Label } from '@/components/ui/v3/label';
 import { useRemoteApplicationGQLClient } from '@/features/orgs/hooks/useRemoteApplicationGQLClient';
-import type { GraphiteFileStore } from '@/features/orgs/projects/ai/assistants/types';
+import type { GraphiteFileStore } from '@/features/orgs/projects/ai/file-stores/types';
 import { execPromiseWithErrorToast } from '@/features/orgs/utils/execPromiseWithErrorToast';
 import { useDeleteFileStoreMutation } from '@/generated/graphite';
 
@@ -43,47 +40,50 @@ export default function DeleteFileStoreModal({
   async function handleClick() {
     setLoading(true);
 
-    await execPromiseWithErrorToast(deleteFileStore, {
-      loadingMessage: 'Deleting the file store...',
-      successMessage: 'The file store has been deleted successfully.',
-      errorMessage:
-        'An error occurred while deleting the file store. Please try again.',
-    });
+    try {
+      await execPromiseWithErrorToast(deleteFileStore, {
+        loadingMessage: 'Deleting the file store...',
+        successMessage: 'The file store has been deleted successfully.',
+        errorMessage:
+          'An error occurred while deleting the file store. Please try again.',
+      });
+    } finally {
+      setLoading(false);
+    }
   }
 
   return (
-    <Box className={twMerge('w-full rounded-lg p-6 text-left')}>
-      {' '}
+    <div className="w-full rounded-lg p-6 text-left">
       <div className="grid grid-flow-row gap-1">
-        {' '}
-        <Text variant="h3" component="h2">
-          {' '}
-          Delete File Store {fileStore?.name}{' '}
-        </Text>{' '}
-        <Text variant="subtitle2">
-          {' '}
-          Are you sure you want to delete this File Store?{' '}
-        </Text>{' '}
-        <Text
-          variant="subtitle2"
-          className="font-bold"
-          sx={{ color: (theme) => `${theme.palette.error.main} !important` }}
-        >
+        <h2 className="font-semibold text-lg">
+          Delete File Store {fileStore.name}
+        </h2>
+
+        <p className="text-muted-foreground text-sm">
+          Are you sure you want to delete this File Store?
+        </p>
+
+        <p className="font-bold text-destructive text-sm">
           This cannot be undone.
-        </Text>
-        <Box className="my-4">
+        </p>
+
+        <div className="my-4">
           <div className="flex items-center gap-2 py-2">
             <Checkbox
-              id="accept-1"
+              id="accept-delete-file-store"
               checked={remove}
               onCheckedChange={(checked) => setRemove(checked === true)}
               aria-label="Confirm Delete File Store"
             />
-            <Label htmlFor="accept-1" className="cursor-pointer font-normal">
-              {`I'm sure I want to delete ${fileStore?.name}`}
+            <Label
+              htmlFor="accept-delete-file-store"
+              className="cursor-pointer font-normal"
+            >
+              {`I'm sure I want to delete ${fileStore.name}`}
             </Label>
           </div>
-        </Box>
+        </div>
+
         <div className="grid grid-flow-row gap-2">
           <ButtonWithLoading
             variant="destructive"
@@ -99,6 +99,6 @@ export default function DeleteFileStoreModal({
           </Button>
         </div>
       </div>
-    </Box>
+    </div>
   );
 }

--- a/dashboard/src/features/orgs/projects/ai/FileStoreForm/FileStoreForm.tsx
+++ b/dashboard/src/features/orgs/projects/ai/FileStoreForm/FileStoreForm.tsx
@@ -1,14 +1,11 @@
 import { yupResolver } from '@hookform/resolvers/yup';
-import { InfoIcon, PlusIcon, RefreshCwIcon } from 'lucide-react';
+import { PlusIcon, RefreshCwIcon } from 'lucide-react';
 import { useEffect } from 'react';
 import { FormProvider, useForm } from 'react-hook-form';
 import * as Yup from 'yup';
 import { useDialog } from '@/components/common/DialogProvider';
 import { Form } from '@/components/form/Form';
-import { Box } from '@/components/ui/v2/Box';
-import { Input } from '@/components/ui/v2/Input';
-import { Text } from '@/components/ui/v2/Text';
-import { Tooltip } from '@/components/ui/v2/Tooltip';
+import { FormInput } from '@/components/form/FormInput';
 import { Button } from '@/components/ui/v3/button';
 import {
   FormControl,
@@ -26,6 +23,7 @@ import {
   MultiSelectValue,
 } from '@/components/ui/v3/multi-select';
 import { useRemoteApplicationGQLClient } from '@/features/orgs/hooks/useRemoteApplicationGQLClient';
+import { InfoTooltip } from '@/features/orgs/projects/common/components/InfoTooltip';
 import { execPromiseWithErrorToast } from '@/features/orgs/utils/execPromiseWithErrorToast';
 import {
   useInsertFileStoreMutation,
@@ -105,7 +103,6 @@ export default function FileStoreForm({
   });
 
   const {
-    register,
     formState: { errors, isSubmitting, dirtyFields },
   } = form;
 
@@ -164,25 +161,11 @@ export default function FileStoreForm({
         className="flex h-full flex-col overflow-hidden border-t"
       >
         <div className="flex flex-1 flex-col space-y-4 overflow-auto p-4">
-          <Input
-            {...register('name')}
-            id="name"
-            label={
-              <Box className="flex flex-row items-center space-x-2">
-                <Text>Name</Text>
-                <Tooltip title="Name of the file store">
-                  <InfoIcon
-                    aria-label="Info"
-                    className="h-4 w-4 text-primary"
-                  />
-                </Tooltip>
-              </Box>
-            }
+          <FormInput
+            control={form.control}
+            name="name"
+            label="Name"
             placeholder=""
-            hideEmptyHelperText
-            error={!!errors.name}
-            helperText={errors?.name?.message}
-            fullWidth
             autoComplete="off"
             autoFocus
           />
@@ -193,24 +176,21 @@ export default function FileStoreForm({
             render={({ field }) => (
               <FormItem className="flex flex-col gap-2">
                 <FormLabel>
-                  <Box className="flex flex-row items-center space-x-2">
-                    <Text>Buckets</Text>
-                    <Tooltip title="One or more buckets from storage from which documents can be used by Assistants">
-                      <InfoIcon
-                        aria-label="Info"
-                        className="h-4 w-4 text-primary"
-                      />
-                    </Tooltip>
-                  </Box>
+                  <div className="flex flex-row items-center space-x-2">
+                    <span>Buckets</span>
+                    <InfoTooltip>
+                      One or more buckets from storage from which documents can
+                      be used by Assistants
+                    </InfoTooltip>
+                  </div>
                 </FormLabel>
                 <MultiSelect
-                  values={(field.value || []).map(
-                    // biome-ignore lint/suspicious/noExplicitAny: Will be fixed later.
-                    (v: any) => v.value,
+                  values={(field.value ?? []).flatMap((value) =>
+                    value.value ? [value.value] : [],
                   )}
                   onValuesChange={(nextValues) =>
                     field.onChange(
-                      nextValues.map((v) => ({ label: v, value: v })),
+                      nextValues.map((value) => ({ label: value, value })),
                     )
                   }
                 >
@@ -244,7 +224,7 @@ export default function FileStoreForm({
           />
         </div>
 
-        <Box className="flex w-full flex-row justify-between rounded border-t p-4">
+        <div className="flex w-full flex-row justify-between rounded border-t p-4">
           <Button variant="outline" onClick={onCancel}>
             Cancel
           </Button>
@@ -256,7 +236,7 @@ export default function FileStoreForm({
             )}
             {id ? 'Update' : 'Create'}
           </Button>
-        </Box>
+        </div>
       </Form>
     </FormProvider>
   );

--- a/dashboard/src/features/orgs/projects/ai/FileStoresList/FileStoresList.tsx
+++ b/dashboard/src/features/orgs/projects/ai/FileStoresList/FileStoresList.tsx
@@ -5,9 +5,7 @@ import {
   Trash2 as TrashIcon,
 } from 'lucide-react';
 import { useDialog } from '@/components/common/DialogProvider';
-import { Box } from '@/components/ui/v2/Box';
-import { IconButton } from '@/components/ui/v2/IconButton';
-import { Text } from '@/components/ui/v2/Text';
+import { Button } from '@/components/ui/v3/button';
 import {
   DropdownMenu,
   DropdownMenuContent,
@@ -15,9 +13,9 @@ import {
   DropdownMenuTrigger,
 } from '@/components/ui/v3/dropdown-menu';
 import { FileStoresIcon } from '@/components/ui/v3/icons/FileStoresIcon';
-import type { GraphiteFileStore } from '@/features/orgs/projects/ai/assistants/types';
 import { DeleteFileStoreModal } from '@/features/orgs/projects/ai/DeleteFileStoreModal';
 import { FileStoreForm } from '@/features/orgs/projects/ai/FileStoreForm';
+import type { GraphiteFileStore } from '@/features/orgs/projects/ai/file-stores/types';
 import { copy } from '@/utils/copy';
 
 interface FileStoresListProps {
@@ -73,58 +71,53 @@ export default function FileStoresList({
   };
 
   return (
-    <Box className="flex flex-col">
+    <div className="flex flex-col">
       {fileStores.map((fileStore) => (
-        <Box
+        <div
           key={fileStore.id}
-          className="flex h-[64px] w-full cursor-pointer items-center justify-between space-x-4 border-b-1 px-4 py-2 transition-colors"
-          sx={{
-            [`&:hover`]: {
-              backgroundColor: 'action.hover',
-            },
-          }}
+          className="flex h-16 w-full items-center justify-between gap-4 border-b-1 px-4 py-2 transition-colors hover:bg-accent"
         >
-          <Box
+          <button
+            type="button"
             onClick={() => viewFileStore(fileStore)}
-            className="flex w-full flex-row justify-between"
-            sx={{ backgroundColor: 'transparent' }}
+            className="flex min-w-0 flex-1 cursor-pointer flex-row items-center gap-4 text-left"
           >
-            <div className="flex flex-1 flex-row items-center space-x-4">
-              <FileStoresIcon className="h-5 w-5" />
-              <div className="flex flex-col">
-                <Text variant="h4" className="font-semibold">
-                  {fileStore?.name ?? 'unset'}
-                </Text>
-                <div className="hidden flex-row items-center space-x-2 md:flex">
-                  <Text variant="subtitle1" className="font-mono text-xs">
-                    {fileStore.id}
-                  </Text>
-                  <IconButton
-                    variant="borderless"
-                    color="secondary"
-                    onClick={(event) => {
-                      copy(fileStore.id, 'File Store Id');
-                      event.stopPropagation();
-                    }}
-                    aria-label="Service Id"
-                  >
-                    <CopyIcon className="h-4 w-4" />
-                  </IconButton>
-                </div>
-              </div>
+            <FileStoresIcon className="h-5 w-5 flex-shrink-0" />
+            <div className="flex min-w-0 flex-col">
+              <span className="truncate font-semibold text-sm+">
+                {fileStore.name ?? 'unset'}
+              </span>
+              <span className="hidden truncate font-mono text-muted-foreground text-xs md:inline">
+                {fileStore.id}
+              </span>
             </div>
-          </Box>
+          </button>
+
+          <Button
+            type="button"
+            variant="ghost"
+            size="icon"
+            onClick={(event) => {
+              copy(fileStore.id, 'File Store Id');
+              event.stopPropagation();
+            }}
+            aria-label="File Store Id"
+            className="hidden h-8 w-8 flex-shrink-0 md:inline-flex"
+          >
+            <CopyIcon className="h-4 w-4" />
+          </Button>
 
           <DropdownMenu>
             <DropdownMenuTrigger asChild>
-              <IconButton
-                variant="borderless"
-                color="secondary"
+              <Button
+                type="button"
+                variant="ghost"
+                size="icon"
                 aria-label="More options"
                 onClick={(event) => event.stopPropagation()}
               >
-                <DotsHorizontalIcon />
-              </IconButton>
+                <DotsHorizontalIcon className="h-4 w-4" />
+              </Button>
             </DropdownMenuTrigger>
             <DropdownMenuContent align="end" className="w-auto p-0">
               <DropdownMenuItem
@@ -132,19 +125,19 @@ export default function FileStoresList({
                 className="flex h-9 cursor-pointer items-center justify-start gap-2 rounded-none border border-b-1 p-2 font-medium text-sm+ leading-4 hover:bg-data-cell-bg"
               >
                 <EyeIcon className="h-4 w-4" />
-                <span>View {fileStore?.name}</span>
+                <span>View {fileStore.name}</span>
               </DropdownMenuItem>
               <DropdownMenuItem
                 className="!text-destructive flex h-9 cursor-pointer items-center justify-start gap-2 rounded-none border border-b-1 p-2 font-medium text-sm+ leading-4 hover:bg-data-cell-bg"
                 onClick={() => deleteFileStore(fileStore)}
               >
                 <TrashIcon className="h-4 w-4" />
-                <span>Delete {fileStore?.name}</span>
+                <span>Delete {fileStore.name}</span>
               </DropdownMenuItem>
             </DropdownMenuContent>
           </DropdownMenu>
-        </Box>
+        </div>
       ))}
-    </Box>
+    </div>
   );
 }

--- a/dashboard/src/features/orgs/projects/ai/assistants/types.ts
+++ b/dashboard/src/features/orgs/projects/ai/assistants/types.ts
@@ -1,14 +1,6 @@
-import type {
-  GetAssistantsQuery,
-  GetGraphiteFileStoresQuery,
-} from '@/generated/graphite';
+import type { GetAssistantsQuery } from '@/generated/graphite';
 
 export type Assistant = Omit<
   NonNullable<GetAssistantsQuery['graphite']>['assistants'][number],
-  '__typename'
->;
-
-export type GraphiteFileStore = Omit<
-  NonNullable<GetGraphiteFileStoresQuery['graphite']>['fileStores'][number],
   '__typename'
 >;

--- a/dashboard/src/features/orgs/projects/ai/file-stores/types.ts
+++ b/dashboard/src/features/orgs/projects/ai/file-stores/types.ts
@@ -1,0 +1,6 @@
+import type { GetGraphiteFileStoresQuery } from '@/generated/graphite';
+
+export type GraphiteFileStore = Omit<
+  NonNullable<GetGraphiteFileStoresQuery['graphite']>['fileStores'][number],
+  '__typename'
+>;

--- a/dashboard/src/pages/orgs/[orgSlug]/projects/[appSubdomain]/ai/assistants/index.tsx
+++ b/dashboard/src/pages/orgs/[orgSlug]/projects/[appSubdomain]/ai/assistants/index.tsx
@@ -13,10 +13,8 @@ import { AISidebar } from '@/features/orgs/layout/AISidebar';
 import { OrgLayout } from '@/features/orgs/layout/OrgLayout';
 import { AssistantForm } from '@/features/orgs/projects/ai/AssistantForm';
 import { AssistantsList } from '@/features/orgs/projects/ai/AssistantsList';
-import type {
-  Assistant,
-  GraphiteFileStore,
-} from '@/features/orgs/projects/ai/assistants/types';
+import type { Assistant } from '@/features/orgs/projects/ai/assistants/types';
+import type { GraphiteFileStore } from '@/features/orgs/projects/ai/file-stores/types';
 import { useIsFileStoreSupported } from '@/features/orgs/projects/common/hooks/useIsFileStoreSupported';
 import { useIsGraphiteEnabled } from '@/features/orgs/projects/common/hooks/useIsGraphiteEnabled';
 import { useIsPlatform } from '@/features/orgs/projects/common/hooks/useIsPlatform';

--- a/dashboard/src/pages/orgs/[orgSlug]/projects/[appSubdomain]/ai/file-stores/index.tsx
+++ b/dashboard/src/pages/orgs/[orgSlug]/projects/[appSubdomain]/ai/file-stores/index.tsx
@@ -4,9 +4,7 @@ import { type ReactElement, useMemo } from 'react';
 import { useDialog } from '@/components/common/DialogProvider';
 import { UpgradeToProBanner } from '@/components/common/UpgradeToProBanner';
 import { RetryableErrorBoundary } from '@/components/presentational/RetryableErrorBoundary';
-import { Alert } from '@/components/ui/v2/Alert';
-import { Box } from '@/components/ui/v2/Box';
-import { Text } from '@/components/ui/v2/Text';
+import { Alert } from '@/components/ui/v3/alert';
 import { Button } from '@/components/ui/v3/button';
 import { FileStoresIcon } from '@/components/ui/v3/icons/FileStoresIcon';
 import { Spinner } from '@/components/ui/v3/spinner';
@@ -15,6 +13,7 @@ import { AISidebar } from '@/features/orgs/layout/AISidebar';
 import { OrgLayout } from '@/features/orgs/layout/OrgLayout';
 import { FileStoreForm } from '@/features/orgs/projects/ai/FileStoreForm';
 import { FileStoresList } from '@/features/orgs/projects/ai/FileStoresList';
+import type { GraphiteFileStore } from '@/features/orgs/projects/ai/file-stores/types';
 import { useIsFileStoreSupported } from '@/features/orgs/projects/common/hooks/useIsFileStoreSupported';
 import { useIsGraphiteEnabled } from '@/features/orgs/projects/common/hooks/useIsGraphiteEnabled';
 import { useIsPlatform } from '@/features/orgs/projects/common/hooks/useIsPlatform';
@@ -30,14 +29,22 @@ export default function FileStoresPage() {
   const { project, loading: loadingProject } = useProject();
 
   const remoteProjectGQLClient = useRemoteApplicationGQLClient();
-  const { isGraphiteEnabled } = useIsGraphiteEnabled();
-  const { isFileStoreSupported } = useIsFileStoreSupported();
+  const { isGraphiteEnabled, loading: loadingGraphite } =
+    useIsGraphiteEnabled();
+  const { isFileStoreSupported, loading: loadingFileStoreSupport } =
+    useIsFileStoreSupported();
+
+  const isProjectReady = !isPlatform || !!project;
 
   const { data, loading, error, refetch } = useGetGraphiteFileStoresQuery({
     client: remoteProjectGQLClient,
+    skip: !isProjectReady,
   });
 
-  const fileStores = useMemo(() => data?.graphite?.fileStores || [], [data]);
+  const fileStores = useMemo<GraphiteFileStore[]>(
+    () => data?.graphite?.fileStores || [],
+    [data],
+  );
 
   const openCreateFileStoreForm = () => {
     openDrawer({
@@ -46,59 +53,61 @@ export default function FileStoresPage() {
     });
   };
 
-  if (loadingOrg || loadingProject || loading) {
+  const isPageDataLoading =
+    loadingOrg ||
+    loadingProject ||
+    loadingGraphite ||
+    loadingFileStoreSupport ||
+    loading;
+  const shouldShowLoadingState = isPageDataLoading || !isProjectReady;
+
+  if (shouldShowLoadingState) {
     return (
-      <Box className="flex h-full w-full items-center justify-center">
+      <div className="flex h-full w-full items-center justify-center">
         <Spinner size="medium" wrapperClassName="gap-2">
           Loading File Stores...
         </Spinner>
-      </Box>
+      </div>
     );
   }
 
   if (isPlatform && org?.plan?.isFree) {
     return (
-      <Box className="p-4" sx={{ backgroundColor: 'background.default' }}>
+      <div className="bg-background p-4">
         <UpgradeToProBanner
           title="Upgrade to Nhost Pro."
           description={
-            <Text>
+            <p>
               Graphite is an addon to the Pro plan. To unlock it, please upgrade
               to Pro first.
-            </Text>
+            </p>
           }
         />
-      </Box>
+      </div>
     );
   }
 
   const slug = isPlatform ? org?.slug : 'local';
+  const aiServiceUnavailable =
+    isPlatform && !org?.plan?.isFree && !project?.config?.ai;
 
-  if (
-    (isPlatform && !org?.plan?.isFree && !project?.config?.ai) ||
-    !isGraphiteEnabled
-  ) {
+  if (aiServiceUnavailable || !isGraphiteEnabled) {
     return (
-      <Box
-        className="w-full p-4"
-        sx={{ backgroundColor: 'background.default' }}
-      >
+      <div className="w-full bg-background p-4">
         <Alert className="grid w-full grid-flow-col place-content-between items-center gap-2">
-          <Text className="grid grid-flow-row justify-items-start gap-0.5">
-            <Text component="span">
-              To enable graphite, configure the service first in{' '}
-              <Link
-                href={`/orgs/${slug}/projects/${project?.subdomain}/settings/ai`}
-                rel="noopener noreferrer"
-                className="text-primary hover:underline"
-              >
-                AI Settings
-              </Link>
-              .
-            </Text>
-          </Text>
+          <p>
+            To enable graphite, configure the service first in{' '}
+            <Link
+              href={`/orgs/${slug}/projects/${project?.subdomain}/settings/ai`}
+              rel="noopener noreferrer"
+              className="text-primary hover:underline"
+            >
+              AI Settings
+            </Link>
+            .
+          </p>
         </Alert>
-      </Box>
+      </div>
     );
   }
 
@@ -108,28 +117,25 @@ export default function FileStoresPage() {
 
   if (fileStores.length === 0 && !loading) {
     return (
-      <Box
-        className="w-full p-6"
-        sx={{ backgroundColor: 'background.default' }}
-      >
-        <Box className="flex flex-col items-center justify-center space-y-5 rounded-lg border px-48 py-12 shadow-sm">
+      <div className="w-full bg-background p-6">
+        <div className="flex flex-col items-center justify-center space-y-5 rounded-lg border px-48 py-12 shadow-sm">
           <FileStoresIcon className="h-10 w-10" />
 
           <div className="flex flex-col space-y-1">
-            <Text className="text-center font-medium" variant="h3">
+            <h2 className="text-center font-medium text-lg">
               No File Stores are configured
-            </Text>
-            <Text variant="subtitle1" className="text-center">
+            </h2>
+            <p className="text-center text-muted-foreground text-sm">
               File Stores are used to share storage documents with your AI
               assistants.
-            </Text>
-            {!isFileStoreSupported && (
-              <Box className="px-4 pb-4">
-                <Alert className="mt-2 text-left">
+            </p>
+            {isFileStoreSupported === false && (
+              <div className="px-4 pb-4">
+                <Alert variant="warning" className="mt-2 text-left">
                   Please upgrade Graphite to its latest version in order to use
                   file stores.
                 </Alert>
-              </Box>
+              </div>
             )}
           </div>
           <div className="flex flex-row place-content-between rounded-lg">
@@ -143,19 +149,19 @@ export default function FileStoresPage() {
               Add a new File Store
             </Button>
           </div>
-        </Box>
-      </Box>
+        </div>
+      </div>
     );
   }
 
   return (
-    <Box className="flex w-full flex-col overflow-hidden">
-      <Box className="flex flex-row place-content-end border-b-1 p-4">
+    <div className="flex w-full flex-col overflow-hidden">
+      <div className="flex flex-row place-content-end border-b-1 p-4">
         <Button onClick={openCreateFileStoreForm}>
           <PlusIcon className="mr-2 h-4 w-4" />
           New
         </Button>
-      </Box>
+      </div>
       <div>
         <FileStoresList
           fileStores={fileStores}
@@ -163,7 +169,7 @@ export default function FileStoresPage() {
           onCreateOrUpdate={() => refetch()}
         />
       </div>
-    </Box>
+    </div>
   );
 }
 


### PR DESCRIPTION
### Checklist

- [x] No breaking changes
- [x] Tests pass
- [ ] New features have new tests
- [ ] Documentation is updated (if applicable)
- [x] Title of the PR is in the correct format (see below)

<!-- pi-reviewer:start -->
### **What this change solves**
Migrates the AI File Stores dashboard page and supporting components from the older UI primitives to the current v3 dashboard components. The change keeps the file-store create, update, list, delete, and navigation flows available while aligning layout and form styling with the migrated AI pages.

___

### **Change Type**
Refactoring

___

### **Description**
- Reworks the AI sidebar navigation to use shared v3-compatible navigation styling.
- Migrates File Store form, list, modal, and page UI from v2 primitives to v3 components and Tailwind classes.
- Adds a shared feature-local File Store type and updates imports to avoid depending on page exports.
- Guards the File Stores page loading state so empty/upgrade states do not flash before project and Graphite readiness checks finish.

___

### Diagram Walkthrough

```mermaid
flowchart LR
  Sidebar["AI Sidebar"] --> Page["File Stores Page"]
  Page --> List["File Stores List"]
  Page --> Form["File Store Form"]
  List --> DeleteModal["Delete File Store Modal"]
  Form --> Graphite["Graphite mutations"]
  DeleteModal --> Graphite
```

<details> <summary><h3> File Walkthrough</h3></summary>

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody>
<tr><td><strong>AI navigation</strong></td><td><details><summary>1 file</summary><table>
<tr>
  <td><strong>dashboard/src/features/orgs/layout/AISidebar/AISidebar.tsx</strong><dd><code>Replaces v2 list navigation with v3-compatible ListNavLink styling for AI pages.</code></dd></td>
  <td>+27/-28</td>
</tr>
</table></details></td></tr>
<tr><td><strong>File Store components</strong></td><td><details><summary>4 files</summary><table>
<tr>
  <td><strong>dashboard/src/features/orgs/projects/ai/DeleteFileStoreModal/DeleteFileStoreModal.tsx</strong><dd><code>Migrates delete confirmation modal markup to v3 buttons, checkbox, label, and Tailwind typography.</code></dd></td>
  <td>+33/-33</td>
</tr>
<tr>
  <td><strong>dashboard/src/features/orgs/projects/ai/FileStoreForm/FileStoreForm.tsx</strong><dd><code>Migrates name input and buckets multi-select form layout to v3 form primitives.</code></dd></td>
  <td>+19/-39</td>
</tr>
<tr>
  <td><strong>dashboard/src/features/orgs/projects/ai/FileStoresList/FileStoresList.tsx</strong><dd><code>Migrates the file-store list rows and actions to v3 buttons/dropdown menu styling.</code></dd></td>
  <td>+41/-48</td>
</tr>
<tr>
  <td><strong>dashboard/src/features/orgs/projects/ai/file-stores/types.ts</strong><dd><code>Adds a feature-local GraphiteFileStore type for reused component props.</code></dd></td>
  <td>+6/-0</td>
</tr>
</table></details></td></tr>
<tr><td><strong>File Store page</strong></td><td><details><summary>1 file</summary><table>
<tr>
  <td><strong>dashboard/src/pages/orgs/[orgSlug]/projects/[appSubdomain]/ai/file-stores/index.tsx</strong><dd><code>Migrates the page to v3 alert/button/spinner styling and waits for readiness checks before rendering terminal states.</code></dd></td>
  <td>+62/-62</td>
</tr>
</table></details></td></tr>
</tbody></table>

</details>

___

<!-- pi-reviewer:end -->
