### PR TITLE
fix(dashboard): preserve GraphQL playground user selection

### DIFF
--- a/dashboard/src/features/orgs/projects/graphql/common/components/UserSelect/UserSelect.test.tsx
+++ b/dashboard/src/features/orgs/projects/graphql/common/components/UserSelect/UserSelect.test.tsx
@@ -1,0 +1,96 @@
+import UserSelect from '@/features/orgs/projects/graphql/common/components/UserSelect/UserSelect';
+import {
+  act,
+  mockPointerEvent,
+  render,
+  screen,
+  TestUserEvent,
+  waitFor,
+} from '@/tests/testUtils';
+
+const USER_ID = 'c71a4d57-44e7-4de1-92b6-6b9480f7cf67';
+
+const mocks = vi.hoisted(() => ({
+  fetchAppUsers: vi.fn(),
+  userApplicationClient: {},
+}));
+
+vi.mock('@mui/material/utils', () => ({
+  debounce: (callback: (...args: unknown[]) => unknown) => callback,
+}));
+
+vi.mock('@/features/orgs/hooks/useRemoteApplicationGQLClient', () => ({
+  useRemoteApplicationGQLClient: () => mocks.userApplicationClient,
+}));
+
+vi.mock('@/generated/graphql', async (importOriginal) => {
+  const actual = await importOriginal<typeof import('@/generated/graphql')>();
+
+  return {
+    ...actual,
+    useRemoteAppGetUsersAndAuthRolesLazyQuery: () => [mocks.fetchAppUsers],
+  };
+});
+
+mockPointerEvent();
+
+const usersResponse = {
+  data: {
+    users: [
+      {
+        id: USER_ID,
+        displayName: 'Tutorial User',
+        roles: [{ role: 'user' }],
+      },
+    ],
+    authRoles: [{ role: 'user' }],
+  },
+};
+
+describe('UserSelect', () => {
+  afterEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it('keeps the selected user when the user list is refreshed', async () => {
+    let resolveRefetch: (response: typeof usersResponse) => void = () => {};
+    const refetchResponse = new Promise<typeof usersResponse>((resolve) => {
+      resolveRefetch = resolve;
+    });
+
+    mocks.fetchAppUsers
+      .mockResolvedValueOnce(usersResponse)
+      .mockReturnValueOnce(refetchResponse);
+
+    const onUserChange = vi.fn();
+    const user = new TestUserEvent();
+
+    render(<UserSelect onUserChange={onUserChange} />);
+
+    await waitFor(() => {
+      expect(mocks.fetchAppUsers).toHaveBeenCalledTimes(1);
+      expect(onUserChange).toHaveBeenCalledWith('admin', [
+        'admin',
+        'public',
+        'anonymous',
+        'user',
+      ]);
+    });
+
+    await user.click(screen.getByRole('combobox'));
+    await user.click(screen.getByRole('option', { name: 'Tutorial User' }));
+
+    expect(onUserChange).toHaveBeenLastCalledWith(USER_ID, ['user']);
+
+    await waitFor(() => {
+      expect(mocks.fetchAppUsers).toHaveBeenCalledTimes(2);
+    });
+
+    await act(async () => {
+      resolveRefetch(usersResponse);
+      await refetchResponse;
+    });
+
+    expect(onUserChange).toHaveBeenLastCalledWith(USER_ID, ['user']);
+  });
+});

--- a/dashboard/src/features/orgs/projects/graphql/common/components/UserSelect/UserSelect.test.tsx
+++ b/dashboard/src/features/orgs/projects/graphql/common/components/UserSelect/UserSelect.test.tsx
@@ -8,7 +8,7 @@ import {
   waitFor,
 } from '@/tests/testUtils';
 
-const USER_ID = 'c71a4d57-44e7-4de1-92b6-6b9480f7cf67';
+const USER_ID = '00000000-0000-0000-0000-000000000001';
 
 const mocks = vi.hoisted(() => ({
   fetchAppUsers: vi.fn(),

--- a/dashboard/src/features/orgs/projects/graphql/common/components/UserSelect/UserSelect.tsx
+++ b/dashboard/src/features/orgs/projects/graphql/common/components/UserSelect/UserSelect.tsx
@@ -92,7 +92,9 @@ export default function UserSelect({
 
   // biome-ignore lint/correctness/useExhaustiveDependencies: only want to run the effect when adminAuthRoles changes
   useEffect(() => {
-    onUserChange('admin', getAdminRoles(adminAuthRoles));
+    if (selectedUserId === 'admin') {
+      onUserChange('admin', getAdminRoles(adminAuthRoles));
+    }
   }, [adminAuthRoles]);
 
   const autocompleteOptions = [
@@ -136,7 +138,7 @@ export default function UserSelect({
         }}
         options={autocompleteOptions}
         placeholder="Select user..."
-        className="w-full"
+        className="h-10 w-full"
         popoverContentClassName="w-80"
         onSearchChange={setInputValue}
       />


### PR DESCRIPTION
### Checklist

- [x] No breaking changes
- [x] Tests pass
- [x] New features have new tests
- [x] Documentation is updated (if applicable)
- [x] Title of the PR is in the correct format (see below)

<!-- pi-reviewer:start -->
### **What this change solves**
In the GraphQL playground, selecting a user and then having the user list refresh (the lazy users/auth-roles query re-resolving) reset the request identity back to `admin`, so subsequent requests ran with the wrong user. The selection now survives refreshes.

___

### **Change Type**
Bug fix

___

### **Description**
- Guard the `adminAuthRoles` effect in `UserSelect` so it only re-emits the admin identity when `admin` is actually the selected user, instead of unconditionally overwriting the current selection on every roles refresh.
- Add a component regression test that selects a user, triggers a second users fetch, and asserts the selection (user id and roles) is preserved after the refetch resolves.
- Fix the user select trigger height by adding `h-10` to the autocomplete class.

___

<details> <summary><h3> File Walkthrough</h3></summary>

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody>
<tr><td><strong>Bug fix</strong></td><td><details><summary>1 file</summary><table>
<tr>
  <td><strong>UserSelect.tsx</strong><dd><code>Only emit admin identity from the roles effect when admin is selected; add h-10 trigger height.</code></dd></td>
  <td>+4/-2</td>
</tr>
</table></details></td></tr>
<tr><td><strong>Tests</strong></td><td><details><summary>1 file</summary><table>
<tr>
  <td><strong>UserSelect.test.tsx</strong><dd><code>Regression test: selected user survives a user-list refresh.</code></dd></td>
  <td>+96/-0</td>
</tr>
</table></details></td></tr>
</tbody></table>

</details>

___

<!-- pi-reviewer:end -->
