### PR TITLE
fix(dashboard): make primary key columns searchable

### DIFF
--- a/dashboard/src/features/orgs/projects/database/dataGrid/components/BaseTableForm/BaseTableForm.test.tsx
+++ b/dashboard/src/features/orgs/projects/database/dataGrid/components/BaseTableForm/BaseTableForm.test.tsx
@@ -7,6 +7,7 @@ import {
   render,
   screen,
   TestUserEvent,
+  waitFor,
 } from '@/tests/testUtils';
 import BaseTableForm, {
   type BaseTableFormValues,
@@ -192,6 +193,66 @@ describe('BaseTableForm', () => {
     expect(screen.getByTestId('id')).toBeInTheDocument();
     expect(screen.getByTestId('columns.0.isNullable')).toBeDisabled();
     expect(screen.getByTestId('columns.0.isUnique')).toBeDisabled();
+  });
+
+  it('should filter primary key columns by label and submit their original indices', async () => {
+    render(<TestTableFormWrapper />);
+
+    const user = new TestUserEvent();
+
+    await user.type(screen.getByTestId('tableNameInput'), 'test_table');
+    await fillColumnForm(
+      {
+        columnName: 'email',
+        optionName: /^text.*text/,
+        typeValue: 'text',
+      },
+      0,
+      user,
+    );
+
+    await user.click(screen.getByRole('button', { name: /Add Column/ }));
+    await fillColumnForm(
+      {
+        columnName: 'username',
+        optionName: /^text.*text/,
+        typeValue: 'text',
+      },
+      1,
+      user,
+    );
+
+    await user.click(screen.getByText('Add Primary Key'));
+    const searchInput = screen.getByPlaceholderText('Search columns...');
+
+    await user.click(screen.getByRole('option', { name: 'email' }));
+    await user.type(searchInput, 'user');
+
+    expect(
+      screen.getByRole('option', { name: 'username' }),
+    ).toBeInTheDocument();
+    expect(
+      screen.queryByRole('option', { name: 'email' }),
+    ).not.toBeInTheDocument();
+
+    await user.clear(searchInput);
+    await user.type(searchInput, 'zzz');
+
+    expect(screen.getByText('No columns found.')).toBeInTheDocument();
+
+    await user.clear(searchInput);
+    await user.type(searchInput, 'user');
+    await user.click(screen.getByRole('option', { name: 'username' }));
+    await user.keyboard('{Escape}');
+    await TestUserEvent.fireClickEvent(
+      screen.getByRole('button', { name: 'Save' }),
+    );
+
+    await waitFor(() => expect(mocks.onSubmit).toHaveBeenCalledTimes(1));
+    expect(mocks.onSubmit.mock.calls[0][0].primaryKeyIndices).toStrictEqual([
+      '0',
+      '1',
+    ]);
   });
 
   it('should disable the nullable and unique checkboxes and default value if the column is an identity column', async () => {

--- a/dashboard/src/features/orgs/projects/database/dataGrid/components/BaseTableForm/PrimaryKeySelect.tsx
+++ b/dashboard/src/features/orgs/projects/database/dataGrid/components/BaseTableForm/PrimaryKeySelect.tsx
@@ -53,12 +53,19 @@ export default function PrimaryKeySelect() {
                   />
                 </MultiSelectTrigger>
               </FormControl>
-              <MultiSelectContent className="!rounded-sm">
+              <MultiSelectContent
+                className="!rounded-sm"
+                search={{
+                  placeholder: 'Search columns...',
+                  emptyMessage: 'No columns found.',
+                }}
+              >
                 <MultiSelectGroup>
                   {columnsWithNames.map((col) => (
                     <MultiSelectItem
                       key={col.value}
                       value={col.value}
+                      keywords={[col.label]}
                       className="data-[selected='true']:bg-[#ebf3ff] data-[selected='true']:dark:bg-[#1b2534]"
                     >
                       {col.label}


### PR DESCRIPTION
### Checklist

- [x] No breaking changes
- [x] Tests pass
- [x] New features have new tests
- [x] Documentation is updated (if applicable)
- [x] Title of the PR is in the correct format (see below)

<!-- pi-reviewer:start -->
### **What this change solves**
The primary key selector in the table creation/edit form was not searchable: its options carry numeric column indices as values, so there was no way to filter by column name. This change enables the search input in the multi-select and makes filtering match on column labels while still submitting the original column indices.

___

### **Change Type**
Bug fix

___

### **Description**
- Enable the search input in `PrimaryKeySelect`'s `MultiSelectContent` with a "Search columns..." placeholder and a "No columns found." empty message
- Pass `keywords={[col.label]}` to each `MultiSelectItem` so filtering matches column names instead of the index-based item values
- Add a `BaseTableForm` test covering label-based filtering, the empty-state message, and that submission still yields the original column indices

___

<details> <summary><h3> File Walkthrough</h3></summary>

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody>
<tr><td><strong>Bug fix</strong></td><td><details><summary>1 files</summary><table>
<tr>
  <td><strong>PrimaryKeySelect.tsx</strong><dd><code>Enable search in the primary key multi-select and match items by column label</code></dd></td>
  <td>+8/-1</td>
</tr>
</table></details></td></tr>
<tr><td><strong>Tests</strong></td><td><details><summary>1 files</summary><table>
<tr>
  <td><strong>BaseTableForm.test.tsx</strong><dd><code>Test primary key search filtering, empty state, and original-index submission</code></dd></td>
  <td>+61/-0</td>
</tr>
</table></details></td></tr>
</tbody></table>

</details>

___

<!-- pi-reviewer:end -->
