### PR TITLE
fix(dashboard): migrate leaf pages v3

### DIFF
--- a/dashboard/src/pages/404.tsx
+++ b/dashboard/src/pages/404.tsx
@@ -2,18 +2,15 @@ import NavLink from 'next/link';
 import type { ReactElement } from 'react';
 import { BaseLayout } from '@/components/layout/BaseLayout';
 import { Container } from '@/components/layout/Container';
-import { Text } from '@/components/ui/v2/Text';
 
 export default function NotFoundPage() {
   return (
     <Container className="grid h-screen max-w-2xl grid-flow-row place-content-center place-items-center gap-2 text-center">
-      <Text variant="h1" className="font-semibold text-6xl">
-        404
-      </Text>
+      <h1 className="font-semibold text-6xl">404</h1>
 
-      <Text className="font-display font-normal text-lg leading-6">
+      <p className="font-display font-normal text-lg leading-6">
         Page Not Found
-      </Text>
+      </p>
 
       <NavLink href="/" className="text-primary hover:underline">
         Go back to home page

--- a/dashboard/src/pages/email/verify.tsx
+++ b/dashboard/src/pages/email/verify.tsx
@@ -2,8 +2,6 @@ import { useRouter } from 'next/router';
 import type { ReactElement } from 'react';
 import { NavLink } from '@/components/common/NavLink';
 import { UnauthenticatedLayout } from '@/components/layout/UnauthenticatedLayout';
-import { Box } from '@/components/ui/v2/Box';
-import { Text } from '@/components/ui/v2/Text';
 import { ButtonWithLoading } from '@/components/ui/v3/button';
 import SendVerificationEmailForm from '@/features/auth/SignIn/SignInWithEmailAndPassword/components/SendVerificationEmailForm';
 import useResendVerificationEmail from '@/features/auth/SignIn/SignInWithEmailAndPassword/hooks/useResendVerificationEmail';
@@ -24,20 +22,16 @@ export default function VerifyEmailPage() {
 
   return (
     <>
-      <Text
-        variant="h2"
-        component="h1"
-        className="text-center font-semibold text-3.5xl lg:text-4.5xl"
-      >
+      <h1 className="text-center font-semibold text-3.5xl lg:text-4.5xl">
         Verify your email
-      </Text>
+      </h1>
 
-      <Box className="grid grid-flow-row gap-4 rounded-md border bg-transparent p-6 lg:p-12">
+      <div className="grid grid-flow-row gap-4 rounded-md border bg-transparent p-6 lg:p-12">
         <div className="relative py-2">
-          <Text color="secondary" className="text-center text-sm">
+          <p className="text-center text-muted-foreground text-sm">
             Please check your inbox for the verification email. Follow the link
             to verify your email address and complete your registration.
-          </Text>
+          </p>
         </div>
         {email ? (
           <ButtonWithLoading
@@ -62,7 +56,7 @@ export default function VerifyEmailPage() {
             Sign In
           </NavLink>
         </div>
-      </Box>
+      </div>
     </>
   );
 }

--- a/dashboard/src/pages/oauth2/authorize.tsx
+++ b/dashboard/src/pages/oauth2/authorize.tsx
@@ -1,4 +1,3 @@
-import GlobalStyles from '@mui/material/GlobalStyles';
 import type { ErrorResponse, OAuth2LoginResponse } from '@nhost/nhost-js/auth';
 import type { FetchError } from '@nhost/nhost-js/fetch';
 import Image from 'next/image';
@@ -6,7 +5,6 @@ import { useRouter } from 'next/router';
 import { type ReactElement, useCallback, useEffect, useState } from 'react';
 import { BaseLayout } from '@/components/layout/BaseLayout';
 import { Container } from '@/components/layout/Container';
-import { ThemeProvider } from '@/components/ui/v2/ThemeProvider';
 import { Badge } from '@/components/ui/v3/badge';
 import { Button } from '@/components/ui/v3/button';
 import { Spinner } from '@/components/ui/v3/spinner';
@@ -231,20 +229,10 @@ export default function OAuth2AuthorizePage() {
 
 OAuth2AuthorizePage.getLayout = function getLayout(page: ReactElement) {
   return (
-    <ThemeProvider color="dark">
-      <BaseLayout title="Authorize Application">
-        <GlobalStyles
-          styles={{
-            'html, body': {
-              backgroundColor: '#000 !important',
-            },
-            '#__next': {
-              overflow: 'auto',
-            },
-          }}
-        />
+    <BaseLayout title="Authorize Application">
+      <div className="dark h-screen overflow-auto bg-black text-foreground">
         {page}
-      </BaseLayout>
-    </ThemeProvider>
+      </div>
+    </BaseLayout>
   );
 };

--- a/dashboard/src/pages/onboarding/index.tsx
+++ b/dashboard/src/pages/onboarding/index.tsx
@@ -7,9 +7,7 @@ import { useForm } from 'react-hook-form';
 import { z } from 'zod';
 import { AuthenticatedLayout } from '@/components/layout/AuthenticatedLayout';
 import { Container } from '@/components/layout/Container';
-import { Alert } from '@/components/ui/v2/Alert';
-import { Box } from '@/components/ui/v2/Box';
-import { Text } from '@/components/ui/v2/Text';
+import { Alert, AlertDescription } from '@/components/ui/v3/alert';
 import { Button, ButtonWithLoading } from '@/components/ui/v3/button';
 import {
   Form,
@@ -176,39 +174,39 @@ export default function OnboardingPage() {
       <Container rootClassName="h-full">
         <div className="mx-auto max-w-2xl py-12">
           <div className="mb-8 text-center">
-            <Text variant="h2" className="mb-4 font-bold text-3xl">
+            <h2 className="mb-4 font-bold text-3xl">
               You&apos;ve been invited!
-            </Text>
-            <Text className="text-lg text-muted-foreground">
+            </h2>
+            <p className="text-lg text-muted-foreground">
               You have{' '}
               {invites.length === 1
                 ? 'an invitation'
                 : `${invites.length} invitations`}{' '}
               to join
               {invites.length === 1 ? ' an organization' : ' organizations'}
-            </Text>
+            </p>
           </div>
 
           <div className="space-y-4">
             {invites.map((invite) => (
-              <Box
+              <div
                 key={invite.id}
                 className="rounded-lg border border-border bg-card p-6 shadow-sm"
               >
                 <div className="flex items-center justify-between">
                   <div className="flex-1">
-                    <Text variant="h3" className="mb-2 font-semibold text-xl">
+                    <h3 className="mb-2 font-semibold text-xl">
                       {invite.organization.name}
-                    </Text>
-                    <Text className="text-muted-foreground">
+                    </h3>
+                    <p className="text-muted-foreground">
                       Join as {invite.role.toLowerCase()}
-                    </Text>
-                    <Text className="mt-1 text-muted-foreground text-sm">
+                    </p>
+                    <p className="mt-1 text-muted-foreground text-sm">
                       Invited{' '}
                       {formatDistance(new Date(invite.createdAt), new Date(), {
                         addSuffix: true,
                       })}
-                    </Text>
+                    </p>
                   </div>
                   <div className="ml-6">
                     <Button
@@ -219,15 +217,15 @@ export default function OnboardingPage() {
                     </Button>
                   </div>
                 </div>
-              </Box>
+              </div>
             ))}
           </div>
 
           <div className="mt-8 text-center">
-            <Text className="mb-4 text-muted-foreground text-sm">
+            <p className="mb-4 text-muted-foreground text-sm">
               Don&apos;t want to join? You can create your own organization
               instead.
-            </Text>
+            </p>
             <Button
               variant="outline"
               onClick={() => setShowOnboardingForm(true)}
@@ -259,18 +257,18 @@ export default function OnboardingPage() {
           </div>
         </div>
 
-        <Box className="rounded-lg border border-border bg-white p-6 shadow-sm">
+        <div className="rounded-lg border border-border bg-white p-6 shadow-sm">
           <div className="mb-6 text-center">
-            <Text variant="h2" className="mb-2 font-bold text-2xl text-black">
+            <h2 className="mb-2 font-bold text-2xl text-black">
               Complete Payment
-            </Text>
-            <Text className="text-gray-600">
+            </h2>
+            <p className="text-gray-600">
               Complete your payment to create your organization
-            </Text>
+            </p>
           </div>
 
           <StripeEmbeddedForm clientSecret={stripeClientSecret} />
-        </Box>
+        </div>
       </Container>
     );
   }
@@ -297,14 +295,12 @@ export default function OnboardingPage() {
         </div>
       </div>
 
-      <Box className="rounded-lg border border-border bg-card p-6 shadow-sm">
+      <div className="rounded-lg border border-border bg-card p-6 shadow-sm">
         <div className="mb-6 text-center">
-          <Text variant="h2" className="mb-2 font-bold text-2xl">
-            Welcome to Nhost!
-          </Text>
-          <Text className="text-muted-foreground">
+          <h2 className="mb-2 font-bold text-2xl">Welcome to Nhost!</h2>
+          <p className="text-muted-foreground">
             Let&apos;s create your organization to get started
-          </Text>
+          </p>
         </div>
         <div>
           <Form {...form}>
@@ -423,11 +419,8 @@ export default function OnboardingPage() {
               </div>
 
               {invites && invites.length > 0 && (
-                <Alert
-                  severity="info"
-                  className="mt-4 rounded-lg border border-primary/20 bg-primary/8"
-                >
-                  <Text className="text-sm">
+                <Alert variant="info" className="mt-4">
+                  <AlertDescription>
                     <span className="font-medium text-primary">
                       💡 Pending Invitation{invites.length > 1 ? 's' : ''}
                     </span>
@@ -439,13 +432,13 @@ export default function OnboardingPage() {
                       accept {invites.length > 1 ? 'them' : 'it'} instead of
                       creating a new organization.
                     </span>
-                  </Text>
+                  </AlertDescription>
                 </Alert>
               )}
             </form>
           </Form>
         </div>
-      </Box>
+      </div>
     </Container>
   );
 }

--- a/dashboard/src/pages/onboarding/project.tsx
+++ b/dashboard/src/pages/onboarding/project.tsx
@@ -8,8 +8,6 @@ import slugify from 'slugify';
 import { z } from 'zod';
 import { AuthenticatedLayout } from '@/components/layout/AuthenticatedLayout';
 import { Container } from '@/components/layout/Container';
-import { Box } from '@/components/ui/v2/Box';
-import { Text } from '@/components/ui/v2/Text';
 import { ButtonWithLoading } from '@/components/ui/v3/button';
 import {
   Form,
@@ -192,14 +190,14 @@ export default function OnboardingProjectPage() {
           </div>
         </div>
 
-        <Box className="rounded-lg border border-border bg-card p-6 shadow-sm">
+        <div className="rounded-lg border border-border bg-card p-6 shadow-sm">
           <div className="mb-6 text-center">
-            <Text variant="h2" className="mb-2 font-bold text-2xl">
+            <h2 className="mb-2 font-bold text-2xl">
               Create Your First Project
-            </Text>
-            <Text className="text-muted-foreground">
+            </h2>
+            <p className="text-muted-foreground">
               Projects contain your backend services, database, and APIs
-            </Text>
+            </p>
           </div>
           <div>
             <Form {...form}>
@@ -316,7 +314,7 @@ export default function OnboardingProjectPage() {
               </form>
             </Form>
           </div>
-        </Box>
+        </div>
       </div>
     </Container>
   );

--- a/dashboard/src/pages/signin.tsx
+++ b/dashboard/src/pages/signin.tsx
@@ -2,8 +2,8 @@ import NextLink from 'next/link';
 import { type ReactElement, useEffect } from 'react';
 import { SignInRightColumn } from '@/components/auth/SignInRightColumn';
 import { UnauthenticatedLayout } from '@/components/layout/UnauthenticatedLayout';
-import { Divider } from '@/components/ui/v2/Divider';
 import { Button } from '@/components/ui/v3/button';
+import { Separator } from '@/components/ui/v3/separator';
 import { SignInWithSecurityKey } from '@/features/auth/SignIn/SecurityKey';
 import { SignInWithGithub } from '@/features/auth/SignIn/SignInWithGithub';
 import { useAuth } from '@/providers/Auth';
@@ -37,7 +37,7 @@ export default function SigninPage() {
             OR
           </p>
 
-          <Divider className="!my-2" />
+          <Separator className="my-2" />
         </div>
         <Button
           asChild

--- a/dashboard/src/pages/signup.tsx
+++ b/dashboard/src/pages/signup.tsx
@@ -4,7 +4,7 @@ import type { ReactElement } from 'react';
 import { useCallback } from 'react';
 import { CookieConsent } from '@/components/common/CookieConsent';
 import { UnauthenticatedLayout } from '@/components/layout/UnauthenticatedLayout';
-import { Divider } from '@/components/ui/v2/Divider';
+import { Separator } from '@/components/ui/v3/separator';
 import { SignUpTabs } from '@/features/auth/SignUp/SignUpTabs';
 import { SignUpWithGithub } from '@/features/auth/SignUp/SignUpWithGithub';
 
@@ -144,10 +144,10 @@ export default function SignUpPage() {
               OR
             </p>
 
-            <Divider />
+            <Separator />
           </div>
           <SignUpTabs />
-          <Divider className="!my-2" />
+          <Separator className="my-2" />
           <p className="text-center text-[#A2B3BE] text-sm">
             By signing up, you agree to our{' '}
             <NextLink

--- a/dashboard/src/pages/support/index.tsx
+++ b/dashboard/src/pages/support/index.tsx
@@ -2,27 +2,22 @@ import { SiGithub as GitHubIcon } from '@icons-pack/react-simple-icons';
 import { ArrowRightIcon, FileTextIcon, UsersRoundIcon } from 'lucide-react';
 import Link from 'next/link';
 import { Logo } from '@/components/presentational/Logo';
-import { Box } from '@/components/ui/v2/Box';
-import { Text } from '@/components/ui/v2/Text';
 import { Button } from '@/components/ui/v3/button';
 
 function SupportPage() {
   return (
-    <Box className="h-full overflow-auto pb-4">
-      <Box className="flex w-full justify-start border-b-1 px-4 py-3">
+    <div className="box h-full overflow-auto pb-4">
+      <div className="flex w-full justify-start border-b-1 px-4 py-3">
         <Link href="https://app.nhost.io" rel="noopener noreferrer">
           <Logo className="w-6" />
         </Link>
-      </Box>
+      </div>
 
       <div className="flex flex-col items-center justify-center">
-        <Box
-          sx={{ backgroundColor: 'background.default' }}
-          className="mb-10 flex h-64 w-full flex-col items-center justify-center gap-10 border-b-1 px-4"
-        >
+        <div className="mb-10 flex h-64 w-full flex-col items-center justify-center gap-10 border-b-1 bg-background-default px-4">
           <div>
-            <Text variant="h4">Nhost Support</Text>
-            <Text variant="h2">How can we help?</Text>
+            <h4 className="font-medium text-base">Nhost Support</h4>
+            <h2 className="font-medium text-2xl">How can we help?</h2>
           </div>
           <Button
             onClick={() => window.open('https://docs.nhost.io')}
@@ -31,25 +26,22 @@ function SupportPage() {
             <FileTextIcon className="mr-2 h-4 w-4 self-center" />
             Read our docs
           </Button>
-        </Box>
+        </div>
 
-        <Box className="flex w-full flex-row items-center justify-center gap-10">
+        <div className="flex w-full flex-row items-center justify-center gap-10">
           <div className="flex w-[900px] flex-col gap-10 p-4">
             <div className="flex w-full flex-col gap-10 md:flex-row">
-              <Box
-                className="flex h-full w-full flex-col place-content-between gap-12 rounded-lg px-4 py-3 shadow-sm"
-                sx={{ backgroundColor: 'grey.200' }}
-              >
+              <div className="flex h-full w-full flex-col place-content-between gap-12 rounded-lg bg-muted px-4 py-3 shadow-sm">
                 <div className="flex flex-col gap-4">
                   <GitHubIcon className="h-8 w-8" />
                   <div className="grid grid-flow-row gap-1">
-                    <Text variant="h3" className="!font-bold">
+                    <h3 className="!font-bold text-lg">
                       Issues & feature requests
-                    </Text>
-                    <Text className="!font-medium" color="secondary">
+                    </h3>
+                    <p className="!font-medium text-muted-foreground text-sm">
                       Found a bug? We&apos;d love to hear about it in our GitHub
                       issues.
-                    </Text>
+                    </p>
                   </div>
                 </div>
                 <Link
@@ -61,21 +53,16 @@ function SupportPage() {
                   Open new Issue / Feature request
                   <ArrowRightIcon className="h-4 w-4" />
                 </Link>
-              </Box>
-              <Box
-                className="flex h-full w-full flex-col place-content-between gap-12 rounded-lg px-4 py-3 shadow-sm"
-                sx={{ backgroundColor: 'grey.200' }}
-              >
+              </div>
+              <div className="flex h-full w-full flex-col place-content-between gap-12 rounded-lg bg-muted px-4 py-3 shadow-sm">
                 <div className="flex flex-col gap-4">
                   <UsersRoundIcon className="h-8 w-8" />
                   <div className="grid grid-flow-row gap-1">
-                    <Text variant="h3" className="!font-bold">
-                      Ask the Community
-                    </Text>
-                    <Text className="!font-medium" color="secondary">
+                    <h3 className="!font-bold text-lg">Ask the Community</h3>
+                    <p className="!font-medium text-muted-foreground text-sm">
                       Join our Discord server to browse for help and best
                       practices.
-                    </Text>
+                    </p>
                   </div>
                 </div>
                 <Link
@@ -87,20 +74,22 @@ function SupportPage() {
                   Join our Discord
                   <ArrowRightIcon className="h-4 w-4" />
                 </Link>
-              </Box>
+              </div>
             </div>
-            <Box className="flex h-full w-full xs+:flex-row flex-col place-content-between gap-4 rounded-lg border p-4 shadow-sm">
+            <div className="flex h-full w-full xs+:flex-row flex-col place-content-between gap-4 rounded-lg border p-4 shadow-sm">
               <div className="flex flex-1">
-                <Text variant="h3" className="w-full">
+                <h3 className="w-full font-medium text-lg">
                   Can&apos;t find what you&apos;re looking for?
-                </Text>
+                </h3>
               </div>
               <div className="flex flex-1 flex-col gap-4">
-                <Text variant="h4">Our Support Team is ready to help.</Text>
-                <Text>
+                <h4 className="font-medium text-base">
+                  Our Support Team is ready to help.
+                </h4>
+                <p className="text-sm">
                   Response time for support tickets will vary depending on plan
                   type and severity of the issue.
-                </Text>
+                </p>
                 <Link
                   href="/support/ticket"
                   target="_blank"
@@ -111,11 +100,11 @@ function SupportPage() {
                   <ArrowRightIcon className="h-4 w-4" />
                 </Link>
               </div>
-            </Box>
+            </div>
           </div>
-        </Box>
+        </div>
       </div>
-    </Box>
+    </div>
   );
 }
 


### PR DESCRIPTION
### Checklist

- [ ] No breaking changes
- [ ] Tests pass
- [ ] New features have new tests
- [ ] Documentation is updated (if applicable)
- [ ] Title of the PR is in the correct format (see below)

<!-- pi-reviewer:start -->
### **What this change solves**
Continues the dashboard's removal of the legacy v2 (MUI-based) UI layer by migrating eight standalone leaf pages off `@/components/ui/v2/*` primitives and MUI helpers onto v3 primitives and plain semantic HTML. This reduces the remaining MUI surface area and keeps these pages consistent with the v3 theme foundation.

___

### **Change Type**
Refactoring

___

### **Description**
- Replace v2 `Text` with semantic HTML (`h1`/`h2`/`h3`/`h4`/`p`) plus Tailwind classes across all migrated pages.
- Replace v2 `Box` with plain `div` elements, porting MUI `sx` background props to Tailwind utility classes (`bg-muted`, `bg-background-default`, etc.).
- Migrate v2 `Divider` to v3 `Separator` on the sign-in and sign-up pages.
- Migrate v2 `Alert` + `Text` to v3 `Alert` + `AlertDescription` on the onboarding page.
- On the OAuth2 authorize page, drop the MUI `ThemeProvider color="dark"` + `GlobalStyles` forced-dark approach in favor of a Tailwind `dark` wrapper `div` (`dark ... bg-black text-foreground`), preserving the intentional always-dark auth flow.

___

<details> <summary><h3> File Walkthrough</h3></summary>

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody>
<tr><td><strong>Auth / unauthenticated pages</strong></td><td><details><summary>4 files</summary><table>
<tr>
  <td><strong>signin.tsx</strong><dd><code>Swap v2 Divider for v3 Separator</code></dd></td>
  <td>+2/-2</td>
</tr>
<tr>
  <td><strong>signup.tsx</strong><dd><code>Swap v2 Divider for v3 Separator</code></dd></td>
  <td>+3/-3</td>
</tr>
<tr>
  <td><strong>email/verify.tsx</strong><dd><code>Replace v2 Text/Box with h1/p/div and muted-foreground classes</code></dd></td>
  <td>+6/-12</td>
</tr>
<tr>
  <td><strong>oauth2/authorize.tsx</strong><dd><code>Replace MUI ThemeProvider + GlobalStyles forced-dark with a Tailwind dark wrapper div</code></dd></td>
  <td>+4/-16</td>
</tr>
</table></details></td></tr>
<tr><td><strong>Onboarding pages</strong></td><td><details><summary>2 files</summary><table>
<tr>
  <td><strong>onboarding/index.tsx</strong><dd><code>Migrate Text/Box to semantic HTML and v2 Alert to v3 Alert/AlertDescription</code></dd></td>
  <td>+30/-35</td>
</tr>
<tr>
  <td><strong>onboarding/project.tsx</strong><dd><code>Replace v2 Box/Text with div/h2/p</code></dd></td>
  <td>+6/-8</td>
</tr>
</table></details></td></tr>
<tr><td><strong>Other leaf pages</strong></td><td><details><summary>2 files</summary><table>
<tr>
  <td><strong>404.tsx</strong><dd><code>Replace v2 Text with h1/p</code></dd></td>
  <td>+3/-6</td>
</tr>
<tr>
  <td><strong>support/index.tsx</strong><dd><code>Replace v2 Box/Text with div/h*/p and port sx backgrounds to Tailwind classes</code></dd></td>
  <td>+30/-41</td>
</tr>
</table></details></td></tr>
</tbody></table>

</details>

___

<!-- pi-reviewer:end -->

