### PR TITLE
fix(dashboard): migrate authenticated layout to v3

### DIFF
--- a/dashboard/src/components/layout/AuthenticatedLayout/AuthenticatedLayout.tsx
+++ b/dashboard/src/components/layout/AuthenticatedLayout/AuthenticatedLayout.tsx
@@ -12,7 +12,6 @@ import PinnedMainNav from '@/components/layout/MainNav/PinnedMainNav';
 import { useTreeNavState } from '@/components/layout/MainNav/TreeNavStateContext';
 import { HighlightedText } from '@/components/presentational/HighlightedText';
 import { RetryableErrorBoundary } from '@/components/presentational/RetryableErrorBoundary';
-import { Text } from '@/components/ui/v2/Text';
 import { Spinner } from '@/components/ui/v3/spinner';
 import { TextLink } from '@/components/ui/v3/text-link';
 import { CommandPaletteProvider } from '@/features/command-palette';
@@ -99,11 +98,9 @@ function AuthenticatedLayoutContent({
             />
           </div>
 
-          <Text variant="h3" component="h1">
-            Error Connecting
-          </Text>
+          <h1 className="font-semibold text-2xl">Error Connecting</h1>
 
-          <Text>
+          <p>
             Did you forget to start{' '}
             <HighlightedText className="font-mono">nhost up</HighlightedText>?
             Please refer to the{' '}
@@ -115,7 +112,7 @@ function AuthenticatedLayoutContent({
               CLI documentation
             </TextLink>{' '}
             if you are having trouble starting your project.
-          </Text>
+          </p>
 
           <Spinner size="medium" wrapperClassName="gap-2">
             Checking status...


### PR DESCRIPTION
<!-- pi-reviewer:start -->
### **What this change solves**
Continues the dashboard v2→v3 UI migration by removing the last MUI-era `v2/Text` usage from `AuthenticatedLayout`, so the "Error Connecting" state renders with native semantic elements and Tailwind instead of the legacy component.

___

### **Change Type**
Refactoring

___

### **Description**
- Replace the v2 `<Text variant="h3" component="h1">` heading with a native `<h1>` styled via Tailwind (`font-semibold text-2xl`).
- Replace the v2 `<Text>` body copy with a native `<p>`.
- Drop the now-unused `@/components/ui/v2/Text` import.

___

<details> <summary><h3> File Walkthrough</h3></summary>

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody>
<tr><td><strong>UI migration</strong></td><td><details><summary>1 files</summary><table>
<tr>
  <td><strong>AuthenticatedLayout.tsx</strong><dd><code>v2 Text → native h1/p + Tailwind in the error state; remove v2 Text import</code></dd></td>
  <td>+3/-6</td>
</tr>
</table></details></td></tr>
</tbody></table>

</details>

___

<!-- pi-reviewer:end -->
