### PR TITLE
fix(dashboard): migrate project layout & graphiql styling to v3

### DIFF
--- a/dashboard/src/features/orgs/layout/OrgLayout/ProjectLayoutContent.tsx
+++ b/dashboard/src/features/orgs/layout/OrgLayout/ProjectLayoutContent.tsx
@@ -1,17 +1,15 @@
 import { useRouter } from 'next/router';
 import { NextSeo } from 'next-seo';
-import { useEffect } from 'react';
+import { type ComponentPropsWithoutRef, useEffect } from 'react';
 import { twMerge } from 'tailwind-merge';
 import type { AuthenticatedLayoutProps } from '@/components/layout/AuthenticatedLayout';
 import { LoadingScreen } from '@/components/presentational/LoadingScreen';
-import type { BoxProps } from '@/components/ui/v2/Box';
-import { Box } from '@/components/ui/v2/Box';
+import ProjectViewWithState from '@/features/orgs/layout/OrgLayout/ProjectViewWithState';
 import { useIsPlatform } from '@/features/orgs/projects/common/hooks/useIsPlatform';
 import { useProject } from '@/features/orgs/projects/hooks/useProject';
 import { isEmptyValue, isNotEmptyValue } from '@/lib/utils';
 import { useAuth } from '@/providers/Auth';
 import { getConfigServerUrl, isPlatform as isPlatformFn } from '@/utils/env';
-import ProjectViewWithState from './ProjectViewWithState';
 
 const platFormOnlyPages = [
   '/orgs/[orgSlug]/projects/[appSubdomain]/deployments',
@@ -40,13 +38,15 @@ export interface ProjectLayoutContentProps extends AuthenticatedLayoutProps {
   /**
    * Props passed to the internal `<main />` element.
    */
-  mainContainerProps?: BoxProps;
+  mainContainerProps?: ComponentPropsWithoutRef<'main'>;
 }
 
 function ProjectLayoutContent({
   children,
   mainContainerProps = {},
 }: ProjectLayoutContentProps) {
+  const { className: mainContainerClassName, ...mainContainerRest } =
+    mainContainerProps;
   const { route, push } = useRouter();
 
   const isPlatform = useIsPlatform();
@@ -92,17 +92,16 @@ function ProjectLayoutContent({
   }
 
   return (
-    <Box
-      component="main"
+    <main
+      {...mainContainerRest}
       className={twMerge(
         'relative h-full flex-auto overflow-y-auto',
-        mainContainerProps.className,
+        mainContainerClassName,
       )}
-      {...mainContainerProps}
     >
       <ProjectViewWithState>{children}</ProjectViewWithState>
       <NextSeo title={!isPlatform ? 'Local App' : project?.name} />
-    </Box>
+    </main>
   );
 }
 

--- a/dashboard/src/features/orgs/layout/OrgLayout/ProjectViewWithState.tsx
+++ b/dashboard/src/features/orgs/layout/OrgLayout/ProjectViewWithState.tsx
@@ -1,7 +1,7 @@
 import { useQueryClient } from '@tanstack/react-query';
 import { useRouter } from 'next/router';
 import { type PropsWithChildren, useEffect, useMemo } from 'react';
-import { Alert } from '@/components/ui/v2/Alert';
+import { Alert } from '@/components/ui/v3/alert';
 import { ApplicationProvisioning } from '@/features/orgs/projects/common/components/ApplicationProvisioning';
 import { ApplicationRestoring } from '@/features/orgs/projects/common/components/ApplicationRestoring';
 import { ApplicationUnknown } from '@/features/orgs/projects/common/components/ApplicationUnknown';
@@ -59,7 +59,7 @@ function ProjectViewWithState({ children }: PropsWithChildren) {
           return (
             <>
               <div className="w-full p-4">
-                <Alert severity="error" className="mx-auto max-w-7xl">
+                <Alert variant="destructive" className="mx-auto max-w-7xl">
                   Error deploying the project most likely due to invalid
                   configuration. Please review your project&apos;s configuration
                   and logs for more information.

--- a/dashboard/src/pages/orgs/[orgSlug]/projects/[appSubdomain]/graphql/index.tsx
+++ b/dashboard/src/pages/orgs/[orgSlug]/projects/[appSubdomain]/graphql/index.tsx
@@ -303,35 +303,7 @@ GraphQLPage.getLayout = function getLayout(page: ReactElement) {
   return (
     <OrgLayout
       mainContainerProps={{
-        className: 'flex flex-col h-full',
-        sx: {
-          [`& .graphiql-container`]: {
-            [`& .graphiql-main, & .graphiql-sessions`]: {
-              backgroundColor: 'background.default',
-            },
-            [`& .graphiql-editors, & .graphiql-editor, & .CodeMirror, & .CodeMirror-gutters, & .graphiql-container .graphiql-doc-explorer, & .graphiql-doc-explorer-search-input + div > ul, & .cm-searching`]:
-              {
-                backgroundColor: 'background.paper',
-              },
-            [`& .CodeMirror-linenumber, & .CodeMirror-line, & .graphiql-tabs button.graphiql-tab, & .graphiql-editor-tools-tabs button`]:
-              {
-                color: 'text.disabled',
-              },
-            [`& .graphiql-editor-tools-tabs button.active, & .graphiql-tabs button.graphiql-tab-active, & .graphiql-markdown-description, & .graphiql-doc-explorer-section-title`]:
-              {
-                color: 'text.secondary',
-              },
-            [`& .graphiql-doc-explorer .graphiql-doc-explorer-header`]: {
-              color: 'text.primary',
-            },
-            [`& .graphiql-tabs button`]: {
-              outline: 'none',
-            },
-            [`& .CodeMirror-hint`]: {
-              borderColor: `grey.300`,
-            },
-          },
-        },
+        className: 'graphiql-themed flex h-full flex-col',
       }}
     >
       {page}

--- a/dashboard/src/styles/globals.css
+++ b/dashboard/src/styles/globals.css
@@ -96,6 +96,54 @@ body {
   @apply rounded-none shadow-none !important;
 }
 
+.graphiql-themed .graphiql-container .graphiql-main,
+.graphiql-themed .graphiql-container .graphiql-sessions {
+  background-color: hsl(var(--background-default));
+}
+
+.graphiql-themed .graphiql-container .graphiql-editors,
+.graphiql-themed .graphiql-container .graphiql-editor,
+.graphiql-themed .graphiql-container .CodeMirror,
+.graphiql-themed .graphiql-container .CodeMirror-gutters,
+.graphiql-themed .graphiql-container .graphiql-doc-explorer,
+.graphiql-themed
+  .graphiql-container
+  .graphiql-doc-explorer-search-input
+  + div
+  > ul,
+.graphiql-themed .graphiql-container .cm-searching {
+  background-color: hsl(var(--paper));
+}
+
+.graphiql-themed .graphiql-container .CodeMirror-linenumber,
+.graphiql-themed .graphiql-container .CodeMirror-line,
+.graphiql-themed .graphiql-container .graphiql-tabs button.graphiql-tab,
+.graphiql-themed .graphiql-container .graphiql-editor-tools-tabs button {
+  color: hsl(var(--disabled));
+}
+
+.graphiql-themed .graphiql-container .graphiql-editor-tools-tabs button.active,
+.graphiql-themed .graphiql-container .graphiql-tabs button.graphiql-tab-active,
+.graphiql-themed .graphiql-container .graphiql-markdown-description,
+.graphiql-themed .graphiql-container .graphiql-doc-explorer-section-title {
+  color: hsl(var(--muted-foreground));
+}
+
+.graphiql-themed
+  .graphiql-container
+  .graphiql-doc-explorer
+  .graphiql-doc-explorer-header {
+  color: hsl(var(--primary-text));
+}
+
+.graphiql-themed .graphiql-container .graphiql-tabs button {
+  outline: none;
+}
+
+.graphiql-themed .graphiql-container .CodeMirror-hint {
+  border-color: hsl(var(--divider));
+}
+
 /* Layout bugs on codemirror */
 
 .drop {


### PR DESCRIPTION
<!-- pi-reviewer:start -->
### **What this change solves**
Migrates the project layout and the GraphiQL page styling off MUI-era v2 components and inline `sx` theming onto native elements plus a CSS class, moving the large GraphiQL theme override out of the page into `globals.css` using CSS variables.

___

### **Change Type**
Refactoring

___

### **Description**
- `ProjectLayoutContent`: replace `<Box component="main">` with a native `<main>`; change `mainContainerProps` from v2 `BoxProps` to `ComponentPropsWithoutRef<'main'>`, destructuring `className` so caller props no longer override the merged classes.
- `ProjectViewWithState`: switch the deploy-error `Alert` from v2 (`severity="error"`) to v3 (`variant="destructive"`).
- GraphQL page: remove the inline MUI `sx` GraphiQL theming object and apply a single `graphiql-themed` class instead.
- `globals.css`: add `.graphiql-themed` rules (ported from the removed `sx` object) using `hsl(var(--…))` design tokens. GraphiQL now uses the shared v3 `--disabled`/`--muted-foreground` tokens in place of the hardcoded MUI `text.disabled`/`text.secondary` values; the resulting minor color shift (slightly lighter line numbers and inactive tabs in dark mode) is intentional.

___

### Diagram Walkthrough

```mermaid
flowchart LR
  A["graphql/index.tsx<br/>(inline sx theme)"] -->|extracted to class| B[".graphiql-themed<br/>in globals.css"]
  C["OrgLayout main"] -->|mainContainerProps| A
```

<details> <summary><h3> File Walkthrough</h3></summary>

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody>
<tr><td><strong>UI migration</strong></td><td><details><summary>3 files</summary><table>
<tr>
  <td><strong>ProjectLayoutContent.tsx</strong><dd><code>v2 Box → native main; BoxProps → ComponentPropsWithoutRef&lt;'main'&gt;; destructure className</code></dd></td>
  <td>+9/-10</td>
</tr>
<tr>
  <td><strong>ProjectViewWithState.tsx</strong><dd><code>v2 Alert severity=error → v3 Alert variant=destructive</code></dd></td>
  <td>+2/-2</td>
</tr>
<tr>
  <td><strong>graphql/index.tsx</strong><dd><code>remove inline MUI sx GraphiQL theming; apply graphiql-themed class</code></dd></td>
  <td>+1/-29</td>
</tr>
</table></details></td></tr>
<tr><td><strong>Styles</strong></td><td><details><summary>1 files</summary><table>
<tr>
  <td><strong>globals.css</strong><dd><code>add .graphiql-themed rules ported from sx, using CSS variable tokens</code></dd></td>
  <td>+41/-0</td>
</tr>
</table></details></td></tr>
</tbody></table>

</details>

___

<!-- pi-reviewer:end -->
