### PR TITLE
fix(dashboard): raise error when provider tokens request fails after sign-in

### DIFF
--- a/dashboard/src/providers/Auth/AuthProvider.test.tsx
+++ b/dashboard/src/providers/Auth/AuthProvider.test.tsx
@@ -7,12 +7,12 @@ import {
 } from '@apollo/client';
 import { createServerClient } from '@nhost/nhost-js';
 import type { ProviderSession } from '@nhost/nhost-js/auth';
-import { HttpResponse, http, type HttpResponseResolver } from 'msw';
+import { HttpResponse, type HttpResponseResolver, http } from 'msw';
 import { setupServer } from 'msw/node';
 import type { NextRouter } from 'next/router';
 import type React from 'react';
 import { useContext } from 'react';
-import { toast, Toaster } from 'react-hot-toast';
+import { Toaster, toast } from 'react-hot-toast';
 
 import * as gitUtils from '@/features/orgs/projects/git/common/utils';
 import { AuthContext } from '@/providers/Auth/AuthContext';
@@ -66,9 +66,7 @@ const ContextConsumer = () => {
       <span data-testid="is-authenticated">
         {ctx?.isAuthenticated ? 'true' : 'false'}
       </span>
-      <span data-testid="is-loading">
-        {ctx?.isLoading ? 'true' : 'false'}
-      </span>
+      <span data-testid="is-loading">{ctx?.isLoading ? 'true' : 'false'}</span>
       <span data-testid="is-signing-out">
         {ctx?.isSigningOut ? 'true' : 'false'}
       </span>
@@ -311,20 +309,17 @@ describe('AuthProvider', () => {
     it.each([
       ['empty object', () => HttpResponse.json({})],
       ['no content', () => new HttpResponse(null, { status: 204 })],
-    ])(
-      'shows an error and skips saving for a %s response body',
-      async (_bodyType, providerTokens) => {
-        renderGithubCallback(baseQuery, providerTokens);
+    ])('shows an error and skips saving for a %s response body', async (_bodyType, providerTokens) => {
+      renderGithubCallback(baseQuery, providerTokens);
 
-        expect(
-          await screen.findByText(providerTokensErrorMessage),
-        ).toBeInTheDocument();
-        await waitFor(() => {
-          expect(screen.getByTestId('is-loading').textContent).toBe('false');
-        });
-        expect(gitUtils.getGitHubToken()).toBeNull();
-      },
-    );
+      expect(
+        await screen.findByText(providerTokensErrorMessage),
+      ).toBeInTheDocument();
+      await waitFor(() => {
+        expect(screen.getByTestId('is-loading').textContent).toBe('false');
+      });
+      expect(gitUtils.getGitHubToken()).toBeNull();
+    });
   });
 
   describe('Re-render Edge Cases', () => {

--- a/dashboard/src/providers/Auth/AuthProvider.test.tsx
+++ b/dashboard/src/providers/Auth/AuthProvider.test.tsx
@@ -1,13 +1,25 @@
 /// <reference types="vitest/globals" />
+import {
+  ApolloClient,
+  ApolloProvider,
+  createHttpLink,
+  InMemoryCache,
+} from '@apollo/client';
 import { createServerClient } from '@nhost/nhost-js';
+import type { ProviderSession } from '@nhost/nhost-js/auth';
+import { HttpResponse, http, type HttpResponseResolver } from 'msw';
+import { setupServer } from 'msw/node';
+import type { NextRouter } from 'next/router';
 import type React from 'react';
 import { useContext } from 'react';
+import { toast, Toaster } from 'react-hot-toast';
 
 import * as gitUtils from '@/features/orgs/projects/git/common/utils';
 import { AuthContext } from '@/providers/Auth/AuthContext';
 import AuthProvider from '@/providers/Auth/AuthProvider';
 import { NhostProvider } from '@/providers/nhost';
 import { mockMatchMediaValue, mockRouter, mockSession } from '@/tests/mocks';
+import nhostGraphQLLink from '@/tests/msw/mocks/graphql/nhostGraphQLLink';
 import { render, screen, waitFor } from '@/tests/testUtils';
 import { DummySessionStorage } from '@/utils/nhost';
 
@@ -26,6 +38,25 @@ vi.mock('next/router', () => ({
   default: { push: vi.fn(), query: {}, pathname: '/' },
 }));
 
+const authUrl = 'https://local.auth.local.nhost.run/v1';
+
+const server = setupServer(
+  http.post(`${authUrl}/token/exchange`, () =>
+    HttpResponse.json({ session: mockSession }),
+  ),
+  http.post(
+    `${authUrl}/signout`,
+    () => new HttpResponse(null, { status: 204 }),
+  ),
+);
+
+beforeAll(() => server.listen());
+afterEach(() => server.resetHandlers());
+afterAll(() => server.close());
+
+const providerTokensErrorMessage =
+  'Signed in, but we could not retrieve your GitHub credentials. Please try signing in with GitHub again.';
+
 // Create a component that consumes the AuthContext to trigger and test state changes
 const ContextConsumer = () => {
   const ctx = useContext(AuthContext);
@@ -34,6 +65,9 @@ const ContextConsumer = () => {
     <div>
       <span data-testid="is-authenticated">
         {ctx?.isAuthenticated ? 'true' : 'false'}
+      </span>
+      <span data-testid="is-loading">
+        {ctx?.isLoading ? 'true' : 'false'}
       </span>
       <span data-testid="is-signing-out">
         {ctx?.isSigningOut ? 'true' : 'false'}
@@ -140,6 +174,157 @@ describe('AuthProvider', () => {
       ).toBeInTheDocument();
       expect(mockRouter.push).toHaveBeenCalledWith('/signin');
     });
+  });
+
+  describe('GitHub provider tokens', () => {
+    const baseQuery = {
+      code: 'auth-code',
+      pkceId: 'pkce-1',
+      signinProvider: 'github',
+    };
+
+    const renderGithubCallback = (
+      query: NextRouter['query'],
+      providerTokens: HttpResponseResolver,
+    ) => {
+      localStorage.setItem('nhost_pkce_verifier:pkce-1', 'verifier');
+      mocks.useRouter.mockReturnValue({ ...mockRouter, query });
+      server.use(
+        http.get(
+          `${authUrl}/signin/provider/github/callback/tokens`,
+          providerTokens,
+        ),
+      );
+
+      const nhost = createServerClient({
+        subdomain: 'local',
+        region: 'local',
+        storage: new DummySessionStorage(),
+      });
+
+      const apolloClient = new ApolloClient({
+        cache: new InMemoryCache(),
+        link: createHttpLink({
+          uri: 'https://local.graphql.local.nhost.run/v1',
+        }),
+        defaultOptions: {
+          query: { fetchPolicy: 'no-cache' },
+          watchQuery: { fetchPolicy: 'no-cache' },
+        },
+      });
+
+      const GitHubCallbackWrapper = ({
+        children,
+      }: {
+        children: React.ReactNode;
+      }) => (
+        <NhostProvider nhost={nhost}>
+          <ApolloProvider client={apolloClient}>
+            <AuthProvider>
+              <Toaster />
+              {children}
+            </AuthProvider>
+          </ApolloProvider>
+        </NhostProvider>
+      );
+
+      return render(<ContextConsumer />, { wrapper: GitHubCallbackWrapper });
+    };
+
+    beforeEach(() => {
+      toast.remove();
+      localStorage.clear();
+      sessionStorage.clear();
+      vi.spyOn(console, 'error').mockImplementation(() => {});
+    });
+
+    afterEach(() => {
+      toast.remove();
+      localStorage.clear();
+      sessionStorage.clear();
+    });
+
+    it('shows an error without blocking sign-in when provider tokens fail', async () => {
+      renderGithubCallback(baseQuery, () =>
+        HttpResponse.json({ message: 'boom' }, { status: 500 }),
+      );
+
+      expect(
+        await screen.findByText(providerTokensErrorMessage),
+      ).toBeInTheDocument();
+      await waitFor(() => {
+        expect(screen.getByTestId('is-authenticated').textContent).toBe('true');
+        expect(screen.getByTestId('is-loading').textContent).toBe('false');
+      });
+      expect(mockRouter.push).not.toHaveBeenCalledWith('/signin');
+      expect(gitUtils.getGitHubToken()).toBeNull();
+    });
+
+    it('keeps the signin-refresh redirect when provider tokens fail', async () => {
+      renderGithubCallback(
+        { ...baseQuery, state: 'signin-refresh:my-org:my-proj' },
+        () => HttpResponse.json({ message: 'boom' }, { status: 500 }),
+      );
+
+      expect(
+        await screen.findByText(providerTokensErrorMessage),
+      ).toBeInTheDocument();
+      await waitFor(() => {
+        expect(mockRouter.push).toHaveBeenCalledWith(
+          '/orgs/my-org/projects/my-proj/settings/deployments?github-modal',
+        );
+      });
+      expect(mockRouter.push).not.toHaveBeenCalledWith('/signin');
+    });
+
+    it('saves valid provider tokens without showing an error', async () => {
+      const providerTokens: ProviderSession = {
+        accessToken: 'gh',
+        refreshToken: 'r',
+        expiresIn: 3599,
+        expiresAt: '2099-01-01T00:00:00.000Z',
+      };
+      server.use(
+        nhostGraphQLLink.query('getAuthUserProviders', () =>
+          HttpResponse.json({
+            data: {
+              authUserProviders: [
+                { id: 'auth-user-provider-1', providerId: 'github' },
+              ],
+            },
+          }),
+        ),
+      );
+
+      renderGithubCallback(baseQuery, () => HttpResponse.json(providerTokens));
+
+      await waitFor(() => {
+        expect(gitUtils.getGitHubToken()).toEqual({
+          ...providerTokens,
+          authUserProviderId: 'auth-user-provider-1',
+        });
+        expect(screen.getByTestId('is-loading').textContent).toBe('false');
+      });
+      expect(screen.queryByText(providerTokensErrorMessage)).toBeNull();
+    });
+
+    it.each([
+      ['empty object', () => HttpResponse.json({})],
+      ['no content', () => new HttpResponse(null, { status: 204 })],
+    ])(
+      'shows an error and skips saving for a %s response body',
+      async (_bodyType, providerTokens) => {
+        renderGithubCallback(baseQuery, providerTokens);
+
+        expect(
+          await screen.findByText(providerTokensErrorMessage),
+        ).toBeInTheDocument();
+        await waitFor(() => {
+          expect(screen.getByTestId('is-loading').textContent).toBe('false');
+        });
+        expect(gitUtils.getGitHubToken()).toBeNull();
+      },
+    );
   });
 
   describe('Re-render Edge Cases', () => {

--- a/dashboard/src/providers/Auth/AuthProvider.tsx
+++ b/dashboard/src/providers/Auth/AuthProvider.tsx
@@ -10,7 +10,7 @@ import {
 import { useGetAuthUserProvidersLazyQuery } from '@/generated/graphql';
 import { useRemoveQueryParamsFromUrl } from '@/hooks/useRemoveQueryParamsFromUrl';
 import { consumePKCEVerifier } from '@/lib/pkce';
-import { isNotEmptyValue } from '@/lib/utils';
+import { isEmptyValue, isNotEmptyValue } from '@/lib/utils';
 import { useNhostClient } from '@/providers/nhost/';
 import { getToastStyleProps } from '@/utils/constants/settings';
 import { AuthContext, type AuthContextType } from './AuthContext';
@@ -96,23 +96,28 @@ function AuthProvider({ children }: PropsWithChildren) {
             try {
               const providerTokensResponse =
                 await nhost.auth.getProviderTokens('github');
-              if (providerTokensResponse.body) {
-                const { data } = await getAuthUserProviders();
-                const githubProvider = data?.authUserProviders?.find(
-                  (provider) => provider.providerId === 'github',
-                );
-                const newGitHubToken: GitHubProviderToken =
-                  providerTokensResponse.body;
-                if (
-                  isNotEmptyValue(githubProvider) &&
-                  isNotEmptyValue(githubProvider?.id)
-                ) {
-                  newGitHubToken.authUserProviderId = githubProvider.id;
-                }
-                saveGitHubToken(newGitHubToken);
+              if (isEmptyValue(providerTokensResponse.body)) {
+                throw new Error('Empty provider tokens response');
               }
+              const { data } = await getAuthUserProviders();
+              const githubProvider = data?.authUserProviders?.find(
+                (provider) => provider.providerId === 'github',
+              );
+              const newGitHubToken: GitHubProviderToken =
+                providerTokensResponse.body;
+              if (
+                isNotEmptyValue(githubProvider) &&
+                isNotEmptyValue(githubProvider?.id)
+              ) {
+                newGitHubToken.authUserProviderId = githubProvider.id;
+              }
+              saveGitHubToken(newGitHubToken);
             } catch (err) {
               console.error('Failed to fetch provider tokens:', err);
+              toast.error(
+                'Signed in, but we could not retrieve your GitHub credentials. Please try signing in with GitHub again.',
+                getToastStyleProps(),
+              );
             }
           }
 


### PR DESCRIPTION
Resolves #4129

<img width="526" height="231" alt="Screenshot 2026-08-06 at 17 34 44" src="https://github.com/user-attachments/assets/bbd33be1-94c7-45fc-980b-c3f88012a8e7" />

### Checklist

- [X] No breaking changes
- [X] Tests pass
- [X] New features have new tests
- [X] Documentation is updated (if applicable)
- [X] Title of the PR is in the correct format (see below)

<!-- pi-reviewer:start -->
### **What this change solves**
After a GitHub OAuth sign-in, a failed or empty response from the provider-tokens endpoint was silently swallowed: the user appeared fully signed in but had no GitHub credentials, so Git-integration features broke with no explanation. The user is now shown an error toast asking them to sign in with GitHub again, while the sign-in itself still completes.

___

### **Change Type**
Bug fix

___

### **Description**
- Treat an empty `getProviderTokens` response body as an error instead of silently skipping the token save
- Show an error toast when fetching or saving GitHub provider tokens fails, without blocking sign-in or the post-sign-in redirect
- Add MSW-backed tests covering the GitHub OAuth callback: 500 response, empty/no-content response bodies, the signin-refresh redirect, and the successful token-save path

___

<details> <summary><h3> File Walkthrough</h3></summary>

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody>
<tr><td><strong>Bug fix</strong></td><td><details><summary>1 files</summary><table>
<tr>
  <td><strong>dashboard/src/providers/Auth/AuthProvider.tsx</strong><dd><code>Throw on empty provider-tokens body; show error toast when provider-token retrieval fails</code></dd></td>
  <td>+20/-15</td>
</tr>
</table></details></td></tr>
<tr><td><strong>Tests</strong></td><td><details><summary>1 files</summary><table>
<tr>
  <td><strong>dashboard/src/providers/Auth/AuthProvider.test.tsx</strong><dd><code>MSW-backed tests for GitHub provider-token failure, empty-body, redirect, and success paths</code></dd></td>
  <td>+185/-0</td>
</tr>
</table></details></td></tr>
</tbody></table>

</details>

___

<!-- pi-reviewer:end -->
