### PR TITLE
fix(observability): Excessive low memory alerts due to page cache

### DIFF
--- a/docs/src/content/docs/platform/cloud/metrics.mdx
+++ b/docs/src/content/docs/platform/cloud/metrics.mdx
@@ -79,7 +79,7 @@ This will enable the following rules, which you can find in your grafana dashboa
    - Duration: Persistent for 5-10 minutes
 
 3. **Low free memory**
-   - Trigger: Memory usage > 75%
+   - Trigger: Working set memory (excludes reclaimable disk cache) > 75%
    - Duration: Continuous for 5-10 minutes
 
 4. **Service restarted due to lack of memory**

--- a/docs/src/content/docs/platform/cloud/metrics.mdx
+++ b/docs/src/content/docs/platform/cloud/metrics.mdx
@@ -79,7 +79,7 @@ This will enable the following rules, which you can find in your grafana dashboa
    - Duration: Persistent for 5-10 minutes
 
 3. **Low free memory**
-   - Trigger: Working set memory (excludes reclaimable disk cache) > 75%
+   - Trigger: Memory usage > 75% (cold file cache is excluded; recently accessed file cache still counts)
    - Duration: Continuous for 5-10 minutes
 
 4. **Service restarted due to lack of memory**

--- a/observability/grafana/README.md
+++ b/observability/grafana/README.md
@@ -6,3 +6,7 @@ To contribute a dashboard, please follow the steps below:
 4. Make sure the "Export for sharing externally" checkbox is NOT checked.
 5. Click on the "Save to file" button.
 6. Save the file in the `dashboards` directory.
+
+## Template safety
+
+`rules_nhost.yaml` and the dashboard JSON files are Go templates. Preserve their `{{ ... }}` actions exactly; do not run formatters that rewrite template delimiters or insert spaces between their braces.

--- a/observability/grafana/dashboard_graphql.json
+++ b/observability/grafana/dashboard_graphql.json
@@ -162,7 +162,7 @@
         "type": "prometheus",
         "uid": "nhost"
       },
-      "description": "Working set memory per replica: memory that is actively in use and cannot be reclaimed by the kernel. Reclaimable disk cache is excluded, so this is the value that is compared against the service's memory limit when deciding whether to restart (OOM-kill) it.",
+      "description": "Total container memory usage, minus file cache that's gone cold.",
       "fieldConfig": {
         "defaults": {
           "color": {

--- a/observability/grafana/dashboard_graphql.json
+++ b/observability/grafana/dashboard_graphql.json
@@ -162,6 +162,7 @@
         "type": "prometheus",
         "uid": "nhost"
       },
+      "description": "Working set memory per replica: memory that is actively in use and cannot be reclaimed by the kernel. Reclaimable disk cache is excluded, so this is the value that is compared against the service's memory limit when deciding whether to restart (OOM-kill) it.",
       "fieldConfig": {
         "defaults": {
           "color": {
@@ -241,7 +242,7 @@
             "uid": "nhost"
           },
           "editorMode": "code",
-          "expr": "sum by(container,pod) (container_memory_usage_bytes{container=~\"hasura|hasura-graphi\"})",
+          "expr": "sum by(container,pod) (container_memory_working_set_bytes{container=~\"hasura|hasura-graphi\"})",
           "interval": "2m",
           "legendFormat": "{{ print "{{pod}}::{{container}}" }}",
           "range": true,

--- a/observability/grafana/dashboard_project_metrics.json
+++ b/observability/grafana/dashboard_project_metrics.json
@@ -1087,8 +1087,8 @@
         "overrides": [
           {
             "matcher": {
-              "id": "byRegexp",
-              "options": ".*-cache \\(reclaimable\\)"
+              "id": "byFrameRefID",
+              "options": "C"
             },
             "properties": [
               {

--- a/observability/grafana/dashboard_project_metrics.json
+++ b/observability/grafana/dashboard_project_metrics.json
@@ -205,7 +205,7 @@
         "type": "prometheus",
         "uid": "nhost"
       },
-      "description": "Working set memory per service replica: memory that is actively in use and cannot be reclaimed by the kernel. Reclaimable disk cache is excluded, so this is the value that is compared against the service's memory limit when deciding whether to restart (OOM-kill) it.",
+      "description": "Total container memory usage, minus file cache that's gone cold.",
       "fieldConfig": {
         "defaults": {
           "color": {
@@ -1033,7 +1033,7 @@
         "type": "prometheus",
         "uid": "nhost"
       },
-      "description": "This graph shows memory utilization for the service. The used line shows the service's working set: memory that is actively in use and cannot be reclaimed by the kernel. This is the value that is compared against the limit when deciding whether to restart (OOM-kill) the service. The cache (reclaimable) line shows disk cache the kernel keeps while memory is free; it is evicted automatically under memory pressure and does not put the service at risk, so it is normal for used + cache to sit near the limit on a database doing regular I/O. The allotted line shows what's the amount of memory a service is allowed to consume. As resources are shared there is the possibility that the actual memory available is slightly lower. If a service's working set exceeds the amount of memory it can use, it is restarted automatically.",
+      "description": "The used line shows the service's working set: the container's memory usage, excluding cached file data it hasn't touched recently. The cache (reclaimable) line shows disk cache the kernel keeps while memory is free; it is evicted automatically under memory pressure. The allotted line shows the amount of memory a service is allowed to consume. As resources are shared, the actual memory available may be slightly lower. If a service's working set exceeds the amount of memory it can use, it may be restarted automatically.",
       "fieldConfig": {
         "defaults": {
           "color": {
@@ -1503,7 +1503,7 @@
         "type": "prometheus",
         "uid": "nhost"
       },
-      "description": "This graph shows memory utilization for the service. The used line shows the service's working set: memory that is actively in use and cannot be reclaimed by the kernel. This is the value that is compared against the limit when deciding whether to restart (OOM-kill) the service. The allotted line shows what's the amount of memory a service is allowed to consume. As resources are shared there is the possibility that the actual memory available is slightly lower. If a service's working set exceeds the amount of memory it can use, it is restarted automatically.",
+      "description": "This graph shows memory utilization for the service. The used line shows the service's working set: the container's memory usage, excluding cached file data it hasn't touched recently. The allotted line shows the amount of memory a service is allowed to consume. As resources are shared, the actual memory available may be slightly lower. If a service's working set exceeds the amount of memory it can use, it may be restarted automatically.",
       "fieldConfig": {
         "defaults": {
           "color": {
@@ -1727,7 +1727,7 @@
         "type": "prometheus",
         "uid": "nhost"
       },
-      "description": "This graph shows memory utilization for the service. The used line shows the service's working set: memory that is actively in use and cannot be reclaimed by the kernel. This is the value that is compared against the limit when deciding whether to restart (OOM-kill) the service. The allotted line shows what's the amount of memory a service is allowed to consume. As resources are shared there is the possibility that the actual memory available is slightly lower. If a service's working set exceeds the amount of memory it can use, it is restarted automatically.",
+      "description": "This graph shows memory utilization for the service. The used line shows the service's working set: the container's memory usage, excluding cached file data it hasn't touched recently. The allotted line shows the amount of memory a service is allowed to consume. As resources are shared, the actual memory available may be slightly lower. If a service's working set exceeds the amount of memory it can use, it may be restarted automatically.",
       "fieldConfig": {
         "defaults": {
           "color": {
@@ -1951,7 +1951,7 @@
         "type": "prometheus",
         "uid": "nhost"
       },
-      "description": "This graph shows memory utilization for the service. The used line shows the service's working set: memory that is actively in use and cannot be reclaimed by the kernel. This is the value that is compared against the limit when deciding whether to restart (OOM-kill) the service. The allotted line shows what's the amount of memory a service is allowed to consume. As resources are shared there is the possibility that the actual memory available is slightly lower. If a service's working set exceeds the amount of memory it can use, it is restarted automatically.",
+      "description": "This graph shows memory utilization for the service. The used line shows the service's working set: the container's memory usage, excluding cached file data it hasn't touched recently. The allotted line shows the amount of memory a service is allowed to consume. As resources are shared, the actual memory available may be slightly lower. If a service's working set exceeds the amount of memory it can use, it may be restarted automatically.",
       "fieldConfig": {
         "defaults": {
           "color": {

--- a/observability/grafana/dashboard_project_metrics.json
+++ b/observability/grafana/dashboard_project_metrics.json
@@ -205,6 +205,7 @@
         "type": "prometheus",
         "uid": "nhost"
       },
+      "description": "Working set memory per service replica: memory that is actively in use and cannot be reclaimed by the kernel. Reclaimable disk cache is excluded, so this is the value that is compared against the service's memory limit when deciding whether to restart (OOM-kill) it.",
       "fieldConfig": {
         "defaults": {
           "color": {
@@ -287,7 +288,7 @@
             "uid": "nhost"
           },
           "editorMode": "code",
-          "expr": "sum by (pod) (container_memory_usage_bytes{container!~\"POD|\"})",
+          "expr": "sum by (pod) (container_memory_working_set_bytes{container!~\"POD|\"})",
           "legendFormat": "__auto",
           "range": true,
           "refId": "A"
@@ -1032,7 +1033,7 @@
         "type": "prometheus",
         "uid": "nhost"
       },
-      "description": "This graph shows memory utilization for the service. The allotted line shows what's the amount of memory a service is allowed to consume. As resources are shared there is the possibility that the actual memory available is slightly lower. If a service exceeds the amount of memory it can use, it is restarted automatically.",
+      "description": "This graph shows memory utilization for the service. The used line shows the service's working set: memory that is actively in use and cannot be reclaimed by the kernel. This is the value that is compared against the limit when deciding whether to restart (OOM-kill) the service. The cache (reclaimable) line shows disk cache the kernel keeps while memory is free; it is evicted automatically under memory pressure and does not put the service at risk, so it is normal for used + cache to sit near the limit on a database doing regular I/O. The allotted line shows what's the amount of memory a service is allowed to consume. As resources are shared there is the possibility that the actual memory available is slightly lower. If a service's working set exceeds the amount of memory it can use, it is restarted automatically.",
       "fieldConfig": {
         "defaults": {
           "color": {
@@ -1083,7 +1084,30 @@
           },
           "unit": "bytes"
         },
-        "overrides": []
+        "overrides": [
+          {
+            "matcher": {
+              "id": "byRegexp",
+              "options": ".*-cache \\(reclaimable\\)"
+            },
+            "properties": [
+              {
+                "id": "custom.lineStyle",
+                "value": {
+                  "dash": [10, 10],
+                  "fill": "dash"
+                }
+              },
+              {
+                "id": "color",
+                "value": {
+                  "fixedColor": "text",
+                  "mode": "fixed"
+                }
+              }
+            ]
+          }
+        ]
       },
       "gridPos": {
         "h": 8,
@@ -1111,11 +1135,23 @@
             "uid": "nhost"
           },
           "editorMode": "code",
-          "expr": "sum by(pod) (container_memory_usage_bytes{container=\"postgres\"})",
+          "expr": "sum by(pod) (container_memory_working_set_bytes{container=\"postgres\"})",
           "hide": false,
           "legendFormat": "{{ print "{{pod}}-used" }}",
           "range": true,
           "refId": "A"
+        },
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "nhost"
+          },
+          "editorMode": "code",
+          "expr": "sum by(pod) (container_memory_usage_bytes{container=\"postgres\"} - container_memory_working_set_bytes{container=\"postgres\"})",
+          "hide": false,
+          "legendFormat": "{{ print "{{pod}}-cache (reclaimable)" }}",
+          "range": true,
+          "refId": "C"
         },
         {
           "datasource": {
@@ -1467,7 +1503,7 @@
         "type": "prometheus",
         "uid": "nhost"
       },
-      "description": "This graph shows memory utilization for the service. The allotted line shows what's the amount of memory a service is allowed to consume. As resources are shared there is the possibility that the actual memory available is slightly lower. If a service exceeds the amount of memory it can use, it is restarted automatically.",
+      "description": "This graph shows memory utilization for the service. The used line shows the service's working set: memory that is actively in use and cannot be reclaimed by the kernel. This is the value that is compared against the limit when deciding whether to restart (OOM-kill) the service. The allotted line shows what's the amount of memory a service is allowed to consume. As resources are shared there is the possibility that the actual memory available is slightly lower. If a service's working set exceeds the amount of memory it can use, it is restarted automatically.",
       "fieldConfig": {
         "defaults": {
           "color": {
@@ -1546,7 +1582,7 @@
             "uid": "nhost"
           },
           "editorMode": "code",
-          "expr": "sum by(pod) (container_memory_usage_bytes{container=\"hasura\"})",
+          "expr": "sum by(pod) (container_memory_working_set_bytes{container=\"hasura\"})",
           "hide": false,
           "legendFormat": "{{ print "{{pod}}-used" }}",
           "range": true,
@@ -1691,7 +1727,7 @@
         "type": "prometheus",
         "uid": "nhost"
       },
-      "description": "This graph shows memory utilization for the service. The allotted line shows what's the amount of memory a service is allowed to consume. As resources are shared there is the possibility that the actual memory available is slightly lower. If a service exceeds the amount of memory it can use, it is restarted automatically.",
+      "description": "This graph shows memory utilization for the service. The used line shows the service's working set: memory that is actively in use and cannot be reclaimed by the kernel. This is the value that is compared against the limit when deciding whether to restart (OOM-kill) the service. The allotted line shows what's the amount of memory a service is allowed to consume. As resources are shared there is the possibility that the actual memory available is slightly lower. If a service's working set exceeds the amount of memory it can use, it is restarted automatically.",
       "fieldConfig": {
         "defaults": {
           "color": {
@@ -1770,7 +1806,7 @@
             "uid": "nhost"
           },
           "editorMode": "code",
-          "expr": "sum by(pod) (container_memory_usage_bytes{container=\"hasura-auth\"})",
+          "expr": "sum by(pod) (container_memory_working_set_bytes{container=\"hasura-auth\"})",
           "hide": false,
           "legendFormat": "{{ print "{{pod}}-used" }}",
           "range": true,
@@ -1915,7 +1951,7 @@
         "type": "prometheus",
         "uid": "nhost"
       },
-      "description": "This graph shows memory utilization for the service. The allotted line shows what's the amount of memory a service is allowed to consume. As resources are shared there is the possibility that the actual memory available is slightly lower. If a service exceeds the amount of memory it can use, it is restarted automatically.",
+      "description": "This graph shows memory utilization for the service. The used line shows the service's working set: memory that is actively in use and cannot be reclaimed by the kernel. This is the value that is compared against the limit when deciding whether to restart (OOM-kill) the service. The allotted line shows what's the amount of memory a service is allowed to consume. As resources are shared there is the possibility that the actual memory available is slightly lower. If a service's working set exceeds the amount of memory it can use, it is restarted automatically.",
       "fieldConfig": {
         "defaults": {
           "color": {
@@ -1994,7 +2030,7 @@
             "uid": "nhost"
           },
           "editorMode": "code",
-          "expr": "sum by(pod) (container_memory_usage_bytes{container=\"hasura-storage\"})",
+          "expr": "sum by(pod) (container_memory_working_set_bytes{container=\"hasura-storage\"})",
           "hide": false,
           "legendFormat": "{{ print "{{pod}}-used" }}",
           "range": true,

--- a/observability/grafana/dashboard_project_metrics.json
+++ b/observability/grafana/dashboard_project_metrics.json
@@ -1033,7 +1033,7 @@
         "type": "prometheus",
         "uid": "nhost"
       },
-      "description": "The used line shows the service's working set: the container's memory usage, excluding cached file data it hasn't touched recently. The cache (reclaimable) line shows disk cache the kernel keeps while memory is free; it is evicted automatically under memory pressure. The allotted line shows the amount of memory a service is allowed to consume. As resources are shared, the actual memory available may be slightly lower. If a service's working set exceeds the amount of memory it can use, it may be restarted automatically.",
+      "description": "The used line shows the service's working set: the container's memory usage, excluding cached file data it hasn't touched recently. The cold cache (reclaimable) line shows that excluded cache. Recently accessed file cache remains in the used line, so high used memory may still include reclaimable cache. The allotted line shows the amount of memory a service is allowed to consume. As resources are shared, the actual memory available may be slightly lower. If a service's working set exceeds the amount of memory it can use, it may be restarted automatically.",
       "fieldConfig": {
         "defaults": {
           "color": {
@@ -1094,7 +1094,10 @@
               {
                 "id": "custom.lineStyle",
                 "value": {
-                  "dash": [10, 10],
+                  "dash": [
+                    10,
+                    10
+                  ],
                   "fill": "dash"
                 }
               },
@@ -1147,11 +1150,11 @@
             "uid": "nhost"
           },
           "editorMode": "code",
-          "expr": "sum by(pod) (container_memory_usage_bytes{container=\"postgres\"} - container_memory_working_set_bytes{container=\"postgres\"})",
+          "expr": "sum by(pod) (container_spec_memory_limit_bytes{container=\"postgres\"})",
           "hide": false,
-          "legendFormat": "{{ print "{{pod}}-cache (reclaimable)" }}",
+          "legendFormat": "{{ print "{{pod}}-alloted" }}",
           "range": true,
-          "refId": "C"
+          "refId": "B"
         },
         {
           "datasource": {
@@ -1159,11 +1162,11 @@
             "uid": "nhost"
           },
           "editorMode": "code",
-          "expr": "sum by(pod) (container_spec_memory_limit_bytes{container=\"postgres\"})",
+          "expr": "sum by(pod) (container_memory_usage_bytes{container=\"postgres\"}) - sum by(pod) (container_memory_working_set_bytes{container=\"postgres\"})",
           "hide": false,
-          "legendFormat": "{{ print "{{pod}}-alloted" }}",
+          "legendFormat": "{{ print "{{pod}}-cold cache (reclaimable)" }}",
           "range": true,
-          "refId": "B"
+          "refId": "C"
         }
       ],
       "title": "Memory Usage",

--- a/observability/grafana/rules_nhost.yaml
+++ b/observability/grafana/rules_nhost.yaml
@@ -203,10 +203,12 @@ groups:
           Subdomain: {{ .Subdomain }}
           Project Name: {{ .ProjectName }}
           description: |
-            Low memory (excluding cache) can be caused by a number of factors, including but not limited to:
+            Low memory can be caused by a number of factors, including but not limited to:
             - High traffic
             - Inefficient code/queries
             - Inadequate resources
+
+            The reported usage excludes cold file cache, but recently accessed file cache still counts.
 
             To resolve this issue, consider the following:
             - Optimize your code/queries
@@ -217,7 +219,7 @@ groups:
             For more information, see the [Nhost documentation](https://docs.nhost.io/platform/cloud/compute-resources)
 
           summary: |
-            The service replica {{ print "{{ index $labels \"pod\" }}" }} is experiencing, or has experienced, low memory. Current usage (minus reclaimable cache) is at {{ print "{{ index $values \"A\" }}" }}%.
+            The service replica {{ print "{{ index $labels \"pod\" }}" }} is experiencing, or has experienced, low memory. Current usage (excluding cold file cache) is at {{ print "{{ index $values \"A\" }}" }}%.
         labels: {}
         isPaused: false
 

--- a/observability/grafana/rules_nhost.yaml
+++ b/observability/grafana/rules_nhost.yaml
@@ -56,8 +56,8 @@ groups:
         for: 15m
         annotations:
           runbook_url: https://docs.nhost.io/platform/cloud/compute-resources
-          Project Subdomain: { { .Subdomain } }
-          Project Name: { { .ProjectName } }
+          Project Subdomain: {{ .Subdomain }}
+          Project Name: {{ .ProjectName }}
           description: |
             High CPU usage can be caused by a number of factors, including but not limited to:
             - High traffic
@@ -128,8 +128,8 @@ groups:
         for: 15m
         annotations:
           runbook_url: https://docs.nhost.io/products/database/configuring-postgres
-          Subdomain: { { .Subdomain } }
-          Project Name: { { .ProjectName } }
+          Subdomain: {{ .Subdomain }}
+          Project Name: {{ .ProjectName }}
           description: |
             An increase in disk space usage can be caused by a number of factors, including but not limited to:
             - Large amounts of data
@@ -160,7 +160,7 @@ groups:
             datasourceUid: nhost
             model:
               editorMode: code
-              expr: sum by(pod) (container_memory_usage_bytes{container!~"grafana|"}) / sum by(pod) (container_spec_memory_limit_bytes{container!~"grafana|"}) * 100
+              expr: sum by(pod) (container_memory_working_set_bytes{container!~"grafana|"}) / sum by(pod) (container_spec_memory_limit_bytes{container!~"grafana|"}) * 100
               instant: true
               intervalMs: 1000
               legendFormat: __auto
@@ -200,10 +200,10 @@ groups:
         for: 15m
         annotations:
           runbook_url: https://docs.nhost.io/platform/cloud/compute-resources
-          Subdomain: { { .Subdomain } }
-          Project Name: { { .ProjectName } }
+          Subdomain: {{ .Subdomain }}
+          Project Name: {{ .ProjectName }}
           description: |
-            Low memory can be caused by a number of factors, including but not limited to:
+            Low memory (excluding cache) can be caused by a number of factors, including but not limited to:
             - High traffic
             - Inefficient code/queries
             - Inadequate resources
@@ -217,7 +217,7 @@ groups:
             For more information, see the [Nhost documentation](https://docs.nhost.io/platform/cloud/compute-resources)
 
           summary: |
-            The service replica {{ print "{{ index $labels \"pod\" }}" }} is experiencing, or has experienced, low memory. Current usage is at {{ print "{{ index $values \"A\" }}" }}%.
+            The service replica {{ print "{{ index $labels \"pod\" }}" }} is experiencing, or has experienced, low memory. Current usage (minus reclaimable cache) is at {{ print "{{ index $values \"A\" }}" }}%.
         labels: {}
         isPaused: false
 
@@ -291,8 +291,8 @@ groups:
 
             For more information, see the [Nhost documentation](https://docs.nhost.io/platform/cloud/compute-resources)
           runbook_url: https://docs.nhost.io/platform/cloud/compute-resources
-          Subdomain: { { .Subdomain } }
-          Project Name: { { .ProjectName } }
+          Subdomain: {{ .Subdomain }}
+          Project Name: {{ .ProjectName }}
         labels: {}
         isPaused: false
 
@@ -346,8 +346,8 @@ groups:
         execErrState: Alerting
         for: 15m
         annotations:
-          Subdomain: { { .Subdomain } }
-          Project Name: { { .ProjectName } }
+          Subdomain: {{ .Subdomain }}
+          Project Name: {{ .ProjectName }}
           summary: |
             The service {{ print "{{ index $labels \"ingress\" }}" }} is experiencing, or has experienced, a high error rate. Current error rate is at {{ print "{{ index $values \"A\" }}" }}%.
           description: |


### PR DESCRIPTION
`container_memory_usage_bytes` includes the Linux page cache, which the kernel deliberately keeps until the memory is needed elsewhere. Any I/O-heavy service (like Postgres) with more data than memory therefore sits near 100% forever, firing a "Low free memory", causing users ignore it, letting true low memory to be ignored (when non-reclaimable memory reaches the limit)

This switches the alert rule and all dashboard memory panels to `container_memory_working_set_bytes`, which excludes reclaimable cache but keeps shared_buffers. It's the value used for OOM decisions anyway, so the alert now fires only on real memory pressure. Also add a dashed "cache (reclaimable)" series to the Postgres panel and update panel/alert descriptions and docs accordingly.

### Checklist

- [x] No breaking changes
- [x] Tests pass
- [x] New features have new tests
- [x] Documentation is updated (if applicable)
- [x] Title of the PR is in the correct format (see below)
