### PR TITLE
fix(auth): block IPv6 transition addresses in the CIMD SSRF guard

### DIFF
--- a/services/auth/go/oauth2/cimd.go
+++ b/services/auth/go/oauth2/cimd.go
@@ -1,6 +1,7 @@
 package oauth2
 
 import (
+	"bytes"
 	"context"
 	"crypto/tls"
 	"encoding/json"
@@ -99,7 +100,7 @@ func ValidateCIMDURL(
 		}
 	}
 
-	if !allowInsecure && isPrivateOrLoopback(ctx, u.Hostname()) {
+	if !allowInsecure && isBlockedHost(ctx, u.Hostname()) {
 		return nil, &Error{
 			Err:         "invalid_client",
 			Description: "Client ID metadata document URL must not point to a private address",
@@ -116,11 +117,69 @@ func hasDotSegments(path string) bool {
 		strings.HasSuffix(path, "/..")
 }
 
-func isPrivateOrLoopback(ctx context.Context, host string) bool {
-	ip := net.ParseIP(host)
-	if ip != nil {
-		return ip.IsLoopback() || ip.IsPrivate() ||
-			ip.IsLinkLocalUnicast() || ip.IsLinkLocalMulticast()
+// embeddedIPv4 returns the IPv4 address wrapped by an IPv6 transition address,
+// or nil if there is none. Go's net.IP predicates only look at the IPv6 bits,
+// so 64:ff9b::a9fe:a9fe passes IsLinkLocalUnicast while still routing to
+// 169.254.169.254.
+func embeddedIPv4(ip net.IP) net.IP {
+	ip16 := ip.To16()
+	if ip16 == nil || ip.To4() != nil {
+		// IPv4-mapped (::ffff:a.b.c.d) also lands here, via To4.
+		return nil
+	}
+
+	// Prefixes carrying the IPv4 address in the last 32 bits.
+	for _, prefix := range [][]byte{
+		{0x00, 0x64, 0xff, 0x9b, 0, 0, 0, 0, 0, 0, 0, 0}, // NAT64, RFC 6052
+		{0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0},             // IPv4-compatible, RFC 4291
+		{0, 0, 0, 0, 0, 0, 0, 0, 0xff, 0xff, 0, 0},       // IPv4-translated, RFC 6145
+	} {
+		if bytes.HasPrefix(ip16, prefix) {
+			return net.IPv4(ip16[12], ip16[13], ip16[14], ip16[15])
+		}
+	}
+
+	switch {
+	case ip16[0] == 0x20 && ip16[1] == 0x02: // 6to4, RFC 3056
+		return net.IPv4(ip16[2], ip16[3], ip16[4], ip16[5])
+	case ip16[0] == 0x20 && ip16[1] == 0x01 &&
+		ip16[2] == 0x00 && ip16[3] == 0x00: // Teredo, RFC 4380
+		return net.IPv4(^ip16[12], ^ip16[13], ^ip16[14], ^ip16[15])
+	default:
+		return nil
+	}
+}
+
+func isBlockedIP(ip net.IP) bool {
+	if ip == nil {
+		return true
+	}
+
+	// 64:ff9b:1::/48 is NAT64 local use (RFC 8215): the embedded IPv4 sits at
+	// an offset that varies with the deployment's prefix length, so the whole
+	// range is blocked rather than decoded.
+	if bytes.HasPrefix(ip.To16(), []byte{0x00, 0x64, 0xff, 0x9b, 0x00, 0x01}) {
+		return true
+	}
+
+	for _, candidate := range []net.IP{ip, embeddedIPv4(ip)} {
+		if candidate == nil {
+			continue
+		}
+
+		if candidate.IsUnspecified() || candidate.IsLoopback() ||
+			candidate.IsPrivate() || candidate.IsLinkLocalUnicast() ||
+			candidate.IsMulticast() {
+			return true
+		}
+	}
+
+	return false
+}
+
+func isBlockedHost(ctx context.Context, host string) bool {
+	if ip := net.ParseIP(host); ip != nil {
+		return isBlockedIP(ip)
 	}
 
 	resolver := net.DefaultResolver
@@ -132,8 +191,7 @@ func isPrivateOrLoopback(ctx context.Context, host string) bool {
 	}
 
 	for _, resolved := range ips {
-		if resolved.IP.IsLoopback() || resolved.IP.IsPrivate() ||
-			resolved.IP.IsLinkLocalUnicast() || resolved.IP.IsLinkLocalMulticast() {
+		if isBlockedIP(resolved.IP) {
 			return true
 		}
 	}
@@ -461,8 +519,7 @@ func newSafeHTTPClient() *http.Client {
 			}
 
 			for _, ip := range ips {
-				if ip.IP.IsLoopback() || ip.IP.IsPrivate() ||
-					ip.IP.IsLinkLocalUnicast() || ip.IP.IsLinkLocalMulticast() {
+				if isBlockedIP(ip.IP) {
 					return nil, fmt.Errorf(
 						"%w: %s", errPrivateIP, ip.IP.String(),
 					)

--- a/services/auth/go/oauth2/cimd_internal_test.go
+++ b/services/auth/go/oauth2/cimd_internal_test.go
@@ -3,6 +3,7 @@ package oauth2
 import (
 	"context"
 	"log/slog"
+	"net"
 	"net/url"
 	"testing"
 )
@@ -74,7 +75,7 @@ func TestIsLoopbackRedirectURI(t *testing.T) {
 	}
 }
 
-func TestIsPrivateOrLoopback(t *testing.T) {
+func TestIsBlockedHost(t *testing.T) {
 	t.Parallel()
 
 	tests := []struct {
@@ -118,6 +119,11 @@ func TestIsPrivateOrLoopback(t *testing.T) {
 			expected: true,
 		},
 		{
+			name:     "nat64 wrapped cloud metadata",
+			host:     "64:ff9b::a9fe:a9fe",
+			expected: true,
+		},
+		{
 			name:     "public IP",
 			host:     "8.8.8.8",
 			expected: false,
@@ -138,9 +144,116 @@ func TestIsPrivateOrLoopback(t *testing.T) {
 		t.Run(tc.name, func(t *testing.T) {
 			t.Parallel()
 
-			got := isPrivateOrLoopback(context.Background(), tc.host)
+			got := isBlockedHost(context.Background(), tc.host)
 			if got != tc.expected {
-				t.Errorf("isPrivateOrLoopback(%q) = %v, want %v", tc.host, got, tc.expected)
+				t.Errorf("isBlockedHost(%q) = %v, want %v", tc.host, got, tc.expected)
+			}
+		})
+	}
+}
+
+func TestIsBlockedIP(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name     string
+		ip       string
+		expected bool
+	}{
+		{
+			name:     "nat64 wrapped cloud metadata",
+			ip:       "64:ff9b::a9fe:a9fe",
+			expected: true,
+		},
+		{
+			name:     "nat64 wrapped private ipv4",
+			ip:       "64:ff9b::a00:1",
+			expected: true,
+		},
+		{
+			name:     "nat64 local use prefix",
+			ip:       "64:ff9b:1::1",
+			expected: true,
+		},
+		{
+			name:     "6to4 wrapped loopback",
+			ip:       "2002:7f00:1::",
+			expected: true,
+		},
+		{
+			name:     "teredo wrapped loopback",
+			ip:       "2001:0000:4136:e378:8000:63bf:80ff:fffe",
+			expected: true,
+		},
+		{
+			name:     "ipv4 compatible wrapped private ipv4",
+			ip:       "::10.0.0.1",
+			expected: true,
+		},
+		{
+			name:     "ipv4 translated wrapped private ipv4",
+			ip:       "::ffff:0:10.0.0.1",
+			expected: true,
+		},
+		{
+			name:     "ipv4 mapped private ipv4",
+			ip:       "::ffff:192.168.1.1",
+			expected: true,
+		},
+		{
+			name:     "unspecified ipv4",
+			ip:       "0.0.0.0",
+			expected: true,
+		},
+		{
+			name:     "unspecified ipv6",
+			ip:       "::",
+			expected: true,
+		},
+		{
+			name:     "multicast",
+			ip:       "224.0.0.1",
+			expected: true,
+		},
+		{
+			name:     "unique local ipv6",
+			ip:       "fd00::1",
+			expected: true,
+		},
+		{
+			name:     "public ipv4",
+			ip:       "8.8.8.8",
+			expected: false,
+		},
+		{
+			name:     "public ipv6",
+			ip:       "2606:4700:4700::1111",
+			expected: false,
+		},
+		{
+			name:     "nat64 wrapped public ipv4",
+			ip:       "64:ff9b::808:808",
+			expected: false,
+		},
+		{
+			name:     "6to4 wrapped public ipv4",
+			ip:       "2002:808:808::",
+			expected: false,
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+
+			ip := net.ParseIP(tc.ip)
+			if ip == nil {
+				t.Fatalf("failed to parse IP %q", tc.ip)
+			}
+
+			got := isBlockedIP(ip)
+			if got != tc.expected {
+				t.Errorf("isBlockedIP(%q) = %v, want %v", tc.ip, got, tc.expected)
 			}
 		})
 	}


### PR DESCRIPTION
<!-- claude-reviewer:start -->
### **What this change solves**
The CIMD (Client ID Metadata Document) SSRF guard only inspected an address's IPv6 bits, so IPv6 transition addresses such as `64:ff9b::a9fe:a9fe` passed every `net.IP` predicate while still routing to `169.254.169.254`. This change decodes the IPv4 address embedded in NAT64, IPv4-compatible, IPv4-translated, 6to4, and Teredo addresses and blocks the address if either the outer IPv6 address or the embedded IPv4 address lands in private space.

___

### **Change Type**
Bug fix

___

### **Description**
- Extract a single `isBlockedIP(net.IP) bool` predicate and use it at all three guard sites: the literal-IP path and the DNS-resolution path of the renamed `isBlockedHost`, and the `DialContext` hook in `newSafeHTTPClient`.
- Add `embeddedIPv4` to decode the IPv4 address wrapped by NAT64 (RFC 6052), IPv4-compatible (RFC 4291), IPv4-translated (RFC 6145), 6to4 (RFC 3056), and Teredo (RFC 4380) addresses; `isBlockedIP` tests both the outer address and the decoded one.
- Block `64:ff9b:1::/48` (NAT64 local use, RFC 8215) wholesale, since the embedded IPv4 offset varies with the deployment's prefix length.
- Widen the blocked predicate set with `IsUnspecified` and `IsMulticast`, replacing the narrower `IsLinkLocalMulticast`.
- Rename `isPrivateOrLoopback` to `isBlockedHost` to reflect that it now covers more than private and loopback ranges.
- Add `TestIsBlockedIP` covering each transition format in both blocked and allowed directions, and extend `TestIsBlockedHost` with a NAT64-wrapped cloud-metadata case.

___

### Diagram Walkthrough

```mermaid
flowchart LR
  A["ResolveCIMDClient"] --> B["ValidateCIMDURL"]
  B -->|"hostname"| C["isBlockedHost"]
  C -->|"literal IP"| D["isBlockedIP"]
  C -->|"LookupIPAddr"| D
  A --> E["FetchCIMDMetadata"]
  E --> F["newSafeHTTPClient<br/>DialContext"]
  F -->|"resolved IPs"| D
  D --> G["embeddedIPv4<br/>NAT64 / 6to4 / Teredo / ::ffff:0:"]
  G --> D
```

<details> <summary><h3> File Walkthrough</h3></summary>


  | Relevant files
-- | --
Bug fix | 1 files    cimd.goAdds embeddedIPv4 and isBlockedIP, renames isPrivateOrLoopback to isBlockedHost, routes all three guard sites through the shared predicate   +67/-10 | cimd.goAdds embeddedIPv4 and isBlockedIP, renames isPrivateOrLoopback to isBlockedHost, routes all three guard sites through the shared predicate | +67/-10
cimd.goAdds embeddedIPv4 and isBlockedIP, renames isPrivateOrLoopback to isBlockedHost, routes all three guard sites through the shared predicate | +67/-10
Tests | 1 files    cimd_internal_test.goAdds TestIsBlockedIP covering each IPv6 transition format, renames and extends TestIsBlockedHost   +116/-3 | cimd_internal_test.goAdds TestIsBlockedIP covering each IPv6 transition format, renames and extends TestIsBlockedHost | +116/-3
cimd_internal_test.goAdds TestIsBlockedIP covering each IPv6 transition format, renames and extends TestIsBlockedHost | +116/-3



</details>

___

<!-- claude-reviewer:end -->
