### PR TITLE
fix(dashboard): Migrate SelcetOrg component

### DIFF
--- a/dashboard/src/components/common/SelectOrg/SelectOrg.tsx
+++ b/dashboard/src/components/common/SelectOrg/SelectOrg.tsx
@@ -1,20 +1,16 @@
-import { Divider } from '@mui/material';
 import debounce from 'lodash.debounce';
 import Image from 'next/image';
 import { useRouter } from 'next/router';
 import type { ChangeEvent } from 'react';
-import { Fragment, useEffect, useMemo, useState } from 'react';
+import { useEffect, useMemo, useState } from 'react';
 import { RetryableErrorBoundary } from '@/components/presentational/RetryableErrorBoundary';
-import { Box } from '@/components/ui/v2/Box';
-import { Button } from '@/components/ui/v2/Button';
-import { Input } from '@/components/ui/v2/Input';
-import { List } from '@/components/ui/v2/List';
-import { ListItem } from '@/components/ui/v2/ListItem';
-import { Text } from '@/components/ui/v2/Text';
+import { Button } from '@/components/ui/v3/button';
+import { Input } from '@/components/ui/v3/input';
 import { Spinner } from '@/components/ui/v3/spinner';
 import { useOrgs } from '@/features/orgs/projects/hooks/useOrgs';
+import { cn } from '@/lib/utils';
 
-export default function SelectOrganizationAndProject() {
+export default function SelectOrganization() {
   const { orgs, loading } = useOrgs();
   const router = useRouter();
 
@@ -68,60 +64,55 @@ export default function SelectOrganizationAndProject() {
   return (
     <div className="mx-auto flex h-full w-full flex-col items-start bg-background px-5 py-4">
       <div className="mx-auto flex h-full w-full max-w-[760px] flex-col gap-4 py-6 sm:py-14">
-        <Text variant="h2" component="h1" className="">
-          Select an Organization
-        </Text>
+        <h1 className="font-medium text-2xl">Select an Organization</h1>
 
         <div>
           <div className="mb-2 flex w-full">
             <Input
               placeholder="Search..."
               onChange={handleFilterChange}
-              fullWidth
+              wrapperClassName="w-full"
               autoFocus
             />
           </div>
           <RetryableErrorBoundary>
             {orgsToDisplay.length === 0 ? (
-              <Box className="h-import py-2">
-                <Text variant="subtitle2">No results found.</Text>
-              </Box>
+              <div className="h-import py-2">
+                <p className="text-muted-foreground text-sm">
+                  No results found.
+                </p>
+              </div>
             ) : (
-              <List className="h-import overflow-y-auto">
+              <ul className="flex h-import flex-col overflow-y-auto rounded-md border">
                 {orgsToDisplay.map((org, index) => (
-                  <Fragment key={org.value}>
-                    <ListItem.Root
-                      className="grid grid-flow-col justify-start gap-2 py-2.5"
-                      secondaryAction={
-                        <Button
-                          variant="borderless"
-                          color="primary"
-                          onClick={() => goToOrgPage(org)}
-                        >
-                          Select
-                        </Button>
-                      }
-                    >
-                      <ListItem.Avatar>
-                        <span className="inline-block h-6 w-6 overflow-hidden rounded-md">
-                          <Image
-                            src="/logos/new.svg"
-                            alt="Nhost Logo"
-                            width={24}
-                            height={24}
-                          />
-                        </span>
-                      </ListItem.Avatar>
-                      <ListItem.Text
-                        primary={org.name}
-                        secondary={`${org.name} / ${org.name}`}
+                  <li
+                    key={org.value}
+                    className={cn(
+                      'flex flex-row items-center justify-center gap-4 p-3',
+                      index < orgsToDisplay.length - 1 && 'border-b',
+                    )}
+                  >
+                    <div className="flex h-full items-center justify-center">
+                      <Image
+                        src="/logos/new.svg"
+                        alt="Nhost Logo"
+                        className="h-10 w-10 rounded-md"
+                        width={38}
+                        height={38}
                       />
-                    </ListItem.Root>
-
-                    {index < orgs.length - 1 && <Divider component="li" />}
-                  </Fragment>
+                    </div>
+                    <div className="min-w-0 flex-1">
+                      <span className="block truncate">{org.name}</span>
+                      <p className="truncate text-muted-foreground text-sm">
+                        {`${org.name} / ${org.name}`}
+                      </p>
+                    </div>
+                    <Button variant="link" onClick={() => goToOrgPage(org)}>
+                      Select
+                    </Button>
+                  </li>
                 ))}
-              </List>
+              </ul>
             )}
           </RetryableErrorBoundary>
         </div>


### PR DESCRIPTION
### Checklist

- [x] No breaking changes
- [x] Tests pass
- [ ] New features have new tests
- [ ] Documentation is updated (if applicable)
- [x] Title of the PR is in the correct format (see below)

<!-- pi-reviewer:start -->
### **What this change solves**
Migrates the `SelectOrg` component off the legacy MUI-based v2 UI primitives to the v3 (Tailwind/Radix) component set, keeping the dashboard's "Select an Organization" screen consistent with the ongoing v2→v3 migration.

___

### **Change Type**
Refactoring

___

### **Description**
- Replaces v2 primitives (`Box`, `Button`, `Input`, `List`, `ListItem`, `Text`, MUI `Divider`) with v3 `Button`/`Input` and plain semantic HTML (`h1`, `ul`, `li`, `p`, `span`).
- Rebuilds the org list markup with Tailwind utility classes and `cn`, using per-item `border-b` dividers instead of MUI `Divider`/`Fragment`.
- Renames the default export component from `SelectOrganizationAndProject` to `SelectOrganization`.
- Switches list divider logic to `index < orgsToDisplay.length - 1` (from `orgs.length - 1`), aligning the divider count with the filtered list actually rendered.

___

<details> <summary><h3> File Walkthrough</h3></summary>

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody>
<tr><td><strong>Refactoring</strong></td><td><details><summary>1 files</summary><table>
<tr>
  <td><strong>SelectOrg.tsx</strong><dd><code>Migrate SelectOrg from v2 MUI primitives to v3 UI + semantic HTML</code></dd></td>
  <td>+39/-48</td>
</tr>
</table></details></td></tr>
</tbody></table>

</details>

___

<!-- pi-reviewer:end -->


