### PR TITLE
fix(dashboard): migrate billing & members components to v3

### DIFF
--- a/dashboard/src/features/orgs/components/billing/BillingEstimate/BillingEstimate.tsx
+++ b/dashboard/src/features/orgs/components/billing/BillingEstimate/BillingEstimate.tsx
@@ -1,4 +1,4 @@
-import { Divider } from '@/components/ui/v2/Divider';
+import { Separator } from '@/components/ui/v3/separator';
 import { useIsOrgAdmin } from '@/features/orgs/hooks/useIsOrgAdmin';
 import { BillingCycle } from './components/BillingCycle';
 import { BillingDetails } from './components/BillingDetails';
@@ -15,15 +15,15 @@ export default function BillingEstimate() {
           <span className="font-medium text-xl">Billing Estimate</span>
         </div>
         <div className="flex flex-col">
-          <Divider />
+          <Separator />
           <BillingCycle />
-          <Divider />
+          <Separator />
           <Estimate />
-          <Divider />
+          <Separator />
           <SpendingNotifications />
           {isOrgAdmin && (
             <>
-              <Divider />
+              <Separator />
               <BillingDetails />
             </>
           )}

--- a/dashboard/src/features/orgs/components/billing/BillingEstimate/components/SpendingNotifications/SpendingNotifications.tsx
+++ b/dashboard/src/features/orgs/components/billing/BillingEstimate/components/SpendingNotifications/SpendingNotifications.tsx
@@ -1,8 +1,7 @@
-import { yupResolver } from '@hookform/resolvers/yup';
+import { zodResolver } from '@hookform/resolvers/zod';
 import { type ChangeEvent, useEffect, useMemo } from 'react';
 import { useForm } from 'react-hook-form';
-import * as Yup from 'yup';
-import { Switch } from '@/components/ui/v2/Switch';
+import { z } from 'zod';
 import { ButtonWithLoading } from '@/components/ui/v3/button';
 import {
   Form,
@@ -15,6 +14,7 @@ import {
 import { Input } from '@/components/ui/v3/input';
 import { Progress } from '@/components/ui/v3/progress';
 import { Spinner } from '@/components/ui/v3/spinner';
+import { Switch } from '@/components/ui/v3/switch';
 import {
   Tooltip,
   TooltipContent,
@@ -30,25 +30,28 @@ import {
   useUpdateOrganizationSpendingNotificationMutation,
 } from '@/generated/graphql';
 
-const validationSchema = Yup.object({
-  enabled: Yup.boolean().required(),
-  threshold: Yup.number().test(
-    'is-valid-threshold',
-    `Threshold must be greater than 110% of your plan's price`,
-    (value, { options }) => {
-      const planPrice = options?.context?.planPrice || 0;
-      if (value === 0) {
-        return true;
-      }
-      if (typeof value === 'number' && value > 1.1 * planPrice) {
-        return true;
-      }
-      return false;
-    },
-  ),
-});
+const getValidationSchema = (planPrice: number) =>
+  z.object({
+    enabled: z.boolean(),
+    threshold: z
+      .number()
+      .optional()
+      .refine(
+        (value) => {
+          const isDisabled = value === 0;
+          const isAboveMinimum =
+            typeof value === 'number' && value > 1.1 * planPrice;
+          return isDisabled || isAboveMinimum;
+        },
+        {
+          message: `Threshold must be greater than 110% of your plan's price`,
+        },
+      ),
+  });
 
-type SpendingNotificationsFormValues = Yup.InferType<typeof validationSchema>;
+type SpendingNotificationsFormValues = z.infer<
+  ReturnType<typeof getValidationSchema>
+>;
 
 export default function SpendingNotifications() {
   const { org } = useCurrentOrg();
@@ -78,24 +81,25 @@ export default function SpendingNotifications() {
 
   const { threshold } = data?.organizations[0] ?? {};
 
+  const validationSchema = useMemo(
+    () => getValidationSchema(org?.plan?.price ?? 0),
+    [org?.plan?.price],
+  );
+
   const form = useForm<SpendingNotificationsFormValues>({
     reValidateMode: 'onSubmit',
     defaultValues: {
       enabled: false,
       threshold: threshold ?? 0,
     },
-    resolver: yupResolver(validationSchema),
-    context: {
-      planPrice: org?.plan?.price ?? 0,
-    },
+    resolver: zodResolver(validationSchema),
   });
 
   const { watch, setValue } = form;
 
   const currentThreshold = watch('threshold');
 
-  const handleEnabledChange = (event: ChangeEvent<HTMLInputElement>) => {
-    const { checked } = event.target;
+  const handleEnabledChange = (checked: boolean) => {
     setValue('enabled', checked, { shouldDirty: true });
     if (!checked) {
       setValue('threshold', 0, { shouldDirty: true });
@@ -200,7 +204,7 @@ export default function SpendingNotifications() {
             className="self-end"
             id="enabled"
             checked={enabled}
-            onChange={handleEnabledChange}
+            onCheckedChange={handleEnabledChange}
           />
         </div>
         <div className="flex w-full flex-col justify-between gap-8 md:flex-row">

--- a/dashboard/src/features/orgs/components/members/components/OrgMember/OrgMember.tsx
+++ b/dashboard/src/features/orgs/components/members/components/OrgMember/OrgMember.tsx
@@ -4,7 +4,6 @@ import { useRouter } from 'next/router';
 import { useState } from 'react';
 import { useForm } from 'react-hook-form';
 import { z } from 'zod';
-import { Avatar } from '@/components/ui/v2/Avatar';
 import {
   AlertDialog,
   AlertDialogAction,
@@ -15,6 +14,7 @@ import {
   AlertDialogHeader,
   AlertDialogTitle,
 } from '@/components/ui/v3/alert-dialog';
+import { Avatar } from '@/components/ui/v3/avatar';
 import { Badge } from '@/components/ui/v3/badge';
 import { Button, buttonVariants } from '@/components/ui/v3/button';
 import {
@@ -165,12 +165,11 @@ export default function OrgMember({ member, isAdmin }: OrgMemberProps) {
       <div className="flex w-full flex-row items-center justify-between gap-2">
         <div className="flex min-w-0 flex-row items-center gap-3">
           <Avatar
-            className="shrink-0 rounded-full"
+            className="shrink-0"
             alt={member.user.displayName}
+            name={member.user.displayName || 'local'}
             src={member.user.avatarUrl}
-          >
-            {member.user.displayName || 'local'}
-          </Avatar>
+          />
 
           <div className="flex min-w-0 flex-col">
             <div className="flex flex-row items-center gap-2">


### PR DESCRIPTION
### Checklist

- [ ] No breaking changes
- [ ] Tests pass
- [ ] New features have new tests
- [ ] Documentation is updated (if applicable)
- [ ] Title of the PR is in the correct format (see below)

<!-- pi-reviewer:start -->
### **What this change solves**
Continues the dashboard v2→v3 component migration by moving the org billing estimate and members components off the legacy v2 MUI primitives (`Divider`, `Switch`, `Avatar`, `Alert`) and the Yup validation stack onto their v3/Shadcn equivalents and Zod.

___

### **Change Type**
Refactoring

___

### **Description**
- Replace v2 `Divider` with v3 `Separator` in the billing estimate layout.
- Rewrite `SpendingNotifications` validation from Yup (with resolver `context`) to a Zod schema factory parameterized by `planPrice`, and switch the enabled toggle to v3 `Switch` (`onCheckedChange`).
- Migrate `OrgMember` avatar from v2 `Avatar` (children-based fallback) to v3 `Avatar` with a `name` prop.
- Migrate `PendingInvites` off v2 `Alert`, removing the inline foreign-key-violation error message and its associated `orgInviteError` state.

___

<details> <summary><h3> File Walkthrough</h3></summary>

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody>
<tr><td><strong>Billing</strong></td><td><details><summary>2 files</summary><table>
<tr>
  <td><strong>BillingEstimate.tsx</strong><dd><code>Swap v2 Divider for v3 Separator</code></dd></td>
  <td>+5/-5</td>
</tr>
<tr>
  <td><strong>SpendingNotifications.tsx</strong><dd><code>Yup→Zod schema factory; v3 Switch with onCheckedChange</code></dd></td>
  <td>+32/-28</td>
</tr>
</table></details></td></tr>
<tr><td><strong>Members</strong></td><td><details><summary>2 files</summary><table>
<tr>
  <td><strong>OrgMember.tsx</strong><dd><code>Migrate to v3 Avatar with name prop</code></dd></td>
  <td>+4/-5</td>
</tr>
<tr>
  <td><strong>PendingInvites.tsx</strong><dd><code>Drop v2 Alert and inline invite-error state</code></dd></td>
  <td>+1/-28</td>
</tr>
</table></details></td></tr>
</tbody></table>

</details>

___

<!-- pi-reviewer:end -->

