### PR TITLE
fix(dashboard): exclude unnamed columns from foreign key column select

### DIFF
--- a/dashboard/src/features/orgs/projects/database/dataGrid/components/BaseForeignKeyForm/BaseForeignKeyForm.tsx
+++ b/dashboard/src/features/orgs/projects/database/dataGrid/components/BaseForeignKeyForm/BaseForeignKeyForm.tsx
@@ -131,11 +131,13 @@ export default function BaseForeignKeyForm({
             disabled={disableOriginColumn}
             contentClassName="z-[1400]"
           >
-            {availableColumns?.map(({ name }) => (
-              <SelectItem value={name} key={name}>
-                {name}
-              </SelectItem>
-            ))}
+            {availableColumns
+              ?.filter(({ name }) => Boolean(name))
+              .map(({ name }) => (
+                <SelectItem value={name} key={name}>
+                  {name}
+                </SelectItem>
+              ))}
           </FormSelect>
         </section>
 


### PR DESCRIPTION
### Checklist

- [X] No breaking changes
- [X] Tests pass
- [X] New features have new tests
- [X] Documentation is updated (if applicable)
- [X] Title of the PR is in the correct format (see below)

<!-- pi-reviewer:start -->
### **What this change solves**
The foreign key form's origin column select rendered an option for every entry in `availableColumns`, including columns whose `name` is empty (e.g. a not-yet-named column row in the table editor). This produced select items with an empty value/key; filtering them out ensures only named columns can be chosen as the foreign key source.

___

### **Change Type**
Bug fix

___

### **Description**
- Filter `availableColumns` to entries with a truthy `name` before mapping them to `SelectItem` options in the origin column select of `BaseForeignKeyForm`.

___

<details> <summary><h3> File Walkthrough</h3></summary>

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody>
<tr><td><strong>Bug fix</strong></td><td><details><summary>1 files</summary><table>
<tr>
  <td><strong>dashboard/src/features/orgs/projects/database/dataGrid/components/BaseForeignKeyForm/BaseForeignKeyForm.tsx</strong><dd><code>Exclude unnamed columns from the origin column select options</code></dd></td>
  <td>+7/-5</td>
</tr>
</table></details></td></tr>
</tbody></table>

</details>

___

<!-- pi-reviewer:end -->
