### PR TITLE
fix(dashboard): make URL the single source of truth for pagination

### DIFF
--- a/dashboard/src/features/orgs/projects/common/hooks/useRunServices/useRunServices.ts
+++ b/dashboard/src/features/orgs/projects/common/hooks/useRunServices/useRunServices.ts
@@ -1,6 +1,10 @@
 import { useRouter } from 'next/router';
-import { useEffect, useMemo, useRef, useState } from 'react';
+import { useMemo } from 'react';
 import { useIsPlatform } from '@/features/orgs/projects/common/hooks/useIsPlatform';
+import {
+  getPageNumberFromQuery,
+  useUrlPagination,
+} from '@/features/orgs/projects/common/hooks/useUrlPagination';
 import { useLocalMimirClient } from '@/features/orgs/projects/hooks/useLocalMimirClient';
 import { useProject } from '@/features/orgs/projects/hooks/useProject';
 import {
@@ -28,20 +32,17 @@ export type RunServiceConfig = Omit<
   '__typename'
 >;
 
+const ELEMENTS_PER_PAGE = 25;
+
 export default function useRunServices() {
-  const limit = useRef(25);
   const router = useRouter();
   const isPlatform = useIsPlatform();
   const localMimirClient = useLocalMimirClient();
   const { project } = useProject();
 
-  const [nrOfPages, setNrOfPages] = useState(0);
-  const [totalServicesCount, setTotalServicesCount] = useState(0);
-  const [currentPage, setCurrentPage] = useState(
-    parseInt(router.query.page as string, 10) || 1,
-  );
+  const currentPage = getPageNumberFromQuery(router.query.page);
   const offset = useMemo(
-    () => getPaginationOffset(currentPage, limit.current),
+    () => getPaginationOffset(currentPage, ELEMENTS_PER_PAGE),
     [currentPage],
   );
 
@@ -53,7 +54,7 @@ export default function useRunServices() {
     variables: {
       appID: project?.id,
       resolve: false,
-      limit: limit.current,
+      limit: ELEMENTS_PER_PAGE,
       offset,
     },
     skip: !isPlatform,
@@ -83,33 +84,30 @@ export default function useRunServices() {
   const loading = isPlatform ? loadingPlatformServices : loadingLocalServices;
   const refetch = isPlatform ? refetchPlatformServices : refetchLocalServices;
 
-  useEffect(() => {
-    if (!isPlatform) {
-      return;
-    }
+  const totalServicesCount = isPlatform
+    ? (data?.app?.runServices_aggregate.aggregate?.count ?? 0)
+    : 0;
 
-    if (loading) {
-      return;
-    }
-
-    const userCount = data?.app?.runServices_aggregate.aggregate?.count ?? 0;
-
-    setTotalServicesCount(
-      data?.app?.runServices_aggregate.aggregate?.count ?? 0,
-    );
-    setNrOfPages(Math.ceil(userCount / limit.current));
-  }, [data, loading, isPlatform]);
+  const { nrOfPages, goToPage, goToNextPage, goToPreviousPage } =
+    useUrlPagination({
+      currentPage,
+      elementsPerPage: ELEMENTS_PER_PAGE,
+      totalNrOfElements: totalServicesCount,
+      loading,
+    });
 
   return {
     services,
     loading,
     refetch,
 
-    limit,
+    limit: ELEMENTS_PER_PAGE,
     totalServicesCount,
     nrOfPages,
 
     currentPage,
-    setCurrentPage,
+    goToPage,
+    goToNextPage,
+    goToPreviousPage,
   };
 }

--- a/dashboard/src/features/orgs/projects/common/hooks/useUrlPagination/index.ts
+++ b/dashboard/src/features/orgs/projects/common/hooks/useUrlPagination/index.ts
@@ -1,0 +1,2 @@
+export * from './useUrlPagination';
+export { default as useUrlPagination } from './useUrlPagination';

--- a/dashboard/src/features/orgs/projects/common/hooks/useUrlPagination/useUrlPagination.test.ts
+++ b/dashboard/src/features/orgs/projects/common/hooks/useUrlPagination/useUrlPagination.test.ts
@@ -1,0 +1,162 @@
+import { vi } from 'vitest';
+import { act, renderHook } from '@/tests/testUtils';
+import useUrlPagination, { getPageNumberFromQuery } from './useUrlPagination';
+
+const mocks = vi.hoisted(() => ({
+  useRouter: vi.fn(),
+}));
+
+vi.mock('next/router', () => ({
+  useRouter: mocks.useRouter,
+}));
+
+describe('getPageNumberFromQuery', () => {
+  it.each<[string | string[] | undefined, number]>([
+    [undefined, 1],
+    ['', 1],
+    ['abc', 1],
+    ['0', 1],
+    ['-5', 1],
+    ['1', 1],
+    ['2', 2],
+    ['10', 10],
+    ['3.9', 3],
+    [['2', '3'], 2],
+  ])('maps %o to page %i', (input, expected) => {
+    expect(getPageNumberFromQuery(input)).toBe(expected);
+  });
+});
+
+const PATHNAME = '/orgs/[orgSlug]/projects/[appSubdomain]/auth/users';
+
+function createRouter(query: Record<string, string> = { orgSlug: 'xyz' }) {
+  return {
+    pathname: PATHNAME,
+    query,
+    push: vi.fn(),
+    replace: vi.fn(),
+  };
+}
+
+function renderPagination(
+  options: Partial<Parameters<typeof useUrlPagination>[0]> = {},
+  router = createRouter(),
+) {
+  mocks.useRouter.mockReturnValue(router);
+
+  const { result } = renderHook(() =>
+    useUrlPagination({
+      currentPage: 1,
+      elementsPerPage: 25,
+      totalNrOfElements: 0,
+      loading: false,
+      ...options,
+    }),
+  );
+
+  return { result, router };
+}
+
+describe('useUrlPagination', () => {
+  afterEach(() => vi.restoreAllMocks());
+
+  it.each<[number, number, number]>([
+    [0, 25, 1],
+    [25, 25, 1],
+    [26, 25, 2],
+    [100, 25, 4],
+  ])('reports %i elements at %i per page as %i pages', (totalNrOfElements, elementsPerPage, expected) => {
+    const { result } = renderPagination({
+      totalNrOfElements,
+      elementsPerPage,
+    });
+
+    expect(result.current.nrOfPages).toBe(expected);
+  });
+
+  it('pushes the target page number when navigating to a page > 1', () => {
+    const { result, router } = renderPagination();
+
+    act(() => result.current.goToPage(3));
+
+    expect(router.push).toHaveBeenCalledWith({
+      pathname: PATHNAME,
+      query: { orgSlug: 'xyz', page: '3' },
+    });
+  });
+
+  it('drops the page param when navigating to page 1', () => {
+    const { result, router } = renderPagination(
+      { currentPage: 3, totalNrOfElements: 100 },
+      createRouter({ orgSlug: 'xyz', page: '3' }),
+    );
+
+    act(() => result.current.goToPage(1));
+
+    expect(router.push).toHaveBeenCalledWith({
+      pathname: PATHNAME,
+      query: { orgSlug: 'xyz' },
+    });
+  });
+
+  it('goToNextPage pushes currentPage + 1', () => {
+    const { result, router } = renderPagination({
+      currentPage: 2,
+      totalNrOfElements: 100,
+    });
+
+    act(() => result.current.goToNextPage());
+
+    expect(router.push).toHaveBeenCalledWith({
+      pathname: PATHNAME,
+      query: { orgSlug: 'xyz', page: '3' },
+    });
+  });
+
+  it('goToPreviousPage from page 1 drops the page param', () => {
+    const { result, router } = renderPagination({
+      currentPage: 1,
+      totalNrOfElements: 100,
+    });
+
+    act(() => result.current.goToPreviousPage());
+
+    expect(router.push).toHaveBeenCalledWith({
+      pathname: PATHNAME,
+      query: { orgSlug: 'xyz' },
+    });
+  });
+
+  it('replaces an out-of-range page with the last page once loaded', () => {
+    const { router } = renderPagination(
+      { currentPage: 5, totalNrOfElements: 100, loading: false },
+      createRouter({ orgSlug: 'xyz', page: '5' }),
+    );
+
+    expect(router.replace).toHaveBeenCalledTimes(1);
+    expect(router.replace).toHaveBeenCalledWith({
+      pathname: PATHNAME,
+      query: { orgSlug: 'xyz', page: '4' },
+    });
+    expect(router.push).not.toHaveBeenCalled();
+  });
+
+  it('does not clamp an out-of-range page while loading', () => {
+    const { router } = renderPagination(
+      { currentPage: 5, totalNrOfElements: 100, loading: true },
+      createRouter({ orgSlug: 'xyz', page: '5' }),
+    );
+
+    expect(router.replace).not.toHaveBeenCalled();
+  });
+
+  it('does not clamp when there are no elements', () => {
+    const { router } = renderPagination({
+      currentPage: 5,
+      totalNrOfElements: 0,
+      loading: false,
+    });
+
+    expect(router.replace).not.toHaveBeenCalled();
+  });
+});

--- a/dashboard/src/features/orgs/projects/common/hooks/useUrlPagination/useUrlPagination.ts
+++ b/dashboard/src/features/orgs/projects/common/hooks/useUrlPagination/useUrlPagination.ts
@@ -1,0 +1,116 @@
+import { useRouter } from 'next/router';
+import { useCallback, useEffect, useRef } from 'react';
+
+/**
+ * Parse the `page` query param into a 1-based page number. Missing, non-numeric
+ * or out-of-range-low values fall back to page 1.
+ */
+export function getPageNumberFromQuery(
+  page: string | string[] | undefined,
+): number {
+  return Math.max(parseInt(page as string, 10) || 1, 1);
+}
+
+export interface UseUrlPaginationOptions {
+  /**
+   * 1-based current page. Derive it from the URL with `getPageNumberFromQuery`
+   * so the same value drives the query offset and the pagination controls.
+   */
+  currentPage: number;
+  /**
+   * Number of rows per page.
+   */
+  elementsPerPage: number;
+  /**
+   * Total number of rows across all pages (the query's aggregate count).
+   */
+  totalNrOfElements: number;
+  /**
+   * Whether the underlying data is still loading. Guards the out-of-range
+   * clamp so it never fires against a stale count mid-fetch.
+   */
+  loading?: boolean;
+}
+
+export interface UseUrlPaginationResult {
+  /**
+   * Total number of pages (always at least 1).
+   */
+  nrOfPages: number;
+  /**
+   * Navigate to a specific 1-based page.
+   */
+  goToPage: (page: number) => void;
+  /**
+   * Navigate to the next page.
+   */
+  goToNextPage: () => void;
+  /**
+   * Navigate to the previous page.
+   */
+  goToPreviousPage: () => void;
+}
+
+/**
+ * URL-backed pagination controls. The `page` query param is the single source
+ * of truth: the caller derives `currentPage` from it, navigation only writes
+ * the URL, and the page re-renders from the new param. Page 1 is represented by
+ * the absence of the param so the URL stays clean.
+ */
+export default function useUrlPagination({
+  currentPage,
+  elementsPerPage,
+  totalNrOfElements,
+  loading = false,
+}: UseUrlPaginationOptions): UseUrlPaginationResult {
+  const router = useRouter();
+
+  // Keep the latest router in a ref so `navigate`/`goToPage` stay referentially
+  // stable — callers pass them into memoized/debounced handlers (e.g. search).
+  const routerRef = useRef(router);
+  routerRef.current = router;
+
+  const nrOfPages = Math.max(1, Math.ceil(totalNrOfElements / elementsPerPage));
+
+  const navigate = useCallback((page: number, method: 'push' | 'replace') => {
+    const { pathname, query: currentQuery } = routerRef.current;
+    const query = { ...currentQuery };
+    if (page <= 1) {
+      delete query.page;
+    } else {
+      query.page = String(page);
+    }
+    routerRef.current[method]({ pathname, query });
+  }, []);
+
+  const goToPage = useCallback(
+    (page: number) => navigate(page, 'push'),
+    [navigate],
+  );
+
+  const goToNextPage = useCallback(
+    () => navigate(currentPage + 1, 'push'),
+    [navigate, currentPage],
+  );
+
+  const goToPreviousPage = useCallback(
+    () => navigate(currentPage - 1, 'push'),
+    [navigate, currentPage],
+  );
+
+  // Correct an out-of-range page in the URL (e.g. a stale deep link, or data
+  // that shrank) once the real page count is known. `replace` keeps the bounce
+  // out of history; the `!loading` guard stops it fighting an in-flight fetch.
+  useEffect(() => {
+    if (!loading && totalNrOfElements > 0 && currentPage > nrOfPages) {
+      navigate(nrOfPages, 'replace');
+    }
+  }, [loading, totalNrOfElements, currentPage, nrOfPages, navigate]);
+
+  return {
+    nrOfPages,
+    goToPage,
+    goToNextPage,
+    goToPreviousPage,
+  };
+}

--- a/dashboard/src/pages/orgs/[orgSlug]/projects/[appSubdomain]/ai/auto-embeddings/index.tsx
+++ b/dashboard/src/pages/orgs/[orgSlug]/projects/[appSubdomain]/ai/auto-embeddings/index.tsx
@@ -1,7 +1,7 @@
 import { PlusIcon } from 'lucide-react';
 import Link from 'next/link';
 import { useRouter } from 'next/router';
-import { type ReactElement, useEffect, useMemo, useRef, useState } from 'react';
+import { type ReactElement, useMemo } from 'react';
 import { useDialog } from '@/components/common/DialogProvider';
 import { Pagination } from '@/components/common/Pagination';
 import { UpgradeToProBanner } from '@/components/common/UpgradeToProBanner';
@@ -19,13 +19,18 @@ import { AutoEmbeddingsList } from '@/features/orgs/projects/ai/AutoEmbeddingsLi
 import type { AutoEmbeddingsConfiguration } from '@/features/orgs/projects/ai/auto-embeddings/types';
 import { useIsGraphiteEnabled } from '@/features/orgs/projects/common/hooks/useIsGraphiteEnabled';
 import { useIsPlatform } from '@/features/orgs/projects/common/hooks/useIsPlatform';
+import {
+  getPageNumberFromQuery,
+  useUrlPagination,
+} from '@/features/orgs/projects/common/hooks/useUrlPagination';
 import { useCurrentOrg } from '@/features/orgs/projects/hooks/useCurrentOrg';
 import { useProject } from '@/features/orgs/projects/hooks/useProject';
 import { useGetGraphiteAutoEmbeddingsConfigurationsQuery } from '@/generated/graphite';
 import { getPaginationOffset } from '@/utils/getPaginationOffset';
 
+const ELEMENTS_PER_PAGE = 25;
+
 export default function AutoEmbeddingsPage() {
-  const limit = useRef(25);
   const router = useRouter();
 
   const { openDrawer } = useDialog();
@@ -40,12 +45,9 @@ export default function AutoEmbeddingsPage() {
 
   const isProjectReady = !isPlatform || !!project;
 
-  const [currentPage, setCurrentPage] = useState(
-    parseInt(router.query.page as string, 10) || 1,
-  );
-  const [nrOfPages, setNrOfPages] = useState(0);
+  const currentPage = getPageNumberFromQuery(router.query.page);
   const offset = useMemo(
-    () => getPaginationOffset(currentPage, limit.current),
+    () => getPaginationOffset(currentPage, ELEMENTS_PER_PAGE),
     [currentPage],
   );
 
@@ -53,22 +55,22 @@ export default function AutoEmbeddingsPage() {
     useGetGraphiteAutoEmbeddingsConfigurationsQuery({
       client: remoteProjectGQLClient,
       variables: {
-        limit: limit.current,
+        limit: ELEMENTS_PER_PAGE,
         offset,
       },
       skip: !isProjectReady,
     });
 
-  useEffect(() => {
-    if (loading || !isProjectReady) {
-      return;
-    }
+  const totalNrOfElements =
+    data?.graphiteAutoEmbeddingsConfigurationAggregate?.aggregate?.count ?? 0;
 
-    const autoEmbeddingsCount =
-      data?.graphiteAutoEmbeddingsConfigurationAggregate?.aggregate?.count ?? 0;
-
-    setNrOfPages(Math.ceil(autoEmbeddingsCount / limit.current));
-  }, [data, isProjectReady, loading]);
+  const { nrOfPages, goToPage, goToNextPage, goToPreviousPage } =
+    useUrlPagination({
+      currentPage,
+      elementsPerPage: ELEMENTS_PER_PAGE,
+      totalNrOfElements,
+      loading: loading || !isProjectReady,
+    });
 
   const autoEmbeddingsConfigurations = useMemo<AutoEmbeddingsConfiguration[]>(
     () => data?.graphiteAutoEmbeddingsConfigurations || [],
@@ -188,33 +190,12 @@ export default function AutoEmbeddingsPage() {
           className="px-2 py-4"
           totalNrOfPages={nrOfPages}
           currentPageNumber={currentPage}
-          totalNrOfElements={
-            data?.graphiteAutoEmbeddingsConfigurationAggregate?.aggregate
-              ?.count ?? 0
-          }
+          totalNrOfElements={totalNrOfElements}
           itemsLabel="Auto-Embeddings Configurations"
-          elementsPerPage={limit.current}
-          onPrevPageClick={async () => {
-            setCurrentPage((page) => page - 1);
-            await router.push({
-              pathname: router.pathname,
-              query: { ...router.query, page: currentPage - 1 },
-            });
-          }}
-          onNextPageClick={async () => {
-            setCurrentPage((page) => page + 1);
-            await router.push({
-              pathname: router.pathname,
-              query: { ...router.query, page: currentPage + 1 },
-            });
-          }}
-          onPageChange={async (page) => {
-            setCurrentPage(page);
-            await router.push({
-              pathname: router.pathname,
-              query: { ...router.query, page },
-            });
-          }}
+          elementsPerPage={ELEMENTS_PER_PAGE}
+          onPrevPageClick={goToPreviousPage}
+          onNextPageClick={goToNextPage}
+          onPageChange={goToPage}
         />
       </div>
     </div>

--- a/dashboard/src/pages/orgs/[orgSlug]/projects/[appSubdomain]/auth/oauth2-clients.tsx
+++ b/dashboard/src/pages/orgs/[orgSlug]/projects/[appSubdomain]/auth/oauth2-clients.tsx
@@ -19,6 +19,10 @@ import { CreateOAuth2ClientForm } from '@/features/orgs/projects/authentication/
 import { OAuth2ClientsList } from '@/features/orgs/projects/authentication/oauth2-clients/components/OAuth2ClientsList';
 import { useIsPlatform } from '@/features/orgs/projects/common/hooks/useIsPlatform';
 import { useSoftwareVersionsInfo } from '@/features/orgs/projects/common/hooks/useSoftwareVersionsInfo';
+import {
+  getPageNumberFromQuery,
+  useUrlPagination,
+} from '@/features/orgs/projects/common/hooks/useUrlPagination';
 import { useLocalMimirClient } from '@/features/orgs/projects/hooks/useLocalMimirClient';
 import { useProject } from '@/features/orgs/projects/hooks/useProject';
 import {
@@ -48,10 +52,7 @@ function OAuth2ClientsPageContent() {
   const { auth, loading: loadingVersions } = useSoftwareVersionsInfo();
 
   const [searchString, setSearchString] = useState('');
-  const [currentPage, setCurrentPage] = useState(
-    parseInt(router.query.page as string, 10) || 1,
-  );
-  const [nrOfPages, setNrOfPages] = useState(1);
+  const currentPage = getPageNumberFromQuery(router.query.page);
 
   const offset = useMemo(
     () => getPaginationOffset(currentPage, ELEMENTS_PER_PAGE),
@@ -98,39 +99,21 @@ function OAuth2ClientsPageContent() {
   const totalNrOfElements =
     clientsData?.authOauth2ClientsAggregate?.aggregate?.count ?? 0;
 
-  useEffect(() => {
-    if (clientsLoading) {
-      return;
-    }
-    if (totalNrOfElements > 0) {
-      setNrOfPages(Math.ceil(totalNrOfElements / ELEMENTS_PER_PAGE));
-    } else {
-      setNrOfPages(1);
-    }
-  }, [totalNrOfElements, clientsLoading]);
-
-  useEffect(() => {
-    if (router.query.page === undefined) {
-      setCurrentPage(1);
-      return;
-    }
-    if (router.query.page && typeof router.query.page === 'string') {
-      const pageNumber = parseInt(router.query.page, 10);
-      if (nrOfPages >= pageNumber) {
-        setCurrentPage(pageNumber);
-      } else {
-        setCurrentPage(1);
-      }
-    }
-  }, [nrOfPages, router.query.page]);
+  const { nrOfPages, goToPage, goToNextPage, goToPreviousPage } =
+    useUrlPagination({
+      currentPage,
+      elementsPerPage: ELEMENTS_PER_PAGE,
+      totalNrOfElements,
+      loading: clientsLoading,
+    });
 
   const handleSearchStringChange = useMemo(
     () =>
       debounce((event: ChangeEvent<HTMLInputElement>) => {
-        setCurrentPage(1);
+        goToPage(1);
         setSearchString(event.target.value);
       }, 1000),
-    [],
+    [goToPage],
   );
 
   useEffect(
@@ -338,27 +321,9 @@ function OAuth2ClientsPageContent() {
                   totalNrOfElements={totalNrOfElements}
                   itemsLabel="clients"
                   elementsPerPage={ELEMENTS_PER_PAGE}
-                  onPrevPageClick={async () => {
-                    setCurrentPage((page) => page - 1);
-                    await router.push({
-                      pathname: router.pathname,
-                      query: { ...router.query, page: currentPage - 1 },
-                    });
-                  }}
-                  onNextPageClick={async () => {
-                    setCurrentPage((page) => page + 1);
-                    await router.push({
-                      pathname: router.pathname,
-                      query: { ...router.query, page: currentPage + 1 },
-                    });
-                  }}
-                  onPageChange={async (page) => {
-                    setCurrentPage(page);
-                    await router.push({
-                      pathname: router.pathname,
-                      query: { ...router.query, page },
-                    });
-                  }}
+                  onPrevPageClick={goToPreviousPage}
+                  onNextPageClick={goToNextPage}
+                  onPageChange={goToPage}
                 />
               </div>
             )}

--- a/dashboard/src/pages/orgs/[orgSlug]/projects/[appSubdomain]/auth/users.tsx
+++ b/dashboard/src/pages/orgs/[orgSlug]/projects/[appSubdomain]/auth/users.tsx
@@ -2,7 +2,7 @@ import debounce from 'lodash.debounce';
 import { PlusIcon, SearchIcon, UserIcon } from 'lucide-react';
 import { useRouter } from 'next/router';
 import type { ChangeEvent, ReactElement } from 'react';
-import { useEffect, useMemo, useRef, useState } from 'react';
+import { useEffect, useMemo, useState } from 'react';
 import { useDialog } from '@/components/common/DialogProvider';
 import { Pagination } from '@/components/common/Pagination';
 import { Container } from '@/components/layout/Container';
@@ -16,10 +16,13 @@ import { useRemoteApplicationGQLClient } from '@/features/orgs/hooks/useRemoteAp
 import { OrgLayout } from '@/features/orgs/layout/OrgLayout';
 import { CreateUserForm } from '@/features/orgs/projects/authentication/users/components/CreateUserForm';
 import { UsersBody } from '@/features/orgs/projects/authentication/users/components/UsersBody';
+import {
+  getPageNumberFromQuery,
+  useUrlPagination,
+} from '@/features/orgs/projects/common/hooks/useUrlPagination';
 import { getUserRoles } from '@/features/orgs/projects/roles/settings/utils/getUserRoles';
 import type { RemoteAppGetUsersAndAuthRolesQuery } from '@/generated/graphql';
 import { useRemoteAppGetUsersAndAuthRolesQuery } from '@/generated/graphql';
-import { useRemoveQueryParamsFromUrl } from '@/hooks/useRemoveQueryParamsFromUrl';
 import { isNotEmptyValue } from '@/lib/utils';
 import { getPaginationOffset } from '@/utils/getPaginationOffset';
 
@@ -27,6 +30,8 @@ export type RemoteAppUser = Exclude<
   RemoteAppGetUsersAndAuthRolesQuery['users'][0],
   '__typename'
 >;
+
+const ELEMENTS_PER_PAGE = 25;
 
 export default function UsersPage() {
   return (
@@ -41,18 +46,12 @@ function UsersPageContent() {
   const remoteProjectGQLClient = useRemoteApplicationGQLClient();
   const [searchString, setSearchString] = useState<string>('');
 
-  const limit = useRef(25);
   const router = useRouter();
-  const [nrOfPages, setNrOfPages] = useState(1);
 
-  const [currentPage, setCurrentPage] = useState(
-    parseInt(router.query.page as string, 10) || 1,
-  );
-
-  const removeQueryParamsFromUrl = useRemoveQueryParamsFromUrl();
+  const currentPage = getPageNumberFromQuery(router.query.page);
 
   const offset = useMemo(
-    () => getPaginationOffset(currentPage, limit.current),
+    () => getPaginationOffset(currentPage, ELEMENTS_PER_PAGE),
     [currentPage],
   );
 
@@ -79,7 +78,7 @@ function UsersPageContent() {
                 },
               ],
             },
-      limit: limit.current,
+      limit: ELEMENTS_PER_PAGE,
       offset,
     }),
     [router.query.userId, searchString, offset],
@@ -95,42 +94,18 @@ function UsersPageContent() {
     client: remoteProjectGQLClient,
   });
 
-  /**
-   * If a user of the app enters the users tab with a page query param of the following structure:
-   * `users?page=2` this useEffect will update the current page to 2.
-   * which in turn will update the offset and trigger fetching the data with the new variables.
-   * If the user enters a page number that is greater than the number of pages we will redirect
-   * the user to the first page and update the URL.
-   *
-   * @remarks If the user navigates the page back and forth we handle the URL change through
-   * props passed to the Pagination component.
-   * @see {@link Pagination}
-   *
-   */
-  useEffect(() => {
-    if (router.query.page === undefined) {
-      setCurrentPage(1);
-      return;
-    }
-    if (router.query.page && typeof router.query.page === 'string') {
-      const pageNumber = parseInt(router.query.page, 10);
-      if (nrOfPages >= pageNumber || loadingRemoteAppUsersQuery) {
-        setCurrentPage(pageNumber);
-      } else {
-        setCurrentPage(1);
-      }
-    }
-  }, [nrOfPages, router.query.page, loadingRemoteAppUsersQuery]);
+  const totalUsersCount = searchString
+    ? (dataRemoteAppUsersAndAuthRoles?.filteredUsersAggreggate?.aggregate
+        ?.count ?? 0)
+    : (dataRemoteAppUsersAndAuthRoles?.usersAggregate?.aggregate?.count ?? 0);
 
-  /**
-   * If the user is on the first page, we want to remove the page query param from the URL.
-   * e.g. `users?page=1` -> `users`
-   */
-  useEffect(() => {
-    if (currentPage === 1 && isNotEmptyValue(router.query.page)) {
-      removeQueryParamsFromUrl('page');
-    }
-  }, [currentPage, removeQueryParamsFromUrl, router.query.page]);
+  const { nrOfPages, goToPage, goToNextPage, goToPreviousPage } =
+    useUrlPagination({
+      currentPage,
+      elementsPerPage: ELEMENTS_PER_PAGE,
+      totalNrOfElements: totalUsersCount,
+      loading: loadingRemoteAppUsersQuery,
+    });
 
   /**
    * If the users enters the page with a page query param with the following structure:
@@ -144,40 +119,13 @@ function UsersPageContent() {
     }
   }, [router.query.userId]);
 
-  /**
-   * We want to update the number of pages when the data changes
-   * (either fetch for the first time or making a search).
-   */
-  useEffect(() => {
-    if (loadingRemoteAppUsersQuery) {
-      return;
-    }
-    if (
-      dataRemoteAppUsersAndAuthRoles?.filteredUsersAggreggate.aggregate
-        ?.count &&
-      dataRemoteAppUsersAndAuthRoles?.usersAggregate.aggregate?.count
-    ) {
-      const userCount = searchString
-        ? dataRemoteAppUsersAndAuthRoles?.filteredUsersAggreggate?.aggregate
-            ?.count
-        : dataRemoteAppUsersAndAuthRoles?.usersAggregate?.aggregate?.count;
-
-      setNrOfPages(Math.ceil(userCount / limit.current));
-    }
-  }, [
-    dataRemoteAppUsersAndAuthRoles?.filteredUsersAggreggate?.aggregate?.count,
-    dataRemoteAppUsersAndAuthRoles?.usersAggregate?.aggregate?.count,
-    loadingRemoteAppUsersQuery,
-    searchString,
-  ]);
-
   const handleSearchStringChange = useMemo(
     () =>
       debounce((event: ChangeEvent<HTMLInputElement>) => {
-        setCurrentPage(1);
+        goToPage(1);
         setSearchString(event.target.value);
       }, 1000),
-    [],
+    [goToPage],
   );
 
   useEffect(
@@ -257,7 +205,7 @@ function UsersPageContent() {
       dataRemoteAppUsersAndAuthRoles?.filteredUsersAggreggate.aggregate?.count,
     )
       ? dataRemoteAppUsersAndAuthRoles.filteredUsersAggreggate.aggregate.count
-      : limit.current;
+      : ELEMENTS_PER_PAGE;
   const totalNrOfElements =
     searchString &&
     isNotEmptyValue(
@@ -347,27 +295,9 @@ function UsersPageContent() {
                   totalNrOfElements={totalNrOfElements}
                   itemsLabel="users"
                   elementsPerPage={elementsPerPage}
-                  onPrevPageClick={async () => {
-                    setCurrentPage((page) => page - 1);
-                    await router.push({
-                      pathname: router.pathname,
-                      query: { ...router.query, page: currentPage - 1 },
-                    });
-                  }}
-                  onNextPageClick={async () => {
-                    setCurrentPage((page) => page + 1);
-                    await router.push({
-                      pathname: router.pathname,
-                      query: { ...router.query, page: currentPage + 1 },
-                    });
-                  }}
-                  onPageChange={async (page) => {
-                    setCurrentPage(page);
-                    await router.push({
-                      pathname: router.pathname,
-                      query: { ...router.query, page },
-                    });
-                  }}
+                  onPrevPageClick={goToPreviousPage}
+                  onNextPageClick={goToNextPage}
+                  onPageChange={goToPage}
                 />
               </div>
             )}

--- a/dashboard/src/pages/orgs/[orgSlug]/projects/[appSubdomain]/run.tsx
+++ b/dashboard/src/pages/orgs/[orgSlug]/projects/[appSubdomain]/run.tsx
@@ -32,7 +32,9 @@ export default function RunPage() {
     limit,
     nrOfPages,
     currentPage,
-    setCurrentPage,
+    goToPage,
+    goToNextPage,
+    goToPreviousPage,
     refetch,
   } = useRunServices();
 
@@ -163,28 +165,10 @@ export default function RunPage() {
             currentPageNumber={currentPage}
             totalNrOfElements={totalServicesCount}
             itemsLabel="services"
-            elementsPerPage={limit.current}
-            onPrevPageClick={async () => {
-              setCurrentPage((page) => page - 1);
-              await router.push({
-                pathname: router.pathname,
-                query: { ...router.query, page: currentPage - 1 },
-              });
-            }}
-            onNextPageClick={async () => {
-              setCurrentPage((page) => page + 1);
-              await router.push({
-                pathname: router.pathname,
-                query: { ...router.query, page: currentPage + 1 },
-              });
-            }}
-            onPageChange={async (page) => {
-              setCurrentPage(page);
-              await router.push({
-                pathname: router.pathname,
-                query: { ...router.query, page },
-              });
-            }}
+            elementsPerPage={limit}
+            onPrevPageClick={goToPreviousPage}
+            onNextPageClick={goToNextPage}
+            onPageChange={goToPage}
           />
         ) : null}
       </div>


### PR DESCRIPTION
### Checklist

- [x] No breaking changes
- [ ] Tests pass
- [ ] New features have new tests
- [x] Documentation is updated (if applicable)
- [x] Title of the PR is in the correct format (see below)

<!-- pi-reviewer:start -->
### **What this change solves**
Pagination state was duplicated between React state and the `page` URL query param across several pages, kept in sync with fragile `useEffect` chains. This makes the URL the single source of truth: pages derive `currentPage` directly from the query param and navigation only writes the URL.

___

### **Change Type**
Refactoring

___

### **Description**
- Adds a new `useUrlPagination` hook (plus `getPageNumberFromQuery` helper) that computes `nrOfPages` and returns URL-writing `goToPage` / `goToNextPage` / `goToPreviousPage` navigators. Page 1 is represented by the absence of the `page` param.
- Includes an out-of-range clamp: once the real page count is known (and not loading), an over-range `page` param is corrected via `router.replace` so it stays out of history.
- Migrates `useRunServices` and four pages (`ai/auto-embeddings`, `auth/oauth2-clients`, `auth/users`, `run`) off local `useState`/`useRef`/`useEffect` pagination bookkeeping onto the hook.
- Removes now-redundant sync effects and the `useRemoveQueryParamsFromUrl` usage in `users`.
- Replaces per-page inline `router.push` pagination handlers with the hook's stable navigators.

___

### Diagram Walkthrough

```mermaid
flowchart LR
  URL["page query param"] --> GPNFQ["getPageNumberFromQuery"]
  GPNFQ --> CP["currentPage"]
  CP --> Q["GraphQL offset/limit query"]
  CP --> H["useUrlPagination"]
  Q --> H
  H --> Nav["goToPage / next / prev"]
  Nav --> URL
```

<details> <summary><h3> File Walkthrough</h3></summary>

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody>
<tr><td><strong>New hook</strong></td><td><details><summary>2 files</summary><table>
<tr>
  <td><strong>useUrlPagination.ts</strong><dd><code>URL-backed pagination hook + getPageNumberFromQuery; out-of-range replace clamp</code></dd></td>
  <td>+116/-0</td>
</tr>
<tr>
  <td><strong>index.ts</strong><dd><code>Barrel re-export of the hook + helper</code></dd></td>
  <td>+5/-0</td>
</tr>
</table></details></td></tr>
<tr><td><strong>Hook migration</strong></td><td><details><summary>1 files</summary><table>
<tr>
  <td><strong>useRunServices.ts</strong><dd><code>Derive currentPage from URL; delegate paging to useUrlPagination; drop state/effect</code></dd></td>
  <td>+24/-26</td>
</tr>
</table></details></td></tr>
<tr><td><strong>Page migrations</strong></td><td><details><summary>4 files</summary><table>
<tr>
  <td><strong>ai/auto-embeddings/index.tsx</strong><dd><code>Use useUrlPagination; remove local pagination state/effect and inline push handlers</code></dd></td>
  <td>+24/-43</td>
</tr>
<tr>
  <td><strong>auth/oauth2-clients.tsx</strong><dd><code>Use useUrlPagination; drop nrOfPages/currentPage sync effects</code></dd></td>
  <td>+17/-52</td>
</tr>
<tr>
  <td><strong>auth/users.tsx</strong><dd><code>Use useUrlPagination; drop sync effects and useRemoveQueryParamsFromUrl</code></dd></td>
  <td>+27/-97</td>
</tr>
<tr>
  <td><strong>run.tsx</strong><dd><code>Use hook navigators instead of inline router.push handlers</code></dd></td>
  <td>+7/-23</td>
</tr>
</table></details></td></tr>
</tbody></table>

</details>

___

<!-- pi-reviewer:end -->
