### PR TITLE
fix(functions): upgrade serverless http version

### DIFF
--- a/services/functions/nhost-install-deps.sh
+++ b/services/functions/nhost-install-deps.sh
@@ -38,7 +38,7 @@
 # package.json matches NHOST_EXPRESS_VERSION. serverless-http is prod-only
 # (Lambda); the dev runtime is a long-lived express server. Bump in lockstep.
 NHOST_EXPRESS_VERSION=5.2.1
-NHOST_SERVERLESS_HTTP_VERSION=3.0.2
+NHOST_SERVERLESS_HTTP_VERSION=4.0.0
 
 nhost_install_deps() {
 	set -eu

--- a/services/functions/test/nhost-install-deps.test.js
+++ b/services/functions/test/nhost-install-deps.test.js
@@ -9,7 +9,7 @@ const SCRIPT = join(__dirname, '..', 'nhost-install-deps.sh');
 // pinned. On an intentional edit: update this hash AND copy the file to the
 // other repo so the two stay in sync.
 const WANT_CHECKSUM =
-  '7eb4533c1481d324a79e14ec6a133b84e80f39a7636d9ce9e43ebde41181a01c';
+  '62b2278e154adab2c05d6a7d29eb05eec44fdd43b5b4d357e1032305a8c373f7';
 
 describe('shared install library (parity with nhost/be services/cd)', () => {
   test('checksum is in sync with nhost/be', () => {


### PR DESCRIPTION
NOTE: this is actually a noop and has no effect in local functions. This update is only to maintain parity with be.

### Checklist

- [x] No breaking changes
- [x] Tests pass
- [ ] New features have new tests
- [ ] Documentation is updated (if applicable)
- [x] Title of the PR is in the correct format (see below)
