### PR TITLE
fix(dashboard): Migrate support, new and reset password pages to v3

### DIFF
--- a/dashboard/src/components/layout/UnauthenticatedLayout/UnauthenticatedLayout.tsx
+++ b/dashboard/src/components/layout/UnauthenticatedLayout/UnauthenticatedLayout.tsx
@@ -1,4 +1,3 @@
-import GlobalStyles from '@mui/material/GlobalStyles';
 import Image from 'next/image';
 import { useRouter } from 'next/router';
 import { useEffect } from 'react';
@@ -7,8 +6,6 @@ import { BaseLayout } from '@/components/layout/BaseLayout';
 import { Container } from '@/components/layout/Container';
 import { LoadingScreen } from '@/components/presentational/LoadingScreen';
 import { RetryableErrorBoundary } from '@/components/presentational/RetryableErrorBoundary';
-import { Box } from '@/components/ui/v2/Box';
-import { ThemeProvider } from '@/components/ui/v2/ThemeProvider';
 import { useIsPlatform } from '@/features/orgs/projects/common/hooks/useIsPlatform';
 import { useAuth } from '@/providers/Auth';
 
@@ -59,24 +56,10 @@ export default function UnauthenticatedLayout({
   }
 
   return (
-    <ThemeProvider color="dark">
-      <BaseLayout {...props}>
-        <GlobalStyles
-          styles={{
-            'html, body': {
-              backgroundColor: `#000 !important`,
-            },
-            '#__next': {
-              overflow: 'auto',
-            },
-          }}
-        />
-
+    <BaseLayout {...props}>
+      <div className="dark h-screen overflow-auto bg-black text-foreground">
         <RetryableErrorBoundary>
-          <Box
-            className="flex min-h-screen items-center"
-            sx={{ backgroundColor: (theme) => theme.palette.common.black }}
-          >
+          <div className="flex min-h-screen items-center bg-black">
             <Container
               rootClassName="bg-transparent h-full"
               className="grid h-full w-full items-center justify-items-center gap-12 bg-transparent pt-8 pb-12 lg:grid-cols-2 lg:gap-4 lg:pt-8 lg:pb-0"
@@ -99,12 +82,7 @@ export default function UnauthenticatedLayout({
                     />
                   </div>
 
-                  <Box
-                    className="backface-hidden absolute right-0 left-0 z-0 mx-auto h-20 w-20 transform-gpu rounded-full opacity-80 blur-[56px]"
-                    sx={{
-                      backgroundColor: (theme) => theme.palette.primary.main,
-                    }}
-                  />
+                  <div className="backface-hidden absolute right-0 left-0 z-0 mx-auto h-20 w-20 transform-gpu rounded-full bg-primary-main opacity-80 blur-[56px]" />
 
                   <Image
                     src="/assets/logo.svg"
@@ -121,9 +99,9 @@ export default function UnauthenticatedLayout({
                 )}
               </div>
             </Container>
-          </Box>
+          </div>
         </RetryableErrorBoundary>
-      </BaseLayout>
-    </ThemeProvider>
+      </div>
+    </BaseLayout>
   );
 }

--- a/dashboard/src/pages/password/new.tsx
+++ b/dashboard/src/pages/password/new.tsx
@@ -1,16 +1,13 @@
 import { yupResolver } from '@hookform/resolvers/yup';
 import { Turnstile } from '@marsidev/react-turnstile';
-import { styled } from '@mui/material';
 import { type ReactElement, useState } from 'react';
 import { FormProvider, useForm } from 'react-hook-form';
 import { toast } from 'react-hot-toast';
 import * as Yup from 'yup';
 import { NavLink } from '@/components/common/NavLink';
 import { Form } from '@/components/form/Form';
+import { FormInput } from '@/components/form/FormInput';
 import { UnauthenticatedLayout } from '@/components/layout/UnauthenticatedLayout';
-import { Box } from '@/components/ui/v2/Box';
-import { Input, inputClasses } from '@/components/ui/v2/Input';
-import { Text } from '@/components/ui/v2/Text';
 import { ButtonWithLoading } from '@/components/ui/v3/button';
 import { appendPkceId, generateAndStorePKCE } from '@/lib/pkce';
 import { useNhostClient } from '@/providers/nhost';
@@ -25,13 +22,6 @@ const validationSchema = Yup.object({
 
 export type NewPasswordFormValues = Yup.InferType<typeof validationSchema>;
 
-const StyledInput = styled(Input)({
-  backgroundColor: 'transparent',
-  [`& .${inputClasses.input}`]: {
-    backgroundColor: 'transparent !important',
-  },
-});
-
 export default function NewPasswordPage() {
   const nhost = useNhostClient();
   const [isSent, setIsSent] = useState(false);
@@ -45,7 +35,7 @@ export default function NewPasswordPage() {
     resolver: yupResolver(validationSchema),
   });
 
-  const { register, formState, getValues, setValue } = form;
+  const { formState, getValues, setValue } = form;
 
   async function handleSubmit({
     email,
@@ -91,37 +81,28 @@ export default function NewPasswordPage() {
 
   return (
     <>
-      <Text
-        variant="h2"
-        component="h1"
-        className="text-center font-semibold text-3.5xl lg:text-4.5xl"
-      >
+      <h1 className="text-center font-semibold text-3.5xl lg:text-4.5xl">
         Reset Password
-      </Text>
+      </h1>
 
-      <Box className="grid grid-flow-row gap-4 rounded-md border bg-transparent p-6 lg:p-12">
+      <div className="grid grid-flow-row gap-4 rounded-md border bg-transparent p-6 lg:p-12">
         <FormProvider {...form}>
           <Form
             onSubmit={handleSubmit}
-            className="grid grid-flow-row gap-4 bg-transparent"
+            className="grid grid-flow-row gap-4 [&&]:bg-transparent"
           >
-            <StyledInput
-              {...register('email')}
+            <FormInput
+              control={form.control}
+              name="email"
               type="email"
-              id="email"
               label="Email"
               placeholder="Email"
-              fullWidth
               autoFocus
-              inputProps={{ min: 2, max: 128 }}
-              error={!!formState.errors.email}
-              helperText={formState.errors.email?.message}
+              className="!bg-transparent border-border text-white placeholder:text-white"
             />
 
-            <Box className="grid grid-flow-row gap-2">
-              <Text variant="body2" className="text-sm">
-                Verification
-              </Text>
+            <div className="grid grid-flow-row gap-2">
+              <p className="text-sm">Verification</p>
               <Turnstile
                 siteKey={process.env.NEXT_PUBLIC_TURNSTILE_SITE_KEY!}
                 options={{ theme: 'dark', size: 'flexible' }}
@@ -142,11 +123,11 @@ export default function NewPasswordPage() {
                 }}
               />
               {formState.errors.turnstileToken && (
-                <Text variant="body2" className="text-red-500 text-sm">
+                <p className="text-red-500 text-sm">
                   {formState.errors.turnstileToken.message}
-                </Text>
+                </p>
               )}
-            </Box>
+            </div>
 
             <ButtonWithLoading
               className="!bg-white !text-black disabled:!text-black disabled:!text-opacity-60"
@@ -159,9 +140,9 @@ export default function NewPasswordPage() {
             </ButtonWithLoading>
           </Form>
         </FormProvider>
-      </Box>
+      </div>
 
-      <Text color="secondary" className="text-center text-base lg:text-lg">
+      <p className="text-center text-[#A2B3BE] text-base lg:text-lg">
         Is your password okay?{' '}
         <NavLink
           href="/signin/email"
@@ -169,7 +150,7 @@ export default function NewPasswordPage() {
         >
           Sign In
         </NavLink>
-      </Text>
+      </p>
     </>
   );
 }

--- a/dashboard/src/pages/password/reset.tsx
+++ b/dashboard/src/pages/password/reset.tsx
@@ -1,15 +1,12 @@
 import { yupResolver } from '@hookform/resolvers/yup';
-import { styled } from '@mui/material';
 import { useRouter } from 'next/router';
 import type { ReactElement } from 'react';
 import { FormProvider, useForm } from 'react-hook-form';
 import * as Yup from 'yup';
 import { NavLink } from '@/components/common/NavLink';
 import { Form } from '@/components/form/Form';
+import { FormInput } from '@/components/form/FormInput';
 import { UnauthenticatedLayout } from '@/components/layout/UnauthenticatedLayout';
-import { Box } from '@/components/ui/v2/Box';
-import { Input, inputClasses } from '@/components/ui/v2/Input';
-import { Text } from '@/components/ui/v2/Text';
 import { ButtonWithLoading } from '@/components/ui/v3/button';
 import useActionWithElevatedPermissions from '@/features/account/settings/hooks/useActionWithElevatedPermissions';
 import { useNhostClient } from '@/providers/nhost';
@@ -26,13 +23,6 @@ const validationSchema = Yup.object({
 
 export type ResetPasswordFormValues = Yup.InferType<typeof validationSchema>;
 
-const StyledInput = styled(Input)({
-  backgroundColor: 'transparent',
-  [`& .${inputClasses.input}`]: {
-    backgroundColor: 'transparent !important',
-  },
-});
-
 export default function ResetPasswordPage() {
   const router = useRouter();
   const nhost = useNhostClient();
@@ -46,7 +36,7 @@ export default function ResetPasswordPage() {
     resolver: yupResolver(validationSchema),
   });
 
-  const { register, formState } = form;
+  const { formState } = form;
 
   const changePassword = useActionWithElevatedPermissions({
     actionFn: nhost.auth.changeUserPassword,
@@ -62,40 +52,30 @@ export default function ResetPasswordPage() {
 
   return (
     <>
-      <Text
-        variant="h2"
-        component="h1"
-        className="text-center font-semibold text-3.5xl lg:text-4.5xl"
-      >
+      <h1 className="text-center font-semibold text-3.5xl lg:text-4.5xl">
         Change password
-      </Text>
+      </h1>
 
-      <Box className="grid grid-flow-row gap-4 rounded-md border bg-transparent p-6 lg:p-12">
+      <div className="grid grid-flow-row gap-4 rounded-md border bg-transparent p-6 lg:p-12">
         <FormProvider {...form}>
           <Form
             onSubmit={handleSubmit}
-            className="grid grid-flow-row gap-4 bg-transparent"
+            className="grid grid-flow-row gap-4 [&&]:bg-transparent"
           >
-            <StyledInput
-              {...register('newPassword')}
+            <FormInput
+              control={form.control}
+              name="newPassword"
               type="password"
-              id="newPassword"
               label="New Password"
-              fullWidth
-              inputProps={{ min: 2, max: 128 }}
-              error={!!formState.errors.newPassword}
-              helperText={formState.errors.newPassword?.message}
+              className="!bg-transparent border-border text-white placeholder:text-white"
             />
 
-            <StyledInput
-              {...register('confirmNewPassword')}
+            <FormInput
+              control={form.control}
+              name="confirmNewPassword"
               type="password"
-              id="confirmNewPassword"
               label="Confirm New Password"
-              fullWidth
-              inputProps={{ min: 2, max: 128 }}
-              error={!!formState.errors.confirmNewPassword}
-              helperText={formState.errors.confirmNewPassword?.message}
+              className="!bg-transparent border-border text-white placeholder:text-white"
             />
 
             <ButtonWithLoading
@@ -109,9 +89,9 @@ export default function ResetPasswordPage() {
             </ButtonWithLoading>
           </Form>
         </FormProvider>
-      </Box>
+      </div>
 
-      <Text color="secondary" className="text-center text-base lg:text-lg">
+      <p className="text-center text-[#A2B3BE] text-base lg:text-lg">
         Go back to{' '}
         <NavLink
           href="/signin/email"
@@ -119,7 +99,7 @@ export default function ResetPasswordPage() {
         >
           Sign In
         </NavLink>
-      </Text>
+      </p>
     </>
   );
 }

--- a/dashboard/src/pages/support/ticket.tsx
+++ b/dashboard/src/pages/support/ticket.tsx
@@ -1,16 +1,13 @@
 import { yupResolver } from '@hookform/resolvers/yup';
-import { styled } from '@mui/material';
 import { Mail } from 'lucide-react';
 import { type ReactElement, useEffect } from 'react';
 import { FormProvider, useForm } from 'react-hook-form';
 import * as Yup from 'yup';
 import { Form } from '@/components/form/Form';
+import { FormInput } from '@/components/form/FormInput';
 import { FormSelect } from '@/components/form/FormSelect';
+import { FormTextarea } from '@/components/form/FormTextarea';
 import { AuthenticatedLayout } from '@/components/layout/AuthenticatedLayout';
-import { Box } from '@/components/ui/v2/Box';
-import { Divider } from '@/components/ui/v2/Divider';
-import { Input, inputClasses } from '@/components/ui/v2/Input';
-import { Text } from '@/components/ui/v2/Text';
 import { ButtonWithLoading } from '@/components/ui/v3/button';
 import {
   FormControl,
@@ -28,6 +25,7 @@ import {
   MultiSelectValue,
 } from '@/components/ui/v3/multi-select';
 import { SelectItem } from '@/components/ui/v3/select';
+import { Separator } from '@/components/ui/v3/separator';
 import { execPromiseWithErrorToast } from '@/features/orgs/utils/execPromiseWithErrorToast';
 import {
   type GetOrganizationsQuery,
@@ -55,13 +53,6 @@ const validationSchema = Yup.object({
 
 export type CreateTicketFormValues = Yup.InferType<typeof validationSchema>;
 
-const StyledInput = styled(Input)({
-  backgroundColor: 'transparent',
-  [`& .${inputClasses.input}`]: {
-    backgroundColor: 'transparent !important',
-  },
-});
-
 function TicketPage() {
   const form = useForm<CreateTicketFormValues>({
     reValidateMode: 'onSubmit',
@@ -77,7 +68,6 @@ function TicketPage() {
   });
 
   const {
-    register,
     watch,
     setValue,
     formState: { errors, isSubmitting },
@@ -161,26 +151,21 @@ function TicketPage() {
   };
 
   return (
-    <Box
-      className="flex flex-col items-center justify-center py-10"
-      sx={{ backgroundColor: 'background.default' }}
-    >
+    <div className="flex min-h-full flex-col items-center justify-center bg-background-default py-10">
       <div className="flex w-full max-w-3xl flex-col">
         <div className="mb-4 flex flex-col items-center">
-          <Text variant="h4" className="font-bold">
-            Nhost Support
-          </Text>
-          <Text variant="h4">How can we help you?</Text>
+          <h4 className="font-bold text-2xl">Nhost Support</h4>
+          <h4 className="text-2xl">How can we help you?</h4>
         </div>
-        <Box className="w-full rounded-md border p-10">
-          <Box className="grid grid-flow-row gap-4">
-            <Box className="flex flex-col gap-4">
+        <div className="box w-full rounded-md border p-10">
+          <div className="grid grid-flow-row gap-4">
+            <div className="flex flex-col gap-4">
               <FormProvider {...form}>
                 <Form
                   onSubmit={handleSubmit}
                   className="grid grid-flow-row gap-4"
                 >
-                  <Text className="font-bold">Which project is affected ?</Text>
+                  <p className="font-bold">Which project is affected ?</p>
 
                   <FormSelect
                     control={form.control}
@@ -210,9 +195,9 @@ function TicketPage() {
                     ))}
                   </FormSelect>
 
-                  <Divider />
+                  <Separator />
 
-                  <Text className="mt-4 font-bold">Impact</Text>
+                  <p className="mt-4 font-bold">Impact</p>
 
                   <FormField
                     control={form.control}
@@ -320,39 +305,29 @@ function TicketPage() {
                     ))}
                   </FormSelect>
 
-                  <Divider />
+                  <Separator />
 
-                  <Text className="mt-4 font-bold">Issue</Text>
+                  <p className="mt-4 font-bold">Issue</p>
 
-                  <StyledInput
-                    {...register('subject')}
-                    id="subject"
+                  <FormInput
+                    control={form.control}
+                    name="subject"
                     label="Subject"
                     placeholder="Summary of the problem you are experiencing"
-                    fullWidth
-                    inputProps={{ min: 2, max: 128 }}
-                    error={!!errors.subject}
-                    helperText={errors.subject?.message}
                   />
 
-                  <StyledInput
-                    {...register('description')}
-                    id="description"
+                  <FormTextarea
+                    control={form.control}
+                    name="description"
                     label="Description"
                     placeholder="Describe the issue you are experiencing in detail, along with any relevant information. Please be as detailed as possible."
-                    fullWidth
-                    multiline
-                    inputProps={{
-                      className: 'resize-y min-h-[120px]',
-                    }}
-                    error={!!errors.description}
-                    helperText={errors.description?.message}
+                    className="min-h-[120px] resize-y"
                   />
 
-                  <Box className="ml-auto flex flex-col gap-4 lg:w-80">
-                    <Text color="secondary" className="text-right text-sm">
+                  <div className="ml-auto flex flex-col gap-4 lg:w-80">
+                    <p className="text-right text-muted-foreground text-sm">
                       We will contact you at <strong>{user?.email}</strong>
-                    </Text>
+                    </p>
                     <ButtonWithLoading
                       variant="outline"
                       className="hover:!bg-white hover:!bg-opacity-10 text-base focus:ring-0"
@@ -364,14 +339,14 @@ function TicketPage() {
                       {!isSubmitting && <Mail className="mr-2 size-4" />}
                       Create Support Ticket
                     </ButtonWithLoading>
-                  </Box>
+                  </div>
                 </Form>
               </FormProvider>
-            </Box>
-          </Box>
-        </Box>
+            </div>
+          </div>
+        </div>
       </div>
-    </Box>
+    </div>
   );
 }
 


### PR DESCRIPTION
### Checklist

- [x] No breaking changes
- [ ] Tests pass
- [ ] New features have new tests
- [ ] Documentation is updated (if applicable)
- [x] Title of the PR is in the correct format (see below)

<!-- pi-reviewer:start -->
### **What this change solves**
Removes Material UI / v2 (`components/ui/v2/*`) coupling from the unauthenticated layout and the password + support-ticket pages, advancing the dashboard's incremental v2→v3 migration. The `UnauthenticatedLayout` now provides the auth flow's forced-dark treatment with a plain v3 `.dark` wrapper instead of the v2 `ThemeProvider` + MUI `GlobalStyles`.

___

### **Change Type**
Refactoring

___

### **Description**
- Migrate `UnauthenticatedLayout` off v2: drop `ThemeProvider color="dark"`, MUI `GlobalStyles`, and two v2 `Box`es in favor of a single `<div className="dark h-screen overflow-auto bg-black text-foreground">` wrapper (the same pattern `oauth2/authorize` uses); glow circle uses `bg-primary-main`.
- Migrate `password/new` and `password/reset` v2→v3: `Text`→`<h1>`/`<p>`, `Box`→`<div>`, and the MUI `styled(Input)` transparent hack → `FormInput` (which bakes in `!bg-transparent`). These pages now inherit forced-dark from the layout, with no per-page wrapper.
- Migrate `support/ticket` v2→v3: `Box`→`<div>` (theme-aware `sx` background → `bg-background-default`), `Divider`→v3 `Separator`, subject `Input`→`FormInput`, multiline description→`FormTextarea`, secondary text→`text-muted-foreground`.
- Net removal of `register` destructuring and per-field `error`/`helperText` wiring, now handled internally by the v3 `Form*` components.

___

<details> <summary><h3> File Walkthrough</h3></summary>

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody>
<tr><td><strong>Layout</strong></td><td><details><summary>1 files</summary><table>
<tr>
  <td><strong>UnauthenticatedLayout.tsx</strong><dd><code>Replace v2 ThemeProvider + MUI GlobalStyles + Box with a v3 .dark/bg-black/text-foreground wrapper</code></dd></td>
  <td>+7/-29</td>
</tr>
</table></details></td></tr>
<tr><td><strong>Auth pages</strong></td><td><details><summary>2 files</summary><table>
<tr>
  <td><strong>password/new.tsx</strong><dd><code>v2 Box/Text/StyledInput → div/p/FormInput; drop register</code></dd></td>
  <td>+16/-36</td>
</tr>
<tr>
  <td><strong>password/reset.tsx</strong><dd><code>v2 Box/Text/StyledInput → div/p/FormInput; drop register</code></dd></td>
  <td>+14/-36</td>
</tr>
</table></details></td></tr>
<tr><td><strong>Support</strong></td><td><details><summary>1 files</summary><table>
<tr>
  <td><strong>support/ticket.tsx</strong><dd><code>v2 Box/Text/Divider/StyledInput → div/p/Separator/FormInput/FormTextarea; theme-aware bg token</code></dd></td>
  <td>+29/-54</td>
</tr>
</table></details></td></tr>
</tbody></table>

</details>

___

<!-- pi-reviewer:end -->
