### PR TITLE
fix(dashboard): Migrate SelectOrgAndProject and ProjectStatus

### DIFF
--- a/dashboard/src/components/common/SelectOrg/SelectOrg.tsx
+++ b/dashboard/src/components/common/SelectOrg/SelectOrg.tsx
@@ -51,12 +51,11 @@ export default function SelectOrganization() {
 
   if (loading) {
     return (
-      <div className="flex w-full justify-center">
-        <Spinner size="xs" wrapperClassName="flex-row gap-1.5">
-          <span className="text-muted-foreground text-xs">
-            Loading organizations...
-          </span>
-        </Spinner>
+      <div className="flex h-full w-full flex-col items-center justify-center gap-3 px-5 py-4">
+        <Spinner size="medium" />
+        <span className="text-muted-foreground text-sm">
+          Loading organizations...
+        </span>
       </div>
     );
   }

--- a/dashboard/src/components/common/SelectOrgAndProject/SelectOrgAndProject.tsx
+++ b/dashboard/src/components/common/SelectOrgAndProject/SelectOrgAndProject.tsx
@@ -1,18 +1,14 @@
-import { Divider } from '@mui/material';
 import debounce from 'lodash.debounce';
 import Image from 'next/image';
 import { useRouter } from 'next/router';
 import type { ChangeEvent } from 'react';
-import { Fragment, useEffect, useMemo, useState } from 'react';
+import { useEffect, useMemo, useState } from 'react';
 import { RetryableErrorBoundary } from '@/components/presentational/RetryableErrorBoundary';
-import { Box } from '@/components/ui/v2/Box';
-import { Button } from '@/components/ui/v2/Button';
-import { Input } from '@/components/ui/v2/Input';
-import { List } from '@/components/ui/v2/List';
-import { ListItem } from '@/components/ui/v2/ListItem';
-import { Text } from '@/components/ui/v2/Text';
+import { Button } from '@/components/ui/v3/button';
+import { Input } from '@/components/ui/v3/input';
 import { Spinner } from '@/components/ui/v3/spinner';
 import { useOrgs } from '@/features/orgs/projects/hooks/useOrgs';
+import { cn } from '@/lib/utils';
 
 export default function SelectOrganizationAndProject() {
   const { orgs, loading } = useOrgs();
@@ -62,12 +58,11 @@ export default function SelectOrganizationAndProject() {
 
   if (loading) {
     return (
-      <div className="flex w-full justify-center">
-        <Spinner size="xs" wrapperClassName="flex-row gap-1.5">
-          <span className="text-muted-foreground text-xs">
-            Loading organizations and projects...
-          </span>
-        </Spinner>
+      <div className="flex h-full w-full flex-col items-center justify-center gap-3 px-5 py-4">
+        <Spinner size="medium" />
+        <span className="text-muted-foreground text-sm">
+          Loading organizations and projects...
+        </span>
       </div>
     );
   }
@@ -75,60 +70,60 @@ export default function SelectOrganizationAndProject() {
   return (
     <div className="mx-auto flex h-full w-full flex-col items-start bg-background px-5 py-4">
       <div className="mx-auto flex h-full w-full max-w-[760px] flex-col gap-4 py-6 sm:py-14">
-        <Text variant="h2" component="h1" className="">
-          Select a Project
-        </Text>
+        <h1 className="font-medium text-2xl">Select a Project</h1>
 
         <div>
           <div className="mb-2 flex w-full">
             <Input
               placeholder="Search..."
               onChange={handleFilterChange}
-              fullWidth
+              wrapperClassName="w-full"
               autoFocus
             />
           </div>
           <RetryableErrorBoundary>
             {projectsToDisplay.length === 0 ? (
-              <Box className="h-import py-2">
-                <Text variant="subtitle2">No results found.</Text>
-              </Box>
+              <div className="h-import py-2">
+                <p className="text-muted-foreground text-sm">
+                  No results found.
+                </p>
+              </div>
             ) : (
-              <List className="h-import overflow-y-auto">
+              <ul className="flex h-import flex-col overflow-y-auto rounded-md border">
                 {projectsToDisplay.map((project, index) => (
-                  <Fragment key={project.value}>
-                    <ListItem.Root
-                      className="grid grid-flow-col justify-start gap-2 py-2.5"
-                      secondaryAction={
-                        <Button
-                          variant="borderless"
-                          color="primary"
-                          onClick={() => goToProjectPage(project)}
-                        >
-                          Select
-                        </Button>
-                      }
-                    >
-                      <ListItem.Avatar>
-                        <span className="inline-block h-6 w-6 overflow-hidden rounded-md">
-                          <Image
-                            src="/logos/new.svg"
-                            alt="Nhost Logo"
-                            width={24}
-                            height={24}
-                          />
-                        </span>
-                      </ListItem.Avatar>
-                      <ListItem.Text
-                        primary={project.projectName}
-                        secondary={`${project.organizationName} / ${project.projectName}`}
+                  <li
+                    key={project.value}
+                    className={cn(
+                      'flex flex-row items-center justify-center gap-4 p-3',
+                      index < projectsToDisplay.length - 1 && 'border-b',
+                    )}
+                  >
+                    <div className="flex h-full items-center justify-center">
+                      <Image
+                        src="/logos/new.svg"
+                        alt="Nhost Logo"
+                        className="h-10 w-10 rounded-md"
+                        width={38}
+                        height={38}
                       />
-                    </ListItem.Root>
-
-                    {index < projects.length - 1 && <Divider component="li" />}
-                  </Fragment>
+                    </div>
+                    <div className="min-w-0 flex-1">
+                      <span className="block truncate">
+                        {project.projectName}
+                      </span>
+                      <p className="truncate text-muted-foreground text-sm">
+                        {`${project.organizationName} / ${project.projectName}`}
+                      </p>
+                    </div>
+                    <Button
+                      variant="link"
+                      onClick={() => goToProjectPage(project)}
+                    >
+                      Select
+                    </Button>
+                  </li>
                 ))}
-              </List>
+              </ul>
             )}
           </RetryableErrorBoundary>
         </div>

--- a/dashboard/src/components/layout/Header/ProjectStatus.tsx
+++ b/dashboard/src/components/layout/Header/ProjectStatus.tsx
@@ -1,7 +1,10 @@
 import { useEffect } from 'react';
-import { Chip } from '@/components/ui/v2/Chip';
+import { Badge } from '@/components/ui/v3/badge';
 import { useProject } from '@/features/orgs/projects/hooks/useProject';
 import { ApplicationStatus } from '@/types/application';
+
+const WARNING_BADGE =
+  'pointer-events-none border-transparent font-medium bg-[rgba(255,154,35,0.2)] text-[#ff9a23]';
 
 export default function ProjectStatus() {
   const { project, refetch: refetchProject } = useProject();
@@ -28,12 +31,18 @@ export default function ProjectStatus() {
   }, [isProjectUpdating, isProjectMigratingDatabase, refetchProject]);
 
   if (isProjectUpdating) {
-    return <Chip size="small" label="Updating" color="warning" />;
+    return (
+      <Badge variant="outline" className={WARNING_BADGE}>
+        Updating
+      </Badge>
+    );
   }
 
   if (isProjectMigratingDatabase) {
     return (
-      <Chip size="small" label="Upgrading Postgres version" color="warning" />
+      <Badge variant="outline" className={WARNING_BADGE}>
+        Upgrading Postgres version
+      </Badge>
     );
   }
 


### PR DESCRIPTION
### Checklist

- [x] No breaking changes
- [x] Tests pass
- [ ] New features have new tests
- [ ] Documentation is updated (if applicable)
- [x] Title of the PR is in the correct format (see below)

<!-- pi-reviewer:start -->
### **What this change solves**
Migrates the org/project selection screens and the header project-status indicator from legacy v2 (MUI-based) UI primitives to the v3 (Tailwind/Shadcn) component system, removing the last `@mui/material` and v2 imports from these files.

___

### **Change Type**
Refactoring

___

### **Description**
- `SelectOrgAndProject`: replaces v2 `Box`/`Button`/`Input`/`List`/`ListItem`/`Text` and MUI `Divider` with v3 `Button`/`Input`, native `ul`/`li`/`h1`/`p` markup, and `cn` for conditional borders.
- `SelectOrg`: aligns the loading state with the new full-height centered `Spinner size="medium"` layout.
- `ProjectStatus`: swaps the v2 `Chip` for a v3 `Badge` with a shared `WARNING_BADGE` class constant for the "Updating" / "Upgrading Postgres version" states.
- Fixes the list separator to use `projectsToDisplay.length` (visible list) instead of the unfiltered `projects.length` when deciding the last-row border.

___

<details> <summary><h3> File Walkthrough</h3></summary>

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody>
<tr><td><strong>Dashboard (v2→v3 migration)</strong></td><td><details><summary>3 files</summary><table>
<tr>
  <td><strong>SelectOrgAndProject.tsx</strong><dd><code>Rewrite list/loading/header UI onto v3 primitives and native markup</code></dd></td>
  <td>+48/-53</td>
</tr>
<tr>
  <td><strong>SelectOrg.tsx</strong><dd><code>Align loading state with v3 centered Spinner layout</code></dd></td>
  <td>+5/-6</td>
</tr>
<tr>
  <td><strong>ProjectStatus.tsx</strong><dd><code>Replace v2 Chip with v3 Badge using a shared warning-style class</code></dd></td>
  <td>+12/-3</td>
</tr>
</table></details></td></tr>
</tbody></table>

</details>

___

<!-- pi-reviewer:end -->

