### PR TITLE
fix(dashboard): disable delete project/organization actions for non-admins

### DIFF
--- a/dashboard/src/features/orgs/components/general/components/DeleteOrg/DeleteOrg.tsx
+++ b/dashboard/src/features/orgs/components/general/components/DeleteOrg/DeleteOrg.tsx
@@ -1,4 +1,4 @@
-import { Loader2 } from 'lucide-react';
+import { Loader2, Lock } from 'lucide-react';
 import { useRouter } from 'next/router';
 import { useState } from 'react';
 import {
@@ -15,6 +15,7 @@ import {
 import { Button, buttonVariants } from '@/components/ui/v3/button';
 import { Checkbox } from '@/components/ui/v3/checkbox';
 import { Separator } from '@/components/ui/v3/separator';
+import { useIsOrgAdmin } from '@/features/orgs/hooks/useIsOrgAdmin';
 import { useCurrentOrg } from '@/features/orgs/projects/hooks/useCurrentOrg';
 import { useOrgs } from '@/features/orgs/projects/hooks/useOrgs';
 import { execPromiseWithErrorToast } from '@/features/orgs/utils/execPromiseWithErrorToast';
@@ -23,11 +24,13 @@ import { useDeleteOrganizationMutation } from '@/generated/graphql';
 export default function DeleteOrg() {
   const router = useRouter();
   const { org } = useCurrentOrg();
+  const isOrgAdmin = useIsOrgAdmin();
   const { refetch: refetchOrgs } = useOrgs();
   const [deleting, setDeleting] = useState(false);
   const [deleteCheck1, setDeleteCheck1] = useState(false);
   const [deleteCheck2, setDeleteCheck2] = useState(false);
   const [deleteOrgMutation] = useDeleteOrganizationMutation();
+  const deleteDisabled = deleting || !isOrgAdmin;
 
   const handleDeleteOrg = async () => {
     setDeleting(true);
@@ -63,13 +66,21 @@ export default function DeleteOrg() {
         </p>
       </div>
 
-      <div className="flex justify-end gap-2 p-2">
+      <div className="flex items-center justify-end gap-2 px-4 py-2">
+        {!isOrgAdmin && (
+          <p className="mr-auto flex items-center gap-2 text-muted-foreground text-sm">
+            <Lock className="h-4 w-4 shrink-0" />
+            Only organization admins can delete this organization.
+          </p>
+        )}
         <AlertDialog>
-          <AlertDialogTrigger asChild>
-            <Button variant="destructive" disabled={deleting}>
-              Delete
-            </Button>
-          </AlertDialogTrigger>
+          <span className={deleteDisabled ? 'cursor-not-allowed' : undefined}>
+            <AlertDialogTrigger asChild>
+              <Button variant="destructive" disabled={deleteDisabled}>
+                Delete
+              </Button>
+            </AlertDialogTrigger>
+          </span>
           <AlertDialogContent className="flex w-full max-w-sm flex-col gap-6 p-6 text-left text-foreground">
             <AlertDialogHeader>
               <AlertDialogTitle>Delete Organization</AlertDialogTitle>

--- a/dashboard/src/pages/orgs/[orgSlug]/projects/[appSubdomain]/settings/index.tsx
+++ b/dashboard/src/pages/orgs/[orgSlug]/projects/[appSubdomain]/settings/index.tsx
@@ -37,7 +37,6 @@ import {
   useUpdateApplicationMutation,
 } from '@/generated/graphql';
 import { useUserData } from '@/hooks/useUserData';
-import { cn } from '@/lib/utils';
 import { ApplicationStatus } from '@/types/application';
 import { getErrorMessageSuffix } from '@/utils/databaseErrors';
 import { slugifyString } from '@/utils/helpers';
@@ -371,12 +370,7 @@ export default function SettingsGeneralPage() {
                 Only organization admins can delete this project.
               </p>
             )}
-            <span
-              className={cn(
-                'w-full sm:w-auto',
-                !isOwner && 'inline-block cursor-not-allowed',
-              )}
-            >
+            <span className={!isOwner ? 'cursor-not-allowed' : undefined}>
               <ButtonWithLoading
                 type="button"
                 disabled={!isOwner}
@@ -394,7 +388,7 @@ export default function SettingsGeneralPage() {
                   });
                 }}
                 variant="destructive"
-                className="w-full"
+                className="w-full sm:w-auto"
               >
                 Delete
               </ButtonWithLoading>

--- a/dashboard/src/pages/orgs/[orgSlug]/projects/[appSubdomain]/settings/index.tsx
+++ b/dashboard/src/pages/orgs/[orgSlug]/projects/[appSubdomain]/settings/index.tsx
@@ -25,7 +25,6 @@ import { useAppState } from '@/features/orgs/projects/common/hooks/useAppState';
 import { useIsCurrentUserOwner } from '@/features/orgs/projects/common/hooks/useIsCurrentUserOwner';
 import { useIsPlatform } from '@/features/orgs/projects/common/hooks/useIsPlatform';
 import { useRunServices } from '@/features/orgs/projects/common/hooks/useRunServices';
-import { useCurrentOrg } from '@/features/orgs/projects/hooks/useCurrentOrg';
 import { useOrgs } from '@/features/orgs/projects/hooks/useOrgs';
 import { useProject } from '@/features/orgs/projects/hooks/useProject';
 import { execPromiseWithErrorToast } from '@/features/orgs/utils/execPromiseWithErrorToast';
@@ -68,7 +67,6 @@ export default function SettingsGeneralPage() {
 
   const isOwner = useIsCurrentUserOwner();
   const { currentOrg: org } = useOrgs();
-  const { loading: loadingOrg } = useCurrentOrg();
   const userData = useUserData();
   const { project, loading, refetch: refetchProject } = useProject();
   const { state } = useAppState();
@@ -232,7 +230,7 @@ export default function SettingsGeneralPage() {
 
   const wakeUpDisabled = !isPlatform || unpauseApplicationLoading || isPausing;
 
-  if (loading || loadingOrg) {
+  if (loading) {
     return <LoadingScreen />;
   }
 
@@ -359,49 +357,51 @@ export default function SettingsGeneralPage() {
 
       <TransferProject />
 
-      <SettingsCard className="border-destructive">
-        <SettingsCardHeader
-          title="Delete Project"
-          description="The project will be permanently deleted, including its database, metadata, files, etc. This action is irreversible and can not be undone."
-        />
+      {isPlatform && (
+        <SettingsCard className="border-destructive">
+          <SettingsCardHeader
+            title="Delete Project"
+            description="The project will be permanently deleted, including its database, metadata, files, etc. This action is irreversible and can not be undone."
+          />
 
-        <SettingsCardFooter>
-          {!isOwner && (
-            <p className="flex items-center gap-2 text-muted-foreground text-sm sm:mr-auto">
-              <Lock className="h-4 w-4 shrink-0" />
-              Only organization admins can delete this project.
-            </p>
-          )}
-          <span
-            className={cn(
-              'w-full sm:w-auto',
-              !isOwner && 'inline-block cursor-not-allowed',
+          <SettingsCardFooter>
+            {!isOwner && (
+              <p className="flex items-center gap-2 text-muted-foreground text-sm sm:mr-auto">
+                <Lock className="h-4 w-4 shrink-0" />
+                Only organization admins can delete this project.
+              </p>
             )}
-          >
-            <ButtonWithLoading
-              type="button"
-              disabled={!isOwner}
-              onClick={() => {
-                openDialog({
-                  component: (
-                    <RemoveApplicationModal
-                      close={closeDialog}
-                      handler={handleDeleteApplication}
-                    />
-                  ),
-                  props: {
-                    PaperProps: { className: 'max-w-sm' },
-                  },
-                });
-              }}
-              variant="destructive"
-              className="w-full"
+            <span
+              className={cn(
+                'w-full sm:w-auto',
+                !isOwner && 'inline-block cursor-not-allowed',
+              )}
             >
-              Delete
-            </ButtonWithLoading>
-          </span>
-        </SettingsCardFooter>
-      </SettingsCard>
+              <ButtonWithLoading
+                type="button"
+                disabled={!isOwner}
+                onClick={() => {
+                  openDialog({
+                    component: (
+                      <RemoveApplicationModal
+                        close={closeDialog}
+                        handler={handleDeleteApplication}
+                      />
+                    ),
+                    props: {
+                      PaperProps: { className: 'max-w-sm' },
+                    },
+                  });
+                }}
+                variant="destructive"
+                className="w-full"
+              >
+                Delete
+              </ButtonWithLoading>
+            </span>
+          </SettingsCardFooter>
+        </SettingsCard>
+      )}
     </div>
   );
 }

--- a/dashboard/src/pages/orgs/[orgSlug]/projects/[appSubdomain]/settings/index.tsx
+++ b/dashboard/src/pages/orgs/[orgSlug]/projects/[appSubdomain]/settings/index.tsx
@@ -1,4 +1,5 @@
 import { yupResolver } from '@hookform/resolvers/yup';
+import { Lock } from 'lucide-react';
 import Link from 'next/link';
 import { useRouter } from 'next/router';
 import { type ReactElement, useEffect, useMemo } from 'react';
@@ -24,6 +25,7 @@ import { useAppState } from '@/features/orgs/projects/common/hooks/useAppState';
 import { useIsCurrentUserOwner } from '@/features/orgs/projects/common/hooks/useIsCurrentUserOwner';
 import { useIsPlatform } from '@/features/orgs/projects/common/hooks/useIsPlatform';
 import { useRunServices } from '@/features/orgs/projects/common/hooks/useRunServices';
+import { useCurrentOrg } from '@/features/orgs/projects/hooks/useCurrentOrg';
 import { useOrgs } from '@/features/orgs/projects/hooks/useOrgs';
 import { useProject } from '@/features/orgs/projects/hooks/useProject';
 import { execPromiseWithErrorToast } from '@/features/orgs/utils/execPromiseWithErrorToast';
@@ -36,6 +38,7 @@ import {
   useUpdateApplicationMutation,
 } from '@/generated/graphql';
 import { useUserData } from '@/hooks/useUserData';
+import { cn } from '@/lib/utils';
 import { ApplicationStatus } from '@/types/application';
 import { getErrorMessageSuffix } from '@/utils/databaseErrors';
 import { slugifyString } from '@/utils/helpers';
@@ -65,6 +68,7 @@ export default function SettingsGeneralPage() {
 
   const isOwner = useIsCurrentUserOwner();
   const { currentOrg: org } = useOrgs();
+  const { loading: loadingOrg } = useCurrentOrg();
   const userData = useUserData();
   const { project, loading, refetch: refetchProject } = useProject();
   const { state } = useAppState();
@@ -228,7 +232,7 @@ export default function SettingsGeneralPage() {
 
   const wakeUpDisabled = !isPlatform || unpauseApplicationLoading || isPausing;
 
-  if (loading) {
+  if (loading || loadingOrg) {
     return <LoadingScreen />;
   }
 
@@ -355,16 +359,28 @@ export default function SettingsGeneralPage() {
 
       <TransferProject />
 
-      {isOwner && (
-        <SettingsCard className="border-destructive">
-          <SettingsCardHeader
-            title="Delete Project"
-            description="The project will be permanently deleted, including its database, metadata, files, etc. This action is irreversible and can not be undone."
-          />
+      <SettingsCard className="border-destructive">
+        <SettingsCardHeader
+          title="Delete Project"
+          description="The project will be permanently deleted, including its database, metadata, files, etc. This action is irreversible and can not be undone."
+        />
 
-          <SettingsCardFooter>
+        <SettingsCardFooter>
+          {!isOwner && (
+            <p className="flex items-center gap-2 text-muted-foreground text-sm sm:mr-auto">
+              <Lock className="h-4 w-4 shrink-0" />
+              Only organization admins can delete this project.
+            </p>
+          )}
+          <span
+            className={cn(
+              'w-full sm:w-auto',
+              !isOwner && 'inline-block cursor-not-allowed',
+            )}
+          >
             <ButtonWithLoading
               type="button"
+              disabled={!isOwner}
               onClick={() => {
                 openDialog({
                   component: (
@@ -379,13 +395,13 @@ export default function SettingsGeneralPage() {
                 });
               }}
               variant="destructive"
-              className="w-full sm:w-auto"
+              className="w-full"
             >
               Delete
             </ButtonWithLoading>
-          </SettingsCardFooter>
-        </SettingsCard>
-      )}
+          </span>
+        </SettingsCardFooter>
+      </SettingsCard>
     </div>
   );
 }

--- a/dashboard/src/pages/orgs/[orgSlug]/settings.tsx
+++ b/dashboard/src/pages/orgs/[orgSlug]/settings.tsx
@@ -1,18 +1,10 @@
 import type { ReactElement } from 'react';
-import { LoadingScreen } from '@/components/presentational/LoadingScreen';
 import { DeleteOrg } from '@/features/orgs/components/general/components/DeleteOrg';
 import { GeneralSettings } from '@/features/orgs/components/general/components/GeneralSettings';
 import { Soc2Download } from '@/features/orgs/components/general/components/Soc2Download';
 import { OrgLayout } from '@/features/orgs/layout/OrgLayout';
-import { useCurrentOrg } from '@/features/orgs/projects/hooks/useCurrentOrg';
 
 export default function OrgSettings() {
-  const { loading } = useCurrentOrg();
-
-  if (loading) {
-    return <LoadingScreen />;
-  }
-
   return (
     <div className="flex h-full flex-col gap-4 overflow-auto bg-accent-background p-4">
       <GeneralSettings />

--- a/dashboard/src/pages/orgs/[orgSlug]/settings.tsx
+++ b/dashboard/src/pages/orgs/[orgSlug]/settings.tsx
@@ -1,10 +1,18 @@
 import type { ReactElement } from 'react';
+import { LoadingScreen } from '@/components/presentational/LoadingScreen';
 import { DeleteOrg } from '@/features/orgs/components/general/components/DeleteOrg';
 import { GeneralSettings } from '@/features/orgs/components/general/components/GeneralSettings';
 import { Soc2Download } from '@/features/orgs/components/general/components/Soc2Download';
 import { OrgLayout } from '@/features/orgs/layout/OrgLayout';
+import { useCurrentOrg } from '@/features/orgs/projects/hooks/useCurrentOrg';
 
 export default function OrgSettings() {
+  const { loading } = useCurrentOrg();
+
+  if (loading) {
+    return <LoadingScreen />;
+  }
+
   return (
     <div className="flex h-full flex-col gap-4 overflow-auto bg-accent-background p-4">
       <GeneralSettings />


### PR DESCRIPTION

<img width="2406" height="1982" alt="image" src="https://github.com/user-attachments/assets/be5f3721-df22-4bac-bc8e-3439e5cf0197" />


### Checklist

- [X] No breaking changes
- [X] Tests pass
- [X] New features have new tests
- [X] Documentation is updated (if applicable)
- [X] Title of the PR is in the correct format (see below)

___

<!-- pi-reviewer:start -->
### **What this change solves**
Non-admin organization members were shown an enabled "Delete" button on the organization settings page, so the action only failed server-side, while the project "Delete Project" card was hidden outright for non-admins with no explanation. Both destructive controls are now always visible to members but disabled, with an inline lock message stating that only organization admins can perform them; the project card is not rendered at all in the local/self-hosted dashboard, where organization roles do not apply.

___

### **Change Type**
Bug fix

___

### **Description**
- Gate the organization delete button on `useIsOrgAdmin`, combining it with the in-flight `deleting` state into a single `deleteDisabled` flag, and show a lock hint for non-admins.
- Render the "Delete Project" card for every organization member instead of only admins, disabling its button and showing a lock hint when `useIsCurrentUserOwner` is false.
- Switch the card's render condition from `isOwner` to `isPlatform`, so the local/self-hosted dashboard — where `useCurrentOrg` never fetches an org and no member roles exist — keeps hiding the section instead of showing a permanently disabled control with a misleading permissions message.
- Adjust footer layout for the added hint text (`items-center`, `px-4 py-2`, `sm:mr-auto`) and wrap each disabled trigger in a span carrying `cursor-not-allowed`, since disabled buttons set `pointer-events-none`.

<details> <summary><h3> File Walkthrough</h3></summary>

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody>
<tr><td><strong>Permission gating</strong></td><td><details><summary>2 files</summary><table>
<tr>
  <td><strong>DeleteOrg.tsx</strong><dd><code>Disable the org delete button for non-admins via useIsOrgAdmin and add a lock hint</code></dd></td>
  <td>+18/-7</td>
</tr>
<tr>
  <td><strong>settings/index.tsx</strong><dd><code>Show the Delete Project card to all members with the button disabled for non-admins, and hide the card off-platform</code></dd></td>
  <td>+36/-20</td>
</tr>
</table></details></td></tr>
</tbody></table>

</details>

___

<!-- pi-reviewer:end -->
