### PR TITLE
fix(dashboard): Migrate auth/users page

### DIFF
--- a/dashboard/src/components/form/FormTextarea/FormTextarea.tsx
+++ b/dashboard/src/components/form/FormTextarea/FormTextarea.tsx
@@ -1,5 +1,7 @@
 import {
+  type ChangeEventHandler,
   type ComponentProps,
+  type FocusEventHandler,
   type ForwardedRef,
   forwardRef,
   type ReactNode,
@@ -37,6 +39,15 @@ interface FormTextareaProps<
   helperText?: string | null;
   autoComplete?: ComponentProps<typeof Textarea>['autoComplete'];
   autoFocus?: ComponentProps<typeof Textarea>['autoFocus'];
+  /**
+   * Called after the field's onChange runs. Use for side effects like live
+   * validation.
+   */
+  onChange?: ChangeEventHandler<HTMLTextAreaElement>;
+  /**
+   * Called after the field's onBlur runs.
+   */
+  onBlur?: FocusEventHandler<HTMLTextAreaElement>;
 }
 
 function FormTextareaImpl<
@@ -54,6 +65,8 @@ function FormTextareaImpl<
     transform,
     autoComplete,
     autoFocus,
+    onChange: onChangeProp,
+    onBlur: onBlurProp,
   }: FormTextareaProps<TFieldValues, TName>,
   ref?: ForwardedRef<HTMLTextAreaElement>,
 ) {
@@ -62,9 +75,24 @@ function FormTextareaImpl<
       control={control}
       name={name}
       render={({ field }) => {
-        const fieldProps = isNotEmptyValue(transform)
+        const baseFieldProps = isNotEmptyValue(transform)
           ? getTransformedFieldProps(field, transform)
           : field;
+        const {
+          onChange: fieldOnChange,
+          onBlur: fieldOnBlur,
+          ...restFieldProps
+        } = baseFieldProps;
+        const handleChange: ChangeEventHandler<HTMLTextAreaElement> = (
+          event,
+        ) => {
+          fieldOnChange(event);
+          onChangeProp?.(event);
+        };
+        const handleBlur: FocusEventHandler<HTMLTextAreaElement> = (event) => {
+          fieldOnBlur();
+          onBlurProp?.(event);
+        };
         return (
           <FormItem
             className={cn({
@@ -90,7 +118,9 @@ function FormTextareaImpl<
                   placeholder={placeholder}
                   autoComplete={autoComplete}
                   autoFocus={autoFocus}
-                  {...fieldProps}
+                  {...restFieldProps}
+                  onChange={handleChange}
+                  onBlur={handleBlur}
                   ref={mergeRefs([field.ref, ref])}
                   className={cn(inputClasses, className)}
                 />

--- a/dashboard/src/components/ui/v3/badge.tsx
+++ b/dashboard/src/components/ui/v3/badge.tsx
@@ -11,7 +11,7 @@ const badgeVariants = cva(
         default:
           'border-transparent bg-primary text-primary-foreground hover:bg-primary/80 dark:text-white',
         secondary:
-          'border-transparent bg-card text-secondary-foreground hover:bg-secondary/80',
+          'border-transparent bg-secondary text-secondary-foreground hover:bg-secondary/80',
         destructive:
           'border-transparent bg-destructive text-destructive-foreground hover:bg-destructive/80',
         outline: 'text-foreground',

--- a/dashboard/src/features/orgs/projects/authentication/users/components/CreateUserForm/CreateUserForm.tsx
+++ b/dashboard/src/features/orgs/projects/authentication/users/components/CreateUserForm/CreateUserForm.tsx
@@ -1,11 +1,12 @@
-import { yupResolver } from '@hookform/resolvers/yup';
+import { zodResolver } from '@hookform/resolvers/zod';
 import { useEffect, useState } from 'react';
 import { FormProvider, useForm } from 'react-hook-form';
-import * as Yup from 'yup';
+import { z } from 'zod';
 import { useDialog } from '@/components/common/DialogProvider';
 import { Form } from '@/components/form/Form';
-import { Alert } from '@/components/ui/v2/Alert';
-import { Input } from '@/components/ui/v2/Input';
+import { FormInput } from '@/components/form/FormInput';
+import { FormPasswordInput } from '@/components/form/FormPasswordInput';
+import { Alert, AlertDescription } from '@/components/ui/v3/alert';
 import { Button } from '@/components/ui/v3/button';
 import { generateAppServiceUrl } from '@/features/orgs/projects/common/utils/generateAppServiceUrl';
 import { useProject } from '@/features/orgs/projects/hooks/useProject';
@@ -24,17 +25,15 @@ export interface CreateUserFormProps extends DialogFormProps {
   onSubmit?: () => Promise<unknown>;
 }
 
-export const validationSchema = Yup.object({
-  email: Yup.string()
+export const validationSchema = z.object({
+  email: z
+    .string()
     .min(5, 'Email must be at least 5 characters long.')
-    .email('Invalid email address')
-    .required('This field is required.'),
-  password: Yup.string()
-    .label('Users Password')
-    .required('This field is required.'),
+    .email('Invalid email address'),
+  password: z.string().min(1, 'This field is required.'),
 });
 
-export type CreateUserFormValues = Yup.InferType<typeof validationSchema>;
+export type CreateUserFormValues = z.infer<typeof validationSchema>;
 
 export default function CreateUserForm({
   onSubmit,
@@ -48,14 +47,16 @@ export default function CreateUserForm({
   );
 
   const form = useForm<CreateUserFormValues>({
-    defaultValues: {},
     reValidateMode: 'onSubmit',
-    resolver: yupResolver(validationSchema),
+    resolver: zodResolver(validationSchema),
+    defaultValues: {
+      email: '',
+      password: '',
+    },
   });
 
   const {
-    register,
-    formState: { errors, isSubmitting, dirtyFields },
+    formState: { isSubmitting, dirtyFields },
     setError,
   } = form;
 
@@ -113,38 +114,29 @@ export default function CreateUserForm({
         onSubmit={handleCreateUser}
         className="grid grid-flow-row gap-4 px-6 pb-6"
       >
-        <Input
-          {...register('email')}
-          id="email"
+        <FormInput
+          control={form.control}
+          name="email"
           label="Email"
           placeholder="Enter Email"
-          hideEmptyHelperText
-          error={!!errors.email}
-          helperText={errors?.email?.message}
-          fullWidth
           autoComplete="off"
           autoFocus
         />
-        <Input
-          {...register('password')}
-          id="password"
+        <FormPasswordInput
+          control={form.control}
+          name="password"
           label="Password"
           placeholder="Enter Password"
-          hideEmptyHelperText
-          error={!!errors.password}
-          helperText={errors?.password?.message}
-          fullWidth
           autoComplete="off"
-          type="password"
         />
         {createUserFormError && (
           <Alert
-            severity="error"
+            variant="destructive"
             className="grid grid-flow-col items-center justify-between px-4 py-3"
           >
-            <span className="text-left">
+            <AlertDescription className="col-start-1 text-left">
               <strong>Error:</strong> {createUserFormError.message}
-            </span>
+            </AlertDescription>
 
             <Button
               variant="ghost"

--- a/dashboard/src/features/orgs/projects/authentication/users/components/EditUserForm/EditUserForm.tsx
+++ b/dashboard/src/features/orgs/projects/authentication/users/components/EditUserForm/EditUserForm.tsx
@@ -1,5 +1,4 @@
-import { yupResolver } from '@hookform/resolvers/yup';
-import { useTheme } from '@mui/material';
+import { zodResolver } from '@hookform/resolvers/zod';
 import { format } from 'date-fns';
 import kebabCase from 'just-kebab-case';
 import debounce from 'lodash.debounce';
@@ -7,18 +6,15 @@ import { ChevronDownIcon, CopyIcon } from 'lucide-react';
 import Image from 'next/image';
 import { useCallback, useEffect, useMemo, useState } from 'react';
 import { FormProvider, useForm } from 'react-hook-form';
-import * as Yup from 'yup';
+import { z } from 'zod';
 import { useDialog } from '@/components/common/DialogProvider';
 import { Form } from '@/components/form/Form';
 import { FormCheckbox } from '@/components/form/FormCheckbox';
+import { FormInput } from '@/components/form/FormInput';
 import { FormSelect } from '@/components/form/FormSelect';
-import { Avatar } from '@/components/ui/v2/Avatar';
-import { Box } from '@/components/ui/v2/Box';
-import { Chip } from '@/components/ui/v2/Chip';
-import { IconButton } from '@/components/ui/v2/IconButton';
-import { Input } from '@/components/ui/v2/Input';
-import { InputLabel } from '@/components/ui/v2/InputLabel';
-import { Text } from '@/components/ui/v2/Text';
+import { FormTextarea } from '@/components/form/FormTextarea';
+import { Avatar } from '@/components/ui/v3/avatar';
+import { Badge } from '@/components/ui/v3/badge';
 import { Button, ButtonWithLoading } from '@/components/ui/v3/button';
 import {
   DropdownMenu,
@@ -40,6 +36,7 @@ import {
   useUpdateRemoteAppUserMutation,
 } from '@/generated/graphql';
 import type { RemoteAppUser } from '@/pages/orgs/[orgSlug]/projects/[appSubdomain]/auth/users';
+import { useThemePreference } from '@/providers/Theme';
 import type { DialogFormProps } from '@/types/common';
 import { copy } from '@/utils/copy';
 
@@ -70,41 +67,38 @@ export interface EditUserFormProps extends DialogFormProps {
   roles: { [key: string]: boolean }[];
 }
 
-export const EditUserFormValidationSchema = Yup.object({
-  displayName: Yup.string(),
-  avatarURL: Yup.string(),
-  email: Yup.string()
-    .email('Invalid email address')
-    .required('This field is required.'),
-  emailVerified: Yup.boolean().optional(),
-  phoneNumber: Yup.string().nullable(),
-  phoneNumberVerified: Yup.boolean().optional(),
-  locale: Yup.string(),
-  defaultRole: Yup.string(),
-  roles: Yup.array().of(Yup.boolean()),
-  metadata: Yup.string().test(
-    'is-valid-json',
-    'Metadata must be valid JSON or empty',
-    (value) => {
-      if (value === '') {
-        return true;
-      } // Allow empty string as valid input
-      try {
-        if (value !== undefined) {
-          JSON.parse(value);
-          return true;
-        }
-        return false;
-      } catch {
-        return false;
-      }
-    },
-  ),
+const isValidMetadata = (value: string) => {
+  if (value === '') {
+    return true;
+  }
+  try {
+    JSON.parse(value);
+    return true;
+  } catch {
+    return false;
+  }
+};
+
+export const EditUserFormValidationSchema = z.object({
+  displayName: z.string().optional(),
+  avatarURL: z.string().optional(),
+  email: z
+    .string()
+    .min(1, 'This field is required.')
+    .email('Invalid email address'),
+  emailVerified: z.boolean().optional(),
+  phoneNumber: z.string().nullable().optional(),
+  phoneNumberVerified: z.boolean().optional(),
+  locale: z.string().optional(),
+  defaultRole: z.string().optional(),
+  roles: z.array(z.boolean()).optional(),
+  metadata: z
+    .string()
+    .refine(isValidMetadata, 'Metadata must be valid JSON or empty')
+    .optional(),
 });
 
-export type EditUserFormValues = Yup.InferType<
-  typeof EditUserFormValidationSchema
->;
+export type EditUserFormValues = z.infer<typeof EditUserFormValidationSchema>;
 
 export default function EditUserForm({
   location,
@@ -116,7 +110,7 @@ export default function EditUserForm({
 }: EditUserFormProps) {
   const isPlatform = useIsPlatform();
   const localMimirClient = useLocalMimirClient();
-  const theme = useTheme();
+  const { resolvedTheme } = useThemePreference();
   const { onDirtyStateChange, openDialog } = useDialog();
   const { project } = useProject();
 
@@ -130,13 +124,13 @@ export default function EditUserForm({
 
   const form = useForm<EditUserFormValues>({
     reValidateMode: 'onSubmit',
-    resolver: yupResolver(EditUserFormValidationSchema),
+    resolver: zodResolver(EditUserFormValidationSchema),
     defaultValues: {
       avatarURL: user.avatarUrl,
       displayName: user.displayName,
-      email: user.email,
+      email: user.email ?? '',
       emailVerified: user.emailVerified,
-      phoneNumber: user.phoneNumber,
+      phoneNumber: user.phoneNumber ?? null,
       phoneNumberVerified: user.phoneNumberVerified,
       locale: user.locale,
       defaultRole: user.defaultRole,
@@ -146,10 +140,9 @@ export default function EditUserForm({
   });
 
   const {
-    register,
     setError,
     clearErrors,
-    formState: { errors, dirtyFields, isSubmitting, isValidating },
+    formState: { dirtyFields, isSubmitting, isValidating },
   } = form;
 
   const handleMetadataError = useMemo(() => {
@@ -172,7 +165,7 @@ export default function EditUserForm({
   }, [setError]);
 
   const handleMetadataChange = useCallback(
-    (event: React.ChangeEvent<HTMLInputElement>) => {
+    (event: React.ChangeEvent<HTMLTextAreaElement>) => {
       const { value } = event.target;
       if (value === '') {
         clearErrors('metadata'); // Clear errors when the input is explicitly cleared
@@ -247,27 +240,24 @@ export default function EditUserForm({
         className="flex flex-col overflow-hidden border-t-1 lg:flex-auto lg:content-between"
         onSubmit={onSubmit}
       >
-        <Box className="flex-auto divide-y overflow-y-auto">
-          <Box
-            component="section"
-            className="grid grid-flow-col p-6 lg:grid-cols-7"
-          >
+        <div className="flex-auto divide-y overflow-y-auto">
+          <section className="grid grid-flow-col p-6 lg:grid-cols-7">
             <div className="col-span-6 grid grid-flow-col place-content-start items-center gap-4">
-              <Avatar className="h-12 w-12" src={user.avatarUrl} />
+              <Avatar
+                className="h-12 w-12"
+                src={user.avatarUrl}
+                alt={user.displayName ?? undefined}
+                name={user.displayName ?? undefined}
+              />
               <div className="grid grid-flow-row items-center">
-                <Text className="font-medium text-lg">{user.displayName}</Text>
-                <Text className="font-normal text-sm+" color="secondary">
+                <p className="font-medium text-foreground text-lg">
+                  {user.displayName}
+                </p>
+                <p className="font-normal text-muted-foreground text-sm+">
                   {user.email}
-                </Text>
+                </p>
               </div>
-              {isUserBanned && (
-                <Chip
-                  component="span"
-                  color="error"
-                  size="small"
-                  label="Banned"
-                />
-              )}
+              {isUserBanned && <Badge variant="destructive">Banned</Badge>}
             </div>
             <div>
               <DropdownMenu>
@@ -298,19 +288,17 @@ export default function EditUserForm({
                 </DropdownMenuContent>
               </DropdownMenu>
             </div>
-          </Box>
-          <Box
-            component="section"
-            className="grid grid-flow-row grid-cols-4 gap-8 p-6"
-          >
-            <InputLabel as="h3" className="col-span-1 self-center">
+          </section>
+          <section className="grid grid-flow-row grid-cols-4 gap-8 p-6">
+            <p className="col-span-1 self-center font-medium text-foreground text-sm leading-none">
               User ID
-            </InputLabel>
+            </p>
             <div className="col-span-3 grid grid-flow-col items-center justify-start gap-2">
-              <Text className="truncate font-medium">{user.id}</Text>
-              <IconButton
-                variant="borderless"
-                color="secondary"
+              <p className="truncate font-medium text-foreground">{user.id}</p>
+              <Button
+                variant="ghost"
+                size="icon"
+                className="h-8 w-8 text-muted-foreground"
                 aria-label="Copy User ID"
                 onClick={(e) => {
                   e.stopPropagation();
@@ -318,78 +306,66 @@ export default function EditUserForm({
                 }}
               >
                 <CopyIcon className="h-4 w-4" />
-              </IconButton>
+              </Button>
             </div>
 
-            <InputLabel as="h3" className="col-span-1 self-center">
+            <p className="col-span-1 self-center font-medium text-foreground text-sm leading-none">
               Created At
-            </InputLabel>
-            <Text className="col-span-3 font-medium">
+            </p>
+            <p className="col-span-3 font-medium text-foreground">
               {format(new Date(user.createdAt), 'yyyy-MM-dd HH:mm:ss')}
-            </Text>
+            </p>
 
-            <InputLabel as="h3" className="col-span-1 self-center">
+            <p className="col-span-1 self-center font-medium text-foreground text-sm leading-none">
               Last Seen
-            </InputLabel>
-            <Text className="col-span-3 font-medium">
+            </p>
+            <p className="col-span-3 font-medium text-foreground">
               {user.lastSeen
                 ? `${format(new Date(user.lastSeen), 'yyyy-MM-dd HH:mm:ss')}`
                 : '-'}
-            </Text>
-          </Box>
-          <Box component="section" className="grid grid-flow-row gap-8 p-6">
-            <Input
-              {...register('displayName')}
-              id="Display Name"
+            </p>
+          </section>
+          <section className="grid grid-flow-row gap-8 p-6">
+            <FormInput
+              control={form.control}
+              name="displayName"
               label="Display Name"
-              variant="inline"
               placeholder="Enter Display Name"
-              hideEmptyHelperText
-              error={!!errors.displayName}
-              helperText={errors?.displayName?.message}
-              fullWidth
+              inline
               autoComplete="off"
             />
-            <Input
-              {...register('avatarURL')}
-              id="Avatar URL"
+            <FormInput
+              control={form.control}
+              name="avatarURL"
               label="Avatar URL"
-              variant="inline"
               placeholder="Enter Avatar URL"
-              hideEmptyHelperText
-              error={!!errors.avatarURL}
-              helperText={errors?.avatarURL?.message}
-              fullWidth
+              inline
               autoComplete="off"
             />
-            <Input
-              {...register('email')}
-              id="email"
-              label="Email"
-              variant="inline"
-              placeholder="Enter Email"
-              hideEmptyHelperText
-              error={!!errors.email}
-              helperText={
-                errors.email ? (
-                  errors?.email?.message
-                ) : (
-                  <FormCheckbox
-                    control={form.control}
-                    name="emailVerified"
-                    label="Verified"
-                    aria-label="Email Verified"
-                  />
-                )
-              }
-              slotProps={{ helperText: { component: 'div' } }}
-              fullWidth
-              autoComplete="off"
-            />
+            <div className="grid gap-2">
+              <FormInput
+                control={form.control}
+                name="email"
+                label="Email"
+                placeholder="Enter Email"
+                inline
+                autoComplete="off"
+              />
+              <div className="sm:pl-56">
+                <FormCheckbox
+                  control={form.control}
+                  name="emailVerified"
+                  label="Verified"
+                  aria-label="Email Verified"
+                />
+              </div>
+            </div>
 
             <div className="col-span-1 my-1 grid grid-flow-col grid-cols-8 items-center">
               <div className="col-span-2">
-                <InputLabel as="h3">Password</InputLabel>
+                <p className="font-medium text-foreground text-sm leading-none">
+                  Password
+                </p>
               </div>
               <Button
                 variant="link"
@@ -400,30 +376,30 @@ export default function EditUserForm({
               </Button>
             </div>
 
-            <Input
-              {...register('phoneNumber')}
-              id="phoneNumber"
-              label="Phone Number"
-              variant="inline"
-              placeholder="Enter Phone Number"
-              error={!!errors.phoneNumber}
-              fullWidth
-              autoComplete="off"
-              helperText={
-                errors.phoneNumber ? (
-                  errors?.phoneNumber?.message
-                ) : (
-                  <FormCheckbox
-                    control={form.control}
-                    name="phoneNumberVerified"
-                    label="Verified"
-                    aria-label="Phone Number Verified"
-                    disabled={!form.watch('phoneNumber')}
-                  />
-                )
-              }
-              slotProps={{ helperText: { component: 'div' } }}
-            />
+            <div className="grid gap-2">
+              <FormInput
+                control={form.control}
+                name="phoneNumber"
+                label="Phone Number"
+                placeholder="Enter Phone Number"
+                inline
+                autoComplete="off"
+                transform={{
+                  in: (value) => value ?? '',
+                  out: (event) =>
+                    event.target.value === '' ? null : event.target.value,
+                }}
+              />
+              <div className="sm:pl-56">
+                <FormCheckbox
+                  control={form.control}
+                  name="phoneNumberVerified"
+                  label="Verified"
+                  aria-label="Phone Number Verified"
+                  disabled={!form.watch('phoneNumber')}
+                />
+              </div>
+            </div>
             <FormSelect
               control={form.control}
               name="locale"
@@ -438,20 +414,19 @@ export default function EditUserForm({
                 </SelectItem>
               ))}
             </FormSelect>
-          </Box>
-          <Box
-            component="section"
-            className="grid place-content-start gap-4 p-6 lg:grid-cols-4"
-          >
+          </section>
+          <section className="grid place-content-start gap-4 p-6 lg:grid-cols-4">
             <div className="col-span-1 items-center self-center align-middle">
-              <InputLabel as="h3">OAuth Providers</InputLabel>
+              <p className="font-medium text-foreground text-sm leading-none">
+                OAuth Providers
+              </p>
             </div>
             <div className="col-span-3 grid w-full grid-flow-row gap-y-6">
               {user.userProviders.length === 0 && (
                 <div className="grid grid-flow-col place-content-between gap-x-1">
-                  <Text className="font-normal" color="disabled">
+                  <p className="font-normal text-disabled">
                     This user has no OAuth providers connected.
-                  </Text>
+                  </p>
                 </div>
               )}
 
@@ -463,7 +438,7 @@ export default function EditUserForm({
                   <div className="span-cols-1 grid grid-flow-col gap-2">
                     <Image
                       src={
-                        theme.palette.mode === 'dark'
+                        resolvedTheme === 'dark'
                           ? `/assets/brands/light/${kebabCase(
                               provider.providerId,
                             )}.svg`
@@ -475,15 +450,15 @@ export default function EditUserForm({
                       height={25}
                       alt="Oauth provider logo"
                     />
-                    <Text className="font-medium capitalize">
+                    <p className="font-medium text-foreground capitalize">
                       {getReadableProviderName(provider.providerId)}
-                    </Text>
+                    </p>
                   </div>
                 </div>
               ))}
             </div>
-          </Box>
-          <Box component="section" className="grid grid-flow-row gap-y-10 p-6">
+          </section>
+          <section className="grid grid-flow-row gap-y-10 p-6">
             <FormSelect
               control={form.control}
               name="defaultRole"
@@ -502,9 +477,9 @@ export default function EditUserForm({
               ))}
             </FormSelect>
             <div className="grid grid-flow-row place-content-start gap-6 lg:grid-flow-col lg:grid-cols-8">
-              <InputLabel as="h3" className="col-span-2">
+              <p className="col-span-2 font-medium text-foreground text-sm leading-none">
                 Allowed Roles
-              </InputLabel>
+              </p>
               <div className="col-span-3 grid grid-flow-row gap-6">
                 {roles.map((role, i) => (
                   <FormCheckbox
@@ -516,32 +491,22 @@ export default function EditUserForm({
                 ))}
               </div>
             </div>
-          </Box>
-          <Box component="section" className="grid grid-flow-row gap-8 p-6">
-            <Input
-              {...register('metadata', { onChange: handleMetadataChange })}
-              id="metadata"
+          </section>
+          <section className="grid grid-flow-row gap-8 p-6">
+            <FormTextarea
+              control={form.control}
+              name="metadata"
               label="Metadata"
-              variant="inline"
-              hideEmptyHelperText
-              error={!!errors.metadata}
-              fullWidth
-              multiline
-              inputProps={{
-                className: 'resize-y min-h-[130px]',
-              }}
-              helperText={
-                errors.metadata
-                  ? errors.metadata.message
-                  : 'Enter valid JSON. This can be a number, boolean, array, or object.'
-              }
-              maxRows={100}
+              inline
+              className="min-h-[130px] resize-y"
+              onChange={handleMetadataChange}
+              helperText="Enter valid JSON. This can be a number, boolean, array, or object."
               autoComplete="off"
             />
-          </Box>
-        </Box>
+          </section>
+        </div>
 
-        <Box className="grid w-full flex-shrink-0 snap-end grid-flow-col justify-between gap-3 place-self-end border-t-1 p-2">
+        <div className="grid w-full flex-shrink-0 snap-end grid-flow-col justify-between gap-3 place-self-end border-t-1 p-2">
           <Button
             variant="outline"
             tabIndex={isDirty ? -1 : 0}
@@ -558,7 +523,7 @@ export default function EditUserForm({
           >
             Save
           </ButtonWithLoading>
-        </Box>
+        </div>
       </Form>
     </FormProvider>
   );

--- a/dashboard/src/features/orgs/projects/authentication/users/components/EditUserPasswordForm/EditUserPasswordForm.tsx
+++ b/dashboard/src/features/orgs/projects/authentication/users/components/EditUserPasswordForm/EditUserPasswordForm.tsx
@@ -1,12 +1,12 @@
-import { yupResolver } from '@hookform/resolvers/yup';
+import { zodResolver } from '@hookform/resolvers/zod';
 import bcrypt from 'bcryptjs';
 import { useState } from 'react';
 import { FormProvider, useForm } from 'react-hook-form';
-import * as Yup from 'yup';
+import { z } from 'zod';
 import { useDialog } from '@/components/common/DialogProvider';
 import { Form } from '@/components/form/Form';
-import { Alert } from '@/components/ui/v2/Alert';
-import { Input } from '@/components/ui/v2/Input';
+import { FormPasswordInput } from '@/components/form/FormPasswordInput';
+import { Alert, AlertDescription } from '@/components/ui/v3/alert';
 import { Button, ButtonWithLoading } from '@/components/ui/v3/button';
 import { useRemoteApplicationGQLClient } from '@/features/orgs/hooks/useRemoteApplicationGQLClient';
 import { useProject } from '@/features/orgs/projects/hooks/useProject';
@@ -47,36 +47,41 @@ export default function EditUserPasswordForm({
   const passwordMinLength =
     data?.config?.auth?.method?.emailPassword?.passwordMinLength || 1;
 
-  const validationSchema = Yup.object({
-    password: Yup.string()
-      .label('Password')
-      .min(
-        passwordMinLength,
-        `Password must be at least ${passwordMinLength} characters long.`,
-      )
-      .required('This field is required.'),
-    cpassword: Yup.string()
-      .label('Password Confirmation')
-      .min(
-        passwordMinLength,
-        `Password must be at least ${passwordMinLength} characters long.`,
-      )
-      .oneOf([Yup.ref('password')], 'Passwords do not match')
-      .required('This field is required.'),
-  });
+  const validationSchema = z
+    .object({
+      password: z
+        .string()
+        .min(
+          passwordMinLength,
+          `Password must be at least ${passwordMinLength} characters long.`,
+        ),
+      cpassword: z
+        .string()
+        .min(
+          passwordMinLength,
+          `Password must be at least ${passwordMinLength} characters long.`,
+        ),
+    })
+    .refine((values) => values.password === values.cpassword, {
+      message: 'Passwords do not match',
+      path: ['cpassword'],
+    });
 
   const [editUserPasswordFormError, setEditUserPasswordFormError] =
     useState<Error | null>(null);
 
-  const form = useForm<Yup.InferType<typeof validationSchema>>({
-    defaultValues: {},
+  const form = useForm<z.infer<typeof validationSchema>>({
     reValidateMode: 'onSubmit',
-    resolver: yupResolver(validationSchema),
+    resolver: zodResolver(validationSchema),
+    defaultValues: {
+      password: '',
+      cpassword: '',
+    },
   });
 
   const handleSubmit = async ({
     password,
-  }: Yup.InferType<typeof validationSchema>) => {
+  }: z.infer<typeof validationSchema>) => {
     setEditUserPasswordFormError(null);
     const passwordHash = await bcrypt.hash(password, 10);
 
@@ -108,8 +113,7 @@ export default function EditUserPasswordForm({
   };
 
   const {
-    register,
-    formState: { errors, isSubmitting },
+    formState: { isSubmitting },
   } = form;
 
   return (
@@ -118,36 +122,25 @@ export default function EditUserPasswordForm({
         onSubmit={handleSubmit}
         className="grid grid-flow-row gap-6 px-6 pb-6"
       >
-        <Input
-          {...register('password')}
-          id="password"
-          type="password"
+        <FormPasswordInput
+          control={form.control}
+          name="password"
           label="Password"
           placeholder="Enter Password"
-          hideEmptyHelperText
-          error={!!errors.password}
-          helperText={errors?.password?.message}
-          fullWidth
           autoComplete="off"
-          autoFocus
         />
-        <Input
-          {...register('cpassword')}
-          id="confirm-password"
-          type="password"
+        <FormPasswordInput
+          control={form.control}
+          name="cpassword"
           label="Confirm Password"
           placeholder="Enter Password"
-          hideEmptyHelperText
-          error={!!errors.cpassword}
-          helperText={errors?.cpassword?.message}
-          fullWidth
           autoComplete="off"
         />
         {editUserPasswordFormError && (
-          <Alert severity="error">
-            <span className="text-left">
+          <Alert variant="destructive">
+            <AlertDescription className="text-left">
               <strong>Error:</strong> {editUserPasswordFormError.message}
-            </span>
+            </AlertDescription>
           </Alert>
         )}
         <div className="grid grid-flow-row gap-2">

--- a/dashboard/src/features/orgs/projects/authentication/users/components/UsersBody/UsersBody.tsx
+++ b/dashboard/src/features/orgs/projects/authentication/users/components/UsersBody/UsersBody.tsx
@@ -1,4 +1,3 @@
-import { useTheme } from '@mui/material';
 import { formatDistance } from 'date-fns';
 import kebabCase from 'just-kebab-case';
 import {
@@ -8,16 +7,11 @@ import {
 } from 'lucide-react';
 import dynamic from 'next/dynamic';
 import Image from 'next/image';
-import { Fragment } from 'react';
 import { useDialog } from '@/components/common/DialogProvider';
 import { FormActivityIndicator } from '@/components/form/FormActivityIndicator';
-import { Avatar } from '@/components/ui/v2/Avatar';
-import { Chip } from '@/components/ui/v2/Chip';
-import { Divider } from '@/components/ui/v2/Divider';
-import { IconButton } from '@/components/ui/v2/IconButton';
-import { List } from '@/components/ui/v2/List';
-import { ListItem } from '@/components/ui/v2/ListItem';
-import { Text } from '@/components/ui/v2/Text';
+import { Avatar } from '@/components/ui/v3/avatar';
+import { Badge } from '@/components/ui/v3/badge';
+import { Button } from '@/components/ui/v3/button';
 import {
   DropdownMenu,
   DropdownMenuContent,
@@ -35,6 +29,7 @@ import {
   useUpdateRemoteAppUserMutation,
 } from '@/generated/graphql';
 import type { RemoteAppUser } from '@/pages/orgs/[orgSlug]/projects/[appSubdomain]/auth/users';
+import { useThemePreference } from '@/providers/Theme';
 import type { Role } from '@/types/application';
 
 const EditUserForm = dynamic(
@@ -66,7 +61,7 @@ export default function UsersBody({
   onSubmit,
   allAvailableProjectRoles,
 }: UsersBodyProps) {
-  const theme = useTheme();
+  const { resolvedTheme } = useThemePreference();
   const { openAlertDialog, openDrawer, closeDrawer } = useDialog();
   const remoteProjectGQLClient = useRemoteApplicationGQLClient();
 
@@ -168,10 +163,10 @@ export default function UsersBody({
     openAlertDialog({
       title: 'Delete User',
       payload: (
-        <Text>
+        <span>
           Are you sure you want to delete the &quot;
           <strong>{user.displayName}</strong>&quot; user? This cannot be undone.
-        </Text>
+        </span>
       ),
       props: {
         onPrimaryAction: async () => {
@@ -219,139 +214,115 @@ export default function UsersBody({
   }
 
   return (
-    <List>
+    <ul>
       {users.map((user) => (
-        <Fragment key={user.id}>
-          <ListItem.Root
-            className="h-[64px] w-full"
-            secondaryAction={
-              <DropdownMenu>
-                <DropdownMenuTrigger asChild>
-                  <IconButton
-                    variant="borderless"
-                    color="secondary"
-                    aria-label={`More options for ${user.displayName}`}
-                  >
-                    <DotsHorizontalIcon />
-                  </IconButton>
-                </DropdownMenuTrigger>
-
-                <DropdownMenuContent align="end" className="w-52 p-0">
-                  <DropdownMenuItem
-                    onClick={() => {
-                      handleViewUser(user);
-                    }}
-                    className="flex h-9 cursor-pointer items-center justify-start gap-2 rounded-none border border-b-1 p-2 font-medium text-sm+ leading-4 hover:bg-data-cell-bg"
-                  >
-                    <UserIcon className="h-4 w-4" />
-                    <span>View User</span>
-                  </DropdownMenuItem>
-
-                  <DropdownMenuItem
-                    className="!text-destructive flex h-9 cursor-pointer items-center justify-start gap-2 rounded-none border border-b-1 p-2 font-medium text-sm+ leading-4 hover:bg-data-cell-bg"
-                    onClick={() => handleDeleteUser(user)}
-                  >
-                    <TrashIcon className="h-4 w-4" />
-                    <span>Delete User</span>
-                  </DropdownMenuItem>
-                </DropdownMenuContent>
-              </DropdownMenu>
-            }
+        <li key={user.id} className="relative border-b">
+          <button
+            type="button"
+            onClick={() => handleViewUser(user)}
+            aria-label={`View ${user.displayName}`}
+            className="grid h-[64px] w-full grid-cols-1 py-2.5 pr-12 text-left lg:grid-cols-6"
           >
-            <ListItem.Button
-              className="grid h-full w-full grid-cols-1 py-2.5 lg:grid-cols-6"
-              onClick={() => handleViewUser(user)}
-              aria-label={`View ${user.displayName}`}
-            >
-              <div className="col-span-2 grid grid-flow-col place-content-start gap-4">
-                <Avatar
-                  src={user.avatarUrl}
-                  alt={`Avatar of ${user.displayName}`}
-                />
-                <div className="grid grid-flow-row items-center">
-                  <div className="grid grid-flow-col items-center gap-2">
-                    <Text className="truncate font-medium leading-5">
-                      {user.displayName}
-                    </Text>
-                    {user.disabled && (
-                      <Chip
-                        component="span"
-                        color="error"
-                        size="small"
-                        label="Banned"
-                      />
-                    )}
-                  </div>
-
-                  <Text className="truncate font-normal" color="secondary">
-                    {user.email}
-                  </Text>
+            <div className="col-span-2 grid grid-flow-col place-content-start gap-4">
+              <Avatar
+                src={user.avatarUrl}
+                alt={`Avatar of ${user.displayName}`}
+                name={user.displayName ?? undefined}
+              />
+              <div className="grid grid-flow-row items-center">
+                <div className="grid grid-flow-col items-center gap-2">
+                  <p className="truncate font-medium text-foreground leading-5">
+                    {user.displayName}
+                  </p>
+                  {user.disabled && <Badge variant="destructive">Banned</Badge>}
                 </div>
+
+                <p className="truncate font-normal text-muted-foreground">
+                  {user.email}
+                </p>
               </div>
+            </div>
 
-              <Text className="hidden px-2 font-normal md:block">
-                {user.createdAt
-                  ? `${formatDistance(
-                      new Date(user.createdAt),
-                      new Date(),
-                    )} ago`
-                  : '-'}
-              </Text>
-              <Text className="hidden px-4 font-normal md:block">
-                {user.lastSeen
-                  ? `${formatDistance(new Date(user.lastSeen), new Date())} ago`
-                  : '-'}
-              </Text>
+            <p className="hidden px-2 font-normal text-foreground md:block">
+              {user.createdAt
+                ? `${formatDistance(new Date(user.createdAt), new Date())} ago`
+                : '-'}
+            </p>
+            <p className="hidden px-4 font-normal text-foreground md:block">
+              {user.lastSeen
+                ? `${formatDistance(new Date(user.lastSeen), new Date())} ago`
+                : '-'}
+            </p>
 
-              <div className="col-span-2 hidden grid-flow-col place-content-start gap-3 px-4 lg:grid">
-                {user.userProviders.length === 0 && (
-                  <Text className="col-span-3 font-medium">-</Text>
-                )}
+            <div className="col-span-2 hidden grid-flow-col place-content-start gap-3 px-4 lg:grid">
+              {user.userProviders.length === 0 && (
+                <p className="col-span-3 font-medium text-foreground">-</p>
+              )}
 
-                {user.userProviders.slice(0, 4).map((provider) => (
-                  <Chip
-                    component="span"
-                    color="default"
-                    size="small"
-                    key={provider.id}
-                    label={getReadableProviderName(provider.providerId)}
-                    sx={{
-                      paddingLeft: '0.55rem',
-                    }}
-                    icon={
-                      <Image
-                        src={
-                          theme.palette.mode === 'dark'
-                            ? `/assets/brands/light/${kebabCase(
-                                provider.providerId,
-                              )}.svg`
-                            : `/assets/brands/${kebabCase(
-                                provider.providerId,
-                              )}.svg`
-                        }
-                        width={16}
-                        height={16}
-                        alt="Oauth provider logo"
-                      />
+              {user.userProviders.slice(0, 4).map((provider) => (
+                <Badge
+                  key={provider.id}
+                  variant="secondary"
+                  className="gap-1.5 font-medium"
+                >
+                  <Image
+                    src={
+                      resolvedTheme === 'dark'
+                        ? `/assets/brands/light/${kebabCase(
+                            provider.providerId,
+                          )}.svg`
+                        : `/assets/brands/${kebabCase(provider.providerId)}.svg`
                     }
+                    width={16}
+                    height={16}
+                    alt="Oauth provider logo"
                   />
-                ))}
+                  {getReadableProviderName(provider.providerId)}
+                </Badge>
+              ))}
 
-                {user.userProviders.length > 3 && (
-                  <Chip
-                    component="span"
-                    color="default"
-                    size="small"
-                    label={`+${user.userProviders.length - 3}`}
-                    className="font-medium"
-                  />
-                )}
-              </div>
-            </ListItem.Button>
-          </ListItem.Root>
-          <Divider component="li" />
-        </Fragment>
+              {user.userProviders.length > 3 && (
+                <Badge variant="secondary" className="font-medium">
+                  {`+${user.userProviders.length - 3}`}
+                </Badge>
+              )}
+            </div>
+          </button>
+
+          <DropdownMenu>
+            <DropdownMenuTrigger asChild>
+              <Button
+                variant="ghost"
+                size="icon"
+                className="absolute top-1/2 right-2 h-8 w-8 -translate-y-1/2"
+                aria-label={`More options for ${user.displayName}`}
+              >
+                <DotsHorizontalIcon className="h-4 w-4" />
+              </Button>
+            </DropdownMenuTrigger>
+
+            <DropdownMenuContent align="end" className="w-52 p-0">
+              <DropdownMenuItem
+                onClick={() => {
+                  handleViewUser(user);
+                }}
+                className="flex h-9 cursor-pointer items-center justify-start gap-2 rounded-none border border-b-1 p-2 font-medium text-sm+ leading-4 hover:bg-data-cell-bg"
+              >
+                <UserIcon className="h-4 w-4" />
+                <span>View User</span>
+              </DropdownMenuItem>
+
+              <DropdownMenuItem
+                className="!text-destructive flex h-9 cursor-pointer items-center justify-start gap-2 rounded-none border border-b-1 p-2 font-medium text-sm+ leading-4 hover:bg-data-cell-bg"
+                onClick={() => handleDeleteUser(user)}
+              >
+                <TrashIcon className="h-4 w-4" />
+                <span>Delete User</span>
+              </DropdownMenuItem>
+            </DropdownMenuContent>
+          </DropdownMenu>
+        </li>
       ))}
-    </List>
+    </ul>
   );
 }

--- a/dashboard/src/pages/orgs/[orgSlug]/projects/[appSubdomain]/auth/users.tsx
+++ b/dashboard/src/pages/orgs/[orgSlug]/projects/[appSubdomain]/auth/users.tsx
@@ -7,10 +7,8 @@ import { useDialog } from '@/components/common/DialogProvider';
 import { Pagination } from '@/components/common/Pagination';
 import { Container } from '@/components/layout/Container';
 import { RetryableErrorBoundary } from '@/components/presentational/RetryableErrorBoundary';
-import { Box } from '@/components/ui/v2/Box';
-import { Input } from '@/components/ui/v2/Input';
-import { Text } from '@/components/ui/v2/Text';
 import { Button } from '@/components/ui/v3/button';
+import { Input } from '@/components/ui/v3/input';
 import { Spinner } from '@/components/ui/v3/spinner';
 import { useRemoteApplicationGQLClient } from '@/features/orgs/hooks/useRemoteApplicationGQLClient';
 import { OrgLayout } from '@/features/orgs/layout/OrgLayout';
@@ -168,12 +166,10 @@ function UsersPageContent() {
       >
         <div className="flex shrink-0 grow-0 flex-col gap-3 sm:flex-row sm:place-content-between sm:items-center">
           <Input
-            className="w-full rounded-sm sm:w-72"
-            fullWidth
+            className="rounded-sm pl-9"
+            wrapperClassName="w-full sm:w-72"
             placeholder="Search users"
-            startAdornment={
-              <SearchIcon className="-mr-1 ml-2 h-4 w-4 shrink-0 text-disabled" />
-            }
+            prefix={<SearchIcon className="h-4 w-4 text-muted-foreground" />}
             onChange={handleSearchStringChange}
           />
           <Button
@@ -217,12 +213,10 @@ function UsersPageContent() {
     <Container className="mx-auto max-w-9xl space-y-5 overflow-x-hidden">
       <div className="flex flex-col gap-3 sm:flex-row sm:place-content-between sm:items-center">
         <Input
-          className="w-full rounded-sm sm:w-72"
-          fullWidth
+          className="rounded-sm pl-9"
+          wrapperClassName="w-full sm:w-72"
           placeholder="Search users"
-          startAdornment={
-            <SearchIcon className="-mr-1 ml-2 h-4 w-4 shrink-0 text-disabled" />
-          }
+          prefix={<SearchIcon className="h-4 w-4 text-muted-foreground" />}
           onChange={handleSearchStringChange}
         />
         <Button
@@ -235,15 +229,15 @@ function UsersPageContent() {
         </Button>
       </div>
       {usersCount === 0 ? (
-        <Box className="flex flex-col items-center justify-center space-y-5 rounded-lg border px-4 py-12 shadow-sm sm:px-48">
+        <div className="flex flex-col items-center justify-center space-y-5 rounded-lg border px-4 py-12 shadow-sm sm:px-48">
           <UserIcon strokeWidth={1} className="h-10 w-10 text-disabled" />
           <div className="flex flex-col space-y-1">
-            <Text className="text-center font-medium" variant="h3">
+            <h3 className="text-center font-medium text-foreground text-lg">
               There are no users yet
-            </Text>
-            <Text variant="subtitle1" className="text-center">
+            </h3>
+            <p className="text-center text-muted-foreground text-sm">
               All users for your project will be listed here.
-            </Text>
+            </p>
           </div>
           <div className="flex flex-row place-content-between rounded-lg lg:w-[230px]">
             <Button className="w-full" onClick={openCreateUserDialog}>
@@ -251,35 +245,39 @@ function UsersPageContent() {
               Create User
             </Button>
           </div>
-        </Box>
+        </div>
       ) : (
         <div className="grid grid-flow-row gap-2 lg:w-9xl">
           <div className="grid h-full w-full grid-flow-row overflow-hidden pb-4">
-            <Box className="grid w-full border-b p-2 md:grid-cols-6">
-              <Text className="font-medium md:col-span-2">Name</Text>
-              <Text className="hidden font-medium md:block">Signed up at</Text>
-              <Text className="hidden font-medium md:block">Last Seen</Text>
-              <Text className="col-span-2 hidden font-medium md:block">
+            <div className="grid w-full border-b p-2 md:grid-cols-6">
+              <p className="font-medium text-foreground md:col-span-2">Name</p>
+              <p className="hidden font-medium text-foreground md:block">
+                Signed up at
+              </p>
+              <p className="hidden font-medium text-foreground md:block">
+                Last Seen
+              </p>
+              <p className="col-span-2 hidden font-medium text-foreground md:block">
                 OAuth Providers
-              </Text>
-            </Box>
+              </p>
+            </div>
             {dataRemoteAppUsersAndAuthRoles?.filteredUsersAggreggate.aggregate
               ?.count === 0 &&
               usersCount !== 0 && (
-                <Box className="flex flex-col items-center justify-center space-y-5 border-x border-b px-48 py-12">
+                <div className="flex flex-col items-center justify-center space-y-5 border-x border-b px-48 py-12">
                   <UserIcon
                     strokeWidth={1}
                     className="h-10 w-10 text-disabled"
                   />
                   <div className="flex flex-col space-y-1">
-                    <Text className="text-center font-medium" variant="h3">
+                    <h3 className="text-center font-medium text-foreground text-lg">
                       No results for &quot;{searchString}&quot;
-                    </Text>
-                    <Text variant="subtitle1" className="text-center">
+                    </h3>
+                    <p className="text-center text-muted-foreground text-sm">
                       Try a different search
-                    </Text>
+                    </p>
                   </div>
-                </Box>
+                </div>
               )}
             {thereAreUsers && (
               <div className="grid grid-flow-row gap-4">


### PR DESCRIPTION
### Checklist

- [x] No breaking changes
- [x] Tests pass
- [ ] New features have new tests
- [ ] Documentation is updated (if applicable)
- [x] Title of the PR is in the correct format (see below)

<!-- pi-reviewer:start -->
### **What this change solves**
The auth/users dashboard page still relied on the deprecated v2 (MUI-backed) UI components and Yup validation. This migrates the page and its forms to the v3 component library and Zod schemas, matching the ongoing dashboard-wide v2→v3 and Yup→Zod effort.

___

### **Change Type**
Refactoring

___

### **Description**
- Migrate `CreateUserForm`, `EditUserForm`, and `EditUserPasswordForm` validation from Yup to Zod, and their fields from v2 `Input` to v3 `FormInput`/`FormPasswordInput`/`FormTextarea`.
- Replace v2 UI primitives (`Box`, `Text`, `Chip`, `IconButton`, `List`, `ListItem`, `Divider`, `Avatar`, `InputLabel`, v2 `Alert`/`Input`) with v3 equivalents and semantic HTML across `UsersBody` and the users page.
- Swap MUI `useTheme` for the dashboard `useThemePreference` provider to drive OAuth provider logo theming.
- Extend `FormTextarea` with `onChange`/`onBlur` passthrough props so metadata live-validation can hook into the field.
- Fix the v3 `badge` `secondary` variant to use `bg-secondary` instead of `bg-card`.

___

<details> <summary><h3> File Walkthrough</h3></summary>

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody>
<tr><td><strong>Form validation & inputs (Yup→Zod, v3)</strong></td><td><details><summary>3 files</summary><table>
<tr>
  <td><strong>CreateUserForm.tsx</strong><dd><code>Zod schema + v3 FormInput/FormPasswordInput and v3 Alert</code></dd></td>
  <td>+26/-34</td>
</tr>
<tr>
  <td><strong>EditUserForm.tsx</strong><dd><code>Zod schema, v3 components, useThemePreference, FormTextarea metadata field</code></dd></td>
  <td>+157/-192</td>
</tr>
<tr>
  <td><strong>EditUserPasswordForm.tsx</strong><dd><code>Zod schema with cross-field confirm refine + v3 FormPasswordInput/Alert</code></dd></td>
  <td>+40/-47</td>
</tr>
</table></details></td></tr>
<tr><td><strong>Page & list UI (v2→v3)</strong></td><td><details><summary>2 files</summary><table>
<tr>
  <td><strong>UsersBody.tsx</strong><dd><code>List rewritten to semantic ul/li + v3 Avatar/Badge/Button, theme provider</code></dd></td>
  <td>+106/-135</td>
</tr>
<tr>
  <td><strong>auth/users.tsx</strong><dd><code>v3 Input with prefix adornment and semantic text/empty-state markup</code></dd></td>
  <td>+30/-32</td>
</tr>
</table></details></td></tr>
<tr><td><strong>Shared components</strong></td><td><details><summary>2 files</summary><table>
<tr>
  <td><strong>FormTextarea.tsx</strong><dd><code>Add onChange/onBlur passthrough props after field handlers run</code></dd></td>
  <td>+32/-2</td>
</tr>
<tr>
  <td><strong>badge.tsx</strong><dd><code>secondary variant background bg-card → bg-secondary</code></dd></td>
  <td>+1/-1</td>
</tr>
</table></details></td></tr>
</tbody></table>

</details>

___

<!-- pi-reviewer:end -->


