### PR TITLE
fix(dashboard): migrate oauth2 clients page to v3

### DIFF
--- a/dashboard/src/features/orgs/projects/authentication/oauth2-clients/components/CreateOAuth2ClientForm/CreateOAuth2ClientForm.tsx
+++ b/dashboard/src/features/orgs/projects/authentication/oauth2-clients/components/CreateOAuth2ClientForm/CreateOAuth2ClientForm.tsx
@@ -1,17 +1,21 @@
-import { yupResolver } from '@hookform/resolvers/yup';
+import { zodResolver } from '@hookform/resolvers/zod';
 import bcrypt from 'bcryptjs';
 import { CopyIcon } from 'lucide-react';
 import { useEffect, useState } from 'react';
 import { FormProvider, useForm } from 'react-hook-form';
-import * as Yup from 'yup';
+import { z } from 'zod';
 import { useDialog } from '@/components/common/DialogProvider';
 import { Form } from '@/components/form/Form';
-import { Divider } from '@/components/ui/v2/Divider';
-import { Input } from '@/components/ui/v2/Input';
-import { InputAdornment } from '@/components/ui/v2/InputAdornment';
-import { InputLabel } from '@/components/ui/v2/InputLabel';
-import { Text } from '@/components/ui/v2/Text';
+import { FormInput } from '@/components/form/FormInput';
+import { FormTextarea } from '@/components/form/FormTextarea';
 import { Button } from '@/components/ui/v3/button';
+import {
+  InputGroup,
+  InputGroupAddon,
+  InputGroupInput,
+} from '@/components/ui/v3/input-group';
+import { Label } from '@/components/ui/v3/label';
+import { Separator } from '@/components/ui/v3/separator';
 import { useRemoteApplicationGQLClient } from '@/features/orgs/hooks/useRemoteApplicationGQLClient';
 import ScopePicker from '@/features/orgs/projects/authentication/oauth2/ScopePicker';
 import { generateClientSecret } from '@/features/orgs/projects/authentication/oauth2/utils';
@@ -30,12 +34,12 @@ export interface CreateOAuth2ClientFormProps extends DialogFormProps {
 
 const DEFAULT_SCOPES = new Set(['openid', 'profile', 'email']);
 
-const validationSchema = Yup.object({
-  description: Yup.string().default(''),
-  redirectUris: Yup.string().default(''),
+const validationSchema = z.object({
+  description: z.string().default(''),
+  redirectUris: z.string().default(''),
 });
 
-type CreateOAuth2ClientFormValues = Yup.InferType<typeof validationSchema>;
+type CreateOAuth2ClientFormValues = z.infer<typeof validationSchema>;
 
 export default function CreateOAuth2ClientForm({
   onSubmit,
@@ -61,12 +65,11 @@ export default function CreateOAuth2ClientForm({
       redirectUris: '',
     },
     reValidateMode: 'onSubmit',
-    resolver: yupResolver(validationSchema),
+    resolver: zodResolver(validationSchema),
   });
 
   const {
-    register,
-    formState: { errors, isSubmitting, dirtyFields },
+    formState: { isSubmitting, dirtyFields },
   } = form;
 
   const isDirty = Object.keys(dirtyFields).length > 0;
@@ -133,114 +136,93 @@ export default function CreateOAuth2ClientForm({
         onSubmit={handleCreate}
         className="grid grid-flow-row gap-6 px-6 pb-6"
       >
-        <Input
-          {...register('description')}
-          id="description"
+        <FormInput
+          control={form.control}
+          name="description"
           label="Description"
           placeholder="Describe this OAuth2 client"
-          hideEmptyHelperText
-          error={!!errors.description}
-          helperText={errors?.description?.message}
-          fullWidth
           autoComplete="off"
         />
 
-        <Input
-          {...register('redirectUris')}
-          id="redirectUris"
+        <FormTextarea
+          control={form.control}
+          name="redirectUris"
           label="Redirect URIs (one per line)"
           placeholder="https://example.com/callback"
-          hideEmptyHelperText
-          error={!!errors.redirectUris}
-          helperText={errors?.redirectUris?.message}
-          fullWidth
-          autoComplete="off"
-          multiline
-          rows={3}
+          className="min-h-[80px]"
         />
 
         <div>
-          <InputLabel className="mb-2">Scopes</InputLabel>
+          <Label className="mb-2 block">Scopes</Label>
           <ScopePicker selected={selectedScopes} onChange={setSelectedScopes} />
         </div>
 
-        <Divider />
+        <Separator />
 
         <div className="grid gap-2">
-          <Text className="font-medium">Client Secret</Text>
-          <Text className="text-sm" color="secondary">
+          <p className="font-medium text-foreground">Client Secret</p>
+          <p className="text-muted-foreground text-sm">
             {pendingSecret
               ? 'A secret has been generated. The client will be created as confidential.'
               : 'No secret configured. The client will be created as public.'}
-          </Text>
+          </p>
 
-          <Input
-            value={pendingSecret ?? ''}
-            placeholder="<no secret configured>"
-            fullWidth
-            readOnly
-            hideEmptyHelperText
-            slotProps={{
-              input: { className: 'lg:w-1/2' },
-              inputRoot: { className: 'font-mono text-sm !pr-8' },
-              helperText: { component: 'div' },
-            }}
-            helperText={
-              <div className="grid grid-flow-row items-center justify-start gap-1 pt-1">
-                {pendingSecret && (
-                  <Text className="text-xs" color="secondary">
-                    Copy this secret now. You will not be able to see it again
-                    after creating the client.
-                  </Text>
-                )}
-                <div className="grid grid-flow-col items-center justify-start gap-1">
-                  <Button
-                    onClick={handleGenerateSecret}
-                    className="h-auto px-1 py-0.5 text-xs"
-                    variant="link"
-                    type="button"
-                  >
-                    Generate a secret
-                  </Button>
-                </div>
-                {pendingSecret && (
-                  <div className="grid grid-flow-col items-center justify-start gap-1">
-                    <Button
-                      variant="link"
-                      onClick={handleRemoveSecret}
-                      type="button"
-                      className="h-auto px-1 py-0.5 text-destructive text-xs"
-                    >
-                      Remove secret (make public)
-                    </Button>
-                  </div>
-                )}
-              </div>
-            }
-            endAdornment={
-              <InputAdornment
-                position="end"
-                className={pendingSecret ? 'absolute right-2' : 'invisible'}
-              >
+          <InputGroup className="lg:w-1/2">
+            <InputGroupInput
+              readOnly
+              value={pendingSecret ?? ''}
+              placeholder="<no secret configured>"
+              className="font-mono text-sm"
+            />
+            {pendingSecret && (
+              <InputGroupAddon align="inline-end">
                 <Button
-                  className="h-auto min-w-0 p-0"
-                  onClick={() => {
-                    if (pendingSecret) {
-                      copy(pendingSecret, 'Client secret');
-                    }
-                  }}
-                  variant="ghost"
-                  aria-label="Copy secret"
                   type="button"
+                  variant="ghost"
+                  size="icon"
+                  className="h-8 w-8"
+                  aria-label="Copy secret"
+                  onClick={() => copy(pendingSecret, 'Client secret')}
                 >
                   <CopyIcon className="h-4 w-4" />
                 </Button>
-              </InputAdornment>
-            }
-          />
+              </InputGroupAddon>
+            )}
+          </InputGroup>
+
+          <div className="grid grid-flow-row items-center justify-start gap-1 pt-1">
+            {pendingSecret && (
+              <p className="text-muted-foreground text-xs">
+                Copy this secret now. You will not be able to see it again after
+                creating the client.
+              </p>
+            )}
+            <div className="grid grid-flow-col items-center justify-start gap-1">
+              <Button
+                onClick={handleGenerateSecret}
+                className="h-auto px-1 py-0.5 text-xs"
+                variant="link"
+                type="button"
+              >
+                Generate a secret
+              </Button>
+            </div>
+            {pendingSecret && (
+              <div className="grid grid-flow-col items-center justify-start gap-1">
+                <Button
+                  variant="link"
+                  onClick={handleRemoveSecret}
+                  type="button"
+                  className="h-auto px-1 py-0.5 text-destructive text-xs"
+                >
+                  Remove secret (make public)
+                </Button>
+              </div>
+            )}
+          </div>
         </div>
 
-        <Divider />
+        <Separator />
 
         <div className="grid grid-flow-row gap-2">
           <Button type="submit" disabled={isSubmitting}>

--- a/dashboard/src/features/orgs/projects/authentication/oauth2-clients/components/EditOAuth2ClientForm/EditOAuth2ClientForm.tsx
+++ b/dashboard/src/features/orgs/projects/authentication/oauth2-clients/components/EditOAuth2ClientForm/EditOAuth2ClientForm.tsx
@@ -1,19 +1,22 @@
-import { yupResolver } from '@hookform/resolvers/yup';
+import { zodResolver } from '@hookform/resolvers/zod';
 import bcrypt from 'bcryptjs';
 import { format } from 'date-fns';
 import { CopyIcon } from 'lucide-react';
 import { useEffect, useMemo, useState } from 'react';
 import { FormProvider, useForm } from 'react-hook-form';
-import * as Yup from 'yup';
+import { z } from 'zod';
 import { useDialog } from '@/components/common/DialogProvider';
 import { Form } from '@/components/form/Form';
-import { Divider } from '@/components/ui/v2/Divider';
-import { IconButton } from '@/components/ui/v2/IconButton';
-import { Input } from '@/components/ui/v2/Input';
-import { InputAdornment } from '@/components/ui/v2/InputAdornment';
-import { InputLabel } from '@/components/ui/v2/InputLabel';
-import { Text } from '@/components/ui/v2/Text';
+import { FormInput } from '@/components/form/FormInput';
+import { FormTextarea } from '@/components/form/FormTextarea';
 import { Button } from '@/components/ui/v3/button';
+import {
+  InputGroup,
+  InputGroupAddon,
+  InputGroupInput,
+} from '@/components/ui/v3/input-group';
+import { Label } from '@/components/ui/v3/label';
+import { Separator } from '@/components/ui/v3/separator';
 import { useRemoteApplicationGQLClient } from '@/features/orgs/hooks/useRemoteApplicationGQLClient';
 import ScopePicker from '@/features/orgs/projects/authentication/oauth2/ScopePicker';
 import { generateClientSecret } from '@/features/orgs/projects/authentication/oauth2/utils';
@@ -34,12 +37,12 @@ export interface EditOAuth2ClientFormProps extends DialogFormProps {
   onSubmit?: () => Promise<unknown>;
 }
 
-const validationSchema = Yup.object({
-  description: Yup.string().default(''),
-  redirectUris: Yup.string().default(''),
+const validationSchema = z.object({
+  description: z.string().default(''),
+  redirectUris: z.string().default(''),
 });
 
-type EditOAuth2ClientFormValues = Yup.InferType<typeof validationSchema>;
+type EditOAuth2ClientFormValues = z.infer<typeof validationSchema>;
 
 export default function EditOAuth2ClientForm({
   client: oauth2Client,
@@ -69,12 +72,11 @@ export default function EditOAuth2ClientForm({
       redirectUris: (oauth2Client.redirectUris ?? []).join('\n'),
     },
     reValidateMode: 'onSubmit',
-    resolver: yupResolver(validationSchema),
+    resolver: zodResolver(validationSchema),
   });
 
   const {
-    register,
-    formState: { errors, isSubmitting, dirtyFields },
+    formState: { isSubmitting, dirtyFields },
   } = form;
 
   const initialScopes = useMemo(
@@ -195,151 +197,132 @@ export default function EditOAuth2ClientForm({
         className="grid grid-flow-row gap-6 px-6 pb-6"
       >
         <div className="grid grid-cols-[auto_1fr] items-center gap-x-6 gap-y-4">
-          <InputLabel as="h3">Client ID</InputLabel>
+          <Label>Client ID</Label>
           <div className="flex items-center gap-1">
-            <Text className="truncate font-medium font-mono text-sm">
+            <p className="truncate font-medium font-mono text-foreground text-sm">
               {oauth2Client.clientId}
-            </Text>
-            <IconButton
-              variant="borderless"
-              color="secondary"
+            </p>
+            <Button
+              type="button"
+              variant="ghost"
+              size="icon"
+              className="h-8 w-8"
               aria-label="Copy Client ID"
               onClick={() => copy(oauth2Client.clientId, 'Client ID')}
             >
               <CopyIcon className="h-4 w-4" />
-            </IconButton>
+            </Button>
           </div>
 
-          <InputLabel as="h3">Created At</InputLabel>
-          <Text className="font-medium">
+          <Label>Created At</Label>
+          <p className="font-medium text-foreground">
             {format(new Date(oauth2Client.createdAt), 'yyyy-MM-dd HH:mm:ss')}
-          </Text>
+          </p>
 
-          <InputLabel as="h3">Updated At</InputLabel>
-          <Text className="font-medium">
+          <Label>Updated At</Label>
+          <p className="font-medium text-foreground">
             {format(new Date(oauth2Client.updatedAt), 'yyyy-MM-dd HH:mm:ss')}
-          </Text>
+          </p>
         </div>
 
-        <Input
-          {...register('description')}
-          id="description"
+        <FormInput
+          control={form.control}
+          name="description"
           label="Description"
           placeholder="Describe this OAuth2 client"
-          hideEmptyHelperText
-          error={!!errors.description}
-          helperText={errors?.description?.message}
-          fullWidth
           autoComplete="off"
         />
 
-        <Input
-          {...register('redirectUris')}
-          id="redirectUris"
+        <FormTextarea
+          control={form.control}
+          name="redirectUris"
           label="Redirect URIs (one per line)"
           placeholder="https://example.com/callback"
-          hideEmptyHelperText
-          error={!!errors.redirectUris}
-          helperText={errors?.redirectUris?.message}
-          fullWidth
-          autoComplete="off"
-          multiline
-          rows={3}
+          className="min-h-[80px]"
         />
 
         <div>
-          <InputLabel className="mb-2">Scopes</InputLabel>
+          <Label className="mb-2 block">Scopes</Label>
           <ScopePicker selected={selectedScopes} onChange={setSelectedScopes} />
         </div>
 
-        <Divider />
+        <Separator />
 
         <div className="grid gap-2">
-          <Text className="font-medium">Client Secret</Text>
-          <Text className="text-sm" color="secondary">
+          <p className="font-medium text-foreground">Client Secret</p>
+          <p className="text-muted-foreground text-sm">
             {isConfidential
               ? 'This client has a secret configured.'
               : 'This is a public client with no secret.'}
-          </Text>
+          </p>
 
-          <Input
-            value={pendingSecret ?? ''}
-            placeholder={
-              isConfidential ? '<secret hidden>' : '<no secret configured>'
-            }
-            fullWidth
-            readOnly
-            hideEmptyHelperText
-            slotProps={{
-              input: { className: 'lg:w-1/2' },
-              inputRoot: { className: 'font-mono text-sm !pr-8' },
-              helperText: { component: 'div' },
-            }}
-            helperText={
-              <div className="grid grid-flow-row items-center justify-start gap-1 pt-1">
-                {pendingSecret && (
-                  <Text className="text-xs" color="secondary">
-                    Copy this secret now. You will not be able to see it again.
-                  </Text>
-                )}
-                <div className="grid grid-flow-col items-center justify-start gap-1">
-                  {isConfidential ? (
-                    <Text className="text-xs" color="secondary">
-                      Generating a new secret will invalidate the current one
-                      when you save.
-                    </Text>
-                  ) : (
-                    <Text className="text-xs" color="secondary">
-                      Generate a secret to make this a confidential client.
-                    </Text>
-                  )}
-                  <Button
-                    onClick={handleGenerateSecret}
-                    className="h-auto px-1 py-0.5 text-xs"
-                    variant="link"
-                    type="button"
-                  >
-                    Generate a secret
-                  </Button>
-                </div>
-                {isConfidential && (
-                  <div className="grid grid-flow-col items-center justify-start gap-1">
-                    <Button
-                      variant="link"
-                      onClick={handleRemoveSecret}
-                      type="button"
-                      className="h-auto px-1 py-0.5 text-destructive text-xs"
-                    >
-                      Remove secret (make public)
-                    </Button>
-                  </div>
-                )}
-              </div>
-            }
-            endAdornment={
-              <InputAdornment
-                position="end"
-                className={pendingSecret ? 'absolute right-2' : 'invisible'}
-              >
+          <InputGroup className="lg:w-1/2">
+            <InputGroupInput
+              readOnly
+              value={pendingSecret ?? ''}
+              placeholder={
+                isConfidential ? '<secret hidden>' : '<no secret configured>'
+              }
+              className="font-mono text-sm"
+            />
+            {pendingSecret && (
+              <InputGroupAddon align="inline-end">
                 <Button
-                  className="h-auto min-w-0 p-0"
-                  onClick={() => {
-                    if (pendingSecret) {
-                      copy(pendingSecret, 'Client secret');
-                    }
-                  }}
-                  variant="ghost"
-                  aria-label="Copy secret"
                   type="button"
+                  variant="ghost"
+                  size="icon"
+                  className="h-8 w-8"
+                  aria-label="Copy secret"
+                  onClick={() => copy(pendingSecret, 'Client secret')}
                 >
                   <CopyIcon className="h-4 w-4" />
                 </Button>
-              </InputAdornment>
-            }
-          />
+              </InputGroupAddon>
+            )}
+          </InputGroup>
+
+          <div className="grid grid-flow-row items-center justify-start gap-1 pt-1">
+            {pendingSecret && (
+              <p className="text-muted-foreground text-xs">
+                Copy this secret now. You will not be able to see it again.
+              </p>
+            )}
+            <div className="grid grid-flow-col items-center justify-start gap-1">
+              {isConfidential ? (
+                <p className="text-muted-foreground text-xs">
+                  Generating a new secret will invalidate the current one when
+                  you save.
+                </p>
+              ) : (
+                <p className="text-muted-foreground text-xs">
+                  Generate a secret to make this a confidential client.
+                </p>
+              )}
+              <Button
+                onClick={handleGenerateSecret}
+                className="h-auto px-1 py-0.5 text-xs"
+                variant="link"
+                type="button"
+              >
+                Generate a secret
+              </Button>
+            </div>
+            {isConfidential && (
+              <div className="grid grid-flow-col items-center justify-start gap-1">
+                <Button
+                  variant="link"
+                  onClick={handleRemoveSecret}
+                  type="button"
+                  className="h-auto px-1 py-0.5 text-destructive text-xs"
+                >
+                  Remove secret (make public)
+                </Button>
+              </div>
+            )}
+          </div>
         </div>
 
-        <Divider />
+        <Separator />
 
         <div className="grid grid-flow-row gap-2">
           <Button type="submit" disabled={isSubmitting || !isDirty}>

--- a/dashboard/src/features/orgs/projects/authentication/oauth2-clients/components/OAuth2ClientsList/OAuth2ClientsList.tsx
+++ b/dashboard/src/features/orgs/projects/authentication/oauth2-clients/components/OAuth2ClientsList/OAuth2ClientsList.tsx
@@ -6,18 +6,15 @@ import {
 } from 'lucide-react';
 import { Fragment } from 'react';
 import { useDialog } from '@/components/common/DialogProvider';
-import { Divider } from '@/components/ui/v2/Divider';
-import { IconButton } from '@/components/ui/v2/IconButton';
-import { List } from '@/components/ui/v2/List';
-import { ListItem } from '@/components/ui/v2/ListItem';
-import { Text } from '@/components/ui/v2/Text';
 import { Badge } from '@/components/ui/v3/badge';
+import { Button } from '@/components/ui/v3/button';
 import {
   DropdownMenu,
   DropdownMenuContent,
   DropdownMenuItem,
   DropdownMenuTrigger,
 } from '@/components/ui/v3/dropdown-menu';
+import { Separator } from '@/components/ui/v3/separator';
 import { useRemoteApplicationGQLClient } from '@/features/orgs/hooks/useRemoteApplicationGQLClient';
 import { EditOAuth2ClientForm } from '@/features/orgs/projects/authentication/oauth2-clients/components/EditOAuth2ClientForm';
 import { execPromiseWithErrorToast } from '@/features/orgs/utils/execPromiseWithErrorToast';
@@ -89,70 +86,38 @@ export default function OAuth2ClientsList({
   }
 
   return (
-    <List>
+    <ul>
       {clients.map((client) => {
         const isConfidential = !!client.clientSecretHash;
         const description = client.metadata?.description as string | undefined;
 
         return (
           <Fragment key={client.clientId}>
-            <ListItem.Root
-              className="h-[64px] w-full"
-              secondaryAction={
-                <DropdownMenu>
-                  <DropdownMenuTrigger asChild>
-                    <IconButton
-                      variant="borderless"
-                      color="secondary"
-                      aria-label={`More options for ${client.clientId}`}
-                    >
-                      <DotsHorizontalIcon />
-                    </IconButton>
-                  </DropdownMenuTrigger>
-
-                  <DropdownMenuContent align="end" className="w-52 p-0">
-                    <DropdownMenuItem
-                      onClick={() => handleEdit(client)}
-                      className="flex h-9 cursor-pointer items-center justify-start gap-2 rounded-none border border-b-1 p-2 font-medium text-sm+ leading-4 hover:bg-data-cell-bg"
-                    >
-                      <UserIcon className="h-4 w-4" />
-                      <span>Edit Client</span>
-                    </DropdownMenuItem>
-
-                    <DropdownMenuItem
-                      onClick={() => handleDelete(client)}
-                      className="!text-destructive flex h-9 cursor-pointer items-center justify-start gap-2 rounded-none border border-b-1 p-2 font-medium text-sm+ leading-4 hover:bg-data-cell-bg"
-                    >
-                      <TrashIcon className="h-4 w-4" />
-                      <span>Delete Client</span>
-                    </DropdownMenuItem>
-                  </DropdownMenuContent>
-                </DropdownMenu>
-              }
-            >
-              <ListItem.Button
-                className="grid h-full w-full grid-cols-1 py-2.5 md:grid-cols-8"
+            <li className="relative">
+              <button
+                type="button"
                 onClick={() => handleEdit(client)}
                 aria-label={`View ${client.clientId}`}
+                className="grid h-[64px] w-full grid-cols-1 py-2.5 text-left md:grid-cols-8"
               >
                 <div className="col-span-2 min-w-0">
-                  <Text className="truncate font-mono text-sm">
+                  <p className="truncate font-mono text-foreground text-sm">
                     {client.clientId}
-                  </Text>
+                  </p>
                   {description && (
-                    <Text className="truncate font-normal" color="secondary">
+                    <p className="truncate text-muted-foreground">
                       {description}
-                    </Text>
+                    </p>
                   )}
                 </div>
-                <Text className="hidden px-2 font-normal md:block">
+                <p className="hidden px-2 font-normal text-foreground md:block">
                   {isConfidential ? 'Confidential' : 'Public'}
-                </Text>
-                <Text className="hidden px-2 font-normal md:block">
+                </p>
+                <p className="hidden px-2 font-normal text-foreground md:block">
                   {formatDistanceToNow(new Date(client.createdAt), {
                     addSuffix: true,
                   })}
-                </Text>
+                </p>
                 <div className="col-span-3 hidden flex-wrap gap-1 px-2 md:flex">
                   {(client.scopes ?? []).length > 0 ? (
                     client.scopes.map((scope) => (
@@ -165,15 +130,46 @@ export default function OAuth2ClientsList({
                       </Badge>
                     ))
                   ) : (
-                    <Text className="font-normal">-</Text>
+                    <p className="font-normal text-foreground">-</p>
                   )}
                 </div>
-              </ListItem.Button>
-            </ListItem.Root>
-            <Divider />
+              </button>
+
+              <DropdownMenu>
+                <DropdownMenuTrigger asChild>
+                  <Button
+                    variant="ghost"
+                    size="icon"
+                    className="absolute top-1/2 right-2 h-8 w-8 -translate-y-1/2"
+                    aria-label={`More options for ${client.clientId}`}
+                  >
+                    <DotsHorizontalIcon className="h-4 w-4" />
+                  </Button>
+                </DropdownMenuTrigger>
+
+                <DropdownMenuContent align="end" className="w-52 p-0">
+                  <DropdownMenuItem
+                    onClick={() => handleEdit(client)}
+                    className="flex h-9 cursor-pointer items-center justify-start gap-2 rounded-none border border-b-1 p-2 font-medium text-sm+ leading-4 hover:bg-data-cell-bg"
+                  >
+                    <UserIcon className="h-4 w-4" />
+                    <span>Edit Client</span>
+                  </DropdownMenuItem>
+
+                  <DropdownMenuItem
+                    onClick={() => handleDelete(client)}
+                    className="!text-destructive flex h-9 cursor-pointer items-center justify-start gap-2 rounded-none border border-b-1 p-2 font-medium text-sm+ leading-4 hover:bg-data-cell-bg"
+                  >
+                    <TrashIcon className="h-4 w-4" />
+                    <span>Delete Client</span>
+                  </DropdownMenuItem>
+                </DropdownMenuContent>
+              </DropdownMenu>
+            </li>
+            <Separator />
           </Fragment>
         );
       })}
-    </List>
+    </ul>
   );
 }

--- a/dashboard/src/pages/orgs/[orgSlug]/projects/[appSubdomain]/auth/oauth2-clients.tsx
+++ b/dashboard/src/pages/orgs/[orgSlug]/projects/[appSubdomain]/auth/oauth2-clients.tsx
@@ -7,10 +7,8 @@ import { useDialog } from '@/components/common/DialogProvider';
 import { Pagination } from '@/components/common/Pagination';
 import { Container } from '@/components/layout/Container';
 import { RetryableErrorBoundary } from '@/components/presentational/RetryableErrorBoundary';
-import { Box } from '@/components/ui/v2/Box';
-import { Input } from '@/components/ui/v2/Input';
-import { Text } from '@/components/ui/v2/Text';
 import { Button } from '@/components/ui/v3/button';
+import { Input } from '@/components/ui/v3/input';
 import { Spinner } from '@/components/ui/v3/spinner';
 import { useRemoteApplicationGQLClient } from '@/features/orgs/hooks/useRemoteApplicationGQLClient';
 import { OrgLayout } from '@/features/orgs/layout/OrgLayout';
@@ -149,15 +147,15 @@ function OAuth2ClientsPageContent() {
   ) {
     return (
       <Container className="mx-auto max-w-9xl space-y-5">
-        <Box className="flex flex-col items-center justify-center space-y-5 rounded-lg border px-48 py-12 shadow-sm">
+        <div className="flex flex-col items-center justify-center space-y-5 rounded-lg border px-48 py-12 shadow-sm">
           <div className="flex flex-col space-y-1">
-            <Text className="text-center font-medium" variant="h3">
+            <h3 className="text-center font-medium text-foreground text-lg">
               Auth Version Too Old
-            </Text>
-            <Text variant="subtitle1" className="text-center">
+            </h3>
+            <p className="text-center text-muted-foreground text-sm">
               OAuth2 Clients require Auth version {MIN_AUTH_VERSION_OAUTH2} or
               later. Please upgrade your Auth service in the Settings page.
-            </Text>
+            </p>
           </div>
           <Button
             onClick={() =>
@@ -168,7 +166,7 @@ function OAuth2ClientsPageContent() {
           >
             Go to Auth Settings
           </Button>
-        </Box>
+        </div>
       </Container>
     );
   }
@@ -195,14 +193,14 @@ function OAuth2ClientsPageContent() {
   if (!oauth2Enabled) {
     return (
       <Container className="mx-auto max-w-9xl space-y-5">
-        <Box className="flex flex-col items-center justify-center space-y-5 rounded-lg border px-48 py-12 shadow-sm">
+        <div className="flex flex-col items-center justify-center space-y-5 rounded-lg border px-48 py-12 shadow-sm">
           <div className="flex flex-col space-y-1">
-            <Text className="text-center font-medium" variant="h3">
+            <h3 className="text-center font-medium text-foreground text-lg">
               OAuth2 Provider is Disabled
-            </Text>
-            <Text variant="subtitle1" className="text-center">
+            </h3>
+            <p className="text-center text-muted-foreground text-sm">
               Enable the OAuth2 provider in settings to manage OAuth2 clients.
-            </Text>
+            </p>
           </div>
           <Button
             onClick={() =>
@@ -213,7 +211,7 @@ function OAuth2ClientsPageContent() {
           >
             Go to OAuth2 Provider Settings
           </Button>
-        </Box>
+        </div>
       </Container>
     );
   }
@@ -226,11 +224,10 @@ function OAuth2ClientsPageContent() {
       >
         <div className="flex shrink-0 grow-0 flex-row place-content-between">
           <Input
-            className="rounded-sm"
+            className="rounded-sm pl-9"
+            wrapperClassName="w-full max-w-xs"
             placeholder="Search clients"
-            startAdornment={
-              <SearchIcon className="-mr-1 ml-2 h-4 w-4 shrink-0 text-disabled" />
-            }
+            prefix={<SearchIcon className="h-4 w-4 text-muted-foreground" />}
             onChange={handleSearchStringChange}
           />
           <Button onClick={openCreateClientDrawer} size="sm">
@@ -258,11 +255,10 @@ function OAuth2ClientsPageContent() {
     <Container className="mx-auto max-w-9xl space-y-5 overflow-x-hidden">
       <div className="flex flex-row place-content-between">
         <Input
-          className="rounded-sm"
+          className="rounded-sm pl-9"
+          wrapperClassName="w-full max-w-xs"
           placeholder="Search clients"
-          startAdornment={
-            <SearchIcon className="-mr-1 ml-2 h-4 w-4 shrink-0 text-disabled" />
-          }
+          prefix={<SearchIcon className="h-4 w-4 text-muted-foreground" />}
           onChange={handleSearchStringChange}
         />
         <Button onClick={openCreateClientDrawer} size="sm">
@@ -271,42 +267,48 @@ function OAuth2ClientsPageContent() {
         </Button>
       </div>
       {clientsCount === 0 && !searchString ? (
-        <Box className="flex flex-col items-center justify-center space-y-5 rounded-lg border px-48 py-12 shadow-sm">
+        <div className="flex flex-col items-center justify-center space-y-5 rounded-lg border px-48 py-12 shadow-sm">
           <div className="flex flex-col space-y-1">
-            <Text className="text-center font-medium" variant="h3">
+            <h3 className="text-center font-medium text-foreground text-lg">
               No OAuth2 Clients
-            </Text>
-            <Text variant="subtitle1" className="text-center">
+            </h3>
+            <p className="text-center text-muted-foreground text-sm">
               Create your first OAuth2 client to get started.
-            </Text>
+            </p>
           </div>
           <Button onClick={openCreateClientDrawer}>
             <PlusIcon className="mr-2 h-4 w-4" />
             Create Client
           </Button>
-        </Box>
+        </div>
       ) : (
         <div className="grid grid-flow-row gap-2 lg:w-9xl">
           <div className="grid h-full w-full grid-flow-row overflow-hidden pb-4">
-            <Box className="grid w-full border-b p-2 md:grid-cols-8">
-              <Text className="font-medium md:col-span-2">Client ID</Text>
-              <Text className="hidden font-medium md:block">Type</Text>
-              <Text className="hidden font-medium md:block">Created</Text>
-              <Text className="col-span-3 hidden font-medium md:block">
+            <div className="grid w-full border-b p-2 md:grid-cols-8">
+              <p className="font-medium text-foreground md:col-span-2">
+                Client ID
+              </p>
+              <p className="hidden font-medium text-foreground md:block">
+                Type
+              </p>
+              <p className="hidden font-medium text-foreground md:block">
+                Created
+              </p>
+              <p className="col-span-3 hidden font-medium text-foreground md:block">
                 Scopes
-              </Text>
-            </Box>
+              </p>
+            </div>
             {clientsCount === 0 && searchString && (
-              <Box className="flex flex-col items-center justify-center space-y-5 border-x border-b px-48 py-12">
+              <div className="flex flex-col items-center justify-center space-y-5 border-x border-b px-48 py-12">
                 <div className="flex flex-col space-y-1">
-                  <Text className="text-center font-medium" variant="h3">
+                  <h3 className="text-center font-medium text-foreground text-lg">
                     No results for &quot;{searchString}&quot;
-                  </Text>
-                  <Text variant="subtitle1" className="text-center">
+                  </h3>
+                  <p className="text-center text-muted-foreground text-sm">
                     Try a different search
-                  </Text>
+                  </p>
                 </div>
-              </Box>
+              </div>
             )}
             {clients.length > 0 && (
               <div className="grid grid-flow-row gap-4">


### PR DESCRIPTION
### Checklist

- [ ] No breaking changes
- [ ] Tests pass
- [ ] New features have new tests
- [ ] Documentation is updated (if applicable)
- [ ] Title of the PR is in the correct format (see below)

<!-- pi-reviewer:start -->
### **What this change solves**
Migrates the dashboard OAuth2 clients page and related forms to the newer v3 form and UI component stack. The change keeps the existing OAuth2 client create/edit/list flows while replacing legacy Yup and v2 UI usage with Zod, React Hook Form wrappers, and v3 layout primitives.

___

### **Change Type**
Refactoring

___

### **Description**
- Replace Yup-based form schemas with Zod resolvers for OAuth2 client create/edit forms.
- Move OAuth2 client form inputs, textareas, separators, labels, and secret controls from legacy v2 components to v3/form components.
- Refresh the OAuth2 clients list and page shell to use v3 table, card, button, link, and typography patterns.

___

<details> <summary><h3> File Walkthrough</h3></summary>

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody>
<tr><td><strong>Dashboard OAuth2 clients</strong></td><td><details><summary>4 files</summary><table>
<tr>
  <td><strong>dashboard/src/features/orgs/projects/authentication/oauth2-clients/components/CreateOAuth2ClientForm/CreateOAuth2ClientForm.tsx</strong><dd><code>Migrates the create form to Zod, form wrappers, and v3 input/secret UI.</code></dd></td>
  <td>+78/-96</td>
</tr>
<tr>
  <td><strong>dashboard/src/features/orgs/projects/authentication/oauth2-clients/components/EditOAuth2ClientForm/EditOAuth2ClientForm.tsx</strong><dd><code>Migrates the edit form to Zod, form wrappers, and v3 input/secret UI.</code></dd></td>
  <td>+104/-121</td>
</tr>
<tr>
  <td><strong>dashboard/src/features/orgs/projects/authentication/oauth2-clients/components/OAuth2ClientsList/OAuth2ClientsList.tsx</strong><dd><code>Updates the OAuth2 clients table/list controls to v3 UI components.</code></dd></td>
  <td>+51/-55</td>
</tr>
<tr>
  <td><strong>dashboard/src/pages/orgs/[orgSlug]/projects/[appSubdomain]/auth/oauth2-clients.tsx</strong><dd><code>Refreshes the OAuth2 clients page layout with v3 card, button, and text styles.</code></dd></td>
  <td>+44/-42</td>
</tr>
</table></details></td></tr>
</tbody></table>

</details>

___

<!-- pi-reviewer:end -->
