### PR TITLE
fix(dashboard): fix avatar CSP and disable Stripe advanced fraud signals

### DIFF
--- a/dashboard/next.config.js
+++ b/dashboard/next.config.js
@@ -15,7 +15,7 @@ function getCspHeader() {
         "script-src 'self' 'unsafe-eval' cdn.segment.com js.stripe.com challenges.cloudflare.com googletagmanager.com",
         "connect-src 'self' *.nhost.run wss://*.nhost.run nhost.run wss://nhost.run discord.com api.segment.io api.segment.com cdn.segment.com nhost.zendesk.com api.github.com",
         "style-src 'self' 'unsafe-inline'",
-        "img-src 'self' blob: data: github.com avatars.githubusercontent.com s.gravatar.com *.nhost.run nhost.run",
+        "img-src 'self' blob: data: github.com *.githubusercontent.com *.gravatar.com *.nhost.run nhost.run",
         "font-src 'self' data:",
         "object-src 'none'",
         "base-uri 'self'",

--- a/dashboard/src/features/orgs/components/StripeEmbeddedForm/StripeEmbeddedForm.tsx
+++ b/dashboard/src/features/orgs/components/StripeEmbeddedForm/StripeEmbeddedForm.tsx
@@ -2,7 +2,9 @@ import {
   EmbeddedCheckout,
   EmbeddedCheckoutProvider,
 } from '@stripe/react-stripe-js';
-import { loadStripe } from '@stripe/stripe-js';
+import { loadStripe } from '@stripe/stripe-js/pure';
+
+loadStripe.setLoadParameters({ advancedFraudSignals: false });
 
 const stripePromise = process.env.NEXT_PUBLIC_STRIPE_PK
   ? loadStripe(process.env.NEXT_PUBLIC_STRIPE_PK)


### PR DESCRIPTION
### Checklist

- [x] No breaking changes
- [ ] Tests pass
- [ ] New features have new tests
- [ ] Documentation is updated (if applicable)
- [x] Title of the PR is in the correct format (see below)

<!-- pi-reviewer:start -->
### **What this change solves**
Avatar images served from GitHub/Gravatar subdomains were being blocked by the dashboard's Content-Security-Policy, and Stripe's advanced fraud-detection frame was loading a hidden iframe/beacons that the CSP blocked in every environment (generating console noise without functioning). This broadens the `img-src` allowlist to the relevant wildcard hosts and disables Stripe's advanced fraud signals for this embedded-checkout integration.

___

### **Change Type**
Bug fix

___

### **Description**
- Replace the exact `avatars.githubusercontent.com` and `s.gravatar.com` `img-src` entries with the `*.githubusercontent.com` and `*.gravatar.com` wildcards so avatars from any GitHub/Gravatar subdomain load.
- Switch the Stripe import to `@stripe/stripe-js/pure` and call `loadStripe.setLoadParameters({ advancedFraudSignals: false })` so the fraud-detection iframe/beacons never load.
- Payment fraud detection still runs inside Stripe's own Embedded Checkout iframe (on Stripe's domain), so this only removes the CSP-blocked host-page signals — which never worked under the CSP in any environment.

___

<details> <summary><h3> File Walkthrough</h3></summary>

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody>
<tr><td><strong>Configuration</strong></td><td><details><summary>1 files</summary><table>
<tr>
  <td><strong>next.config.js</strong><dd><code>Broaden img-src CSP allowlist to GitHub/Gravatar wildcard hosts</code></dd></td>
  <td>+1/-1</td>
</tr>
</table></details></td></tr>
<tr><td><strong>Dashboard</strong></td><td><details><summary>1 files</summary><table>
<tr>
  <td><strong>StripeEmbeddedForm.tsx</strong><dd><code>Use stripe-js/pure and disable advanced fraud signals unconditionally</code></dd></td>
  <td>+3/-1</td>
</tr>
</table></details></td></tr>
</tbody></table>

</details>

___

<!-- pi-reviewer:end -->

