### PR TITLE
feat(dashboard): Allow copying nhost-registry

### DIFF
--- a/dashboard/src/features/orgs/projects/services/components/ServiceForm/ServiceForm.tsx
+++ b/dashboard/src/features/orgs/projects/services/components/ServiceForm/ServiceForm.tsx
@@ -49,6 +49,8 @@ import { cn } from '@/lib/utils';
 import { RESOURCE_VCPU_MULTIPLIER } from '@/utils/constants/common';
 import { copy } from '@/utils/copy';
 
+const NEW_SERVICE_ID_PLACEHOLDER = '<uuid-to-be-generated-on-creation>';
+
 export default function ServiceForm({
   serviceID,
   initialData,
@@ -90,14 +92,12 @@ export default function ServiceForm({
 
   const isDirty = Object.keys(dirtyFields).length > 0;
 
-  const newServiceID = useMemo(() => {
-    if (serviceID) {
-      return serviceID;
-    }
-    return '<uuid-to-be-generated-on-creation>';
-  }, [serviceID]);
+  const serviceIDOrPlaceholder = useMemo(
+    () => serviceID || NEW_SERVICE_ID_PLACEHOLDER,
+    [serviceID],
+  );
 
-  const privateRegistryImage = `registry.${project?.region.name}.${project?.region.domain}/${newServiceID}`;
+  const privateRegistryImage = `registry.${project?.region.name}.${project?.region.domain}/${serviceIDOrPlaceholder}`;
 
   let initialImageType: 'public' | 'private' | 'nhost' = 'public';
 
@@ -326,6 +326,7 @@ export default function ServiceForm({
           imageType={imageType}
           initialImageTag={initialImageTag}
           privateRegistryImage={privateRegistryImage}
+          serviceID={serviceID}
         />
 
         <ComputeFormSection showTooltip />

--- a/dashboard/src/features/orgs/projects/services/components/ServiceForm/components/ImageField/ImageField.tsx
+++ b/dashboard/src/features/orgs/projects/services/components/ServiceForm/components/ImageField/ImageField.tsx
@@ -1,6 +1,7 @@
 import { InfoIcon } from 'lucide-react';
 import { useEffect, useState } from 'react';
 import { useFormContext } from 'react-hook-form';
+import { CopyToClipboardButton } from '@/components/presentational/CopyToClipboardButton';
 import { Input } from '@/components/ui/v3/input';
 import {
   InputGroup,
@@ -21,12 +22,14 @@ interface ImageFieldProps {
   privateRegistryImage: string;
   imageType: 'private' | 'nhost' | 'public';
   initialImageTag?: string;
+  serviceID?: string;
 }
 
 export default function ImageField({
   privateRegistryImage,
   imageType,
   initialImageTag,
+  serviceID,
 }: ImageFieldProps) {
   const {
     register,
@@ -35,6 +38,7 @@ export default function ImageField({
   } = useFormContext<ServiceFormValues>();
 
   const [imageTag, setImageTag] = useState(initialImageTag || '');
+  const isExistingService = !!serviceID;
 
   useEffect(() => {
     if (imageType === 'nhost' && privateRegistryImage) {
@@ -58,9 +62,23 @@ export default function ImageField({
           >
             <InputGroupAddon
               align="inline-start"
-              className="max-w-[70%] justify-start truncate font-normal"
+              className="max-w-[70%] justify-start font-normal"
             >
-              <span className="truncate">{privateRegistryImage}:</span>
+              {isExistingService && (
+                <Tooltip>
+                  <TooltipTrigger asChild>
+                    <span className="inline-flex shrink-0">
+                      <CopyToClipboardButton
+                        aria-label="Copy registry"
+                        textToCopy={privateRegistryImage}
+                        title="Nhost registry"
+                      />
+                    </span>
+                  </TooltipTrigger>
+                  <TooltipContent>Copy registry</TooltipContent>
+                </Tooltip>
+              )}
+              <span className="min-w-0 truncate">{privateRegistryImage}:</span>
             </InputGroupAddon>
             <InputGroupInput
               value={imageTag}

--- a/dashboard/src/features/orgs/projects/services/components/ServiceForm/components/ImageFormSection/ImageFormSection.tsx
+++ b/dashboard/src/features/orgs/projects/services/components/ServiceForm/components/ImageFormSection/ImageFormSection.tsx
@@ -7,6 +7,7 @@ interface ImageFormSectionProps {
   privateRegistryImage: string;
   imageType: 'public' | 'private' | 'nhost';
   initialImageTag?: string;
+  serviceID?: string;
 }
 
 export default function ImageFormSection({
@@ -14,6 +15,7 @@ export default function ImageFormSection({
   imageType,
   onImageTypeChange,
   initialImageTag,
+  serviceID,
 }: ImageFormSectionProps) {
   return (
     <div className="space-y-4 rounded border-1 p-4">
@@ -43,6 +45,7 @@ export default function ImageFormSection({
         privateRegistryImage={privateRegistryImage}
         imageType={imageType}
         initialImageTag={initialImageTag}
+        serviceID={serviceID}
       />
     </div>
   );


### PR DESCRIPTION
### Checklist

- [x] No breaking changes
- [x] Tests pass
- [ ] New features have new tests
- [ ] Documentation is updated (if applicable)
- [x] Title of the PR is in the correct format (see below)

<!-- pi-reviewer:start -->
### **What this change solves**
This change makes the Nhost registry image path easier to copy from the Run service image form when editing an existing service. It also keeps the new-service placeholder value named explicitly so create-mode registry paths are clearer in code.

___

### **Change Type**
Enhancement

___

### **Description**
- Adds a copy control with a hover tooltip to the Nhost registry image prefix in the service image field.
- Passes the service identifier into the image form components so the copy control is only shown for existing services.
- Extracts the new-service registry ID placeholder into a named constant.

___

<details> <summary><h3> File Walkthrough</h3></summary>

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody>
<tr><td><strong>Dashboard Run service form</strong></td><td><details><summary>3 files</summary><table>
<tr>
  <td><strong>dashboard/src/features/orgs/projects/services/components/ServiceForm/ServiceForm.tsx</strong><dd><code>Names the new-service ID placeholder and forwards serviceID to image form components.</code></dd></td>
  <td>+8/-7</td>
</tr>
<tr>
  <td><strong>dashboard/src/features/orgs/projects/services/components/ServiceForm/components/ImageField/ImageField.tsx</strong><dd><code>Adds a tooltip-wrapped copy button for the Nhost registry image prefix when editing existing services.</code></dd></td>
  <td>+20/-2</td>
</tr>
<tr>
  <td><strong>dashboard/src/features/orgs/projects/services/components/ServiceForm/components/ImageFormSection/ImageFormSection.tsx</strong><dd><code>Forwards the optional serviceID to the image field.</code></dd></td>
  <td>+3/-0</td>
</tr>
</table></details></td></tr>
</tbody></table>

</details>

___

<!-- pi-reviewer:end -->

