### PR TITLE
fix(dashboard): add background to avatar for transparent images

### DIFF
--- a/dashboard/src/components/ui/v3/avatar.tsx
+++ b/dashboard/src/components/ui/v3/avatar.tsx
@@ -10,7 +10,7 @@ function AvatarRoot({
     <AvatarPrimitive.Root
       data-slot="avatar"
       className={cn(
-        'relative flex h-10 w-10 shrink-0 overflow-hidden rounded-full',
+        'relative flex h-10 w-10 shrink-0 overflow-hidden rounded-full bg-muted',
         className,
       )}
       {...props}


### PR DESCRIPTION
<!-- pi-reviewer:start -->
### **What this change solves**
The shadcn v3 `Avatar` only applied `bg-muted` to the text fallback, so an image sitting on the transparent root — such as a transparent default gravatar — rendered with no background. Adding the background to the avatar root makes it always present, so image and text-fallback states look consistent.

___

### **Change Type**
Bug fix

___

### **Description**
- Add `bg-muted` to the `AvatarRoot` className so the muted background is always rendered behind both the image and the fallback.
- A transparent default gravatar now shows the same muted background as the text fallback instead of appearing empty.

___

<details> <summary><h3> File Walkthrough</h3></summary>

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody>
<tr><td><strong>Bug fix</strong></td><td><details><summary>1 files</summary><table>
<tr>
  <td><strong>avatar.tsx</strong><dd><code>Add bg-muted to the avatar root so a transparent image shows the same background as the text fallback</code></dd></td>
  <td>+1/-1</td>
</tr>
</table></details></td></tr>
</tbody></table>

</details>

___

<!-- pi-reviewer:end -->
