### PR TITLE
fix(dashboard): restore billing button padding

### DIFF
--- a/dashboard/src/features/orgs/components/billing/BillingEstimate/components/SpendingNotifications/SpendingNotifications.tsx
+++ b/dashboard/src/features/orgs/components/billing/BillingEstimate/components/SpendingNotifications/SpendingNotifications.tsx
@@ -310,7 +310,7 @@ export default function SpendingNotifications() {
             <div className="flex flex-1 flex-col justify-end">
               <ButtonWithLoading
                 type="submit"
-                className="h-fit self-end"
+                className="self-end"
                 disabled={!form.formState.isDirty || !isAdmin}
                 loading={form.formState.isSubmitting}
               >

--- a/dashboard/src/features/orgs/components/billing/SubscriptionPlan/SubscriptionPlan.tsx
+++ b/dashboard/src/features/orgs/components/billing/SubscriptionPlan/SubscriptionPlan.tsx
@@ -244,7 +244,7 @@ export default function SubscriptionPlan() {
             </div>
             <div className="flex w-full flex-row items-center justify-end gap-2">
               <ButtonWithLoading
-                className="h-fit truncate"
+                className="truncate"
                 variant="secondary"
                 onClick={handleUpdatePaymentDetails}
                 disabled={isFreeOrg}
@@ -252,11 +252,7 @@ export default function SubscriptionPlan() {
               >
                 <span className="truncate">Stripe Customer Portal</span>
               </ButtonWithLoading>
-              <Button
-                disabled={loading}
-                className="h-fit"
-                onClick={() => setOpen(true)}
-              >
+              <Button disabled={loading} onClick={() => setOpen(true)}>
                 Upgrade
               </Button>
             </div>


### PR DESCRIPTION

| Before |
| --- |
| <img width="1401" height="417" alt="Screenshot 2026-08-11 at 11 31 38" src="https://github.com/user-attachments/assets/749f7e6c-f6bc-4689-bc65-cf1bd97ae02e" /> |
| **After** |
| <img width="2764" height="614" alt="image" src="https://github.com/user-attachments/assets/694e1c48-b355-44da-a79b-3f147e4983f0" /> |


### Checklist

- [X] No breaking changes
- [X] Tests pass
- [X] New features have new tests
- [X] Documentation is updated (if applicable)
- [X] Title of the PR is in the correct format (see below)


<!-- pi-reviewer:start -->
### **What this change solves**
Buttons in the organization billing screens were rendering with collapsed vertical padding because `h-fit` overrode the button component's own height sizing. Removing the `h-fit` override restores the default button height so the billing actions match the rest of the dashboard.

___

### **Change Type**
Bug fix

___

### **Description**
- Drop the `h-fit` class from the spending-notifications submit button so it uses the default `ButtonWithLoading` height.
- Drop `h-fit` from the Stripe Customer Portal button in the subscription plan card, keeping only `truncate`.
- Simplify the Upgrade button to a single-line JSX element after removing its `h-fit` class.

___

<details> <summary><h3> File Walkthrough</h3></summary>

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody>
<tr><td><strong>Bug fix</strong></td><td><details><summary>2 files</summary><table>
<tr>
  <td><strong>SpendingNotifications.tsx</strong><dd><code>Remove h-fit from the submit button so default padding applies</code></dd></td>
  <td>+1/-1</td>
</tr>
<tr>
  <td><strong>SubscriptionPlan.tsx</strong><dd><code>Remove h-fit from the portal and upgrade buttons; collapse Upgrade button JSX</code></dd></td>
  <td>+2/-6</td>
</tr>
</table></details></td></tr>
</tbody></table>

</details>

___

<!-- pi-reviewer:end -->
