### PR TITLE
fix(dashboard): improve cleanup of event triggers and cron triggers invocations in e2e tests

### DIFF
--- a/dashboard/e2e/events/create-cron-trigger.test.ts
+++ b/dashboard/e2e/events/create-cron-trigger.test.ts
@@ -29,7 +29,13 @@ async function fillBasicFields({
       `https://${TEST_PROJECT_SUBDOMAIN}.hasura.eu-central-1.staging.nhost.run/healthz`,
     );
 
-  await page.getByPlaceholder('* * * * *').fill('0 0 1 1 *');
+  const scheduleInput = page.getByPlaceholder('* * * * *');
+  await scheduleInput.click();
+  await page.getByRole('option', { name: /every minute/i }).click();
+  await expect(scheduleInput).toHaveValue('* * * * *');
+
+  // Prevent a leaked trigger from firing every minute if cleanup fails.
+  await scheduleInput.fill('0 0 1 1 *');
 
   await page.getByPlaceholder(/John Doe/i).fill('{"key": "value"}');
 }

--- a/dashboard/e2e/events/create-cron-trigger.test.ts
+++ b/dashboard/e2e/events/create-cron-trigger.test.ts
@@ -3,8 +3,14 @@ import type { Page } from '@playwright/test';
 import { snakeCase } from 'snake-case';
 import { TEST_ORGANIZATION_SLUG, TEST_PROJECT_SUBDOMAIN } from '@/e2e/env';
 import { expect, test } from '@/e2e/fixtures/auth-hook';
+import { cleanupTriggerTestIfNeeded } from '@/e2e/utils';
 
 const cronTriggersRoute = `/orgs/${TEST_ORGANIZATION_SLUG}/projects/${TEST_PROJECT_SUBDOMAIN}/events/cron-triggers`;
+const cronTriggerName = `e2e_dashboard_cron_${snakeCase(faker.lorem.words(2)).slice(0, 16)}`;
+
+test.beforeAll(async () => {
+  await cleanupTriggerTestIfNeeded('cron');
+});
 
 async function fillBasicFields({
   page,
@@ -23,8 +29,7 @@ async function fillBasicFields({
       `https://${TEST_PROJECT_SUBDOMAIN}.hasura.eu-central-1.staging.nhost.run/healthz`,
     );
 
-  await page.getByPlaceholder('* * * * *').click();
-  await page.getByRole('option', { name: /every minute/i }).click();
+  await page.getByPlaceholder('* * * * *').fill('0 0 1 1 *');
 
   await page.getByPlaceholder(/John Doe/i).fill('{"key": "value"}');
 }
@@ -58,12 +63,10 @@ test('should create and delete a cron trigger with transforms', async ({
   await page.goto(cronTriggersRoute);
   await page.waitForURL(cronTriggersRoute);
 
-  const triggerName = snakeCase(`e2e ${faker.lorem.words(2)}`);
-
   await page.getByRole('button', { name: /new cron trigger/i }).click();
   await expect(page.getByText(/create a new cron trigger/i)).toBeVisible();
 
-  await fillBasicFields({ page, triggerName });
+  await fillBasicFields({ page, triggerName: cronTriggerName });
 
   await page.getByText('Retry and Headers Settings').click();
 
@@ -86,10 +89,10 @@ test('should create and delete a cron trigger with transforms', async ({
 
   await page.getByRole('button', { name: /^create$/i }).click();
 
-  await page.waitForURL(`${cronTriggersRoute}/${triggerName}`);
+  await page.waitForURL(`${cronTriggersRoute}/${cronTriggerName}`);
   await page.waitForSelector(
     'div:has-text("The cron trigger has been created successfully.")',
   );
 
-  await deleteCronTrigger({ page, triggerName });
+  await deleteCronTrigger({ page, triggerName: cronTriggerName });
 });

--- a/dashboard/e2e/events/create-event-trigger.test.ts
+++ b/dashboard/e2e/events/create-event-trigger.test.ts
@@ -3,8 +3,14 @@ import type { Page } from '@playwright/test';
 import { snakeCase } from 'snake-case';
 import { TEST_ORGANIZATION_SLUG, TEST_PROJECT_SUBDOMAIN } from '@/e2e/env';
 import { expect, test } from '@/e2e/fixtures/auth-hook';
+import { cleanupTriggerTestIfNeeded } from '@/e2e/utils';
 
 const eventTriggersRoute = `/orgs/${TEST_ORGANIZATION_SLUG}/projects/${TEST_PROJECT_SUBDOMAIN}/events/event-triggers`;
+const eventTriggerName = `e2e_dashboard_event_${snakeCase(faker.lorem.words(2)).slice(0, 16)}`;
+
+test.beforeAll(async () => {
+  await cleanupTriggerTestIfNeeded('event');
+});
 
 async function fillBasicFields({
   page,
@@ -62,12 +68,10 @@ test('should create and delete an event trigger with transforms', async ({
   await page.goto(eventTriggersRoute);
   await page.waitForURL(eventTriggersRoute);
 
-  const triggerName = snakeCase(`e2e ${faker.lorem.words(2)}`);
-
   await page.getByRole('button', { name: /create event trigger/i }).click();
   await expect(page.getByText(/create a new event trigger/i)).toBeVisible();
 
-  await fillBasicFields({ page, triggerName });
+  await fillBasicFields({ page, triggerName: eventTriggerName });
 
   await page.getByText('Retry and Headers Settings').click();
 
@@ -89,10 +93,10 @@ test('should create and delete an event trigger with transforms', async ({
 
   await page.getByRole('button', { name: /^create$/i }).click();
 
-  await page.waitForURL(`${eventTriggersRoute}/${triggerName}`);
+  await page.waitForURL(`${eventTriggersRoute}/${eventTriggerName}`);
   await page.waitForSelector(
     'div:has-text("The event trigger has been created successfully.")',
   );
 
-  await deleteEventTrigger({ page, triggerName });
+  await deleteEventTrigger({ page, triggerName: eventTriggerName });
 });

--- a/dashboard/e2e/utils.ts
+++ b/dashboard/e2e/utils.ts
@@ -155,6 +155,8 @@ export async function prepareTable({
         if (index < columns.length - 1) {
           await page.getByRole('button', { name: /add column/i }).click();
         }
+
+        return undefined;
       },
     ),
   );
@@ -623,6 +625,72 @@ export async function cleanupRemoteSchemaTestIfNeeded() {
   }
 }
 
+export async function cleanupTriggerTestIfNeeded(kind: 'cron' | 'event') {
+  const metadataUrl = `https://${TEST_PROJECT_SUBDOMAIN}.hasura.eu-central-1.staging.nhost.run/v1/metadata`;
+  const namePrefix = `e2e_dashboard_${kind}_`;
+
+  try {
+    const response = await fetch(metadataUrl, {
+      method: 'POST',
+      headers: {
+        'x-hasura-admin-secret': TEST_PROJECT_ADMIN_SECRET,
+      },
+      body: JSON.stringify({
+        type: 'export_metadata',
+        version: 2,
+        args: {},
+      }),
+    });
+    const data = (await response.json()) as ExportMetadataResponse;
+
+    const operations: Array<{
+      type: 'delete_cron_trigger' | 'pg_delete_event_trigger';
+      args: { name: string; source?: 'default' };
+    }> = [];
+
+    if (kind === 'cron') {
+      for (const trigger of data.metadata.cron_triggers ?? []) {
+        if (trigger.name.startsWith(namePrefix)) {
+          operations.push({
+            type: 'delete_cron_trigger',
+            args: { name: trigger.name },
+          });
+        }
+      }
+    } else {
+      const source = data.metadata.sources?.find(
+        ({ name }) => name === 'default',
+      );
+
+      for (const table of source?.tables ?? []) {
+        for (const trigger of table.event_triggers ?? []) {
+          if (trigger.name.startsWith(namePrefix)) {
+            operations.push({
+              type: 'pg_delete_event_trigger',
+              args: { name: trigger.name, source: 'default' },
+            });
+          }
+        }
+      }
+    }
+
+    await Promise.all(
+      operations.map((operation) =>
+        fetch(metadataUrl, {
+          method: 'POST',
+          headers: {
+            'x-hasura-admin-secret': TEST_PROJECT_ADMIN_SECRET,
+          },
+          body: JSON.stringify(operation),
+        }),
+      ),
+    );
+  } catch (error) {
+    console.error(error);
+    throw error;
+  }
+}
+
 export async function cleanupRunServiceTestIfNeeded() {
   const signinUrl = `https://${TEST_STAGING_SUBDOMAIN}.auth.${TEST_STAGING_REGION}.nhost.run/v1/signin/email-password`;
   const graphqlUrl = `https://${TEST_STAGING_SUBDOMAIN}.graphql.${TEST_STAGING_REGION}.nhost.run/v1`;
@@ -719,6 +787,8 @@ export async function cleanupRunServiceTestIfNeeded() {
             variables: { appID, serviceID: service.id },
           }),
         });
+
+        return undefined;
       }),
     );
   } catch (error) {

--- a/dashboard/e2e/utils.ts
+++ b/dashboard/e2e/utils.ts
@@ -17,6 +17,7 @@ import { isEmptyValue } from '@/lib/utils';
 import type { ExportMetadataResponse } from '@/utils/hasura-api/generated/schemas';
 
 const editorRoute = `/orgs/${TEST_ORGANIZATION_SLUG}/projects/${TEST_PROJECT_SUBDOMAIN}/database/browser/default/editor`;
+const projectMetadataUrl = `https://${TEST_PROJECT_SUBDOMAIN}.hasura.eu-central-1.staging.nhost.run/v1/metadata`;
 
 /**
  * Runs a SQL statement using the SQL Editor UI.
@@ -155,8 +156,6 @@ export async function prepareTable({
         if (index < columns.length - 1) {
           await page.getByRole('button', { name: /add column/i }).click();
         }
-
-        return undefined;
       },
     ),
   );
@@ -568,20 +567,17 @@ export async function cleanupOnboardingTestIfNeeded() {
 
 export async function cleanupRemoteSchemaTestIfNeeded() {
   try {
-    const response = await fetch(
-      `https://${TEST_PROJECT_SUBDOMAIN}.hasura.eu-central-1.staging.nhost.run/v1/metadata`,
-      {
-        method: 'POST',
-        headers: {
-          'x-hasura-admin-secret': TEST_PROJECT_ADMIN_SECRET,
-        },
-        body: JSON.stringify({
-          type: 'export_metadata',
-          version: 2,
-          args: {},
-        }),
+    const response = await fetch(projectMetadataUrl, {
+      method: 'POST',
+      headers: {
+        'x-hasura-admin-secret': TEST_PROJECT_ADMIN_SECRET,
       },
-    );
+      body: JSON.stringify({
+        type: 'export_metadata',
+        version: 2,
+        args: {},
+      }),
+    });
     const data = (await response.json()) as ExportMetadataResponse;
 
     const remoteSchemas = data.metadata?.remote_schemas;
@@ -596,27 +592,24 @@ export async function cleanupRemoteSchemaTestIfNeeded() {
 
     await Promise.all(
       schemasToDelete.map((remoteSchema) =>
-        fetch(
-          `https://${TEST_PROJECT_SUBDOMAIN}.hasura.eu-central-1.staging.nhost.run/v1/metadata`,
-          {
-            method: 'POST',
-            headers: {
-              'x-hasura-admin-secret': TEST_PROJECT_ADMIN_SECRET,
-            },
-            body: JSON.stringify({
-              args: [
-                {
-                  type: 'remove_remote_schema',
-                  args: {
-                    name: remoteSchema.name,
-                  },
-                },
-              ],
-              source: 'default',
-              type: 'bulk',
-            }),
+        fetch(projectMetadataUrl, {
+          method: 'POST',
+          headers: {
+            'x-hasura-admin-secret': TEST_PROJECT_ADMIN_SECRET,
           },
-        ),
+          body: JSON.stringify({
+            args: [
+              {
+                type: 'remove_remote_schema',
+                args: {
+                  name: remoteSchema.name,
+                },
+              },
+            ],
+            source: 'default',
+            type: 'bulk',
+          }),
+        }),
       ),
     );
   } catch (error) {
@@ -626,11 +619,8 @@ export async function cleanupRemoteSchemaTestIfNeeded() {
 }
 
 export async function cleanupTriggerTestIfNeeded(kind: 'cron' | 'event') {
-  const metadataUrl = `https://${TEST_PROJECT_SUBDOMAIN}.hasura.eu-central-1.staging.nhost.run/v1/metadata`;
-  const namePrefix = `e2e_dashboard_${kind}_`;
-
   try {
-    const response = await fetch(metadataUrl, {
+    const response = await fetch(projectMetadataUrl, {
       method: 'POST',
       headers: {
         'x-hasura-admin-secret': TEST_PROJECT_ADMIN_SECRET,
@@ -641,7 +631,14 @@ export async function cleanupTriggerTestIfNeeded(kind: 'cron' | 'event') {
         args: {},
       }),
     });
-    const data = (await response.json()) as ExportMetadataResponse;
+    const data = (await response.json()) as Partial<ExportMetadataResponse> & {
+      code?: string;
+      error?: string;
+    };
+
+    if (!response.ok) {
+      throw new Error(`[${data.code}]:${data.error}`);
+    }
 
     const operations: Array<{
       type: 'delete_cron_trigger' | 'pg_delete_event_trigger';
@@ -649,8 +646,8 @@ export async function cleanupTriggerTestIfNeeded(kind: 'cron' | 'event') {
     }> = [];
 
     if (kind === 'cron') {
-      for (const trigger of data.metadata.cron_triggers ?? []) {
-        if (trigger.name.startsWith(namePrefix)) {
+      for (const trigger of data.metadata?.cron_triggers ?? []) {
+        if (/^e2e[_-]/.test(trigger.name)) {
           operations.push({
             type: 'delete_cron_trigger',
             args: { name: trigger.name },
@@ -658,13 +655,13 @@ export async function cleanupTriggerTestIfNeeded(kind: 'cron' | 'event') {
         }
       }
     } else {
-      const source = data.metadata.sources?.find(
+      const source = data.metadata?.sources?.find(
         ({ name }) => name === 'default',
       );
 
       for (const table of source?.tables ?? []) {
         for (const trigger of table.event_triggers ?? []) {
-          if (trigger.name.startsWith(namePrefix)) {
+          if (/^e2e[_-]/.test(trigger.name)) {
             operations.push({
               type: 'pg_delete_event_trigger',
               args: { name: trigger.name, source: 'default' },
@@ -675,15 +672,25 @@ export async function cleanupTriggerTestIfNeeded(kind: 'cron' | 'event') {
     }
 
     await Promise.all(
-      operations.map((operation) =>
-        fetch(metadataUrl, {
+      operations.map(async (operation) => {
+        const deleteResponse = await fetch(projectMetadataUrl, {
           method: 'POST',
           headers: {
             'x-hasura-admin-secret': TEST_PROJECT_ADMIN_SECRET,
           },
           body: JSON.stringify(operation),
-        }),
-      ),
+        });
+        const deleteBody = (await deleteResponse.json()) as {
+          code?: string;
+          error?: string;
+        };
+
+        if (!deleteResponse.ok) {
+          throw new Error(
+            `Failed to delete trigger "${operation.args.name}": [${deleteBody.code}]:${deleteBody.error}`,
+          );
+        }
+      }),
     );
   } catch (error) {
     console.error(error);
@@ -787,8 +794,6 @@ export async function cleanupRunServiceTestIfNeeded() {
             variables: { appID, serviceID: service.id },
           }),
         });
-
-        return undefined;
       }),
     );
   } catch (error) {

--- a/dashboard/e2e/utils.ts
+++ b/dashboard/e2e/utils.ts
@@ -18,6 +18,7 @@ import type { ExportMetadataResponse } from '@/utils/hasura-api/generated/schema
 
 const editorRoute = `/orgs/${TEST_ORGANIZATION_SLUG}/projects/${TEST_PROJECT_SUBDOMAIN}/database/browser/default/editor`;
 const projectMetadataUrl = `https://${TEST_PROJECT_SUBDOMAIN}.hasura.eu-central-1.staging.nhost.run/v1/metadata`;
+const e2eTriggerNamePattern = /^e2e_/;
 
 /**
  * Runs a SQL statement using the SQL Editor UI.
@@ -647,7 +648,7 @@ export async function cleanupTriggerTestIfNeeded(kind: 'cron' | 'event') {
 
     if (kind === 'cron') {
       for (const trigger of data.metadata?.cron_triggers ?? []) {
-        if (/^e2e[_-]/.test(trigger.name)) {
+        if (e2eTriggerNamePattern.test(trigger.name)) {
           operations.push({
             type: 'delete_cron_trigger',
             args: { name: trigger.name },
@@ -661,7 +662,7 @@ export async function cleanupTriggerTestIfNeeded(kind: 'cron' | 'event') {
 
       for (const table of source?.tables ?? []) {
         for (const trigger of table.event_triggers ?? []) {
-          if (/^e2e[_-]/.test(trigger.name)) {
+          if (e2eTriggerNamePattern.test(trigger.name)) {
             operations.push({
               type: 'pg_delete_event_trigger',
               args: { name: trigger.name, source: 'default' },


### PR DESCRIPTION
Resolves #4846

### Checklist

- [X] No breaking changes
- [X] Tests pass
- [X] New features have new tests
- [X] Documentation is updated (if applicable)
- [X] Title of the PR is in the correct format (see below)

<!-- pi-reviewer:start -->
### **What this change solves**
Interrupted trigger end-to-end tests can leave Hasura metadata behind, causing later runs to collide with stale cron or event triggers. This change removes matching dashboard test triggers before each suite while preserving cron form coverage and avoiding destructive cleanup of unrelated staging resources.

___

### **Change Type**
Tests

___

### **Description**
- Export Hasura metadata before the trigger suites and remove stale `e2e_` cron or event triggers, surfacing cleanup failures instead of continuing with polluted state.
- Use bounded, suite-level trigger names consistently through creation, URL assertions, and deletion.
- Keep coverage of the cron schedule suggestion picker, assert the selected value, and replace the every-minute schedule with an annual expression before submission.
- Reuse the project metadata endpoint and a shared trigger-name pattern across cron and event cleanup paths.

___

<details> <summary><h3> File Walkthrough</h3></summary>

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody>
<tr><td><strong>Trigger end-to-end tests</strong></td><td><details><summary>2 files</summary><table>
<tr>
  <td><strong>dashboard/e2e/events/create-cron-trigger.test.ts</strong><dd><code>Clean stale cron triggers before the suite, reuse a bounded trigger name, preserve suggestion-picker coverage, and submit a safe annual schedule.</code></dd></td>
  <td>+15/-6</td>
</tr>
<tr>
  <td><strong>dashboard/e2e/events/create-event-trigger.test.ts</strong><dd><code>Clean stale event triggers before the suite and reuse one bounded trigger name for creation, navigation, and deletion.</code></dd></td>
  <td>+9/-5</td>
</tr>
</table></details></td></tr>
<tr><td><strong>End-to-end utilities</strong></td><td><details><summary>1 file</summary><table>
<tr>
  <td><strong>dashboard/e2e/utils.ts</strong><dd><code>Add shared Hasura metadata cleanup for orphaned <code>e2e_</code> cron and event triggers with explicit failure handling.</code></dd></td>
  <td>+109/-33</td>
</tr>
</table></details></td></tr>
</tbody></table>

</details>

___

<!-- pi-reviewer:end -->
