### PR TITLE
fix(dashboard): Fix graphiql editor suggestion design

### DIFF
--- a/dashboard/src/styles/globals.css
+++ b/dashboard/src/styles/globals.css
@@ -41,7 +41,7 @@ body {
 
 /* GraphiQL overrides */
 
-#__next .dark .graphiql-container {
+html.dark .graphiql-themed .graphiql-container {
   --color-primary: 349, 87%, 57%;
   --color-secondary: 263, 63%, 66%;
   --color-tertiary: 172, 66%, 50%;


### PR DESCRIPTION
### Checklist

- [ ] No breaking changes
- [ ] Tests pass
- [ ] New features have new tests
- [ ] Documentation is updated (if applicable)
- [ ] Title of the PR is in the correct format (see below)

<!-- pi-reviewer:start -->
### **What this change solves**
This change fixes the GraphiQL editor suggestion styling in dark mode by retargeting the CSS override to the current GraphiQL themed DOM structure.

___

### **Change Type**
Bug fix

___

### **Description**
- Updates the dark-mode GraphiQL CSS selector used for theme variables.
- Scopes the override to `html.dark` and GraphiQL's themed container structure.

___

<details> <summary><h3> File Walkthrough</h3></summary>

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody>
<tr><td><strong>Dashboard styles</strong></td><td><details><summary>1 file</summary><table>
<tr>
  <td><strong>dashboard/src/styles/globals.css</strong><dd><code>Retargets GraphiQL dark theme variable overrides to the themed container selector.</code></dd></td>
  <td>+1/-1</td>
</tr>
</table></details></td></tr>
</tbody></table>

</details>

___

<!-- pi-reviewer:end -->


