### PR TITLE
fix(docs): use light background for sidebar Alpha badge in light theme

### DIFF
--- a/docs/src/plugins/starlight-openapi/styles.css
+++ b/docs/src/plugins/starlight-openapi/styles.css
@@ -47,6 +47,11 @@
   --sl-openapi-method-border-trace: hsl(var(--sl-openapi-method-hue-trace), 10%, 70%);
 }
 
+/* Pinned because these badges inherit caution-variant text color, which the theme retints. */
+.sidebar-content a:not([aria-current='page']) [class*='sl-openapi-method-'] {
+  --sl-color-text-badge: #fff;
+}
+
 .sidebar-content a:not([aria-current='page']) .sl-openapi-method-get {
   --sl-color-bg-badge: var(--sl-openapi-method-bg-get);
   --sl-color-border-badge: var(--sl-openapi-method-border-get);

--- a/docs/src/styles/custom.css
+++ b/docs/src/styles/custom.css
@@ -75,6 +75,9 @@
 
   --sl-color-white: #111111;
   --sl-color-black: #ffffff;
+
+  --sl-badge-caution-bg: var(--sl-color-orange-low);
+  --sl-badge-caution-text: var(--sl-color-orange-high);
 }
 
 /* Apply different font for headings */


### PR DESCRIPTION
| Before (light theme) | After (light theme) |
   | :---: | :---: |
   | <img width="283" height="228" alt="Screenshot 2026-08-20 at 19 39 39" src="https://github.com/user-attachments/assets/34ea52f5-606b-4f99-bb31-13bf0523d4a7" /> | <img width="293" height="229" alt="image" src="https://github.com/user-attachments/assets/b31e80ce-80ec-4ce5-836e-df2609a0023d" /> |

### Checklist

- [X] No breaking changes
- [X] Tests pass
- [X] New features have new tests
- [X] Documentation is updated (if applicable)
- [X] Title of the PR is in the correct format (see below)

<!-- pi-reviewer:start -->
### **What this change solves**
The Constellation sidebar "Alpha" badge inherited Starlight's dark-theme caution colors even in light mode, leaving a dark/low-contrast pill against the white sidebar. This overrides the caution badge background and text tokens inside the light-theme block so the badge reads correctly on a light background, and pins the OpenAPI method badges to their own label color so they no longer follow that shared caution token.

___

### **Change Type**
Bug fix

___

### **Description**
- Add `--sl-badge-caution-bg: var(--sl-color-orange-low)` and `--sl-badge-caution-text: var(--sl-color-orange-high)` to the `[data-theme="light"]` custom-properties block in the docs theme.
- Scoped to the light theme only, so the existing dark-theme badge appearance is untouched.
- Pin `--sl-color-text-badge: #fff` on the OpenAPI method sidebar badges, which are rendered with `variant: 'caution'` and therefore otherwise picked up the new dark-orange label color on top of their dark per-method backgrounds.

___

<details> <summary><h3> File Walkthrough</h3></summary>

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody>
<tr><td><strong>Styling</strong></td><td><details><summary>2 files</summary><table>
<tr>
  <td><strong><a href="https://github.com/nhost/nhost/pull/4862/files">custom.css</a></strong><dd><code>Override caution badge background/text tokens in the light theme block</code></dd></td>
  <td>+3/-0</td>
</tr>
<tr>
  <td><strong><a href="https://github.com/nhost/nhost/pull/4862/files">styles.css</a></strong><dd><code>Keep OpenAPI method badge labels white instead of following the caution text token</code></dd></td>
  <td>+6/-0</td>
</tr>
</table></details></td></tr>
</tbody></table>

</details>

___

<!-- pi-reviewer:end -->
