### PR TITLE
chore(cli): update graphql types

### DIFF
--- a/cli/nhostclient/graphql/models_gen.go
+++ b/cli/nhostclient/graphql/models_gen.go
@@ -5956,6 +5956,63 @@ func (e CheckoutStatus) MarshalJSON() ([]byte, error) {
 	return buf.Bytes(), nil
 }
 
+type DatabaseRestorePurpose string
+
+const (
+	DatabaseRestorePurposeManual    DatabaseRestorePurpose = "MANUAL"
+	DatabaseRestorePurposeMigration DatabaseRestorePurpose = "MIGRATION"
+	DatabaseRestorePurposeUnpause   DatabaseRestorePurpose = "UNPAUSE"
+)
+
+var AllDatabaseRestorePurpose = []DatabaseRestorePurpose{
+	DatabaseRestorePurposeManual,
+	DatabaseRestorePurposeMigration,
+	DatabaseRestorePurposeUnpause,
+}
+
+func (e DatabaseRestorePurpose) IsValid() bool {
+	switch e {
+	case DatabaseRestorePurposeManual, DatabaseRestorePurposeMigration, DatabaseRestorePurposeUnpause:
+		return true
+	}
+	return false
+}
+
+func (e DatabaseRestorePurpose) String() string {
+	return string(e)
+}
+
+func (e *DatabaseRestorePurpose) UnmarshalGQL(v any) error {
+	str, ok := v.(string)
+	if !ok {
+		return fmt.Errorf("enums must be strings")
+	}
+
+	*e = DatabaseRestorePurpose(str)
+	if !e.IsValid() {
+		return fmt.Errorf("%s is not a valid DatabaseRestorePurpose", str)
+	}
+	return nil
+}
+
+func (e DatabaseRestorePurpose) MarshalGQL(w io.Writer) {
+	fmt.Fprint(w, strconv.Quote(e.String()))
+}
+
+func (e *DatabaseRestorePurpose) UnmarshalJSON(b []byte) error {
+	s, err := strconv.Unquote(string(b))
+	if err != nil {
+		return err
+	}
+	return e.UnmarshalGQL(s)
+}
+
+func (e DatabaseRestorePurpose) MarshalJSON() ([]byte, error) {
+	var buf bytes.Buffer
+	e.MarshalGQL(&buf)
+	return buf.Bytes(), nil
+}
+
 type FunctionsAggregate string
 
 const (


### PR DESCRIPTION
Regenerated `cli/nhostclient/graphql/models_gen.go` against the codegen control plane in `cli/gqlgenc.yaml`. It added the `DatabaseRestorePurpose` enum, so the committed file went stale and `go generate ./cli/...` fails the sha1sum check in the `gotests` derivation on any PR that invalidates the CLI cache.

Purely additive: one new enum plus its generated methods, 57 lines, no existing types changed.

Last seen on #4861, which only touches docs mdx, but those are inputs to the CLI derivation via `cli/project.nix`, so a docs change is enough to force a real rebuild and surface the drift.

Verified by generating twice from a clean tree and comparing `git hash-object` on the result, with `golines -w --base-formatter=gofumpt cli` applied after `go generate` to match what the check does before comparing checksums.