### PR TITLE
fix(dashboard): preserve roles and omit the Admin user-id header

### DIFF
--- a/dashboard/e2e/utils.ts
+++ b/dashboard/e2e/utils.ts
@@ -962,9 +962,9 @@ export async function navigateToGraphQLPlayground({
 
 /**
  * Selects a role in the GraphiQL playground's Role dropdown
- * (`UserAndRoleSelect`). Unlike editing the Headers JSON, this Radix Select
- * updates `userHeaders` synchronously (no debounce), so the rebuilt fetcher
- * carries `x-hasura-role: <role>` on the next request the caller triggers.
+ * (`UserAndRoleSelect`). This Radix Select updates the selection state
+ * synchronously, and the selection is composed into outgoing request headers,
+ * so the next request the caller triggers carries `x-hasura-role: <role>`.
  *
  * @param page - The Playwright page object.
  * @param role - The role to select (e.g. `public`).

--- a/dashboard/e2e/utils.ts
+++ b/dashboard/e2e/utils.ts
@@ -962,9 +962,9 @@ export async function navigateToGraphQLPlayground({
 
 /**
  * Selects a role in the GraphiQL playground's Role dropdown
- * (`UserAndRoleSelect`). This Radix Select updates the selection state
- * synchronously, and the selection is composed into outgoing request headers,
- * so the next request the caller triggers carries `x-hasura-role: <role>`.
+ * (`UserAndRoleSelect`). Unlike editing the Headers JSON, this Radix Select
+ * updates `selection` synchronously (no debounce), so the rebuilt fetcher
+ * carries `x-hasura-role: <role>` on the next request the caller triggers.
  *
  * @param page - The Playwright page object.
  * @param role - The role to select (e.g. `public`).

--- a/dashboard/src/features/orgs/projects/graphql/common/components/UserAndRoleSelect/UserAndRoleSelect.test.tsx
+++ b/dashboard/src/features/orgs/projects/graphql/common/components/UserAndRoleSelect/UserAndRoleSelect.test.tsx
@@ -1,0 +1,152 @@
+import UserAndRoleSelect from '@/features/orgs/projects/graphql/common/components/UserAndRoleSelect/UserAndRoleSelect';
+import {
+  act,
+  mockPointerEvent,
+  render,
+  screen,
+  TestUserEvent,
+  waitFor,
+} from '@/tests/testUtils';
+
+const USER_ID = '00000000-0000-0000-0000-000000000001';
+const SECOND_USER_ID = '00000000-0000-0000-0000-000000000002';
+
+const mocks = vi.hoisted(() => ({
+  fetchAppUsers: vi.fn(),
+  userApplicationClient: {},
+}));
+
+vi.mock('@mui/material/utils', () => ({
+  debounce: (callback: (...args: unknown[]) => unknown) => callback,
+}));
+
+vi.mock('@/features/orgs/hooks/useRemoteApplicationGQLClient', () => ({
+  useRemoteApplicationGQLClient: () => mocks.userApplicationClient,
+}));
+
+vi.mock('@/generated/graphql', async (importOriginal) => {
+  const actual = await importOriginal<typeof import('@/generated/graphql')>();
+
+  return {
+    ...actual,
+    useRemoteAppGetUsersAndAuthRolesLazyQuery: () => [mocks.fetchAppUsers],
+  };
+});
+
+mockPointerEvent();
+
+const usersResponse = {
+  data: {
+    users: [
+      {
+        id: USER_ID,
+        displayName: 'Tutorial User',
+        roles: [{ role: 'user' }, { role: 'editor' }],
+      },
+    ],
+    authRoles: [{ role: 'user' }, { role: 'editor' }],
+  },
+};
+
+const multipleUsersResponse = {
+  data: {
+    users: [
+      {
+        id: USER_ID,
+        displayName: 'First User',
+        roles: [{ role: 'user' }],
+      },
+      {
+        id: SECOND_USER_ID,
+        displayName: 'Second User',
+        roles: [{ role: 'me' }, { role: 'user' }],
+      },
+    ],
+    authRoles: [{ role: 'user' }, { role: 'me' }],
+  },
+};
+
+describe('UserAndRoleSelect', () => {
+  beforeEach(() => {
+    mocks.fetchAppUsers.mockReset();
+  });
+
+  it('keeps a non-admin role when the Admin user roles are refreshed by search', async () => {
+    let resolveRefetch: (response: typeof usersResponse) => void = () => {};
+    const refetchResponse = new Promise<typeof usersResponse>((resolve) => {
+      resolveRefetch = resolve;
+    });
+
+    mocks.fetchAppUsers
+      .mockResolvedValueOnce(usersResponse)
+      .mockReturnValueOnce(refetchResponse);
+
+    const onSelectionChange = vi.fn();
+    const user = new TestUserEvent();
+
+    render(<UserAndRoleSelect onSelectionChange={onSelectionChange} />);
+
+    await waitFor(() => {
+      expect(mocks.fetchAppUsers).toHaveBeenCalledTimes(1);
+      expect(onSelectionChange).toHaveBeenLastCalledWith({
+        userId: 'admin',
+        role: 'admin',
+      });
+    });
+
+    const userTrigger = screen.getAllByRole('combobox')[0];
+    const roleTrigger = screen.getByTestId('graphql-role-select');
+    await user.click(roleTrigger);
+    await user.click(screen.getByRole('option', { name: 'public' }));
+
+    await user.click(userTrigger);
+    await user.type(screen.getByPlaceholderText('Search...'), 't');
+
+    await waitFor(() => {
+      expect(mocks.fetchAppUsers).toHaveBeenCalledTimes(2);
+    });
+
+    await act(async () => {
+      resolveRefetch(usersResponse);
+      await refetchResponse;
+    });
+
+    expect(userTrigger).toHaveTextContent('Admin');
+    expect(roleTrigger).toHaveTextContent('public');
+    expect(onSelectionChange).toHaveBeenLastCalledWith({
+      userId: 'admin',
+      role: 'public',
+    });
+  });
+
+  it('resets the role to the first available role when the user changes', async () => {
+    mocks.fetchAppUsers.mockResolvedValue(multipleUsersResponse);
+
+    const onSelectionChange = vi.fn();
+    const user = new TestUserEvent();
+
+    render(<UserAndRoleSelect onSelectionChange={onSelectionChange} />);
+
+    await waitFor(() => {
+      expect(mocks.fetchAppUsers).toHaveBeenCalledTimes(1);
+    });
+
+    const userTrigger = screen.getAllByRole('combobox')[0];
+    await user.click(userTrigger);
+    await user.click(await screen.findByRole('option', { name: 'First User' }));
+
+    expect(onSelectionChange).toHaveBeenLastCalledWith({
+      userId: USER_ID,
+      role: 'user',
+    });
+
+    await user.click(userTrigger);
+    await user.click(screen.getByRole('option', { name: 'Second User' }));
+
+    expect(screen.getByTestId('graphql-role-select')).toHaveTextContent('me');
+    expect(onSelectionChange).toHaveBeenLastCalledWith({
+      userId: SECOND_USER_ID,
+      role: 'me',
+    });
+  });
+});

--- a/dashboard/src/features/orgs/projects/graphql/common/components/UserAndRoleSelect/UserAndRoleSelect.test.tsx
+++ b/dashboard/src/features/orgs/projects/graphql/common/components/UserAndRoleSelect/UserAndRoleSelect.test.tsx
@@ -89,7 +89,7 @@ describe('UserAndRoleSelect', () => {
     await waitFor(() => {
       expect(mocks.fetchAppUsers).toHaveBeenCalledTimes(1);
       expect(onSelectionChange).toHaveBeenLastCalledWith({
-        userId: 'admin',
+        userId: '',
         role: 'admin',
       });
     });
@@ -114,7 +114,7 @@ describe('UserAndRoleSelect', () => {
     expect(userTrigger).toHaveTextContent('Admin');
     expect(roleTrigger).toHaveTextContent('public');
     expect(onSelectionChange).toHaveBeenLastCalledWith({
-      userId: 'admin',
+      userId: '',
       role: 'public',
     });
   });

--- a/dashboard/src/features/orgs/projects/graphql/common/components/UserAndRoleSelect/UserAndRoleSelect.tsx
+++ b/dashboard/src/features/orgs/projects/graphql/common/components/UserAndRoleSelect/UserAndRoleSelect.tsx
@@ -7,38 +7,45 @@ import {
   SelectValue,
 } from '@/components/ui/v3/select';
 import { UserSelect } from '@/features/orgs/projects/graphql/common/components/UserSelect';
+import type { GraphQLPlaygroundSelection } from '@/features/orgs/projects/graphql/common/utils/composeRequestHeaders';
 
 /**
  * Component that combines user selection and role selection functionality
  */
 interface UserAndRoleSelectProps {
   /**
-   * Function to be called when the user changes.
+   * Function to be called when the user or role changes.
    */
-  onUserChange: (userId: string) => void;
-  /**
-   * Function to be called when the role changes.
-   */
-  onRoleChange: (role: string) => void;
+  onSelectionChange: (selection: GraphQLPlaygroundSelection) => void;
 }
 
 export default function UserAndRoleSelect({
-  onUserChange,
-  onRoleChange,
+  onSelectionChange,
 }: UserAndRoleSelectProps) {
   const [availableRoles, setAvailableRoles] = useState<string[]>([]);
-  const [role, setRole] = useState<string>(() => availableRoles[0]);
+  const [userId, setUserId] = useState('');
+  const [role, setRole] = useState('');
 
-  const handleUserChange = (userId: string, availableUserRoles: string[]) => {
-    onUserChange(userId);
+  const handleUserChange = (
+    nextUserId: string,
+    availableUserRoles: string[],
+  ) => {
     setAvailableRoles(availableUserRoles);
 
-    const newRole = availableUserRoles[0];
+    const shouldKeepCurrentRole =
+      nextUserId === userId && availableUserRoles.includes(role);
+    const nextRole = shouldKeepCurrentRole
+      ? role
+      : (availableUserRoles[0] ?? '');
 
-    if (newRole) {
-      setRole(newRole);
-      onRoleChange(newRole);
-    }
+    setUserId(nextUserId);
+    setRole(nextRole);
+    onSelectionChange({ userId: nextUserId, role: nextRole });
+  };
+
+  const handleRoleChange = (nextRole: string) => {
+    setRole(nextRole);
+    onSelectionChange({ userId, role: nextRole });
   };
 
   return (
@@ -52,13 +59,7 @@ export default function UserAndRoleSelect({
         <span className="font-semibold text-muted-foreground text-xs uppercase tracking-wider">
           Role
         </span>
-        <Select
-          value={role}
-          onValueChange={(value) => {
-            setRole(value);
-            onRoleChange(value);
-          }}
-        >
+        <Select value={role} onValueChange={handleRoleChange}>
           <SelectTrigger
             aria-label="Role"
             data-testid="graphql-role-select"

--- a/dashboard/src/features/orgs/projects/graphql/common/components/UserSelect/UserSelect.test.tsx
+++ b/dashboard/src/features/orgs/projects/graphql/common/components/UserSelect/UserSelect.test.tsx
@@ -69,7 +69,7 @@ describe('UserSelect', () => {
 
     await waitFor(() => {
       expect(mocks.fetchAppUsers).toHaveBeenCalledTimes(1);
-      expect(onUserChange).toHaveBeenCalledWith('admin', [
+      expect(onUserChange).toHaveBeenCalledWith('', [
         'admin',
         'public',
         'anonymous',

--- a/dashboard/src/features/orgs/projects/graphql/common/components/UserSelect/UserSelect.tsx
+++ b/dashboard/src/features/orgs/projects/graphql/common/components/UserSelect/UserSelect.tsx
@@ -11,7 +11,8 @@ import { cn, isNotEmptyValue } from '@/lib/utils';
 
 export interface UserSelectProps {
   /**
-   * Function to be called when the user changes.
+   * Function to be called when the user changes. The Admin pseudo-entry
+   * emits an empty `userId` because it does not represent a real user.
    */
   onUserChange: (userId: string, availableRoles: string[]) => void;
   /**
@@ -93,7 +94,7 @@ export default function UserSelect({
   // biome-ignore lint/correctness/useExhaustiveDependencies: only want to run the effect when adminAuthRoles changes
   useEffect(() => {
     if (selectedUserId === 'admin') {
-      onUserChange('admin', getAdminRoles(adminAuthRoles));
+      onUserChange('', getAdminRoles(adminAuthRoles));
     }
   }, [adminAuthRoles]);
 
@@ -126,7 +127,7 @@ export default function UserSelect({
           setSelectedUserId(value);
 
           if (value === 'admin') {
-            onUserChange('admin', getAdminRoles(adminAuthRoles));
+            onUserChange('', getAdminRoles(adminAuthRoles));
             return;
           }
 

--- a/dashboard/src/features/orgs/projects/graphql/common/utils/composeRequestHeaders/composeRequestHeaders.test.ts
+++ b/dashboard/src/features/orgs/projects/graphql/common/utils/composeRequestHeaders/composeRequestHeaders.test.ts
@@ -1,20 +1,80 @@
+import { createGraphiQLFetcher } from '@graphiql/toolkit';
+import { parse } from 'graphql';
+import type {
+  Client,
+  ExecutionResult,
+  Sink,
+  SubscribePayload,
+} from 'graphql-ws';
 import {
   composeRequestHeaders,
   type GraphQLPlaygroundSelection,
 } from '@/features/orgs/projects/graphql/common/utils/composeRequestHeaders';
 
+const adminSecret = 'admin-secret';
 const selection: GraphQLPlaygroundSelection = {
   userId: 'user-1',
   role: 'user',
 };
 
+function createRequestMock() {
+  return vi.fn<typeof fetch>().mockResolvedValue(
+    new Response(JSON.stringify({ data: { __typename: 'query_root' } }), {
+      headers: { 'content-type': 'application/json' },
+    }),
+  );
+}
+
+function createTestFetcher(
+  requestMock: typeof fetch,
+  currentSelection = selection,
+  wsClient?: Client,
+) {
+  const graphiqlFetcher = createGraphiQLFetcher({
+    url: 'https://local.graphql.nhost.run/v1/graphql',
+    fetch: requestMock,
+    enableIncrementalDelivery: false,
+    ...(wsClient ? { wsClient } : {}),
+  });
+  const fetcher: typeof graphiqlFetcher = (graphQLParams, fetcherOpts) =>
+    graphiqlFetcher(graphQLParams, {
+      ...fetcherOpts,
+      headers: composeRequestHeaders({
+        adminSecret,
+        selection: currentSelection,
+        headersTabOverrides: fetcherOpts?.headers,
+      }),
+    });
+
+  return fetcher;
+}
+
+async function sendRequest(
+  headersTabOverrides: Record<string, unknown>,
+  currentSelection = selection,
+) {
+  const requestMock = createRequestMock();
+  const fetcher = createTestFetcher(requestMock, currentSelection);
+
+  await fetcher(
+    { query: 'query TestQuery { __typename }', operationName: 'TestQuery' },
+    { headers: headersTabOverrides },
+  );
+
+  return requestMock;
+}
+
+function getSentHeaders(
+  requestMock: ReturnType<typeof createRequestMock>,
+): Record<string, string> {
+  return requestMock.mock.calls[0][1]?.headers as Record<string, string>;
+}
+
 describe('composeRequestHeaders', () => {
   it('composes the base and selector headers', () => {
-    expect(
-      composeRequestHeaders({ adminSecret: 'admin-secret', selection }),
-    ).toEqual({
+    expect(composeRequestHeaders({ adminSecret, selection })).toEqual({
       'content-type': 'application/json',
-      'x-hasura-admin-secret': 'admin-secret',
+      'x-hasura-admin-secret': adminSecret,
       'x-hasura-user-id': 'user-1',
       'x-hasura-role': 'user',
     });
@@ -23,19 +83,19 @@ describe('composeRequestHeaders', () => {
   it('omits empty selector headers', () => {
     expect(
       composeRequestHeaders({
-        adminSecret: 'admin-secret',
+        adminSecret,
         selection: { userId: '', role: '' },
       }),
     ).toEqual({
       'content-type': 'application/json',
-      'x-hasura-admin-secret': 'admin-secret',
+      'x-hasura-admin-secret': adminSecret,
     });
   });
 
-  it('normalizes Headers-tab overrides and lets them win', () => {
+  it('normalizes WebSocket Headers-tab overrides and lets them win', () => {
     expect(
       composeRequestHeaders({
-        adminSecret: 'admin-secret',
+        adminSecret,
         selection,
         headersTabOverrides: {
           'X-Hasura-Role': '',
@@ -48,11 +108,141 @@ describe('composeRequestHeaders', () => {
         },
       }),
     ).toEqual({
+      accept: 'text/plain',
       'content-type': 'text/plain',
       'x-hasura-admin-secret': 'override-secret',
       'x-hasura-user-id': 'user-1',
       'x-hasura-role': '',
       'x-retry-count': '3',
     });
+  });
+});
+
+describe('GraphiQL fetcher adapter', () => {
+  it('applies mixed-case HTTP overrides exactly once', async () => {
+    const requestMock = await sendRequest(
+      {
+        'X-Hasura-Role': 'editor',
+        'X-Hasura-Admin-Secret': 'override-secret',
+        'Content-Type': 'application/graphql-response+json',
+      },
+      { ...selection, role: 'public' },
+    );
+    const headers = getSentHeaders(requestMock);
+
+    for (const name of [
+      'x-hasura-role',
+      'x-hasura-admin-secret',
+      'content-type',
+    ]) {
+      expect(
+        Object.keys(headers).filter(
+          (headerName) => headerName.toLowerCase() === name,
+        ),
+      ).toEqual([name]);
+    }
+    expect(headers).toMatchObject({
+      'content-type': 'application/graphql-response+json',
+      'x-hasura-admin-secret': 'override-secret',
+      'x-hasura-role': 'editor',
+    });
+  });
+
+  it('preserves selection and admin secret after an unrelated Headers-tab edit', async () => {
+    const requestMock = await sendRequest({
+      'X-Trace-Identifier': 'trace-id',
+    });
+
+    expect(getSentHeaders(requestMock)).toMatchObject({
+      'x-hasura-admin-secret': adminSecret,
+      'x-hasura-user-id': 'user-1',
+      'x-hasura-role': 'user',
+      'x-trace-identifier': 'trace-id',
+    });
+  });
+
+  it('passes a Headers-tab Accept override through exactly once', async () => {
+    const requestMock = await sendRequest({ Accept: 'text/plain' });
+    const headers = getSentHeaders(requestMock);
+
+    expect(
+      Object.keys(headers).filter((name) => name.toLowerCase() === 'accept'),
+    ).toEqual(['accept']);
+    expect(headers.accept).toBe('text/plain');
+  });
+
+  it('returns a Promise for introspection and composes the execution headers', async () => {
+    const requestMock = createRequestMock();
+    const fetcher = createTestFetcher(requestMock);
+    const result = fetcher(
+      {
+        query: 'query IntrospectionQuery { __typename }',
+        operationName: 'IntrospectionQuery',
+      },
+      {
+        headers: {
+          'X-Hasura-Admin-Secret': 'override-secret',
+        },
+      },
+    );
+
+    expect(result).toBeInstanceOf(Promise);
+    await result;
+
+    const headers = getSentHeaders(requestMock);
+    expect(
+      Object.keys(headers).filter(
+        (name) => name.toLowerCase() === 'x-hasura-admin-secret',
+      ),
+    ).toEqual(['x-hasura-admin-secret']);
+    expect(headers).toMatchObject({
+      'content-type': 'application/json',
+      'x-hasura-admin-secret': 'override-secret',
+      'x-hasura-user-id': 'user-1',
+      'x-hasura-role': 'user',
+    });
+  });
+
+  it('preserves documentAST so subscriptions route through the WebSocket client', async () => {
+    const requestMock = createRequestMock();
+    const subscribeMock = vi.fn(
+      (
+        _payload: SubscribePayload,
+        sink: Sink<ExecutionResult>,
+      ): VoidFunction => {
+        queueMicrotask(() => {
+          sink.next({ data: { messages: [] } });
+          sink.complete();
+        });
+
+        return () => {};
+      },
+    );
+    const wsClient = { subscribe: subscribeMock } as unknown as Client;
+    const fetcher = createTestFetcher(requestMock, selection, wsClient);
+    const graphQLParams = {
+      query: 'subscription TestSubscription { messages { id } }',
+      operationName: 'TestSubscription',
+    };
+    const result = fetcher(graphQLParams, {
+      documentAST: parse(graphQLParams.query),
+      headers: { 'X-Hasura-Role': 'editor' },
+    });
+    const iterator = (result as AsyncIterable<ExecutionResult>)[
+      Symbol.asyncIterator
+    ]();
+
+    await expect(iterator.next()).resolves.toMatchObject({
+      value: { data: { messages: [] } },
+    });
+    expect(subscribeMock).toHaveBeenCalledWith(
+      graphQLParams,
+      expect.objectContaining({
+        next: expect.any(Function),
+        error: expect.any(Function),
+        complete: expect.any(Function),
+      }),
+    );
+    expect(requestMock).not.toHaveBeenCalled();
   });
 });

--- a/dashboard/src/features/orgs/projects/graphql/common/utils/composeRequestHeaders/composeRequestHeaders.test.ts
+++ b/dashboard/src/features/orgs/projects/graphql/common/utils/composeRequestHeaders/composeRequestHeaders.test.ts
@@ -1,14 +1,9 @@
-import { createGraphiQLFetcher } from '@graphiql/toolkit';
+import { createGraphiQLFetcher, type Fetcher } from '@graphiql/toolkit';
 import { parse } from 'graphql';
-import type {
-  Client,
-  ExecutionResult,
-  Sink,
-  SubscribePayload,
-} from 'graphql-ws';
 import {
   composeRequestHeaders,
   type GraphQLPlaygroundSelection,
+  withRequestHeaders,
 } from '@/features/orgs/projects/graphql/common/utils/composeRequestHeaders';
 
 const adminSecret = 'admin-secret';
@@ -28,25 +23,18 @@ function createRequestMock() {
 function createTestFetcher(
   requestMock: typeof fetch,
   currentSelection = selection,
-  wsClient?: Client,
 ) {
   const graphiqlFetcher = createGraphiQLFetcher({
     url: 'https://local.graphql.nhost.run/v1/graphql',
     fetch: requestMock,
     enableIncrementalDelivery: false,
-    ...(wsClient ? { wsClient } : {}),
   });
-  const fetcher: typeof graphiqlFetcher = (graphQLParams, fetcherOpts) =>
-    graphiqlFetcher(graphQLParams, {
-      ...fetcherOpts,
-      headers: composeRequestHeaders({
-        adminSecret,
-        selection: currentSelection,
-        headersTabOverrides: fetcherOpts?.headers,
-      }),
-    });
 
-  return fetcher;
+  return withRequestHeaders({
+    fetcher: graphiqlFetcher,
+    adminSecret,
+    selection: currentSelection,
+  });
 }
 
 async function sendRequest(
@@ -203,46 +191,32 @@ describe('GraphiQL fetcher adapter', () => {
     });
   });
 
-  it('preserves documentAST so subscriptions route through the WebSocket client', async () => {
-    const requestMock = createRequestMock();
-    const subscribeMock = vi.fn(
-      (
-        _payload: SubscribePayload,
-        sink: Sink<ExecutionResult>,
-      ): VoidFunction => {
-        queueMicrotask(() => {
-          sink.next({ data: { messages: [] } });
-          sink.complete();
-        });
-
-        return () => {};
-      },
-    );
-    const wsClient = { subscribe: subscribeMock } as unknown as Client;
-    const fetcher = createTestFetcher(requestMock, selection, wsClient);
+  it('preserves fetcher options while composing execution headers', () => {
+    const delegate = vi.fn<Fetcher>().mockResolvedValue({ data: {} });
+    const fetcher = withRequestHeaders({
+      fetcher: delegate,
+      adminSecret,
+      selection,
+    });
     const graphQLParams = {
       query: 'subscription TestSubscription { messages { id } }',
       operationName: 'TestSubscription',
     };
-    const result = fetcher(graphQLParams, {
-      documentAST: parse(graphQLParams.query),
+    const documentAST = parse(graphQLParams.query);
+
+    fetcher(graphQLParams, {
+      documentAST,
       headers: { 'X-Hasura-Role': 'editor' },
     });
-    const iterator = (result as AsyncIterable<ExecutionResult>)[
-      Symbol.asyncIterator
-    ]();
 
-    await expect(iterator.next()).resolves.toMatchObject({
-      value: { data: { messages: [] } },
+    expect(delegate).toHaveBeenCalledWith(graphQLParams, {
+      documentAST,
+      headers: {
+        'content-type': 'application/json',
+        'x-hasura-admin-secret': adminSecret,
+        'x-hasura-user-id': 'user-1',
+        'x-hasura-role': 'editor',
+      },
     });
-    expect(subscribeMock).toHaveBeenCalledWith(
-      graphQLParams,
-      expect.objectContaining({
-        next: expect.any(Function),
-        error: expect.any(Function),
-        complete: expect.any(Function),
-      }),
-    );
-    expect(requestMock).not.toHaveBeenCalled();
   });
 });

--- a/dashboard/src/features/orgs/projects/graphql/common/utils/composeRequestHeaders/composeRequestHeaders.test.ts
+++ b/dashboard/src/features/orgs/projects/graphql/common/utils/composeRequestHeaders/composeRequestHeaders.test.ts
@@ -80,6 +80,45 @@ describe('composeRequestHeaders', () => {
 });
 
 describe('withRequestHeaders', () => {
+  it('sends the selection composed with Headers-tab overrides on wrapped queries', async () => {
+    const requestMock = vi
+      .fn<typeof fetch>()
+      .mockResolvedValue({ json: async () => ({ data: {} }) } as Response);
+    const baseFetcher = createGraphiQLFetcher({
+      url: 'https://local.graphql.nhost.run/v1/graphql',
+      fetch: requestMock,
+      enableIncrementalDelivery: false,
+    });
+    const fetcher = withRequestHeaders({
+      fetcher: baseFetcher,
+      adminSecret,
+      selection,
+    });
+    const graphQLParams = {
+      query: 'query TestQuery { messages { id } }',
+      operationName: 'TestQuery',
+    };
+
+    await fetcher(graphQLParams, {
+      documentAST: parse(graphQLParams.query),
+      headers: { 'X-Hasura-Role': 'editor' },
+    });
+
+    expect(requestMock).toHaveBeenCalledWith(
+      'https://local.graphql.nhost.run/v1/graphql',
+      {
+        method: 'POST',
+        body: JSON.stringify(graphQLParams),
+        headers: {
+          'content-type': 'application/json',
+          'x-hasura-admin-secret': adminSecret,
+          'x-hasura-user-id': 'user-1',
+          'x-hasura-role': 'editor',
+        },
+      },
+    );
+  });
+
   it('routes wrapped subscriptions through the WebSocket client', async () => {
     const requestMock = vi.fn<typeof fetch>();
     const subscribeMock = vi.fn(

--- a/dashboard/src/features/orgs/projects/graphql/common/utils/composeRequestHeaders/composeRequestHeaders.test.ts
+++ b/dashboard/src/features/orgs/projects/graphql/common/utils/composeRequestHeaders/composeRequestHeaders.test.ts
@@ -85,7 +85,7 @@ describe('withRequestHeaders', () => {
       .fn<typeof fetch>()
       .mockResolvedValue({ json: async () => ({ data: {} }) } as Response);
     const baseFetcher = createGraphiQLFetcher({
-      url: 'https://local.graphql.nhost.run/v1/graphql',
+      url: 'https://local.graphql.local.nhost.run/v1/graphql',
       fetch: requestMock,
       enableIncrementalDelivery: false,
     });
@@ -105,7 +105,7 @@ describe('withRequestHeaders', () => {
     });
 
     expect(requestMock).toHaveBeenCalledWith(
-      'https://local.graphql.nhost.run/v1/graphql',
+      'https://local.graphql.local.nhost.run/v1/graphql',
       {
         method: 'POST',
         body: JSON.stringify(graphQLParams),
@@ -131,7 +131,7 @@ describe('withRequestHeaders', () => {
       },
     );
     const baseFetcher = createGraphiQLFetcher({
-      url: 'https://local.graphql.nhost.run/v1/graphql',
+      url: 'https://local.graphql.local.nhost.run/v1/graphql',
       fetch: requestMock,
       enableIncrementalDelivery: false,
       wsClient: { subscribe: subscribeMock } as unknown as Client,

--- a/dashboard/src/features/orgs/projects/graphql/common/utils/composeRequestHeaders/composeRequestHeaders.test.ts
+++ b/dashboard/src/features/orgs/projects/graphql/common/utils/composeRequestHeaders/composeRequestHeaders.test.ts
@@ -1,5 +1,11 @@
-import { createGraphiQLFetcher, type Fetcher } from '@graphiql/toolkit';
+import { createGraphiQLFetcher } from '@graphiql/toolkit';
 import { parse } from 'graphql';
+import type {
+  Client,
+  ExecutionResult,
+  Sink,
+  SubscribePayload,
+} from 'graphql-ws';
 import {
   composeRequestHeaders,
   type GraphQLPlaygroundSelection,
@@ -11,52 +17,6 @@ const selection: GraphQLPlaygroundSelection = {
   userId: 'user-1',
   role: 'user',
 };
-
-function createRequestMock() {
-  return vi.fn<typeof fetch>().mockResolvedValue(
-    new Response(JSON.stringify({ data: { __typename: 'query_root' } }), {
-      headers: { 'content-type': 'application/json' },
-    }),
-  );
-}
-
-function createTestFetcher(
-  requestMock: typeof fetch,
-  currentSelection = selection,
-) {
-  const graphiqlFetcher = createGraphiQLFetcher({
-    url: 'https://local.graphql.nhost.run/v1/graphql',
-    fetch: requestMock,
-    enableIncrementalDelivery: false,
-  });
-
-  return withRequestHeaders({
-    fetcher: graphiqlFetcher,
-    adminSecret,
-    selection: currentSelection,
-  });
-}
-
-async function sendRequest(
-  headersTabOverrides: Record<string, unknown>,
-  currentSelection = selection,
-) {
-  const requestMock = createRequestMock();
-  const fetcher = createTestFetcher(requestMock, currentSelection);
-
-  await fetcher(
-    { query: 'query TestQuery { __typename }', operationName: 'TestQuery' },
-    { headers: headersTabOverrides },
-  );
-
-  return requestMock;
-}
-
-function getSentHeaders(
-  requestMock: ReturnType<typeof createRequestMock>,
-): Record<string, string> {
-  return requestMock.mock.calls[0][1]?.headers as Record<string, string>;
-}
 
 describe('composeRequestHeaders', () => {
   it('composes the base and selector headers', () => {
@@ -77,6 +37,19 @@ describe('composeRequestHeaders', () => {
     ).toEqual({
       'content-type': 'application/json',
       'x-hasura-admin-secret': adminSecret,
+    });
+  });
+
+  it('sends the role without x-hasura-user-id for the Admin selection', () => {
+    expect(
+      composeRequestHeaders({
+        adminSecret,
+        selection: { userId: '', role: 'admin' },
+      }),
+    ).toEqual({
+      'content-type': 'application/json',
+      'x-hasura-admin-secret': adminSecret,
+      'x-hasura-role': 'admin',
     });
   });
 
@@ -106,93 +79,26 @@ describe('composeRequestHeaders', () => {
   });
 });
 
-describe('GraphiQL fetcher adapter', () => {
-  it('applies mixed-case HTTP overrides exactly once', async () => {
-    const requestMock = await sendRequest(
-      {
-        'X-Hasura-Role': 'editor',
-        'X-Hasura-Admin-Secret': 'override-secret',
-        'Content-Type': 'application/graphql-response+json',
-      },
-      { ...selection, role: 'public' },
-    );
-    const headers = getSentHeaders(requestMock);
-
-    for (const name of [
-      'x-hasura-role',
-      'x-hasura-admin-secret',
-      'content-type',
-    ]) {
-      expect(
-        Object.keys(headers).filter(
-          (headerName) => headerName.toLowerCase() === name,
-        ),
-      ).toEqual([name]);
-    }
-    expect(headers).toMatchObject({
-      'content-type': 'application/graphql-response+json',
-      'x-hasura-admin-secret': 'override-secret',
-      'x-hasura-role': 'editor',
-    });
-  });
-
-  it('preserves selection and admin secret after an unrelated Headers-tab edit', async () => {
-    const requestMock = await sendRequest({
-      'X-Trace-Identifier': 'trace-id',
-    });
-
-    expect(getSentHeaders(requestMock)).toMatchObject({
-      'x-hasura-admin-secret': adminSecret,
-      'x-hasura-user-id': 'user-1',
-      'x-hasura-role': 'user',
-      'x-trace-identifier': 'trace-id',
-    });
-  });
-
-  it('passes a Headers-tab Accept override through exactly once', async () => {
-    const requestMock = await sendRequest({ Accept: 'text/plain' });
-    const headers = getSentHeaders(requestMock);
-
-    expect(
-      Object.keys(headers).filter((name) => name.toLowerCase() === 'accept'),
-    ).toEqual(['accept']);
-    expect(headers.accept).toBe('text/plain');
-  });
-
-  it('composes introspection request headers', async () => {
-    const requestMock = createRequestMock();
-    const fetcher = createTestFetcher(requestMock);
-
-    await fetcher(
-      {
-        query: 'query IntrospectionQuery { __typename }',
-        operationName: 'IntrospectionQuery',
-      },
-      {
-        headers: {
-          'X-Hasura-Admin-Secret': 'override-secret',
-        },
+describe('withRequestHeaders', () => {
+  it('routes wrapped subscriptions through the WebSocket client', async () => {
+    const requestMock = vi.fn<typeof fetch>();
+    const subscribeMock = vi.fn(
+      (
+        _payload: SubscribePayload,
+        sink: Sink<ExecutionResult>,
+      ): VoidFunction => {
+        queueMicrotask(() => sink.complete());
+        return () => {};
       },
     );
-
-    const headers = getSentHeaders(requestMock);
-    expect(
-      Object.keys(headers).filter(
-        (name) => name.toLowerCase() === 'x-hasura-admin-secret',
-      ),
-    ).toEqual(['x-hasura-admin-secret']);
-    expect(headers).toMatchObject({
-      'content-type': 'application/json',
-      'x-hasura-admin-secret': 'override-secret',
-      'x-hasura-user-id': 'user-1',
-      'x-hasura-role': 'user',
+    const baseFetcher = createGraphiQLFetcher({
+      url: 'https://local.graphql.nhost.run/v1/graphql',
+      fetch: requestMock,
+      enableIncrementalDelivery: false,
+      wsClient: { subscribe: subscribeMock } as unknown as Client,
     });
-  });
-
-  it('preserves fetcher options while composing execution headers', () => {
-    const delegate = vi.fn<Fetcher>().mockResolvedValue({ data: {} });
     const fetcher = withRequestHeaders({
-      fetcher: delegate,
+      fetcher: baseFetcher,
       adminSecret,
       selection,
     });
@@ -200,21 +106,19 @@ describe('GraphiQL fetcher adapter', () => {
       query: 'subscription TestSubscription { messages { id } }',
       operationName: 'TestSubscription',
     };
-    const documentAST = parse(graphQLParams.query);
-
-    fetcher(graphQLParams, {
-      documentAST,
+    const result = fetcher(graphQLParams, {
+      documentAST: parse(graphQLParams.query),
       headers: { 'X-Hasura-Role': 'editor' },
     });
 
-    expect(delegate).toHaveBeenCalledWith(graphQLParams, {
-      documentAST,
-      headers: {
-        'content-type': 'application/json',
-        'x-hasura-admin-secret': adminSecret,
-        'x-hasura-user-id': 'user-1',
-        'x-hasura-role': 'editor',
-      },
-    });
+    await (result as AsyncIterable<ExecutionResult>)
+      [Symbol.asyncIterator]()
+      .next();
+
+    expect(subscribeMock).toHaveBeenCalledWith(
+      graphQLParams,
+      expect.any(Object),
+    );
+    expect(requestMock).not.toHaveBeenCalled();
   });
 });

--- a/dashboard/src/features/orgs/projects/graphql/common/utils/composeRequestHeaders/composeRequestHeaders.test.ts
+++ b/dashboard/src/features/orgs/projects/graphql/common/utils/composeRequestHeaders/composeRequestHeaders.test.ts
@@ -159,10 +159,11 @@ describe('GraphiQL fetcher adapter', () => {
     expect(headers.accept).toBe('text/plain');
   });
 
-  it('returns a Promise for introspection and composes the execution headers', async () => {
+  it('composes introspection request headers', async () => {
     const requestMock = createRequestMock();
     const fetcher = createTestFetcher(requestMock);
-    const result = fetcher(
+
+    await fetcher(
       {
         query: 'query IntrospectionQuery { __typename }',
         operationName: 'IntrospectionQuery',
@@ -173,9 +174,6 @@ describe('GraphiQL fetcher adapter', () => {
         },
       },
     );
-
-    expect(result).toBeInstanceOf(Promise);
-    await result;
 
     const headers = getSentHeaders(requestMock);
     expect(

--- a/dashboard/src/features/orgs/projects/graphql/common/utils/composeRequestHeaders/composeRequestHeaders.test.ts
+++ b/dashboard/src/features/orgs/projects/graphql/common/utils/composeRequestHeaders/composeRequestHeaders.test.ts
@@ -1,0 +1,58 @@
+import {
+  composeRequestHeaders,
+  type GraphQLPlaygroundSelection,
+} from '@/features/orgs/projects/graphql/common/utils/composeRequestHeaders';
+
+const selection: GraphQLPlaygroundSelection = {
+  userId: 'user-1',
+  role: 'user',
+};
+
+describe('composeRequestHeaders', () => {
+  it('composes the base and selector headers', () => {
+    expect(
+      composeRequestHeaders({ adminSecret: 'admin-secret', selection }),
+    ).toEqual({
+      'content-type': 'application/json',
+      'x-hasura-admin-secret': 'admin-secret',
+      'x-hasura-user-id': 'user-1',
+      'x-hasura-role': 'user',
+    });
+  });
+
+  it('omits empty selector headers', () => {
+    expect(
+      composeRequestHeaders({
+        adminSecret: 'admin-secret',
+        selection: { userId: '', role: '' },
+      }),
+    ).toEqual({
+      'content-type': 'application/json',
+      'x-hasura-admin-secret': 'admin-secret',
+    });
+  });
+
+  it('normalizes Headers-tab overrides and lets them win', () => {
+    expect(
+      composeRequestHeaders({
+        adminSecret: 'admin-secret',
+        selection,
+        headersTabOverrides: {
+          'X-Hasura-Role': '',
+          'X-Hasura-Admin-Secret': 'override-secret',
+          'Content-Type': 'text/plain',
+          Accept: 'text/plain',
+          'X-Retry-Count': 3,
+          'X-Custom-Null': null,
+          'X-Custom-Undefined': undefined,
+        },
+      }),
+    ).toEqual({
+      'content-type': 'text/plain',
+      'x-hasura-admin-secret': 'override-secret',
+      'x-hasura-user-id': 'user-1',
+      'x-hasura-role': '',
+      'x-retry-count': '3',
+    });
+  });
+});

--- a/dashboard/src/features/orgs/projects/graphql/common/utils/composeRequestHeaders/composeRequestHeaders.ts
+++ b/dashboard/src/features/orgs/projects/graphql/common/utils/composeRequestHeaders/composeRequestHeaders.ts
@@ -10,7 +10,7 @@ interface ComposeRequestHeadersOptions {
 }
 
 /**
- * Later layers win case-insensitive key collisions; `accept` is deliberately never emitted.
+ * Later layers win case-insensitive key collisions.
  */
 export default function composeRequestHeaders({
   adminSecret,
@@ -21,10 +21,6 @@ export default function composeRequestHeaders({
 
   const setHeader = (name: string, value: string) => {
     const canonicalName = name.toLowerCase();
-
-    if (canonicalName === 'accept') {
-      return;
-    }
 
     headers[canonicalName] = value;
   };

--- a/dashboard/src/features/orgs/projects/graphql/common/utils/composeRequestHeaders/composeRequestHeaders.ts
+++ b/dashboard/src/features/orgs/projects/graphql/common/utils/composeRequestHeaders/composeRequestHeaders.ts
@@ -1,3 +1,5 @@
+import type { Fetcher } from '@graphiql/toolkit';
+
 export type GraphQLPlaygroundSelection = {
   userId: string;
   role: string;
@@ -7,6 +9,12 @@ interface ComposeRequestHeadersOptions {
   adminSecret: string;
   selection: GraphQLPlaygroundSelection;
   headersTabOverrides?: Record<string, unknown>;
+}
+
+interface WithRequestHeadersOptions {
+  fetcher: Fetcher;
+  adminSecret: string;
+  selection: GraphQLPlaygroundSelection;
 }
 
 /**
@@ -37,12 +45,28 @@ export default function composeRequestHeaders({
   }
 
   for (const [name, value] of Object.entries(headersTabOverrides ?? {})) {
-    if (value === null || value === undefined) {
+    if (value == null) {
       continue;
     }
 
-    setHeader(name, typeof value === 'string' ? value : String(value));
+    setHeader(name, String(value));
   }
 
   return headers;
+}
+
+export function withRequestHeaders({
+  fetcher,
+  adminSecret,
+  selection,
+}: WithRequestHeadersOptions): Fetcher {
+  return (graphQLParams, fetcherOpts) =>
+    fetcher(graphQLParams, {
+      ...fetcherOpts,
+      headers: composeRequestHeaders({
+        adminSecret,
+        selection,
+        headersTabOverrides: fetcherOpts?.headers,
+      }),
+    });
 }

--- a/dashboard/src/features/orgs/projects/graphql/common/utils/composeRequestHeaders/composeRequestHeaders.ts
+++ b/dashboard/src/features/orgs/projects/graphql/common/utils/composeRequestHeaders/composeRequestHeaders.ts
@@ -26,23 +26,17 @@ export default function composeRequestHeaders({
   selection,
   headersTabOverrides,
 }: ComposeRequestHeadersOptions): Record<string, string> {
-  const headers: Record<string, string> = {};
+  const headers = new Headers();
 
-  const setHeader = (name: string, value: string) => {
-    const canonicalName = name.toLowerCase();
-
-    headers[canonicalName] = value;
-  };
-
-  setHeader('content-type', 'application/json');
-  setHeader('x-hasura-admin-secret', adminSecret);
+  headers.set('content-type', 'application/json');
+  headers.set('x-hasura-admin-secret', adminSecret);
 
   if (selection.userId) {
-    setHeader('x-hasura-user-id', selection.userId);
+    headers.set('x-hasura-user-id', selection.userId);
   }
 
   if (selection.role) {
-    setHeader('x-hasura-role', selection.role);
+    headers.set('x-hasura-role', selection.role);
   }
 
   for (const [name, value] of Object.entries(headersTabOverrides ?? {})) {
@@ -50,10 +44,12 @@ export default function composeRequestHeaders({
       continue;
     }
 
-    setHeader(name, String(value));
+    headers.set(name, String(value));
   }
 
-  return headers;
+  // GraphiQL spreads these into a plain object and graphql-ws JSON-serializes
+  // them, so a Headers instance would silently reduce to {}.
+  return Object.fromEntries(headers);
 }
 
 export function withRequestHeaders({

--- a/dashboard/src/features/orgs/projects/graphql/common/utils/composeRequestHeaders/composeRequestHeaders.ts
+++ b/dashboard/src/features/orgs/projects/graphql/common/utils/composeRequestHeaders/composeRequestHeaders.ts
@@ -18,7 +18,8 @@ interface WithRequestHeadersOptions {
 }
 
 /**
- * Later layers win case-insensitive key collisions.
+ * Composes base, selection, and Headers-tab headers in precedence order,
+ * normalizing header names to lowercase.
  */
 export default function composeRequestHeaders({
   adminSecret,

--- a/dashboard/src/features/orgs/projects/graphql/common/utils/composeRequestHeaders/composeRequestHeaders.ts
+++ b/dashboard/src/features/orgs/projects/graphql/common/utils/composeRequestHeaders/composeRequestHeaders.ts
@@ -1,0 +1,52 @@
+export type GraphQLPlaygroundSelection = {
+  userId: string;
+  role: string;
+};
+
+interface ComposeRequestHeadersOptions {
+  adminSecret: string;
+  selection: GraphQLPlaygroundSelection;
+  headersTabOverrides?: Record<string, unknown>;
+}
+
+/**
+ * Later layers win case-insensitive key collisions; `accept` is deliberately never emitted.
+ */
+export default function composeRequestHeaders({
+  adminSecret,
+  selection,
+  headersTabOverrides,
+}: ComposeRequestHeadersOptions): Record<string, string> {
+  const headers: Record<string, string> = {};
+
+  const setHeader = (name: string, value: string) => {
+    const canonicalName = name.toLowerCase();
+
+    if (canonicalName === 'accept') {
+      return;
+    }
+
+    headers[canonicalName] = value;
+  };
+
+  setHeader('content-type', 'application/json');
+  setHeader('x-hasura-admin-secret', adminSecret);
+
+  if (selection.userId) {
+    setHeader('x-hasura-user-id', selection.userId);
+  }
+
+  if (selection.role) {
+    setHeader('x-hasura-role', selection.role);
+  }
+
+  for (const [name, value] of Object.entries(headersTabOverrides ?? {})) {
+    if (value === null || value === undefined) {
+      continue;
+    }
+
+    setHeader(name, typeof value === 'string' ? value : String(value));
+  }
+
+  return headers;
+}

--- a/dashboard/src/features/orgs/projects/graphql/common/utils/composeRequestHeaders/index.ts
+++ b/dashboard/src/features/orgs/projects/graphql/common/utils/composeRequestHeaders/index.ts
@@ -1,2 +1,5 @@
 export type { GraphQLPlaygroundSelection } from './composeRequestHeaders';
-export { default as composeRequestHeaders } from './composeRequestHeaders';
+export {
+  default as composeRequestHeaders,
+  withRequestHeaders,
+} from './composeRequestHeaders';

--- a/dashboard/src/features/orgs/projects/graphql/common/utils/composeRequestHeaders/index.ts
+++ b/dashboard/src/features/orgs/projects/graphql/common/utils/composeRequestHeaders/index.ts
@@ -1,0 +1,2 @@
+export type { GraphQLPlaygroundSelection } from './composeRequestHeaders';
+export { default as composeRequestHeaders } from './composeRequestHeaders';

--- a/dashboard/src/pages/orgs/[orgSlug]/projects/[appSubdomain]/graphql/index.tsx
+++ b/dashboard/src/pages/orgs/[orgSlug]/projects/[appSubdomain]/graphql/index.tsx
@@ -297,7 +297,6 @@ const GraphQLPageContent = dynamic(
         .replace('http', 'ws')}`;
 
       const adminSecret = project.config?.hasura.adminSecret;
-      const httpHeaders = composeRequestHeaders({ adminSecret, selection });
       const socketHeaders = composeRequestHeaders({
         adminSecret,
         selection,
@@ -305,21 +304,27 @@ const GraphQLPageContent = dynamic(
       });
       const baseFetcher = createGraphiQLFetcher({
         url: appUrl,
-        headers: httpHeaders,
         // Response analytics cover non-incremental HTTP queries and mutations.
         // WebSocket subscriptions are returned unchanged and intentionally untracked.
         enableIncrementalDelivery: false,
         wsClient: createClient({
           url: subscriptionUrl,
           keepAlive: 2000,
+          // A supplied WebSocket client ignores per-execution fetcher headers.
           connectionParams: {
             headers: socketHeaders,
           },
         }),
       });
-
-      const fetcher: typeof baseFetcher = (graphQLParams, opts) => {
-        const result = baseFetcher(graphQLParams, opts);
+      const fetcher: typeof baseFetcher = (graphQLParams, fetcherOpts) => {
+        const result = baseFetcher(graphQLParams, {
+          ...fetcherOpts,
+          headers: composeRequestHeaders({
+            adminSecret,
+            selection,
+            headersTabOverrides: fetcherOpts?.headers,
+          }),
+        });
 
         if (
           graphQLParams.operationName !== 'IntrospectionQuery' &&
@@ -334,7 +339,6 @@ const GraphQLPageContent = dynamic(
 
         return result;
       };
-
 
       return (
         <GraphiQLProvider fetcher={fetcher} shouldPersistHeaders>

--- a/dashboard/src/pages/orgs/[orgSlug]/projects/[appSubdomain]/graphql/index.tsx
+++ b/dashboard/src/pages/orgs/[orgSlug]/projects/[appSubdomain]/graphql/index.tsx
@@ -22,6 +22,7 @@ import { UserAndRoleSelect } from '@/features/orgs/projects/graphql/common/compo
 import {
   composeRequestHeaders,
   type GraphQLPlaygroundSelection,
+  withRequestHeaders,
 } from '@/features/orgs/projects/graphql/common/utils/composeRequestHeaders';
 import { useProject } from '@/features/orgs/projects/hooks/useProject';
 import { useTrackEvent } from '@/hooks/useTrackEvent';
@@ -310,21 +311,20 @@ const GraphQLPageContent = dynamic(
         wsClient: createClient({
           url: subscriptionUrl,
           keepAlive: 2000,
-          // A supplied WebSocket client ignores per-execution fetcher headers.
+          // @graphiql/toolkit ignores per-execution headers for subscriptions
+          // when a wsClient is supplied, so they must use connectionParams.
           connectionParams: {
             headers: socketHeaders,
           },
         }),
       });
+      const requestFetcher = withRequestHeaders({
+        fetcher: baseFetcher,
+        adminSecret,
+        selection,
+      });
       const fetcher: typeof baseFetcher = (graphQLParams, fetcherOpts) => {
-        const result = baseFetcher(graphQLParams, {
-          ...fetcherOpts,
-          headers: composeRequestHeaders({
-            adminSecret,
-            selection,
-            headersTabOverrides: fetcherOpts?.headers,
-          }),
-        });
+        const result = requestFetcher(graphQLParams, fetcherOpts);
 
         if (
           graphQLParams.operationName !== 'IntrospectionQuery' &&

--- a/dashboard/src/pages/orgs/[orgSlug]/projects/[appSubdomain]/graphql/index.tsx
+++ b/dashboard/src/pages/orgs/[orgSlug]/projects/[appSubdomain]/graphql/index.tsx
@@ -19,6 +19,10 @@ import {
 import { OrgLayout } from '@/features/orgs/layout/OrgLayout';
 import { generateAppServiceUrl } from '@/features/orgs/projects/common/utils/generateAppServiceUrl';
 import { UserAndRoleSelect } from '@/features/orgs/projects/graphql/common/components/UserAndRoleSelect';
+import {
+  composeRequestHeaders,
+  type GraphQLPlaygroundSelection,
+} from '@/features/orgs/projects/graphql/common/utils/composeRequestHeaders';
 import { useProject } from '@/features/orgs/projects/hooks/useProject';
 import { useTrackEvent } from '@/hooks/useTrackEvent';
 import { isNotEmptyValue } from '@/lib/utils';
@@ -31,7 +35,7 @@ import { createClient } from 'graphql-ws';
 import debounce from 'lodash.debounce';
 import dynamic from 'next/dynamic';
 import type { ReactElement } from 'react';
-import { useEffect, useMemo, useState } from 'react';
+import { useCallback, useEffect, useMemo, useState } from 'react';
 
 function trackGraphQLResponse(
   track: (event: string, properties?: Record<string, unknown>) => void,
@@ -59,16 +63,12 @@ function trackGraphQLResponse(
 
 interface GraphiQLHeaderProps {
   /**
-   * Function to be called when the user changes.
+   * Function to be called when the user or role changes.
    */
-  onUserChange: (userId: string) => void;
-  /**
-   * Function to be called when the user role changes.
-   */
-  onRoleChange: (role: string) => void;
+  onSelectionChange: (selection: GraphQLPlaygroundSelection) => void;
 }
 
-function GraphiQLHeader({ onUserChange, onRoleChange }: GraphiQLHeaderProps) {
+function GraphiQLHeader({ onSelectionChange }: GraphiQLHeaderProps) {
   const copyQuery = useCopyQuery();
   const prettifyEditors = usePrettifyEditors();
 
@@ -156,10 +156,7 @@ function GraphiQLHeader({ onUserChange, onRoleChange }: GraphiQLHeaderProps) {
   return (
     <header className="grid grid-flow-row items-end gap-2 p-2 md:grid-flow-col md:justify-between">
       <div className="grid grid-flow-row gap-2 md:grid-flow-col md:items-end">
-        <UserAndRoleSelect
-          onUserChange={onUserChange}
-          onRoleChange={onRoleChange}
-        />
+        <UserAndRoleSelect onSelectionChange={onSelectionChange} />
 
         <div className="grid grid-cols-2 gap-2 md:grid-flow-col md:grid-cols-[initial]">
           <Tooltip>
@@ -230,8 +227,7 @@ interface GraphiQLEditorProps {
   /**
    * Function to be called when the user changes the headers.
    */
-  // biome-ignore lint/suspicious/noExplicitAny: TODO
-  onHeaderChange: (headers: Record<string, any>) => void;
+  onHeaderChange: (headers: Record<string, unknown>) => void;
 }
 
 function GraphiQLEditor({ onHeaderChange }: GraphiQLEditorProps) {
@@ -245,8 +241,7 @@ function GraphiQLEditor({ onHeaderChange }: GraphiQLEditorProps) {
         }
 
         try {
-          // biome-ignore lint/suspicious/noExplicitAny: TODO
-          const parsedHeaders: Record<string, any> = JSON.parse(headers);
+          const parsedHeaders: Record<string, unknown> = JSON.parse(headers);
 
           onHeaderChange(parsedHeaders);
         } catch {
@@ -273,8 +268,19 @@ const GraphQLPageContent = dynamic(
     Promise.resolve(() => {
       const { project } = useProject();
       const track = useTrackEvent();
-      // biome-ignore lint/suspicious/noExplicitAny: TODO
-      const [userHeaders, setUserHeaders] = useState<Record<string, any>>({});
+      const [selection, setSelection] = useState<GraphQLPlaygroundSelection>({
+        userId: '',
+        role: '',
+      });
+      const [headersTabOverrides, setHeadersTabOverrides] = useState<
+        Record<string, unknown>
+      >({});
+      const handleSelectionChange = useCallback(
+        (nextSelection: GraphQLPlaygroundSelection) => {
+          setSelection(nextSelection);
+        },
+        [],
+      );
 
       if (!project?.subdomain || !project?.config?.hasura.adminSecret) {
         return <LoadingScreen />;
@@ -290,15 +296,16 @@ const GraphQLPageContent = dynamic(
         .replace('https', 'wss')
         .replace('http', 'ws')}`;
 
-      const headers = {
-        'content-type': 'application/json',
-        'x-hasura-admin-secret': project.config?.hasura.adminSecret,
-        ...userHeaders,
-      };
-
+      const adminSecret = project.config?.hasura.adminSecret;
+      const httpHeaders = composeRequestHeaders({ adminSecret, selection });
+      const socketHeaders = composeRequestHeaders({
+        adminSecret,
+        selection,
+        headersTabOverrides,
+      });
       const baseFetcher = createGraphiQLFetcher({
         url: appUrl,
-        headers,
+        headers: httpHeaders,
         // Response analytics cover non-incremental HTTP queries and mutations.
         // WebSocket subscriptions are returned unchanged and intentionally untracked.
         enableIncrementalDelivery: false,
@@ -306,7 +313,7 @@ const GraphQLPageContent = dynamic(
           url: subscriptionUrl,
           keepAlive: 2000,
           connectionParams: {
-            headers,
+            headers: socketHeaders,
           },
         }),
       });
@@ -328,28 +335,12 @@ const GraphQLPageContent = dynamic(
         return result;
       };
 
-      function handleUserChange(userId: string) {
-        setUserHeaders((currentHeaders) => ({
-          ...currentHeaders,
-          'x-hasura-user-id': userId,
-        }));
-      }
-
-      function handleRoleChange(role: string) {
-        setUserHeaders((currentHeaders) => ({
-          ...currentHeaders,
-          'x-hasura-role': role,
-        }));
-      }
 
       return (
         <GraphiQLProvider fetcher={fetcher} shouldPersistHeaders>
-          <GraphiQLHeader
-            onUserChange={handleUserChange}
-            onRoleChange={handleRoleChange}
-          />
+          <GraphiQLHeader onSelectionChange={handleSelectionChange} />
 
-          <GraphiQLEditor onHeaderChange={setUserHeaders} />
+          <GraphiQLEditor onHeaderChange={setHeadersTabOverrides} />
         </GraphiQLProvider>
       );
     }),


### PR DESCRIPTION
### Checklist

- [X] No breaking changes
- [x] Tests pass
- [X] New features have new tests
- [X] Documentation is updated (if applicable)
- [X] Title of the PR is in the correct format (see below)

<!-- pi-reviewer:start -->
### **What this change solves**
Editing the GraphQL playground's Headers tab used to merge into the same state object as the User/Role dropdowns, so a Headers-tab edit could drop the selected role (and vice versa). This change keeps the dropdown selection and Headers-tab overrides as separate state and composes outgoing request headers deterministically, so the selected role survives header edits and the Admin pseudo-user no longer sends a bogus `x-hasura-user-id`.

___

### **Change Type**
Bug fix

___

### **Description**
- Added a `composeRequestHeaders` utility that merges base headers (`content-type`, `x-hasura-admin-secret`), the User/Role selection (`x-hasura-user-id`, `x-hasura-role`), and Headers-tab overrides in precedence order, stringifying/skipping non-string override values. Headers are accumulated in a `Headers` instance (normalizing names to lowercase and trimming values) and returned as a plain object, since GraphiQL spreads the result and graphql-ws JSON-serializes it — a `Headers` instance has no own enumerable properties and would silently reduce to `{}`.
- Added `withRequestHeaders`, a fetcher wrapper that recomposes headers per execution so HTTP requests always carry the current selection plus overrides; WebSocket subscriptions get the composed headers via `connectionParams`.
- Replaced the playground page's single `userHeaders` state with two independent pieces of state: `selection` (user + role) and `headersTabOverrides`, removing the `Record<string, any>` escapes.
- Collapsed `UserAndRoleSelect`'s `onUserChange`/`onRoleChange` callbacks into a single `onSelectionChange({ userId, role })`, keeping the current role when an admin-roles refresh returns the same user and resetting to the first available role when the user actually changes.
- `UserSelect` now emits an empty `userId` for the Admin pseudo-entry instead of the literal string `admin`, so no `x-hasura-user-id` header is sent for Admin.
- Added unit tests for `composeRequestHeaders`/`withRequestHeaders` (including a query-path test pinning that Headers-tab overrides merge with the selection instead of replacing it) and `UserAndRoleSelect`; updated the `UserSelect` test and an e2e helper doc comment.

___

### Diagram Walkthrough

```mermaid
flowchart LR
  US["UserSelect<br/>(Admin => userId '')"] --> UARS["UserAndRoleSelect<br/>onSelectionChange({userId, role})"]
  UARS --> Page["graphql/index.tsx<br/>selection state"]
  HT["GraphiQLEditor Headers tab"] --> Page2["graphql/index.tsx<br/>headersTabOverrides state"]
  Page --> CRH["composeRequestHeaders"]
  Page2 --> CRH
  CRH --> HTTP["withRequestHeaders fetcher<br/>(HTTP queries/mutations)"]
  CRH --> WS["wsClient connectionParams<br/>(subscriptions)"]
```

<details> <summary><h3> File Walkthrough</h3></summary>

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody>
<tr><td><strong>Bug fix</strong></td><td><details><summary>5 files</summary><table>
<tr>
  <td><strong>composeRequestHeaders/composeRequestHeaders.ts</strong><dd><code>New utility composing base, selection, and Headers-tab headers in precedence order; withRequestHeaders fetcher wrapper</code></dd></td>
  <td>+69/-0</td>
</tr>
<tr>
  <td><strong>composeRequestHeaders/index.ts</strong><dd><code>Barrel re-exports for the new utility and its types</code></dd></td>
  <td>+5/-0</td>
</tr>
<tr>
  <td><strong>graphql/index.tsx</strong><dd><code>Split userHeaders into selection + headersTabOverrides state; per-request header composition and ws connectionParams</code></dd></td>
  <td>+43/-48</td>
</tr>
<tr>
  <td><strong>UserAndRoleSelect/UserAndRoleSelect.tsx</strong><dd><code>Single onSelectionChange callback; keep role on same-user refresh, reset on user change</code></dd></td>
  <td>+24/-23</td>
</tr>
<tr>
  <td><strong>UserSelect/UserSelect.tsx</strong><dd><code>Admin pseudo-entry emits empty userId instead of 'admin'</code></dd></td>
  <td>+4/-3</td>
</tr>
</table></details></td></tr>
<tr><td><strong>Tests</strong></td><td><details><summary>3 files</summary><table>
<tr>
  <td><strong>composeRequestHeaders/composeRequestHeaders.test.ts</strong><dd><code>Unit tests for header composition, Admin selection, override normalization, query-path override merging, and ws subscription routing</code></dd></td>
  <td>+163/-0</td>
</tr>
<tr>
  <td><strong>UserAndRoleSelect/UserAndRoleSelect.test.tsx</strong><dd><code>Tests for role persistence across admin-roles refresh and role reset on user change</code></dd></td>
  <td>+152/-0</td>
</tr>
<tr>
  <td><strong>UserSelect/UserSelect.test.tsx</strong><dd><code>Expect empty userId for the Admin entry</code></dd></td>
  <td>+1/-1</td>
</tr>
</table></details></td></tr>
<tr><td><strong>Documentation</strong></td><td><details><summary>1 files</summary><table>
<tr>
  <td><strong>e2e/utils.ts</strong><dd><code>Updated the role-selection e2e helper comment for the renamed selection state</code></dd></td>
  <td>+1/-1</td>
</tr>
</table></details></td></tr>
</tbody></table>

</details>

___

<!-- pi-reviewer:end -->

