### PR TITLE
fix(docs): clean up theme toggle in dark mode

### DIFF
--- a/docs/src/components/ThemeToggle.astro
+++ b/docs/src/components/ThemeToggle.astro
@@ -3,17 +3,6 @@
 
 <button id="custom-theme-toggle" class="theme-toggle" aria-label="Toggle theme">
   <div class="toggle-track">
-    <div class="cloud-icon">
-      <svg width="10" height="10" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round">
-        <path d="M17.5 19H9a7 7 0 1 1 6.71-9h1.79a4.5 4.5 0 1 1 0 9Z" />
-      </svg>
-    </div>
-    <div class="star-icon">
-      <svg width="6" height="6" viewBox="0 0 24 24" fill="currentColor">
-        <polygon points="12 2 15.09 8.26 22 9.27 17 14.14 18.18 21.02 12 17.77 5.82 21.02 7 14.14 2 9.27 8.91 8.26 12 2" />
-      </svg>
-    </div>
-    
     <div class="toggle-thumb">
       <svg class="sun-icon" width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round">
         <circle cx="12" cy="12" r="5"></circle>
@@ -50,15 +39,16 @@
   height: 32px;
   border-radius: 32px;
   position: relative;
-  transition: background-color 0.3s, border-color 0.3s;
-  background-color: #000000;
+  /* Same track in both themes: lifted well clear of the near-black page
+     background in dark mode, and it still reads on white in light mode */
+  background-color: #333333;
+  /* Border matches the fill: no visible outline, but it keeps the 2px inset the
+     thumb is positioned against */
   border: 2px solid #333333;
   box-sizing: border-box;
-}
-
-html[data-theme="light"] .toggle-track {
-  background-color: #222222;
-  border: 2px solid #222222;
+  overflow: hidden; /* Keep the thumb's shadow from bleeding over the border */
+  /* Eased to land with the thumb's slide */
+  transition: background-color 0.4s ease-in-out, border-color 0.4s ease-in-out;
 }
 
 .toggle-thumb {
@@ -68,12 +58,12 @@ html[data-theme="light"] .toggle-track {
   width: 28px;
   height: 28px;
   border-radius: 50%;
-  background-color: #e6e6db;
+  background-color: #111111; /* Inverted against the lighter track */
   box-shadow: 0 1px 3px rgba(0,0,0,0.3);
   display: flex;
   align-items: center;
   justify-content: center;
-  transition: transform 0.4s cubic-bezier(0.4, 0.0, 0.2, 1), background-color 0.4s;
+  transition: transform 0.4s cubic-bezier(0.4, 0.0, 0.2, 1), background-color 0.4s ease-in-out;
   transform: translateY(-50%) translateX(28px); /* Exactly flush with the right inner border */
   box-sizing: border-box;
 }
@@ -84,47 +74,22 @@ html[data-theme="light"] .toggle-thumb {
   transform: translateY(-50%) translateX(0); /* Exactly flush with the left inner border */
 }
 
-/* Icons */
+/* Icons. Each is colored for the thumb it sits on: a dark sun on light mode's
+   white thumb, a light moon on dark mode's near-black thumb. */
 .sun-icon, .moon-icon {
   position: absolute;
-  transition: opacity 0.4s, transform 0.4s cubic-bezier(0.4, 0.0, 0.2, 1);
-  color: #111;
+  transition: opacity 0.4s, transform 0.4s cubic-bezier(0.4, 0.0, 0.2, 1), color 0.4s ease-in-out;
   width: 18px; /* Slightly larger for the bigger thumb */
   height: 18px;
 }
 
 /* Dark mode icons */
-.sun-icon { opacity: 0; transform: scale(0.5) rotate(-45deg); }
-.moon-icon { opacity: 1; transform: scale(1) rotate(0); }
+.sun-icon { opacity: 0; transform: scale(0.5) rotate(-45deg); color: #111111; }
+.moon-icon { opacity: 1; transform: scale(1) rotate(0); color: #e6e6db; }
 
 /* Light mode icons */
 html[data-theme="light"] .sun-icon { opacity: 1; transform: scale(1) rotate(0); }
 html[data-theme="light"] .moon-icon { opacity: 0; transform: scale(0.5) rotate(45deg); }
-
-/* Decorative track icons (cloud/star) */
-.cloud-icon, .star-icon {
-  position: absolute;
-  color: #888;
-  transition: opacity 0.4s, transform 0.4s;
-}
-
-.cloud-icon {
-  bottom: -2px;
-  left: 8px;
-  opacity: 1;
-}
-
-.star-icon {
-  bottom: 3px;
-  left: 26px;
-  opacity: 1;
-}
-
-html[data-theme="light"] .cloud-icon,
-html[data-theme="light"] .star-icon {
-  opacity: 0;
-  transform: translateX(5px);
-}
 </style>
 
 <script is:inline>


### PR DESCRIPTION
preview: https://docs-biv6li3ow-nhost.vercel.app/

---

The decorative star sat at left 26px while the dark-mode thumb starts at 28px, so all but a sliver of it was hidden behind the thumb and read as an artifact on its edge. Drop both decorations, they carried no state.

Use one track color in both themes, lifted to #333333 so the pill reads against the near-black page instead of blending into it, with the border matched to the fill so there is no outline. Invert the dark-mode thumb to a near-black knob with a light moon, and ease the color changes over 0.4s so they land with the thumb's slide.

---

Before:
<img width="75" height="43" alt="Screenshot 2026-08-24 at 6 26 59 PM" src="https://github.com/user-attachments/assets/e05726d7-d19e-40b8-94f8-781abd53b4ea" />

After:
<img width="64" height="42" alt="Screenshot 2026-08-24 at 6 22 53 PM" src="https://github.com/user-attachments/assets/2b15b0aa-3c4f-470d-a5ee-e9ee5b7daf91" />
