### PR TITLE
fix(docs): pin mermaid to an exact version

### DIFF
--- a/docs/src/components/Head.astro
+++ b/docs/src/components/Head.astro
@@ -47,7 +47,9 @@ if (description) ogUrl.searchParams.set('description', description);
 )}
 
 <script type="module">
-    import mermaid from 'https://cdn.jsdelivr.net/npm/mermaid@11/dist/mermaid.esm.min.mjs';
+    // Exact version: `@11` resolves to the newest 11.x per request, so visitors can get
+    // different builds and diagram rendering drifts without a change here.
+    import mermaid from 'https://cdn.jsdelivr.net/npm/mermaid@11.17.1/dist/mermaid.esm.min.mjs';
 
     function getTheme() {
         // Starlight uses data-theme attribute


### PR DESCRIPTION
### Checklist

- [x] No breaking changes
- [x] Tests pass
- [ ] New features have new tests
- [x] Documentation is updated (if applicable)
- [x] Title of the PR is in the correct format (see below)

---

The docs load mermaid from `mermaid@11`. jsDelivr resolves that to the newest 11.x at request time, so two visitors can load different builds of the diagram renderer, and rendering can change without any commit to this repo.

This pins the exact version. I checked that `@11` currently serves 11.17.1 and that `mermaid@11.17.1/dist/mermaid.esm.min.mjs` is byte-identical to what `@11` returns right now, so nothing about today's rendering changes — it only stops future 11.x releases landing on readers unannounced.

This came out of #4878, where sequence-diagram text is reported as unreadable in light theme. I could not reproduce that: on a light-theme load of both `products/ai/mcp/authentication` and `products/auth/oauth2-provider/authorization-flow`, participant headings measure 21:1 and message text 12.63:1 against white, both well above the 4.5:1 AA threshold. The floating version is my best explanation for why it reproduces for the reporter and not for me, since mermaid has changed sequence-diagram theme variables within minor releases before.

So this does not claim to fix #4878 — it makes the rendering deterministic so the report can be reproduced or ruled out against a known version. Measurements and details are in my comment on the issue.