### PR TITLE
fix(dashboard): prevent an error boundary when editing playground headers

### DIFF
--- a/dashboard/src/features/orgs/projects/graphql/common/utils/composeRequestHeaders/composeRequestHeaders.test.ts
+++ b/dashboard/src/features/orgs/projects/graphql/common/utils/composeRequestHeaders/composeRequestHeaders.test.ts
@@ -77,6 +77,16 @@ describe('composeRequestHeaders', () => {
       'x-retry-count': '3',
     });
   });
+
+  it('rejects Headers-tab names that are not valid header tokens', () => {
+    expect(() =>
+      composeRequestHeaders({
+        adminSecret,
+        selection,
+        headersTabOverrides: { 'x hasura role': 'user' },
+      }),
+    ).toThrow(TypeError);
+  });
 });
 
 describe('withRequestHeaders', () => {

--- a/dashboard/src/pages/orgs/[orgSlug]/projects/[appSubdomain]/graphql/index.tsx
+++ b/dashboard/src/pages/orgs/[orgSlug]/projects/[appSubdomain]/graphql/index.tsx
@@ -308,6 +308,8 @@ const GraphQLPageContent = dynamic(
           headersTabOverrides,
         });
       } catch {
+        // Header names are invalid while one is still being typed; executing a
+        // query re-composes them and surfaces the rejection in the response pane.
         socketHeaders = composeRequestHeaders({ adminSecret, selection });
       }
       const baseFetcher = createGraphiQLFetcher({

--- a/dashboard/src/pages/orgs/[orgSlug]/projects/[appSubdomain]/graphql/index.tsx
+++ b/dashboard/src/pages/orgs/[orgSlug]/projects/[appSubdomain]/graphql/index.tsx
@@ -298,11 +298,18 @@ const GraphQLPageContent = dynamic(
         .replace('http', 'ws')}`;
 
       const adminSecret = project.config?.hasura.adminSecret;
-      const socketHeaders = composeRequestHeaders({
-        adminSecret,
-        selection,
-        headersTabOverrides,
-      });
+
+      let socketHeaders: Record<string, string>;
+
+      try {
+        socketHeaders = composeRequestHeaders({
+          adminSecret,
+          selection,
+          headersTabOverrides,
+        });
+      } catch {
+        socketHeaders = composeRequestHeaders({ adminSecret, selection });
+      }
       const baseFetcher = createGraphiQLFetcher({
         url: appUrl,
         // Response analytics cover non-incremental HTTP queries and mutations.


### PR DESCRIPTION
### Checklist

- [X] No breaking changes
- [X] Tests pass
- [X] New features have new tests
- [X] Documentation is updated (if applicable)
- [X] Title of the PR is in the correct format (see below)

<!-- pi-reviewer:start -->
### **What this change solves**
Typing a partially written or otherwise invalid header name in the GraphQL playground's Headers tab made `composeRequestHeaders` throw while building the WebSocket connection params. Because that call sits in the render body of `GraphQLPageContent`, the throw escaped render and the error boundary replaced the whole playground. The subscription socket now falls back to the base headers so editing stays non-fatal, while executing a query still surfaces the rejected header in the response pane.

___

### **Change Type**
Bug fix

___

### **Description**
- Wrap the subscription `socketHeaders` composition in `try`/`catch` inside `GraphQLPageContent`, since `Headers.set` throws `TypeError` on header names that are not valid HTTP tokens.
- On failure, recompose the socket headers without `headersTabOverrides`, keeping the admin secret plus the user/role selection headers.
- Leave the HTTP fetcher path (`withRequestHeaders`) unguarded, so running a query still reports the invalid header instead of silently dropping it.
- Pin the throw-on-invalid-name behavior that the fallback depends on with a `composeRequestHeaders` test, and document in the `catch` why the overrides are dropped there.

___

<details> <summary><h3> File Walkthrough</h3></summary>

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody>
<tr><td><strong>Bug fix</strong></td><td><details><summary>1 files</summary><table>
<tr>
  <td><strong>index.tsx</strong><dd><code>Guard WebSocket header composition against invalid Headers-tab names with a base-header fallback</code></dd></td>
  <td>+14/-5</td>
</tr>
</table></details></td></tr>
<tr><td><strong>Tests</strong></td><td><details><summary>1 files</summary><table>
<tr>
  <td><strong>composeRequestHeaders.test.ts</strong><dd><code>Assert that header names which are not valid HTTP tokens are rejected</code></dd></td>
  <td>+10/-0</td>
</tr>
</table></details></td></tr>
</tbody></table>

</details>

___

<!-- pi-reviewer:end -->
