### PR TITLE
feat(nixops): build nixops docker image in PRs

### DIFF
--- a/.github/workflows/nixops_checks.yaml
+++ b/.github/workflows/nixops_checks.yaml
@@ -71,7 +71,7 @@ jobs:
       PATH: nixops
       GIT_REF: ${{ github.event_name == 'pull_request_target' && github.event.pull_request.head.sha || github.sha }}
       VERSION: 0.0.0-dev # we use a fixed version here to avoid unnecessary rebuilds
-      DOCKER: false
+      DOCKER: true
       OS_MATRIX: '["blacksmith-32vcpu-ubuntu-2404-arm", "blacksmith-8vcpu-ubuntu-2404", "blacksmith-6vcpu-macos-latest"]'
     secrets:
       AWS_ACCOUNT_ID: ${{ secrets.AWS_PRODUCTION_CORE_ACCOUNT_ID }}

--- a/.github/workflows/nixops_checks.yaml
+++ b/.github/workflows/nixops_checks.yaml
@@ -42,39 +42,6 @@ jobs:
       - uses: actions/checkout@v7
       - uses: ./.github/actions/check-permissions
 
-  eval:
-    needs: [detect-changes, check-permissions]
-    if: needs.detect-changes.outputs.should_run == 'true'
-    runs-on: blacksmith-2vcpu-ubuntu-2404
-    timeout-minutes: 15
-    permissions:
-      contents: read
-    steps:
-      - name: "Check out repository"
-        uses: actions/checkout@v7
-        with:
-          ref: ${{ github.event_name == 'pull_request_target' && github.event.pull_request.head.sha || github.sha }}
-          allow-unsafe-pr-checkout: true
-
-      - name: Setup Nix with Cache
-        uses: ./.github/actions/setup-nix
-        with:
-          NAME: nixops
-          NIX_CACHE_PUB_KEY: ${{ secrets.NIX_CACHE_PUB_KEY }}
-          NIX_CACHE_ACCESS_KEY_ID: ${{ secrets.NIX_CACHE_ACCESS_KEY_ID }}
-          NIX_CACHE_SECRET_ACCESS_KEY: ${{ secrets.NIX_CACHE_SECRET_ACCESS_KEY }}
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-
-      - name: "Evaluate nixops-docker-image (no build)"
-        # Forcing the derivation's `.drvPath` instantiates the full build
-        # graph, which fires any eval-time `throw` (removed/renamed attrs,
-        # failed assertions, type errors) without building or fetching. This
-        # does NOT catch build-time failures (broken patches, failing tests,
-        # hash mismatches) — those still need a real build.
-        run: |
-          nix eval --raw \
-            .#packages.x86_64-linux.nixops-docker-image.drvPath
-
   tests:
     uses: ./.github/workflows/wf_check.yaml
     needs:

--- a/.github/workflows/nixops_checks.yaml
+++ b/.github/workflows/nixops_checks.yaml
@@ -42,6 +42,39 @@ jobs:
       - uses: actions/checkout@v7
       - uses: ./.github/actions/check-permissions
 
+  eval:
+    needs: [detect-changes, check-permissions]
+    if: needs.detect-changes.outputs.should_run == 'true'
+    runs-on: blacksmith-2vcpu-ubuntu-2404
+    timeout-minutes: 15
+    permissions:
+      contents: read
+    steps:
+      - name: "Check out repository"
+        uses: actions/checkout@v7
+        with:
+          ref: ${{ github.event_name == 'pull_request_target' && github.event.pull_request.head.sha || github.sha }}
+          allow-unsafe-pr-checkout: true
+
+      - name: Setup Nix with Cache
+        uses: ./.github/actions/setup-nix
+        with:
+          NAME: nixops
+          NIX_CACHE_PUB_KEY: ${{ secrets.NIX_CACHE_PUB_KEY }}
+          NIX_CACHE_ACCESS_KEY_ID: ${{ secrets.NIX_CACHE_ACCESS_KEY_ID }}
+          NIX_CACHE_SECRET_ACCESS_KEY: ${{ secrets.NIX_CACHE_SECRET_ACCESS_KEY }}
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: "Evaluate nixops-docker-image (no build)"
+        # Forcing the derivation's `.drvPath` instantiates the full build
+        # graph, which fires any eval-time `throw` (removed/renamed attrs,
+        # failed assertions, type errors) without building or fetching. This
+        # does NOT catch build-time failures (broken patches, failing tests,
+        # hash mismatches) — those still need a real build.
+        run: |
+          nix eval --raw \
+            .#packages.x86_64-linux.nixops-docker-image.drvPath
+
   tests:
     uses: ./.github/workflows/wf_check.yaml
     needs:


### PR DESCRIPTION
### Checklist

- [x] No breaking changes
- [x] Tests pass
- [ ] New features have new tests
- [ ] Documentation is updated (if applicable)
- [x] Title of the PR is in the correct format (see below)


### Rationale

~~Normally build/check steps should be added into the generic wf_check.yaml template, but nixops is the one user with docker builds for PRs disabled. This adds a basic eval check so that nix evaluation failures under x86_64-linux can be caught by PR checks.~~