### PR TITLE
feat(ai): support Anthropic workspace routing

### DIFF
--- a/services/ai/Makefile
+++ b/services/ai/Makefile
@@ -52,6 +52,7 @@ demo-movies-down:  ## Stops the movies demo environment
 demo-movies-restore-backup:  ## Restores the movies demo data backup
 	pg_restore --format=custom \
 		$(DEMO_MOVIES_PATH)/data/full/01-movies.backup \
+		--exit-on-error \
 		--schema=public \
 		--clean --if-exists --no-owner --no-privileges \
 		--dbname=local --host=localhost --port=5432 --username=postgres
@@ -85,6 +86,7 @@ quickstart-movies-down:  ## Stops the movies quickstart environment
 quickstart-movies-restore-backup:  ## Restores the movies quickstart data backup
 	pg_restore --format=custom \
 		$(DEMO_MOVIES_PATH)/data/qs/01-movies.backup \
+		--exit-on-error \
 		--schema=public \
 		--clean --if-exists --no-owner --no-privileges \
 		--dbname=local --host=localhost --port=5432 --username=postgres

--- a/services/ai/Makefile
+++ b/services/ai/Makefile
@@ -56,6 +56,7 @@ demo-movies-restore-backup:  ## Restores the movies demo data backup
 		--clean --if-exists --no-owner --no-privileges \
 		--dbname=local --host=localhost --port=5432 --username=postgres
 	psql postgres://postgres:postgres@localhost:5432/local \
+		-v ON_ERROR_STOP=1 \
 		-f $(DEMO_MOVIES_PATH)/data/full/02-auto-embeddings-configuration.sql
 	# Restart after the restore because restoring a backup doesn't trigger configuration events.
 	docker restart demo-movies-ai-1
@@ -64,7 +65,9 @@ demo-movies-restore-backup:  ## Restores the movies demo data backup
 .PHONY: quickstart-movies-up
 quickstart-movies-up:  ## Starts the movies quickstart environment
 	cd $(DEMO_MOVIES_PATH) && nhost up
-	psql postgres://postgres:postgres@localhost:5432/local -f $(DEMO_MOVIES_PATH)/data/quickstart.sql
+	psql postgres://postgres:postgres@localhost:5432/local \
+		-v ON_ERROR_STOP=1 \
+		-f $(DEMO_MOVIES_PATH)/data/quickstart.sql
 	cd $(DEMO_MOVIES_PATH) && nhost dev hasura metadata reload \
 		--endpoint https://local.hasura.nhost.run --admin-secret "nhost-admin-secret"
 	cd $(DEMO_MOVIES_PATH) && nhost dev hasura metadata inconsistency drop \
@@ -86,6 +89,7 @@ quickstart-movies-restore-backup:  ## Restores the movies quickstart data backup
 		--clean --if-exists --no-owner --no-privileges \
 		--dbname=local --host=localhost --port=5432 --username=postgres
 	psql postgres://postgres:postgres@localhost:5432/local \
+		-v ON_ERROR_STOP=1 \
 		-f $(DEMO_MOVIES_PATH)/data/quickstart.sql
 	cd $(DEMO_MOVIES_PATH) && nhost dev hasura metadata inconsistency drop \
 		--endpoint https://local.hasura.nhost.run --admin-secret "nhost-admin-secret"

--- a/services/ai/Makefile
+++ b/services/ai/Makefile
@@ -52,12 +52,10 @@ demo-movies-down:  ## Stops the movies demo environment
 demo-movies-restore-backup:  ## Restores the movies demo data backup
 	pg_restore --format=custom \
 		$(DEMO_MOVIES_PATH)/data/full/01-movies.backup \
-		--exit-on-error \
 		--schema=public \
 		--clean --if-exists --no-owner --no-privileges \
 		--dbname=local --host=localhost --port=5432 --username=postgres
 	psql postgres://postgres:postgres@localhost:5432/local \
-		-v ON_ERROR_STOP=1 \
 		-f $(DEMO_MOVIES_PATH)/data/full/02-auto-embeddings-configuration.sql
 	# Restart after the restore because restoring a backup doesn't trigger configuration events.
 	docker restart demo-movies-ai-1
@@ -66,9 +64,7 @@ demo-movies-restore-backup:  ## Restores the movies demo data backup
 .PHONY: quickstart-movies-up
 quickstart-movies-up:  ## Starts the movies quickstart environment
 	cd $(DEMO_MOVIES_PATH) && nhost up
-	psql postgres://postgres:postgres@localhost:5432/local \
-		-v ON_ERROR_STOP=1 \
-		-f $(DEMO_MOVIES_PATH)/data/quickstart.sql
+	psql postgres://postgres:postgres@localhost:5432/local -f $(DEMO_MOVIES_PATH)/data/quickstart.sql
 	cd $(DEMO_MOVIES_PATH) && nhost dev hasura metadata reload \
 		--endpoint https://local.hasura.nhost.run --admin-secret "nhost-admin-secret"
 	cd $(DEMO_MOVIES_PATH) && nhost dev hasura metadata inconsistency drop \
@@ -86,12 +82,10 @@ quickstart-movies-down:  ## Stops the movies quickstart environment
 quickstart-movies-restore-backup:  ## Restores the movies quickstart data backup
 	pg_restore --format=custom \
 		$(DEMO_MOVIES_PATH)/data/qs/01-movies.backup \
-		--exit-on-error \
 		--schema=public \
 		--clean --if-exists --no-owner --no-privileges \
 		--dbname=local --host=localhost --port=5432 --username=postgres
 	psql postgres://postgres:postgres@localhost:5432/local \
-		-v ON_ERROR_STOP=1 \
 		-f $(DEMO_MOVIES_PATH)/data/quickstart.sql
 	cd $(DEMO_MOVIES_PATH) && nhost dev hasura metadata inconsistency drop \
 		--endpoint https://local.hasura.nhost.run --admin-secret "nhost-admin-secret"

--- a/services/ai/README.md
+++ b/services/ai/README.md
@@ -16,6 +16,9 @@ Supported OpenAI models include `text-embedding-ada-002`, `text-embedding-3-smal
 
 Agents support Anthropic, OpenAI, and Google Gemini models with server-sent event streaming. They can use GraphQL, MCP, web search, and web fetch tools, with approval policies configured per agent.
 
+Configure Anthropic with `ANTHROPIC_API_KEY`. To route Anthropic requests to a specific workspace, also set
+`ANTHROPIC_WORKSPACE_ID`; the service sends it as the `anthropic-workspace-id` request header.
+
 Applications stream a message with:
 
 ```text

--- a/services/ai/agents/agents.go
+++ b/services/ai/agents/agents.go
@@ -11,13 +11,14 @@ import (
 	"github.com/nhost/nhost/services/ai/hasura"
 )
 
-// ProviderConfig holds API keys for each provider.
+// ProviderConfig holds credentials and settings for external providers.
 type ProviderConfig struct {
-	AnthropicKey string
-	OpenAIKey    string
-	GoogleKey    string
-	BraveKey     string
-	TavilyKey    string
+	AnthropicKey         string
+	AnthropicWorkspaceID string
+	OpenAIKey            string
+	GoogleKey            string
+	BraveKey             string
+	TavilyKey            string
 }
 
 // agentSessionGetter abstracts the Hasura call used for authorization.
@@ -61,6 +62,7 @@ type providerFactory func(
 	providerName provider.Name,
 	apiKey string,
 	model string,
+	workspaceID string,
 ) (provider.Provider, error)
 
 type sessionLocker func(ctx context.Context, sessionID string) (func(), error)

--- a/services/ai/agents/agents.go
+++ b/services/ai/agents/agents.go
@@ -3,6 +3,7 @@ package agents
 import (
 	"context"
 	"database/sql"
+	"maps"
 	"net/http"
 	"time"
 
@@ -11,14 +12,10 @@ import (
 	"github.com/nhost/nhost/services/ai/hasura"
 )
 
-// ProviderConfig holds credentials and settings for external providers.
-type ProviderConfig struct {
-	AnthropicKey         string
-	AnthropicWorkspaceID string
-	OpenAIKey            string
-	GoogleKey            string
-	BraveKey             string
-	TavilyKey            string
+// ToolConfig holds credentials used by optional agent tools.
+type ToolConfig struct {
+	BraveKey  string
+	TavilyKey string
 }
 
 // agentSessionGetter abstracts the Hasura call used for authorization.
@@ -57,14 +54,6 @@ type hasuraClient interface {
 	) (*hasura.InsertAgentMessages, error)
 }
 
-type providerFactory func(
-	ctx context.Context,
-	providerName provider.Name,
-	apiKey string,
-	model string,
-	workspaceID string,
-) (provider.Provider, error)
-
 type sessionLocker func(ctx context.Context, sessionID string) (func(), error)
 
 // Service is the main agents service.
@@ -72,28 +61,29 @@ type Service struct {
 	hasura      hasuraClient
 	hasuraAuth  agentSessionGetter
 	db          *sql.DB
-	providers   ProviderConfig
+	providers   provider.Registry
+	tools       ToolConfig
 	baseURL     string
 	adminSecret string
 	graphqlURL  string
-	newProvider providerFactory
 	lockSession sessionLocker
 }
 
 // NewService creates a new agents service. db is used for per-session advisory
 // locking and may be shared with other components; NewService does not take
-// ownership of it. Returns nil when no provider API keys are configured so
-// callers can omit the agent routes entirely rather than register handlers
-// that would fail at request time.
+// ownership of it. Returns nil when no providers are configured so callers
+// can omit the agent routes entirely rather than register handlers that would
+// fail at request time.
 func NewService(
 	hc *hasura.Client,
 	db *sql.DB,
-	providers ProviderConfig,
+	providers provider.Registry,
+	tools ToolConfig,
 	baseURL string,
 	adminSecret string,
 	hasuraURL string,
 ) *Service {
-	if providers.AnthropicKey == "" && providers.OpenAIKey == "" && providers.GoogleKey == "" {
+	if len(providers) == 0 {
 		return nil
 	}
 
@@ -109,11 +99,11 @@ func NewService(
 		hasura:      hc,
 		hasuraAuth:  authClient,
 		db:          db,
-		providers:   providers,
+		providers:   maps.Clone(providers),
+		tools:       tools,
 		baseURL:     baseURL,
 		adminSecret: adminSecret,
 		graphqlURL:  hasuraURL,
-		newProvider: nil,
 		lockSession: nil,
 	}
 }

--- a/services/ai/agents/agents_internal_test.go
+++ b/services/ai/agents/agents_internal_test.go
@@ -1,0 +1,42 @@
+package agents
+
+import (
+	"testing"
+
+	"github.com/nhost/nhost/services/ai/agents/provider"
+	providermock "github.com/nhost/nhost/services/ai/agents/provider/mock"
+	"go.uber.org/mock/gomock"
+)
+
+func TestNewServiceClonesProviderRegistry(t *testing.T) {
+	t.Parallel()
+
+	configuredProvider := providermock.NewMockProvider(gomock.NewController(t))
+	providers := provider.Registry{
+		provider.ProviderOpenAI: configuredProvider,
+	}
+
+	service := NewService(
+		nil,
+		nil,
+		providers,
+		ToolConfig{BraveKey: "", TavilyKey: ""},
+		"",
+		"",
+		"http://hasura.test/v1/graphql",
+	)
+	if service == nil {
+		t.Fatal("NewService() returned nil for a configured provider")
+	}
+
+	delete(providers, provider.ProviderOpenAI)
+
+	gotProvider, ok := service.providers[provider.ProviderOpenAI]
+	if !ok {
+		t.Fatal("NewService() provider registry changed when the input registry was mutated")
+	}
+
+	if gotProvider != configuredProvider {
+		t.Error("NewService() stored an unexpected provider")
+	}
+}

--- a/services/ai/agents/agents_test.go
+++ b/services/ai/agents/agents_test.go
@@ -1,0 +1,58 @@
+package agents_test
+
+import (
+	"testing"
+
+	"github.com/nhost/nhost/services/ai/agents"
+	"github.com/nhost/nhost/services/ai/agents/provider"
+	providermock "github.com/nhost/nhost/services/ai/agents/provider/mock"
+	"go.uber.org/mock/gomock"
+)
+
+func TestNewService(t *testing.T) {
+	t.Parallel()
+
+	configuredProvider := providermock.NewMockProvider(gomock.NewController(t))
+	tests := []struct {
+		name      string
+		providers provider.Registry
+		wantNil   bool
+	}{
+		{
+			name:      "nil registry",
+			providers: nil,
+			wantNil:   true,
+		},
+		{
+			name:      "empty registry",
+			providers: provider.Registry{},
+			wantNil:   true,
+		},
+		{
+			name: "configured provider",
+			providers: provider.Registry{
+				provider.ProviderOpenAI: configuredProvider,
+			},
+			wantNil: false,
+		},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			t.Parallel()
+
+			service := agents.NewService(
+				nil,
+				nil,
+				test.providers,
+				agents.ToolConfig{BraveKey: "", TavilyKey: ""},
+				"",
+				"",
+				"http://hasura.test/v1/graphql",
+			)
+			if (service == nil) != test.wantNil {
+				t.Errorf("NewService() nil = %t, want %t", service == nil, test.wantNil)
+			}
+		})
+	}
+}

--- a/services/ai/agents/approval.go
+++ b/services/ai/agents/approval.go
@@ -59,7 +59,7 @@ func (s *Service) HandleApproveTools(c *gin.Context) {
 		return
 	}
 
-	p, ok := s.newProviderForAgent(c, logger, agent)
+	p, ok := s.providerForAgent(c, logger, agent)
 	if !ok {
 		return
 	}
@@ -174,6 +174,7 @@ func (s *Service) resumeAfterApproval(
 	result, err := RunAgentLoop(
 		c.Request.Context(),
 		p,
+		agent.Model,
 		agent.Instructions,
 		allMessages,
 		registry,

--- a/services/ai/agents/approval_internal_test.go
+++ b/services/ai/agents/approval_internal_test.go
@@ -1,6 +1,7 @@
 package agents
 
 import (
+	"context"
 	"errors"
 	"log/slog"
 	"net/http"
@@ -8,6 +9,7 @@ import (
 	"testing"
 
 	"github.com/gin-gonic/gin"
+	"github.com/google/go-cmp/cmp"
 	"github.com/nhost/nhost/services/ai/agents/mock"
 	"github.com/nhost/nhost/services/ai/agents/provider"
 	providermock "github.com/nhost/nhost/services/ai/agents/provider/mock"
@@ -314,11 +316,12 @@ func TestResumeAfterApprovalPersistsToolResultsOnLoopError(t *testing.T) {
 	ctrl := gomock.NewController(t)
 
 	approvedTool := toolmock.NewMockTool(ctrl)
+	approvedDefinition := provider.ToolDefinition{
+		Name: "approved_tool", Description: "", Parameters: nil,
+	}
 	approvedTool.EXPECT().
 		Definition().
-		Return(provider.ToolDefinition{
-			Name: "approved_tool", Description: "", Parameters: nil,
-		}).
+		Return(approvedDefinition).
 		AnyTimes()
 	approvedTool.EXPECT().
 		Execute(gomock.Any(), gomock.Any(), gomock.Any()).
@@ -329,10 +332,42 @@ func TestResumeAfterApprovalPersistsToolResultsOnLoopError(t *testing.T) {
 
 	// Provider returns an error event so RunAgentLoop fails on its first
 	// iteration, after processDecisions has already executed approved_tool.
+	wantRequest := provider.StreamRequest{
+		Model:        "test-model",
+		SystemPrompt: "be helpful",
+		Messages: []provider.Message{
+			priorMessages[0],
+			priorMessages[1],
+			{
+				Role:       provider.RoleTool,
+				Content:    "approved-tool-output",
+				ToolCalls:  nil,
+				ToolCallID: approvedCall.ID,
+				ToolName:   approvedCall.Name,
+			},
+			{
+				Role:       provider.RoleTool,
+				Content:    "Tool call denied by user",
+				ToolCalls:  nil,
+				ToolCallID: deniedCall.ID,
+				ToolName:   deniedCall.Name,
+			},
+		},
+		Tools: []provider.ToolDefinition{approvedDefinition},
+	}
 	p := providermock.NewMockProvider(ctrl)
 	p.EXPECT().
-		StreamResponse(gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any()).
-		Return(eventChan(provider.NewErrorEvent(errProviderStreamUp)))
+		StreamResponse(gomock.Any(), gomock.Any()).
+		DoAndReturn(func(
+			_ context.Context,
+			got provider.StreamRequest,
+		) <-chan provider.Event {
+			if diff := cmp.Diff(wantRequest, got); diff != "" {
+				t.Errorf("StreamRequest mismatch (-want +got):\n%s", diff)
+			}
+
+			return eventChan(provider.NewErrorEvent(errProviderStreamUp))
+		})
 
 	mockHasura := mock.NewMockhasuraClient(ctrl)
 
@@ -358,7 +393,7 @@ func TestResumeAfterApprovalPersistsToolResultsOnLoopError(t *testing.T) {
 	w := &fakeWriter{events: nil}
 
 	agent := &hasura.GetAgent_AiAgent{
-		ID: "agent-1", Instructions: "be helpful",
+		ID: "agent-1", Instructions: "be helpful", Model: "test-model",
 	}
 
 	decisions := []toolDecision{

--- a/services/ai/agents/handlers_internal_test.go
+++ b/services/ai/agents/handlers_internal_test.go
@@ -267,6 +267,7 @@ func TestHandleStreamMessagePendingApprovalsReleasesLock(t *testing.T) {
 		_ provider.Name,
 		_ string,
 		_ string,
+		_ string,
 	) (provider.Provider, error) {
 		return providermock.NewMockProvider(ctrl), nil
 	}
@@ -332,6 +333,7 @@ func TestHandleStreamMessageHappyPathSSEAndReleasesLock(t *testing.T) {
 	factory := func(
 		_ context.Context,
 		_ provider.Name,
+		_ string,
 		_ string,
 		_ string,
 	) (provider.Provider, error) {
@@ -512,6 +514,7 @@ func TestHandleApproveToolsHappyPathSSEAndReleasesLock(t *testing.T) {
 	factory := func(
 		_ context.Context,
 		_ provider.Name,
+		_ string,
 		_ string,
 		_ string,
 	) (provider.Provider, error) {

--- a/services/ai/agents/handlers_internal_test.go
+++ b/services/ai/agents/handlers_internal_test.go
@@ -104,17 +104,17 @@ func assertSSE(t *testing.T, rec *httptest.ResponseRecorder, wantEvents ...strin
 func handlerTestService(
 	hc hasuraClient,
 	lock *handlerLockRecorder,
-	factory providerFactory,
+	p provider.Provider,
 ) *Service {
 	return &Service{
 		hasura:      hc,
 		hasuraAuth:  &mockAuthClient{},
 		db:          nil,
-		providers:   ProviderConfig{OpenAIKey: "test-openai-key"},
+		providers:   provider.Registry{provider.ProviderOpenAI: p},
+		tools:       ToolConfig{BraveKey: "", TavilyKey: ""},
 		baseURL:     "",
 		adminSecret: handlerTestAdminSecret,
 		graphqlURL:  "http://hasura.test/v1/graphql",
-		newProvider: factory,
 		lockSession: lock.lock,
 	}
 }
@@ -262,17 +262,9 @@ func TestHandleStreamMessagePendingApprovalsReleasesLock(t *testing.T) {
 			},
 		}, nil)
 
-	factory := func(
-		_ context.Context,
-		_ provider.Name,
-		_ string,
-		_ string,
-		_ string,
-	) (provider.Provider, error) {
-		return providermock.NewMockProvider(ctrl), nil
-	}
+	p := providermock.NewMockProvider(ctrl)
 	lock := &handlerLockRecorder{}
-	svc := handlerTestService(mockHasura, lock, factory)
+	svc := handlerTestService(mockHasura, lock, p)
 	c, rec := newHandlerContext(`{"message":"hello"}`, handlerTestSessionID)
 
 	svc.HandleStreamMessage(c)
@@ -330,17 +322,8 @@ func TestHandleStreamMessageHappyPathSSEAndReleasesLock(t *testing.T) {
 		provider.NewCompleteEvent(provider.StopReasonEndTurn),
 	))
 
-	factory := func(
-		_ context.Context,
-		_ provider.Name,
-		_ string,
-		_ string,
-		_ string,
-	) (provider.Provider, error) {
-		return p, nil
-	}
 	lock := &handlerLockRecorder{}
-	svc := handlerTestService(mockHasura, lock, factory)
+	svc := handlerTestService(mockHasura, lock, p)
 	c, rec := newHandlerContext(`{"message":"hello"}`, handlerTestSessionID)
 
 	svc.HandleStreamMessage(c)
@@ -511,17 +494,8 @@ func TestHandleApproveToolsHappyPathSSEAndReleasesLock(t *testing.T) {
 		provider.NewCompleteEvent(provider.StopReasonEndTurn),
 	))
 
-	factory := func(
-		_ context.Context,
-		_ provider.Name,
-		_ string,
-		_ string,
-		_ string,
-	) (provider.Provider, error) {
-		return p, nil
-	}
 	lock := &handlerLockRecorder{}
-	svc := handlerTestService(mockHasura, lock, factory)
+	svc := handlerTestService(mockHasura, lock, p)
 	body := `{"decisions":[{"tool_call_id":"tc-denied","approved":false}]}`
 	c, rec := newHandlerContext(body, handlerTestSessionID)
 

--- a/services/ai/agents/loop.go
+++ b/services/ai/agents/loop.go
@@ -48,6 +48,7 @@ type LoopResult struct {
 func RunAgentLoop(
 	ctx context.Context,
 	p provider.Provider,
+	model string,
 	systemPrompt string,
 	messages []provider.Message,
 	tools *tool.Registry,
@@ -72,7 +73,8 @@ func RunAgentLoop(
 		// promptly when processStreamEvents returns early on error — without
 		// it the goroutine would block on its next channel send forever.
 		iterCtx, iterCancel := context.WithCancel(ctx)
-		eventCh := p.StreamResponse(iterCtx, systemPrompt, allMessages, toolDefs)
+		streamRequest := buildStreamRequest(model, systemPrompt, allMessages, toolDefs)
+		eventCh := p.StreamResponse(iterCtx, streamRequest)
 
 		result, err := processStreamEvents(eventCh, writer)
 
@@ -111,6 +113,19 @@ func RunAgentLoop(
 	}
 
 	return LoopResult{Messages: newMessages, PendingCalls: nil}, nil
+}
+
+func buildStreamRequest(
+	model, systemPrompt string,
+	messages []provider.Message,
+	tools []provider.ToolDefinition,
+) provider.StreamRequest {
+	return provider.StreamRequest{
+		Model:        model,
+		SystemPrompt: systemPrompt,
+		Messages:     messages,
+		Tools:        tools,
+	}
 }
 
 func assistantMessageFromResult(result streamResult) provider.Message {

--- a/services/ai/agents/loop_internal_test.go
+++ b/services/ai/agents/loop_internal_test.go
@@ -8,6 +8,7 @@ import (
 	"strings"
 	"testing"
 
+	"github.com/google/go-cmp/cmp"
 	"github.com/nhost/nhost/services/ai/agents/provider"
 	providermock "github.com/nhost/nhost/services/ai/agents/provider/mock"
 	"github.com/nhost/nhost/services/ai/agents/tool"
@@ -384,11 +385,45 @@ func expectStreamResponses(p *providermock.MockProvider, returns ...<-chan provi
 
 	for _, ch := range returns {
 		calls = append(calls, p.EXPECT().
-			StreamResponse(gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any()).
+			StreamResponse(gomock.Any(), gomock.Any()).
 			Return(ch))
 	}
 
 	gomock.InOrder(calls...)
+}
+
+func expectStreamRequest(
+	t *testing.T,
+	p *providermock.MockProvider,
+	want provider.StreamRequest,
+	response <-chan provider.Event,
+) *gomock.Call {
+	t.Helper()
+
+	return p.EXPECT().
+		StreamResponse(gomock.Any(), gomock.Any()).
+		DoAndReturn(func(
+			_ context.Context,
+			got provider.StreamRequest,
+		) <-chan provider.Event {
+			if diff := cmp.Diff(want, got); diff != "" {
+				t.Errorf("StreamRequest mismatch (-want +got):\n%s", diff)
+			}
+
+			return response
+		})
+}
+
+func testStreamRequest(
+	systemPrompt string,
+	messages []provider.Message,
+) provider.StreamRequest {
+	return provider.StreamRequest{
+		Model:        "test-model",
+		SystemPrompt: systemPrompt,
+		Messages:     messages,
+		Tools:        nil,
+	}
 }
 
 func TestRunAgentLoopSimpleResponse(t *testing.T) {
@@ -396,16 +431,39 @@ func TestRunAgentLoopSimpleResponse(t *testing.T) {
 
 	ctrl := gomock.NewController(t)
 	p := providermock.NewMockProvider(ctrl)
-	expectStreamResponses(p, eventChan(
-		provider.NewContentDeltaEvent("hello"),
-		provider.NewCompleteEvent(provider.StopReasonEndTurn),
-	))
+	p.EXPECT().
+		StreamResponse(gomock.Any(), gomock.Any()).
+		DoAndReturn(func(
+			_ context.Context,
+			request provider.StreamRequest,
+		) <-chan provider.Event {
+			if request.Model != "test-model" {
+				t.Errorf("model = %q, want %q", request.Model, "test-model")
+			}
+
+			if request.SystemPrompt != "system" {
+				t.Errorf("system prompt = %q, want %q", request.SystemPrompt, "system")
+			}
+
+			if len(request.Messages) != 0 {
+				t.Errorf("messages = %v, want none", request.Messages)
+			}
+
+			if len(request.Tools) != 0 {
+				t.Errorf("tools = %v, want none", request.Tools)
+			}
+
+			return eventChan(
+				provider.NewContentDeltaEvent("hello"),
+				provider.NewCompleteEvent(provider.StopReasonEndTurn),
+			)
+		})
 
 	w := &fakeWriter{events: nil}
 	r := tool.NewRegistry()
 
 	result, err := RunAgentLoop(
-		context.Background(), p, "system", nil, r, w, slog.Default(),
+		context.Background(), p, "test-model", "system", nil, r, w, slog.Default(),
 	)
 	if err != nil {
 		t.Fatalf("unexpected error: %v", err)
@@ -434,26 +492,48 @@ func TestRunAgentLoopToolCallLoop(t *testing.T) {
 	ctrl := gomock.NewController(t)
 	p := providermock.NewMockProvider(ctrl)
 	tc := &provider.ToolCall{ID: "tc1", Name: testSearchToolName, Arguments: `{"q":"test"}`}
-	expectStreamResponses(
-		p,
-		eventChan(
+
+	r := tool.NewRegistry()
+	searchTool := &fakeTool{name: testSearchToolName, result: "result", err: nil}
+	mustRegister(t, r, searchTool)
+
+	toolDefs := []provider.ToolDefinition{searchTool.Definition()}
+	firstRequest := testStreamRequest("", nil)
+	firstRequest.Tools = toolDefs
+	secondRequest := testStreamRequest("", []provider.Message{
+		{
+			Role:       provider.RoleAssistant,
+			Content:    "",
+			ToolCalls:  []provider.ToolCall{*tc},
+			ToolCallID: "",
+			ToolName:   "",
+		},
+		{
+			Role:       provider.RoleTool,
+			Content:    "result",
+			ToolCalls:  nil,
+			ToolCallID: tc.ID,
+			ToolName:   tc.Name,
+		},
+	})
+	secondRequest.Tools = toolDefs
+
+	gomock.InOrder(
+		expectStreamRequest(t, p, firstRequest, eventChan(
 			provider.NewToolEvent(provider.EventToolUseStart, tc),
 			provider.NewToolEvent(provider.EventToolUseDone, tc),
 			provider.NewCompleteEvent(provider.StopReasonToolUse),
-		),
-		eventChan(
+		)),
+		expectStreamRequest(t, p, secondRequest, eventChan(
 			provider.NewContentDeltaEvent("done"),
 			provider.NewCompleteEvent(provider.StopReasonEndTurn),
-		),
+		)),
 	)
-
-	r := tool.NewRegistry()
-	mustRegister(t, r, &fakeTool{name: testSearchToolName, result: "result", err: nil})
 
 	w := &fakeWriter{events: nil}
 
 	result, err := RunAgentLoop(
-		context.Background(), p, "", nil, r, w, slog.Default(),
+		context.Background(), p, "test-model", "", nil, r, w, slog.Default(),
 	)
 	if err != nil {
 		t.Fatalf("unexpected error: %v", err)
@@ -500,7 +580,7 @@ func TestRunAgentLoopKeepsToolResultWhenToolResultSSEFails(t *testing.T) {
 	w := &failOnEventWriter{events: nil, failEvent: "tool_result"}
 
 	result, err := RunAgentLoop(
-		context.Background(), p, "", nil, r, w, slog.Default(),
+		context.Background(), p, "test-model", "", nil, r, w, slog.Default(),
 	)
 	if !errors.Is(err, errEventWriteFailed) {
 		t.Fatalf("expected %v, got %v", errEventWriteFailed, err)
@@ -551,7 +631,7 @@ func TestRunAgentLoopStreamErrorPropagates(t *testing.T) {
 	r := tool.NewRegistry()
 
 	_, err := RunAgentLoop(
-		context.Background(), p, "", nil, r, w, slog.Default(),
+		context.Background(), p, "test-model", "", nil, r, w, slog.Default(),
 	)
 	if err == nil {
 		t.Fatal("expected error, got nil")
@@ -578,7 +658,7 @@ func TestRunAgentLoopApprovalPause(t *testing.T) {
 	w := &fakeWriter{events: nil}
 
 	result, err := RunAgentLoop(
-		context.Background(), p, "", nil, r, w, slog.Default(),
+		context.Background(), p, "test-model", "", nil, r, w, slog.Default(),
 	)
 	if err != nil {
 		t.Fatalf("unexpected error: %v", err)
@@ -635,7 +715,7 @@ func TestRunAgentLoopNoApprovalNeeded(t *testing.T) {
 	w := &fakeWriter{events: nil}
 
 	result, err := RunAgentLoop(
-		context.Background(), p, "", nil, r, w, slog.Default(),
+		context.Background(), p, "test-model", "", nil, r, w, slog.Default(),
 	)
 	if err != nil {
 		t.Fatalf("unexpected error: %v", err)
@@ -659,12 +739,10 @@ func TestRunAgentLoopMaxIterations(t *testing.T) {
 	tc := &provider.ToolCall{ID: "tc1", Name: testSearchToolName, Arguments: `{"q":"test"}`}
 
 	p.EXPECT().
-		StreamResponse(gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any()).
+		StreamResponse(gomock.Any(), gomock.Any()).
 		DoAndReturn(func(
 			_ context.Context,
-			_ string,
-			_ []provider.Message,
-			_ []provider.ToolDefinition,
+			_ provider.StreamRequest,
 		) <-chan provider.Event {
 			return eventChan(
 				provider.NewToolEvent(provider.EventToolUseStart, tc),
@@ -680,7 +758,7 @@ func TestRunAgentLoopMaxIterations(t *testing.T) {
 	w := &fakeWriter{events: nil}
 
 	result, err := RunAgentLoop(
-		context.Background(), p, "", nil, r, w, slog.Default(),
+		context.Background(), p, "test-model", "", nil, r, w, slog.Default(),
 	)
 	if err != nil {
 		t.Fatalf("unexpected error: %v", err)

--- a/services/ai/agents/provider/anthropic.go
+++ b/services/ai/agents/provider/anthropic.go
@@ -141,7 +141,7 @@ func (a *Anthropic) StreamResponse(
 	ctx context.Context,
 	request StreamRequest,
 ) <-chan Event {
-	if err := request.validate(); err != nil {
+	if err := request.Validate(); err != nil {
 		return requestErrorChannel(err)
 	}
 

--- a/services/ai/agents/provider/anthropic.go
+++ b/services/ai/agents/provider/anthropic.go
@@ -40,27 +40,35 @@ func toStringSlice(v any) ([]string, bool) {
 	}
 }
 
+// AnthropicConfig contains the static configuration for an Anthropic client.
+type AnthropicConfig struct {
+	APIKey      string
+	WorkspaceID string
+}
+
 // Anthropic implements the Provider interface for Anthropic's Claude.
 type Anthropic struct {
 	client anthropic.Client
-	model  string
 }
 
-// NewAnthropic creates a new Anthropic provider. When workspaceID is set,
-// requests are scoped using Anthropic's workspace header.
-func NewAnthropic(apiKey, model, workspaceID string) *Anthropic {
-	clientOptions := []option.RequestOption{option.WithAPIKey(apiKey)}
-	if workspaceID != "" {
+// NewAnthropic creates a reusable Anthropic provider client. When WorkspaceID
+// is set, requests are scoped using Anthropic's workspace header.
+func NewAnthropic(config AnthropicConfig) (*Anthropic, error) {
+	if config.APIKey == "" {
+		return nil, ErrEmptyAPIKey
+	}
+
+	clientOptions := []option.RequestOption{option.WithAPIKey(config.APIKey)}
+	if config.WorkspaceID != "" {
 		clientOptions = append(
 			clientOptions,
-			option.WithHeader(anthropicWorkspaceIDHeader, workspaceID),
+			option.WithHeader(anthropicWorkspaceIDHeader, config.WorkspaceID),
 		)
 	}
 
 	return &Anthropic{
 		client: anthropic.NewClient(clientOptions...),
-		model:  model,
-	}
+	}, nil
 }
 
 func toAnthropicMessages(messages []Message) ([]anthropic.MessageParam, error) {
@@ -131,16 +139,18 @@ func toAnthropicTools(tools []ToolDefinition) []anthropic.ToolUnionParam {
 // StreamResponse implements Provider.StreamResponse for Anthropic.
 func (a *Anthropic) StreamResponse(
 	ctx context.Context,
-	systemPrompt string,
-	messages []Message,
-	tools []ToolDefinition,
+	request StreamRequest,
 ) <-chan Event {
+	if err := request.validate(); err != nil {
+		return requestErrorChannel(err)
+	}
+
 	ch := make(chan Event)
 
 	go func() {
 		defer close(ch)
 
-		a.processStream(ctx, ch, systemPrompt, messages, tools)
+		a.processStream(ctx, ch, request)
 	}()
 
 	return ch
@@ -179,11 +189,14 @@ func buildAnthropicParams(
 func (a *Anthropic) processStream(
 	ctx context.Context,
 	ch chan<- Event,
-	systemPrompt string,
-	messages []Message,
-	tools []ToolDefinition,
+	request StreamRequest,
 ) {
-	params, err := buildAnthropicParams(a.model, systemPrompt, messages, tools)
+	params, err := buildAnthropicParams(
+		request.Model,
+		request.SystemPrompt,
+		request.Messages,
+		request.Tools,
+	)
 	if err != nil {
 		send(ctx, ch, NewErrorEvent(err))
 

--- a/services/ai/agents/provider/anthropic.go
+++ b/services/ai/agents/provider/anthropic.go
@@ -10,7 +10,10 @@ import (
 	"github.com/anthropics/anthropic-sdk-go/option"
 )
 
-const defaultMaxTokens = 8192
+const (
+	anthropicWorkspaceIDHeader = "anthropic-workspace-id"
+	defaultMaxTokens           = 8192
+)
 
 // toStringSlice extracts a []string from an any that holds either a Go-literal
 // []string (the common path today) or a []any of strings (the shape produced
@@ -43,10 +46,19 @@ type Anthropic struct {
 	model  string
 }
 
-// NewAnthropic creates a new Anthropic provider.
-func NewAnthropic(apiKey, model string) *Anthropic {
+// NewAnthropic creates a new Anthropic provider. When workspaceID is set,
+// requests are scoped using Anthropic's workspace header.
+func NewAnthropic(apiKey, model, workspaceID string) *Anthropic {
+	clientOptions := []option.RequestOption{option.WithAPIKey(apiKey)}
+	if workspaceID != "" {
+		clientOptions = append(
+			clientOptions,
+			option.WithHeader(anthropicWorkspaceIDHeader, workspaceID),
+		)
+	}
+
 	return &Anthropic{
-		client: anthropic.NewClient(option.WithAPIKey(apiKey)),
+		client: anthropic.NewClient(clientOptions...),
 		model:  model,
 	}
 }

--- a/services/ai/agents/provider/google.go
+++ b/services/ai/agents/provider/google.go
@@ -10,31 +10,34 @@ import (
 	"google.golang.org/genai"
 )
 
+// GoogleConfig contains the static configuration for a Google Gemini client.
+type GoogleConfig struct {
+	APIKey string
+}
+
 // Google implements the Provider interface for Google Gemini.
 type Google struct {
 	client *genai.Client
-	model  string
 }
 
-// NewGoogle creates a new Google Gemini provider. It rejects empty apiKey to
-// prevent the underlying SDK from silently falling back to ambient credentials
-// (GOOGLE_API_KEY / GEMINI_API_KEY / ADC), and constructs the client once so
-// it can be reused across requests. ctx is forwarded to genai.NewClient so
-// that any credential/init work the SDK performs is cancellable by the caller.
-func NewGoogle(ctx context.Context, apiKey, model string) (*Google, error) {
-	if apiKey == "" {
+// NewGoogle creates a reusable Google Gemini provider client. It rejects an
+// empty APIKey to prevent the underlying SDK from silently falling back to
+// ambient credentials (GOOGLE_API_KEY / GEMINI_API_KEY / ADC). ctx is
+// forwarded to genai.NewClient so credential initialization is cancellable.
+func NewGoogle(ctx context.Context, config GoogleConfig) (*Google, error) {
+	if config.APIKey == "" {
 		return nil, ErrEmptyAPIKey
 	}
 
 	client, err := genai.NewClient(ctx, &genai.ClientConfig{ //nolint:exhaustruct
-		APIKey:  apiKey,
+		APIKey:  config.APIKey,
 		Backend: genai.BackendGeminiAPI,
 	})
 	if err != nil {
 		return nil, fmt.Errorf("failed to create Google client: %w", err)
 	}
 
-	return &Google{client: client, model: model}, nil
+	return &Google{client: client}, nil
 }
 
 func toGeminiContents(
@@ -160,16 +163,18 @@ func toGeminiTools(tools []ToolDefinition) []*genai.Tool {
 // StreamResponse implements Provider.StreamResponse for Google Gemini.
 func (g *Google) StreamResponse(
 	ctx context.Context,
-	systemPrompt string,
-	messages []Message,
-	tools []ToolDefinition,
+	request StreamRequest,
 ) <-chan Event {
+	if err := request.validate(); err != nil {
+		return requestErrorChannel(err)
+	}
+
 	ch := make(chan Event)
 
 	go func() {
 		defer close(ch)
 
-		g.processStream(ctx, ch, systemPrompt, messages, tools)
+		g.processStream(ctx, ch, request)
 	}()
 
 	return ch
@@ -178,21 +183,22 @@ func (g *Google) StreamResponse(
 func (g *Google) processStream(
 	ctx context.Context,
 	ch chan<- Event,
-	systemPrompt string,
-	messages []Message,
-	tools []ToolDefinition,
+	request StreamRequest,
 ) {
 	config := &genai.GenerateContentConfig{} //nolint:exhaustruct
-	if systemPrompt != "" {
-		config.SystemInstruction = genai.NewContentFromText(systemPrompt, genai.RoleUser)
+	if request.SystemPrompt != "" {
+		config.SystemInstruction = genai.NewContentFromText(
+			request.SystemPrompt,
+			genai.RoleUser,
+		)
 	}
 
-	gt := toGeminiTools(tools)
+	gt := toGeminiTools(request.Tools)
 	if len(gt) > 0 {
 		config.Tools = gt
 	}
 
-	contents, err := toGeminiContents(ctx, messages)
+	contents, err := toGeminiContents(ctx, request.Messages)
 	if err != nil {
 		send(ctx, ch, NewErrorEvent(fmt.Errorf("failed to convert messages: %w", err)))
 		return
@@ -200,7 +206,12 @@ func (g *Google) processStream(
 
 	stream := &googleStream{hasToolCalls: false}
 
-	for resp, err := range g.client.Models.GenerateContentStream(ctx, g.model, contents, config) {
+	for resp, err := range g.client.Models.GenerateContentStream(
+		ctx,
+		request.Model,
+		contents,
+		config,
+	) {
 		if ctx.Err() != nil {
 			return
 		}

--- a/services/ai/agents/provider/google.go
+++ b/services/ai/agents/provider/google.go
@@ -165,7 +165,7 @@ func (g *Google) StreamResponse(
 	ctx context.Context,
 	request StreamRequest,
 ) <-chan Event {
-	if err := request.validate(); err != nil {
+	if err := request.Validate(); err != nil {
 		return requestErrorChannel(err)
 	}
 

--- a/services/ai/agents/provider/google_internal_test.go
+++ b/services/ai/agents/provider/google_internal_test.go
@@ -445,7 +445,7 @@ func TestNewGoogle(t *testing.T) {
 		t.Run(tc.name, func(t *testing.T) {
 			t.Parallel()
 
-			g, err := NewGoogle(t.Context(), tc.apiKey, "gemini-2.0-flash")
+			g, err := NewGoogle(t.Context(), GoogleConfig{APIKey: tc.apiKey})
 
 			if tc.wantErr != nil {
 				if err == nil {

--- a/services/ai/agents/provider/mock/provider.go
+++ b/services/ai/agents/provider/mock/provider.go
@@ -42,15 +42,15 @@ func (m *MockProvider) EXPECT() *MockProviderMockRecorder {
 }
 
 // StreamResponse mocks base method.
-func (m *MockProvider) StreamResponse(ctx context.Context, systemPrompt string, messages []provider.Message, tools []provider.ToolDefinition) <-chan provider.Event {
+func (m *MockProvider) StreamResponse(ctx context.Context, request provider.StreamRequest) <-chan provider.Event {
 	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "StreamResponse", ctx, systemPrompt, messages, tools)
+	ret := m.ctrl.Call(m, "StreamResponse", ctx, request)
 	ret0, _ := ret[0].(<-chan provider.Event)
 	return ret0
 }
 
 // StreamResponse indicates an expected call of StreamResponse.
-func (mr *MockProviderMockRecorder) StreamResponse(ctx, systemPrompt, messages, tools any) *gomock.Call {
+func (mr *MockProviderMockRecorder) StreamResponse(ctx, request any) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "StreamResponse", reflect.TypeOf((*MockProvider)(nil).StreamResponse), ctx, systemPrompt, messages, tools)
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "StreamResponse", reflect.TypeOf((*MockProvider)(nil).StreamResponse), ctx, request)
 }

--- a/services/ai/agents/provider/openai.go
+++ b/services/ai/agents/provider/openai.go
@@ -10,18 +10,25 @@ import (
 	"github.com/openai/openai-go/option"
 )
 
+// OpenAIConfig contains the static configuration for an OpenAI client.
+type OpenAIConfig struct {
+	APIKey string
+}
+
 // OpenAI implements the Provider interface for OpenAI.
 type OpenAI struct {
 	client openai.Client
-	model  string
 }
 
-// NewOpenAI creates a new OpenAI provider.
-func NewOpenAI(apiKey, model string) *OpenAI {
-	return &OpenAI{
-		client: openai.NewClient(option.WithAPIKey(apiKey)),
-		model:  model,
+// NewOpenAI creates a reusable OpenAI provider client.
+func NewOpenAI(config OpenAIConfig) (*OpenAI, error) {
+	if config.APIKey == "" {
+		return nil, ErrEmptyAPIKey
 	}
+
+	return &OpenAI{
+		client: openai.NewClient(option.WithAPIKey(config.APIKey)),
+	}, nil
 }
 
 func toOpenAIMessages(
@@ -96,16 +103,18 @@ func toOpenAITools(tools []ToolDefinition) []openai.ChatCompletionToolParam {
 // StreamResponse implements Provider.StreamResponse for OpenAI.
 func (o *OpenAI) StreamResponse(
 	ctx context.Context,
-	systemPrompt string,
-	messages []Message,
-	tools []ToolDefinition,
+	request StreamRequest,
 ) <-chan Event {
+	if err := request.validate(); err != nil {
+		return requestErrorChannel(err)
+	}
+
 	ch := make(chan Event)
 
 	go func() {
 		defer close(ch)
 
-		o.processStream(ctx, ch, systemPrompt, messages, tools)
+		o.processStream(ctx, ch, request)
 	}()
 
 	return ch
@@ -147,13 +156,16 @@ func buildOpenAIParams(
 func (o *OpenAI) processStream(
 	ctx context.Context,
 	ch chan<- Event,
-	systemPrompt string,
-	messages []Message,
-	tools []ToolDefinition,
+	request StreamRequest,
 ) {
 	stream := o.client.Chat.Completions.NewStreaming(
 		ctx,
-		buildOpenAIParams(o.model, systemPrompt, messages, tools),
+		buildOpenAIParams(
+			request.Model,
+			request.SystemPrompt,
+			request.Messages,
+			request.Tools,
+		),
 	)
 	defer func() {
 		if err := stream.Close(); err != nil {

--- a/services/ai/agents/provider/openai.go
+++ b/services/ai/agents/provider/openai.go
@@ -105,7 +105,7 @@ func (o *OpenAI) StreamResponse(
 	ctx context.Context,
 	request StreamRequest,
 ) <-chan Event {
-	if err := request.validate(); err != nil {
+	if err := request.Validate(); err != nil {
 		return requestErrorChannel(err)
 	}
 

--- a/services/ai/agents/provider/openai_internal_test.go
+++ b/services/ai/agents/provider/openai_internal_test.go
@@ -402,14 +402,16 @@ func TestOpenAIProcessStream(t *testing.T) {
 					option.WithAPIKey("test"),
 					option.WithBaseURL(srv.URL+"/"),
 				),
-				model: "gpt-4o",
 			}
 
 			ch := provider.StreamResponse(
 				context.Background(),
-				"",
-				[]Message{{Role: RoleUser, Content: "hi"}},
-				nil,
+				StreamRequest{
+					Model:        "gpt-4o",
+					SystemPrompt: "",
+					Messages:     []Message{{Role: RoleUser, Content: "hi"}},
+					Tools:        nil,
+				},
 			)
 
 			got := collectOpenAIEvents(ch)

--- a/services/ai/agents/provider/provider.go
+++ b/services/ai/agents/provider/provider.go
@@ -133,7 +133,8 @@ type StreamRequest struct {
 	Tools        []ToolDefinition
 }
 
-func (r StreamRequest) validate() error {
+// Validate checks whether the request can be sent to a provider.
+func (r StreamRequest) Validate() error {
 	if r.Model == "" {
 		return ErrEmptyModel
 	}

--- a/services/ai/agents/provider/provider.go
+++ b/services/ai/agents/provider/provider.go
@@ -140,10 +140,11 @@ type Provider interface {
 }
 
 // NewProvider creates a new provider instance based on the provider name.
+// workspaceID is applied only to Anthropic providers and may be empty.
 func NewProvider( //nolint:ireturn,nolintlint
 	ctx context.Context,
 	providerName Name,
-	apiKey, model string,
+	apiKey, model, workspaceID string,
 ) (Provider, error) {
 	if model == "" {
 		return nil, ErrEmptyModel
@@ -155,7 +156,7 @@ func NewProvider( //nolint:ireturn,nolintlint
 
 	switch providerName {
 	case ProviderAnthropic:
-		return NewAnthropic(apiKey, model), nil
+		return NewAnthropic(apiKey, model, workspaceID), nil
 	case ProviderOpenAI:
 		return NewOpenAI(apiKey, model), nil
 	case ProviderGoogle:

--- a/services/ai/agents/provider/provider.go
+++ b/services/ai/agents/provider/provider.go
@@ -7,7 +7,9 @@ import (
 	"github.com/nhost/nhost/services/ai/hasura"
 )
 
-// ErrEmptyModel is returned when a provider is created with an empty model.
+// ErrEmptyModel is returned when a StreamRequest carries an empty Model.
+// Providers deliver it as the only EventError on a closed stream channel because
+// the model is selected per request rather than at provider construction.
 var ErrEmptyModel = errors.New("model must not be empty")
 
 // ErrEmptyAPIKey is returned when a provider is created with an empty API key.
@@ -150,11 +152,14 @@ func requestErrorChannel(err error) <-chan Event {
 
 // Provider is the interface for LLM providers.
 //
-// StreamResponse returns a channel of streaming events. The implementation
-// owns a background goroutine that closes the channel when streaming ends.
-// Callers MUST cancel ctx when they stop consuming events; otherwise the
-// goroutine may block on its next channel send and leak. Cancelling ctx is
-// the only safe way to abort a stream early.
+// StreamResponse returns a channel of streaming events. A valid request starts
+// a background goroutine that closes the channel when streaming ends. A request
+// that fails validation instead returns a closed channel containing exactly one
+// EventError and starts no goroutine.
+//
+// Callers MUST cancel ctx when they stop consuming events from a valid request;
+// otherwise the goroutine may block on its next channel send and leak. Cancelling
+// ctx is the only safe way to abort a stream early.
 //
 //go:generate mockgen -package mock -destination mock/provider.go . Provider
 type Provider interface {

--- a/services/ai/agents/provider/provider.go
+++ b/services/ai/agents/provider/provider.go
@@ -121,6 +121,33 @@ type ToolDefinition struct {
 	Parameters  map[string]any `json:"parameters"`
 }
 
+// StreamRequest contains the request-scoped configuration and conversation
+// passed to a provider. Provider credentials and client options belong in the
+// provider-specific constructor instead.
+type StreamRequest struct {
+	Model        string
+	SystemPrompt string
+	Messages     []Message
+	Tools        []ToolDefinition
+}
+
+func (r StreamRequest) validate() error {
+	if r.Model == "" {
+		return ErrEmptyModel
+	}
+
+	return nil
+}
+
+func requestErrorChannel(err error) <-chan Event {
+	ch := make(chan Event, 1)
+	ch <- NewErrorEvent(err)
+
+	close(ch)
+
+	return ch
+}
+
 // Provider is the interface for LLM providers.
 //
 // StreamResponse returns a channel of streaming events. The implementation
@@ -131,39 +158,7 @@ type ToolDefinition struct {
 //
 //go:generate mockgen -package mock -destination mock/provider.go . Provider
 type Provider interface {
-	StreamResponse(
-		ctx context.Context,
-		systemPrompt string,
-		messages []Message,
-		tools []ToolDefinition,
-	) <-chan Event
-}
-
-// NewProvider creates a new provider instance based on the provider name.
-// workspaceID is applied only to Anthropic providers and may be empty.
-func NewProvider( //nolint:ireturn,nolintlint
-	ctx context.Context,
-	providerName Name,
-	apiKey, model, workspaceID string,
-) (Provider, error) {
-	if model == "" {
-		return nil, ErrEmptyModel
-	}
-
-	if apiKey == "" {
-		return nil, ErrEmptyAPIKey
-	}
-
-	switch providerName {
-	case ProviderAnthropic:
-		return NewAnthropic(apiKey, model, workspaceID), nil
-	case ProviderOpenAI:
-		return NewOpenAI(apiKey, model), nil
-	case ProviderGoogle:
-		return NewGoogle(ctx, apiKey, model)
-	default:
-		return nil, UnknownProviderError{Provider: providerName}
-	}
+	StreamResponse(ctx context.Context, request StreamRequest) <-chan Event
 }
 
 // Name identifies a supported LLM provider.
@@ -175,11 +170,7 @@ const (
 	ProviderGoogle    Name = hasura.AiAgentProvidersEnumGoogle
 )
 
-// UnknownProviderError is returned when an unknown provider name is used.
-type UnknownProviderError struct {
-	Provider Name
-}
-
-func (e UnknownProviderError) Error() string {
-	return "unknown provider: " + string(e.Provider)
-}
+// Registry contains the configured provider clients keyed by provider name.
+// Provider clients are created once at service startup and shared across
+// requests.
+type Registry map[Name]Provider

--- a/services/ai/agents/provider/provider_test.go
+++ b/services/ai/agents/provider/provider_test.go
@@ -1,6 +1,8 @@
 package provider_test
 
 import (
+	"net/http"
+	"net/http/httptest"
 	"testing"
 
 	"github.com/nhost/nhost/services/ai/agents/provider"
@@ -10,17 +12,19 @@ func TestNewProvider(t *testing.T) {
 	t.Parallel()
 
 	cases := []struct {
-		name     string
-		provider provider.Name
-		apiKey   string
-		model    string
-		wantErr  bool
+		name        string
+		provider    provider.Name
+		apiKey      string
+		model       string
+		workspaceID string
+		wantErr     bool
 	}{
 		{
-			name:     "anthropic",
-			provider: provider.ProviderAnthropic,
-			apiKey:   "test-key",
-			model:    "claude-sonnet-4-20250514",
+			name:        "anthropic",
+			provider:    provider.ProviderAnthropic,
+			apiKey:      "test-key",
+			model:       "claude-sonnet-4-20250514",
+			workspaceID: "workspace-id",
 		},
 		{
 			name:     "openai",
@@ -82,7 +86,9 @@ func TestNewProvider(t *testing.T) {
 		t.Run(tc.name, func(t *testing.T) {
 			t.Parallel()
 
-			p, err := provider.NewProvider(t.Context(), tc.provider, tc.apiKey, tc.model)
+			p, err := provider.NewProvider(
+				t.Context(), tc.provider, tc.apiKey, tc.model, tc.workspaceID,
+			)
 			if tc.wantErr { //nolint:nestif
 				if err == nil {
 					t.Error("expected error, got nil")
@@ -99,6 +105,63 @@ func TestNewProvider(t *testing.T) {
 				if p == nil {
 					t.Error("expected non-nil provider")
 				}
+			}
+		})
+	}
+}
+
+func TestNewAnthropicWorkspaceIDHeader(t *testing.T) {
+	requestHeaders := make(chan http.Header, 2)
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		requestHeaders <- r.Header.Clone()
+
+		w.Header().Set("Content-Type", "text/event-stream")
+		w.WriteHeader(http.StatusOK)
+	}))
+	t.Cleanup(server.Close)
+	t.Setenv("ANTHROPIC_BASE_URL", server.URL)
+
+	cases := []struct {
+		name        string
+		workspaceID string
+		wantHeader  bool
+	}{
+		{name: "configured", workspaceID: "workspace-id", wantHeader: true},
+		{name: "not configured", workspaceID: "", wantHeader: false},
+	}
+
+	for _, tc := range cases { //nolint:paralleltest // Subtests share the process-wide base URL.
+		t.Run(tc.name, func(t *testing.T) {
+			p := provider.NewAnthropic("test-key", "test-model", tc.workspaceID)
+			messages := []provider.Message{
+				{
+					Role:       provider.RoleUser,
+					Content:    "hello",
+					ToolCalls:  nil,
+					ToolCallID: "",
+					ToolName:   "",
+				},
+			}
+
+			for event := range p.StreamResponse(t.Context(), "", messages, nil) {
+				if event.Error != nil {
+					t.Fatalf("StreamResponse() returned an error: %v", event.Error)
+				}
+			}
+
+			headers := <-requestHeaders
+
+			values, hasHeader := headers[http.CanonicalHeaderKey("anthropic-workspace-id")]
+			if hasHeader != tc.wantHeader {
+				t.Fatalf(
+					"anthropic-workspace-id header presence = %t, want %t",
+					hasHeader,
+					tc.wantHeader,
+				)
+			}
+
+			if tc.wantHeader && (len(values) != 1 || values[0] != tc.workspaceID) {
+				t.Errorf("anthropic-workspace-id header = %q, want %q", values, tc.workspaceID)
 			}
 		})
 	}

--- a/services/ai/agents/provider/provider_test.go
+++ b/services/ai/agents/provider/provider_test.go
@@ -13,6 +13,48 @@ import (
 	"github.com/nhost/nhost/services/ai/agents/provider"
 )
 
+func TestStreamRequestValidate(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name    string
+		request provider.StreamRequest
+		wantErr error
+	}{
+		{
+			name: "valid request",
+			request: provider.StreamRequest{
+				Model:        "test-model",
+				SystemPrompt: "",
+				Messages:     nil,
+				Tools:        nil,
+			},
+			wantErr: nil,
+		},
+		{
+			name: "empty model",
+			request: provider.StreamRequest{
+				Model:        "",
+				SystemPrompt: "",
+				Messages:     nil,
+				Tools:        nil,
+			},
+			wantErr: provider.ErrEmptyModel,
+		},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			t.Parallel()
+
+			err := test.request.Validate()
+			if !errors.Is(err, test.wantErr) {
+				t.Errorf("Validate() error = %v, want %v", err, test.wantErr)
+			}
+		})
+	}
+}
+
 func TestProviderConstructors(t *testing.T) {
 	t.Parallel()
 

--- a/services/ai/agents/provider/provider_test.go
+++ b/services/ai/agents/provider/provider_test.go
@@ -1,84 +1,73 @@
 package provider_test
 
 import (
+	"context"
+	"errors"
+	"io"
 	"net/http"
 	"net/http/httptest"
+	"strings"
+	"sync"
 	"testing"
 
 	"github.com/nhost/nhost/services/ai/agents/provider"
 )
 
-func TestNewProvider(t *testing.T) {
+func TestProviderConstructors(t *testing.T) {
 	t.Parallel()
 
 	cases := []struct {
 		name        string
-		provider    provider.Name
-		apiKey      string
-		model       string
-		workspaceID string
-		wantErr     bool
+		newProvider func(context.Context) (provider.Provider, error)
+		wantErr     error
 	}{
 		{
-			name:        "anthropic",
-			provider:    provider.ProviderAnthropic,
-			apiKey:      "test-key",
-			model:       "claude-sonnet-4-20250514",
-			workspaceID: "workspace-id",
+			name: "anthropic",
+			newProvider: func(_ context.Context) (provider.Provider, error) {
+				return provider.NewAnthropic(provider.AnthropicConfig{
+					APIKey:      "test-key",
+					WorkspaceID: "workspace-id",
+				})
+			},
+			wantErr: nil,
 		},
 		{
-			name:     "openai",
-			provider: provider.ProviderOpenAI,
-			apiKey:   "test-key",
-			model:    "gpt-4o",
+			name: "openai",
+			newProvider: func(_ context.Context) (provider.Provider, error) {
+				return provider.NewOpenAI(provider.OpenAIConfig{APIKey: "test-key"})
+			},
+			wantErr: nil,
 		},
 		{
-			name:     "google",
-			provider: provider.ProviderGoogle,
-			apiKey:   "test-key",
-			model:    "gemini-2.0-flash",
+			name: "google",
+			newProvider: func(ctx context.Context) (provider.Provider, error) {
+				return provider.NewGoogle(ctx, provider.GoogleConfig{APIKey: "test-key"})
+			},
+			wantErr: nil,
 		},
 		{
-			name:     "unknown provider",
-			provider: "unknown",
-			apiKey:   "test-key",
-			model:    "some-model",
-			wantErr:  true,
+			name: "anthropic rejects empty API key",
+			newProvider: func(_ context.Context) (provider.Provider, error) {
+				return provider.NewAnthropic(provider.AnthropicConfig{
+					APIKey:      "",
+					WorkspaceID: "",
+				})
+			},
+			wantErr: provider.ErrEmptyAPIKey,
 		},
 		{
-			name:     "empty provider",
-			provider: "",
-			apiKey:   "test-key",
-			model:    "some-model",
-			wantErr:  true,
+			name: "openai rejects empty API key",
+			newProvider: func(_ context.Context) (provider.Provider, error) {
+				return provider.NewOpenAI(provider.OpenAIConfig{APIKey: ""})
+			},
+			wantErr: provider.ErrEmptyAPIKey,
 		},
 		{
-			name:     "empty model",
-			provider: provider.ProviderAnthropic,
-			apiKey:   "test-key",
-			model:    "",
-			wantErr:  true,
-		},
-		{
-			name:     "empty apiKey anthropic",
-			provider: provider.ProviderAnthropic,
-			apiKey:   "",
-			model:    "claude-sonnet-4-20250514",
-			wantErr:  true,
-		},
-		{
-			name:     "empty apiKey openai",
-			provider: provider.ProviderOpenAI,
-			apiKey:   "",
-			model:    "gpt-4o",
-			wantErr:  true,
-		},
-		{
-			name:     "empty apiKey google",
-			provider: provider.ProviderGoogle,
-			apiKey:   "",
-			model:    "gemini-2.0-flash",
-			wantErr:  true,
+			name: "google rejects empty API key",
+			newProvider: func(ctx context.Context) (provider.Provider, error) {
+				return provider.NewGoogle(ctx, provider.GoogleConfig{APIKey: ""})
+			},
+			wantErr: provider.ErrEmptyAPIKey,
 		},
 	}
 
@@ -86,25 +75,280 @@ func TestNewProvider(t *testing.T) {
 		t.Run(tc.name, func(t *testing.T) {
 			t.Parallel()
 
-			p, err := provider.NewProvider(
-				t.Context(), tc.provider, tc.apiKey, tc.model, tc.workspaceID,
+			p, err := tc.newProvider(t.Context())
+			if tc.wantErr != nil {
+				if !errors.Is(err, tc.wantErr) {
+					t.Fatalf("error = %v, want %v", err, tc.wantErr)
+				}
+
+				return
+			}
+
+			if err != nil {
+				t.Fatalf("unexpected error: %v", err)
+			}
+
+			if p == nil {
+				t.Error("expected non-nil provider")
+			}
+		})
+	}
+}
+
+type capturedRequest struct {
+	path   string
+	body   string
+	header http.Header
+}
+
+func TestProvidersConcurrentRequests(t *testing.T) {
+	requests := []provider.StreamRequest{
+		{
+			Model:        "model-a",
+			SystemPrompt: "prompt-a",
+			Messages: []provider.Message{
+				{
+					Role:       provider.RoleUser,
+					Content:    "message-a",
+					ToolCalls:  nil,
+					ToolCallID: "",
+					ToolName:   "",
+				},
+			},
+			Tools: nil,
+		},
+		{
+			Model:        "model-b",
+			SystemPrompt: "prompt-b",
+			Messages: []provider.Message{
+				{
+					Role:       provider.RoleUser,
+					Content:    "message-b",
+					ToolCalls:  nil,
+					ToolCallID: "",
+					ToolName:   "",
+				},
+			},
+			Tools: nil,
+		},
+	}
+
+	cases := []struct {
+		name          string
+		baseURLEnv    string
+		baseURL       func(string) string
+		newProvider   func(context.Context) (provider.Provider, error)
+		wantWorkspace bool
+	}{
+		{
+			name:       "anthropic",
+			baseURLEnv: "ANTHROPIC_BASE_URL",
+			baseURL:    func(url string) string { return url },
+			newProvider: func(_ context.Context) (provider.Provider, error) {
+				return provider.NewAnthropic(provider.AnthropicConfig{
+					APIKey:      "test-key",
+					WorkspaceID: "workspace-id",
+				})
+			},
+			wantWorkspace: true,
+		},
+		{
+			name:       "openai",
+			baseURLEnv: "OPENAI_BASE_URL",
+			baseURL:    func(url string) string { return url + "/" },
+			newProvider: func(_ context.Context) (provider.Provider, error) {
+				return provider.NewOpenAI(provider.OpenAIConfig{APIKey: "test-key"})
+			},
+			wantWorkspace: false,
+		},
+		{
+			name:       "google",
+			baseURLEnv: "GOOGLE_GEMINI_BASE_URL",
+			baseURL:    func(url string) string { return url },
+			newProvider: func(ctx context.Context) (provider.Provider, error) {
+				return provider.NewGoogle(ctx, provider.GoogleConfig{APIKey: "test-key"})
+			},
+			wantWorkspace: false,
+		},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			captured := make(chan capturedRequest, len(requests))
+			server := httptest.NewServer(
+				http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+					body, err := io.ReadAll(r.Body)
+					if err != nil {
+						t.Errorf("read request body: %v", err)
+					}
+
+					captured <- capturedRequest{
+						path:   r.URL.Path,
+						body:   string(body),
+						header: r.Header.Clone(),
+					}
+
+					w.Header().Set("Content-Type", "text/event-stream")
+					w.WriteHeader(http.StatusOK)
+				}),
 			)
-			if tc.wantErr { //nolint:nestif
-				if err == nil {
-					t.Error("expected error, got nil")
-				}
+			t.Cleanup(server.Close)
+			t.Setenv(tc.baseURLEnv, tc.baseURL(server.URL))
 
-				if p != nil {
-					t.Error("expected nil provider on error")
-				}
-			} else {
-				if err != nil {
-					t.Errorf("unexpected error: %v", err)
-				}
+			p, err := tc.newProvider(t.Context())
+			if err != nil {
+				t.Fatalf("construct provider: %v", err)
+			}
 
-				if p == nil {
-					t.Error("expected non-nil provider")
+			streamConcurrently(t, p, requests)
+			close(captured)
+
+			got := make([]capturedRequest, 0, len(requests))
+			for request := range captured {
+				got = append(got, request)
+			}
+
+			if len(got) != len(requests) {
+				t.Fatalf("captured %d requests, want %d", len(got), len(requests))
+			}
+
+			assertConcurrentRequests(t, got, requests, tc.wantWorkspace)
+		})
+	}
+}
+
+func streamConcurrently(
+	t *testing.T,
+	p provider.Provider,
+	requests []provider.StreamRequest,
+) {
+	t.Helper()
+
+	errs := make(chan error, len(requests))
+
+	var wg sync.WaitGroup
+
+	for _, request := range requests {
+		wg.Go(func() {
+			for event := range p.StreamResponse(t.Context(), request) {
+				if event.Error != nil {
+					errs <- event.Error
+
+					return
 				}
+			}
+
+			errs <- nil
+		})
+	}
+
+	wg.Wait()
+	close(errs)
+
+	for err := range errs {
+		if err != nil {
+			t.Errorf("StreamResponse() returned an error: %v", err)
+		}
+	}
+}
+
+func assertConcurrentRequests(
+	t *testing.T,
+	got []capturedRequest,
+	want []provider.StreamRequest,
+	wantWorkspace bool,
+) {
+	t.Helper()
+
+	for _, request := range want {
+		var matching *capturedRequest
+		for idx := range got {
+			payload := got[idx].path + "\n" + got[idx].body
+			if strings.Contains(payload, request.Model) {
+				matching = &got[idx]
+
+				break
+			}
+		}
+
+		if matching == nil {
+			t.Errorf("no outgoing request contains model %q", request.Model)
+
+			continue
+		}
+
+		payload := matching.path + "\n" + matching.body
+		for _, value := range []string{request.SystemPrompt, request.Messages[0].Content} {
+			if !strings.Contains(payload, value) {
+				t.Errorf(
+					"request for model %q does not contain %q: %s",
+					request.Model,
+					value,
+					payload,
+				)
+			}
+		}
+
+		workspaceID := matching.header.Get("anthropic-workspace-id")
+		if wantWorkspace && workspaceID != "workspace-id" {
+			t.Errorf("workspace header = %q, want %q", workspaceID, "workspace-id")
+		}
+
+		if !wantWorkspace && workspaceID != "" {
+			t.Errorf("unexpected workspace header %q", workspaceID)
+		}
+	}
+}
+
+func TestProvidersRejectEmptyModel(t *testing.T) {
+	t.Parallel()
+
+	anthropic, err := provider.NewAnthropic(provider.AnthropicConfig{
+		APIKey:      "test-key",
+		WorkspaceID: "",
+	})
+	if err != nil {
+		t.Fatalf("NewAnthropic() returned an error: %v", err)
+	}
+
+	openAI, err := provider.NewOpenAI(provider.OpenAIConfig{APIKey: "test-key"})
+	if err != nil {
+		t.Fatalf("NewOpenAI() returned an error: %v", err)
+	}
+
+	google, err := provider.NewGoogle(t.Context(), provider.GoogleConfig{APIKey: "test-key"})
+	if err != nil {
+		t.Fatalf("NewGoogle() returned an error: %v", err)
+	}
+
+	providers := map[provider.Name]provider.Provider{
+		provider.ProviderAnthropic: anthropic,
+		provider.ProviderOpenAI:    openAI,
+		provider.ProviderGoogle:    google,
+	}
+
+	for name, p := range providers {
+		t.Run(string(name), func(t *testing.T) {
+			t.Parallel()
+
+			eventCh := p.StreamResponse(t.Context(), provider.StreamRequest{
+				Model:        "",
+				SystemPrompt: "",
+				Messages:     nil,
+				Tools:        nil,
+			})
+
+			event, ok := <-eventCh
+			if !ok {
+				t.Fatal("StreamResponse() returned no error event")
+			}
+
+			if !errors.Is(event.Error, provider.ErrEmptyModel) {
+				t.Errorf("error = %v, want %v", event.Error, provider.ErrEmptyModel)
+			}
+
+			if _, ok := <-eventCh; ok {
+				t.Error("StreamResponse() returned more than one event")
 			}
 		})
 	}
@@ -132,18 +376,30 @@ func TestNewAnthropicWorkspaceIDHeader(t *testing.T) {
 
 	for _, tc := range cases { //nolint:paralleltest // Subtests share the process-wide base URL.
 		t.Run(tc.name, func(t *testing.T) {
-			p := provider.NewAnthropic("test-key", "test-model", tc.workspaceID)
-			messages := []provider.Message{
-				{
-					Role:       provider.RoleUser,
-					Content:    "hello",
-					ToolCalls:  nil,
-					ToolCallID: "",
-					ToolName:   "",
-				},
+			p, err := provider.NewAnthropic(provider.AnthropicConfig{
+				APIKey:      "test-key",
+				WorkspaceID: tc.workspaceID,
+			})
+			if err != nil {
+				t.Fatalf("NewAnthropic() returned an error: %v", err)
 			}
 
-			for event := range p.StreamResponse(t.Context(), "", messages, nil) {
+			request := provider.StreamRequest{
+				Model:        "test-model",
+				SystemPrompt: "",
+				Messages: []provider.Message{
+					{
+						Role:       provider.RoleUser,
+						Content:    "hello",
+						ToolCalls:  nil,
+						ToolCallID: "",
+						ToolName:   "",
+					},
+				},
+				Tools: nil,
+			}
+
+			for event := range p.StreamResponse(t.Context(), request) {
 				if event.Error != nil {
 					t.Fatalf("StreamResponse() returned an error: %v", event.Error)
 				}
@@ -164,14 +420,5 @@ func TestNewAnthropicWorkspaceIDHeader(t *testing.T) {
 				t.Errorf("anthropic-workspace-id header = %q, want %q", values, tc.workspaceID)
 			}
 		})
-	}
-}
-
-func TestUnknownProviderError(t *testing.T) {
-	t.Parallel()
-
-	err := provider.UnknownProviderError{Provider: "foobar"}
-	if err.Error() != "unknown provider: foobar" {
-		t.Errorf("unexpected error message: %s", err.Error())
 	}
 }

--- a/services/ai/agents/sse.go
+++ b/services/ai/agents/sse.go
@@ -186,7 +186,12 @@ func (s *Service) newProviderForAgent( //nolint:ireturn,nolintlint
 		newProvider = s.newProvider
 	}
 
-	p, err := newProvider(c.Request.Context(), agent.Provider, apiKey, agent.Model)
+	workspaceID := ""
+	if agent.Provider == provider.ProviderAnthropic {
+		workspaceID = s.providers.AnthropicWorkspaceID
+	}
+
+	p, err := newProvider(c.Request.Context(), agent.Provider, apiKey, agent.Model, workspaceID)
 	if err != nil {
 		logger.ErrorContext(
 			c.Request.Context(), "failed to create provider",

--- a/services/ai/agents/sse.go
+++ b/services/ai/agents/sse.go
@@ -15,17 +15,11 @@ import (
 	"github.com/nhost/nhost/services/ai/hasura"
 )
 
-// Sentinel errors for API key configuration.
 var (
-	ErrAnthropicKeyNotConfigured = errors.New("anthropic API key not configured")
-	ErrOpenAIKeyNotConfigured    = errors.New("openai API key not configured")
-	ErrGoogleKeyNotConfigured    = errors.New("google API key not configured")
-)
-
-var (
-	errSessionNotFound = errors.New("session not found")
-	errAgentNotFound   = errors.New("agent not found")
-	errInvalidSSEEvent = errors.New("invalid SSE event name")
+	errSessionNotFound       = errors.New("session not found")
+	errAgentNotFound         = errors.New("agent not found")
+	errInvalidSSEEvent       = errors.New("invalid SSE event name")
+	errProviderNotConfigured = errors.New("provider not configured")
 )
 
 // SSEWriter implements EventWriter for SSE responses.
@@ -100,7 +94,7 @@ func (s *Service) HandleStreamMessage(c *gin.Context) {
 		return
 	}
 
-	p, ok := s.newProviderForAgent(c, logger, agent)
+	p, ok := s.providerForAgent(c, logger, agent)
 	if !ok {
 		return
 	}
@@ -163,39 +157,31 @@ func (s *Service) persistUserMessageOrRespond(
 	return true
 }
 
-// newProviderForAgent resolves the API key and constructs a provider for the
-// given agent. On failure it writes the response and returns false.
-func (s *Service) newProviderForAgent( //nolint:ireturn,nolintlint
+// providerForAgent resolves an already-configured provider for the given
+// agent. On failure it writes the response and returns false.
+func (s *Service) providerForAgent( //nolint:ireturn,nolintlint
 	c *gin.Context,
 	logger *slog.Logger,
 	agent *hasura.GetAgent_AiAgent,
 ) (provider.Provider, bool) {
-	apiKey, err := s.getAPIKey(agent.Provider)
-	if err != nil {
+	if agent.Model == "" {
 		logger.ErrorContext(
-			c.Request.Context(), "failed to get API key",
-			slog.String("provider", string(agent.Provider)), slog.String("error", err.Error()),
+			c.Request.Context(), "failed to resolve provider",
+			slog.String("provider", string(agent.Provider)),
+			slog.String("error", provider.ErrEmptyModel.Error()),
 		)
 		c.JSON(http.StatusBadRequest, gin.H{"error": "provider not available"})
 
 		return nil, false
 	}
 
-	newProvider := providerFactory(provider.NewProvider)
-	if s.newProvider != nil {
-		newProvider = s.newProvider
-	}
-
-	workspaceID := ""
-	if agent.Provider == provider.ProviderAnthropic {
-		workspaceID = s.providers.AnthropicWorkspaceID
-	}
-
-	p, err := newProvider(c.Request.Context(), agent.Provider, apiKey, agent.Model, workspaceID)
-	if err != nil {
+	p, ok := s.providers[agent.Provider]
+	if !ok {
+		err := fmt.Errorf("%w: %s", errProviderNotConfigured, agent.Provider)
 		logger.ErrorContext(
-			c.Request.Context(), "failed to create provider",
-			slog.String("provider", string(agent.Provider)), slog.String("error", err.Error()),
+			c.Request.Context(), "failed to resolve provider",
+			slog.String("provider", string(agent.Provider)),
+			slog.String("error", err.Error()),
 		)
 		c.JSON(http.StatusBadRequest, gin.H{"error": "provider not available"})
 
@@ -331,6 +317,7 @@ func (s *Service) streamAndPersist(
 	result, err := RunAgentLoop(
 		c.Request.Context(),
 		p,
+		agent.Model,
 		agent.Instructions,
 		messages,
 		registry,
@@ -441,31 +428,6 @@ func setSSEHeaders(c *gin.Context) {
 	c.Header("Connection", "keep-alive")
 }
 
-func (s *Service) getAPIKey(providerName provider.Name) (string, error) {
-	switch providerName {
-	case provider.ProviderAnthropic:
-		if s.providers.AnthropicKey == "" {
-			return "", ErrAnthropicKeyNotConfigured
-		}
-
-		return s.providers.AnthropicKey, nil
-	case provider.ProviderOpenAI:
-		if s.providers.OpenAIKey == "" {
-			return "", ErrOpenAIKeyNotConfigured
-		}
-
-		return s.providers.OpenAIKey, nil
-	case provider.ProviderGoogle:
-		if s.providers.GoogleKey == "" {
-			return "", ErrGoogleKeyNotConfigured
-		}
-
-		return s.providers.GoogleKey, nil
-	default:
-		return "", provider.UnknownProviderError{Provider: providerName}
-	}
-}
-
 func (s *Service) buildToolRegistry(
 	ctx context.Context,
 	agent *hasura.GetAgent_AiAgent,
@@ -542,9 +504,9 @@ func (s *Service) registerWebSearch(
 
 	switch searchProvider {
 	case "brave":
-		apiKey = s.providers.BraveKey
+		apiKey = s.tools.BraveKey
 	case "tavily":
-		apiKey = s.providers.TavilyKey
+		apiKey = s.tools.TavilyKey
 	}
 
 	if apiKey == "" {

--- a/services/ai/agents/sse.go
+++ b/services/ai/agents/sse.go
@@ -164,11 +164,17 @@ func (s *Service) providerForAgent( //nolint:ireturn,nolintlint
 	logger *slog.Logger,
 	agent *hasura.GetAgent_AiAgent,
 ) (provider.Provider, bool) {
-	if agent.Model == "" {
+	request := provider.StreamRequest{
+		Model:        agent.Model,
+		SystemPrompt: agent.Instructions,
+		Messages:     nil,
+		Tools:        nil,
+	}
+	if err := request.Validate(); err != nil {
 		logger.ErrorContext(
 			c.Request.Context(), "failed to resolve provider",
 			slog.String("provider", string(agent.Provider)),
-			slog.String("error", provider.ErrEmptyModel.Error()),
+			slog.String("error", err.Error()),
 		)
 		c.JSON(http.StatusBadRequest, gin.H{"error": "provider not available"})
 

--- a/services/ai/agents/sse_internal_test.go
+++ b/services/ai/agents/sse_internal_test.go
@@ -409,155 +409,95 @@ func TestConvertHasuraMessages(t *testing.T) {
 	})
 }
 
-func TestGetAPIKey(t *testing.T) {
+func TestProviderForAgent(t *testing.T) {
 	t.Parallel()
 
-	s := &Service{
-		providers: ProviderConfig{
-			AnthropicKey: "ak",
-			OpenAIKey:    "ok",
-			GoogleKey:    "gk",
-		},
-	}
-
 	cases := []struct {
-		name     string
-		provider provider.Name
-		wantKey  string
-		wantErr  bool
+		name       string
+		provider   provider.Name
+		model      string
+		configured bool
+		wantOK     bool
 	}{
-		{name: "anthropic", provider: provider.ProviderAnthropic, wantKey: "ak"},
-		{name: "openai", provider: provider.ProviderOpenAI, wantKey: "ok"},
-		{name: "google", provider: provider.ProviderGoogle, wantKey: "gk"},
-		{name: "unknown", provider: "unknown", wantErr: true},
+		{
+			name:       "configured provider",
+			provider:   provider.ProviderAnthropic,
+			model:      "test-model",
+			configured: true,
+			wantOK:     true,
+		},
+		{
+			name:       "provider not configured",
+			provider:   provider.ProviderOpenAI,
+			model:      "test-model",
+			configured: false,
+			wantOK:     false,
+		},
+		{
+			name:       "unknown provider",
+			provider:   "unknown",
+			model:      "test-model",
+			configured: false,
+			wantOK:     false,
+		},
+		{
+			name:       "empty model",
+			provider:   provider.ProviderAnthropic,
+			model:      "",
+			configured: true,
+			wantOK:     false,
+		},
 	}
 
 	for _, tc := range cases {
 		t.Run(tc.name, func(t *testing.T) {
 			t.Parallel()
 
-			key, err := s.getAPIKey(tc.provider)
-			if tc.wantErr {
-				if err == nil {
-					t.Error("expected error")
+			ctrl := gomock.NewController(t)
+			wantProvider := providermock.NewMockProvider(ctrl)
+
+			providers := provider.Registry{}
+			if tc.configured {
+				providers[tc.provider] = wantProvider
+			}
+
+			s := &Service{providers: providers}
+			recorder := httptest.NewRecorder()
+			c, _ := gin.CreateTestContext(recorder)
+			c.Request = httptest.NewRequest(http.MethodPost, "/", nil)
+			logger := slog.New(slog.NewTextHandler(&bytes.Buffer{}, nil))
+			agent := &hasura.GetAgent_AiAgent{
+				CreatedAt:    time.Time{},
+				Description:  "",
+				ID:           "agent-id",
+				Instructions: "",
+				Model:        tc.model,
+				Name:         "test agent",
+				Provider:     tc.provider,
+				ToolsConfig:  nil,
+				UpdatedAt:    time.Time{},
+				UserID:       nil,
+			}
+
+			gotProvider, ok := s.providerForAgent(c, logger, agent)
+			if ok != tc.wantOK {
+				t.Fatalf("providerForAgent() ok = %t, want %t", ok, tc.wantOK)
+			}
+
+			if tc.wantOK {
+				if gotProvider != wantProvider {
+					t.Error("providerForAgent() returned an unexpected provider")
 				}
 
 				return
 			}
 
-			if err != nil {
-				t.Fatalf("unexpected error: %v", err)
+			if gotProvider != nil {
+				t.Error("providerForAgent() returned a provider on failure")
 			}
 
-			if key != tc.wantKey {
-				t.Errorf("expected key %q, got %q", tc.wantKey, key)
-			}
-		})
-	}
-}
-
-func TestNewProviderForAgentPassesAnthropicWorkspaceID(t *testing.T) {
-	t.Parallel()
-
-	ctrl := gomock.NewController(t)
-	wantProvider := providermock.NewMockProvider(ctrl)
-	gotWorkspaceID := ""
-	s := &Service{
-		providers: ProviderConfig{
-			AnthropicKey:         "anthropic-key",
-			AnthropicWorkspaceID: "workspace-id",
-		},
-		newProvider: func(
-			_ context.Context,
-			_ provider.Name,
-			_ string,
-			_ string,
-			workspaceID string,
-		) (provider.Provider, error) {
-			gotWorkspaceID = workspaceID
-
-			return wantProvider, nil
-		},
-	}
-
-	c, _ := gin.CreateTestContext(httptest.NewRecorder())
-	c.Request = httptest.NewRequest(http.MethodPost, "/", nil)
-	logger := slog.New(slog.NewTextHandler(&bytes.Buffer{}, nil))
-	agent := &hasura.GetAgent_AiAgent{
-		CreatedAt:    time.Time{},
-		Description:  "",
-		ID:           "agent-id",
-		Instructions: "",
-		Model:        "test-model",
-		Name:         "test agent",
-		Provider:     provider.ProviderAnthropic,
-		ToolsConfig:  nil,
-		UpdatedAt:    time.Time{},
-		UserID:       nil,
-	}
-
-	gotProvider, ok := s.newProviderForAgent(c, logger, agent)
-	if !ok {
-		t.Fatal("newProviderForAgent() returned false")
-	}
-
-	if gotProvider != wantProvider {
-		t.Error("newProviderForAgent() returned an unexpected provider")
-	}
-
-	if gotWorkspaceID != s.providers.AnthropicWorkspaceID {
-		t.Errorf(
-			"workspace ID = %q, want %q",
-			gotWorkspaceID,
-			s.providers.AnthropicWorkspaceID,
-		)
-	}
-}
-
-func TestGetAPIKeyNotConfigured(t *testing.T) {
-	t.Parallel()
-
-	s := &Service{
-		providers: ProviderConfig{
-			AnthropicKey: "",
-			OpenAIKey:    "",
-			GoogleKey:    "",
-		},
-	}
-
-	cases := []struct {
-		name     string
-		provider provider.Name
-		wantErr  error
-	}{
-		{
-			name:     "anthropic not configured",
-			provider: provider.ProviderAnthropic,
-			wantErr:  ErrAnthropicKeyNotConfigured,
-		},
-		{
-			name:     "openai not configured",
-			provider: provider.ProviderOpenAI,
-			wantErr:  ErrOpenAIKeyNotConfigured,
-		},
-		{
-			name:     "google not configured",
-			provider: provider.ProviderGoogle,
-			wantErr:  ErrGoogleKeyNotConfigured,
-		},
-	}
-
-	for _, tc := range cases {
-		t.Run(tc.name, func(t *testing.T) {
-			t.Parallel()
-
-			_, err := s.getAPIKey(tc.provider)
-			if err == nil {
-				t.Fatal("expected error")
-			}
-
-			if !errors.Is(err, tc.wantErr) {
-				t.Errorf("expected %v, got %v", tc.wantErr, err)
+			if recorder.Code != http.StatusBadRequest {
+				t.Errorf("status = %d, want %d", recorder.Code, http.StatusBadRequest)
 			}
 		})
 	}

--- a/services/ai/agents/sse_internal_test.go
+++ b/services/ai/agents/sse_internal_test.go
@@ -456,6 +456,64 @@ func TestGetAPIKey(t *testing.T) {
 	}
 }
 
+func TestNewProviderForAgentPassesAnthropicWorkspaceID(t *testing.T) {
+	t.Parallel()
+
+	ctrl := gomock.NewController(t)
+	wantProvider := providermock.NewMockProvider(ctrl)
+	gotWorkspaceID := ""
+	s := &Service{
+		providers: ProviderConfig{
+			AnthropicKey:         "anthropic-key",
+			AnthropicWorkspaceID: "workspace-id",
+		},
+		newProvider: func(
+			_ context.Context,
+			_ provider.Name,
+			_ string,
+			_ string,
+			workspaceID string,
+		) (provider.Provider, error) {
+			gotWorkspaceID = workspaceID
+
+			return wantProvider, nil
+		},
+	}
+
+	c, _ := gin.CreateTestContext(httptest.NewRecorder())
+	c.Request = httptest.NewRequest(http.MethodPost, "/", nil)
+	logger := slog.New(slog.NewTextHandler(&bytes.Buffer{}, nil))
+	agent := &hasura.GetAgent_AiAgent{
+		CreatedAt:    time.Time{},
+		Description:  "",
+		ID:           "agent-id",
+		Instructions: "",
+		Model:        "test-model",
+		Name:         "test agent",
+		Provider:     provider.ProviderAnthropic,
+		ToolsConfig:  nil,
+		UpdatedAt:    time.Time{},
+		UserID:       nil,
+	}
+
+	gotProvider, ok := s.newProviderForAgent(c, logger, agent)
+	if !ok {
+		t.Fatal("newProviderForAgent() returned false")
+	}
+
+	if gotProvider != wantProvider {
+		t.Error("newProviderForAgent() returned an unexpected provider")
+	}
+
+	if gotWorkspaceID != s.providers.AnthropicWorkspaceID {
+		t.Errorf(
+			"workspace ID = %q, want %q",
+			gotWorkspaceID,
+			s.providers.AnthropicWorkspaceID,
+		)
+	}
+}
+
 func TestGetAPIKeyNotConfigured(t *testing.T) {
 	t.Parallel()
 

--- a/services/ai/cmd/serve.go
+++ b/services/ai/cmd/serve.go
@@ -11,6 +11,7 @@ import (
 	"github.com/Yamashou/gqlgenc/clientv2"
 	_ "github.com/lib/pq" // postgres driver for database/sql
 	"github.com/nhost/nhost/services/ai/agents"
+	agentprovider "github.com/nhost/nhost/services/ai/agents/provider"
 	"github.com/nhost/nhost/services/ai/autoai"
 	"github.com/nhost/nhost/services/ai/autoai/embeddings"
 	"github.com/nhost/nhost/services/ai/hasura"
@@ -249,10 +250,16 @@ func serve(cCtx *cli.Context) error { //nolint:funlen
 	}
 	defer db.Close()
 
+	agentProviders, err := buildAgentProviders(cCtx.Context, cCtx)
+	if err != nil {
+		return fmt.Errorf("configure agent providers: %w", err)
+	}
+
 	agentService := agents.NewService(
 		hc,
 		db,
-		buildProviderConfig(cCtx),
+		agentProviders,
+		buildAgentToolConfig(cCtx),
 		cCtx.String(flagAIBaseURL),
 		cCtx.String(flagHasuraGraphqlAdminSecret),
 		cCtx.String(flagNhostGraphqlURL),
@@ -310,18 +317,56 @@ func serve(cCtx *cli.Context) error { //nolint:funlen
 	return nil
 }
 
-// buildProviderConfig reads the agent-provider flags off the CLI context.
-// Extracted so the flag-name → struct-field mapping is testable without
-// booting the full serve action — a regression where a flag is renamed and
-// the agent service silently disables itself would otherwise only surface as
-// a 404 against /v1/agents/... at runtime.
-func buildProviderConfig(cCtx *cli.Context) agents.ProviderConfig {
-	return agents.ProviderConfig{
-		AnthropicKey:         cCtx.String(flagAnthropicKey),
-		AnthropicWorkspaceID: cCtx.String(flagAnthropicWorkspaceID),
-		OpenAIKey:            cCtx.String(flagOpenAIKey),
-		GoogleKey:            cCtx.String(flagGoogleKey),
-		BraveKey:             cCtx.String(flagBraveKey),
-		TavilyKey:            cCtx.String(flagTavilyKey),
+// buildAgentProviders creates the configured provider clients once at service
+// startup. Provider-specific options stay with their adapter instead of being
+// threaded through a shared constructor.
+func buildAgentProviders(
+	ctx context.Context,
+	cCtx *cli.Context,
+) (agentprovider.Registry, error) {
+	providers := agentprovider.Registry{}
+
+	anthropicConfig := buildAnthropicConfig(cCtx)
+	if anthropicConfig.APIKey != "" {
+		anthropic, err := agentprovider.NewAnthropic(anthropicConfig)
+		if err != nil {
+			return nil, fmt.Errorf("create Anthropic client: %w", err)
+		}
+
+		providers[agentprovider.ProviderAnthropic] = anthropic
+	}
+
+	if apiKey := cCtx.String(flagOpenAIKey); apiKey != "" {
+		openAI, err := agentprovider.NewOpenAI(agentprovider.OpenAIConfig{APIKey: apiKey})
+		if err != nil {
+			return nil, fmt.Errorf("create OpenAI client: %w", err)
+		}
+
+		providers[agentprovider.ProviderOpenAI] = openAI
+	}
+
+	if apiKey := cCtx.String(flagGoogleKey); apiKey != "" {
+		google, err := agentprovider.NewGoogle(ctx, agentprovider.GoogleConfig{APIKey: apiKey})
+		if err != nil {
+			return nil, fmt.Errorf("create Google client: %w", err)
+		}
+
+		providers[agentprovider.ProviderGoogle] = google
+	}
+
+	return providers, nil
+}
+
+func buildAnthropicConfig(cCtx *cli.Context) agentprovider.AnthropicConfig {
+	return agentprovider.AnthropicConfig{
+		APIKey:      cCtx.String(flagAnthropicKey),
+		WorkspaceID: cCtx.String(flagAnthropicWorkspaceID),
+	}
+}
+
+func buildAgentToolConfig(cCtx *cli.Context) agents.ToolConfig {
+	return agents.ToolConfig{
+		BraveKey:  cCtx.String(flagBraveKey),
+		TavilyKey: cCtx.String(flagTavilyKey),
 	}
 }

--- a/services/ai/cmd/serve.go
+++ b/services/ai/cmd/serve.go
@@ -34,6 +34,7 @@ const (
 	flagAIBaseURL                = "ai-base-url"
 	flagSynchPeriod              = "synch-period"
 	flagAnthropicKey             = "anthropic-key"
+	flagAnthropicWorkspaceID     = "anthropic-workspace-id"
 	flagGoogleKey                = "google-key"
 	flagBraveKey                 = "brave-key"
 	flagTavilyKey                = "tavily-key"
@@ -141,6 +142,13 @@ func CommandServe() *cli.Command { //nolint:funlen
 				Value:    "",
 				Category: "agents",
 				EnvVars:  []string{"ANTHROPIC_API_KEY"},
+			},
+			&cli.StringFlag{ //nolint: exhaustruct
+				Name:     flagAnthropicWorkspaceID,
+				Usage:    "Anthropic workspace ID",
+				Value:    "",
+				Category: "agents",
+				EnvVars:  []string{"ANTHROPIC_WORKSPACE_ID"},
 			},
 			&cli.StringFlag{ //nolint: exhaustruct
 				Name:     flagGoogleKey,
@@ -309,10 +317,11 @@ func serve(cCtx *cli.Context) error { //nolint:funlen
 // a 404 against /v1/agents/... at runtime.
 func buildProviderConfig(cCtx *cli.Context) agents.ProviderConfig {
 	return agents.ProviderConfig{
-		AnthropicKey: cCtx.String(flagAnthropicKey),
-		OpenAIKey:    cCtx.String(flagOpenAIKey),
-		GoogleKey:    cCtx.String(flagGoogleKey),
-		BraveKey:     cCtx.String(flagBraveKey),
-		TavilyKey:    cCtx.String(flagTavilyKey),
+		AnthropicKey:         cCtx.String(flagAnthropicKey),
+		AnthropicWorkspaceID: cCtx.String(flagAnthropicWorkspaceID),
+		OpenAIKey:            cCtx.String(flagOpenAIKey),
+		GoogleKey:            cCtx.String(flagGoogleKey),
+		BraveKey:             cCtx.String(flagBraveKey),
+		TavilyKey:            cCtx.String(flagTavilyKey),
 	}
 }

--- a/services/ai/cmd/serve_internal_test.go
+++ b/services/ai/cmd/serve_internal_test.go
@@ -17,6 +17,7 @@ func newProviderConfigContext(t *testing.T, values map[string]string) *cli.Conte
 
 	set := flag.NewFlagSet("test", flag.ContinueOnError)
 	set.String(flagAnthropicKey, "", "")
+	set.String(flagAnthropicWorkspaceID, "", "")
 	set.String(flagOpenAIKey, "", "")
 	set.String(flagGoogleKey, "", "")
 	set.String(flagBraveKey, "", "")
@@ -43,39 +44,46 @@ func TestBuildProviderConfig(t *testing.T) {
 			name: "no flags set",
 			args: nil,
 			want: agents.ProviderConfig{
-				AnthropicKey: "",
-				OpenAIKey:    "",
-				GoogleKey:    "",
-				BraveKey:     "",
-				TavilyKey:    "",
+				AnthropicKey:         "",
+				AnthropicWorkspaceID: "",
+				OpenAIKey:            "",
+				GoogleKey:            "",
+				BraveKey:             "",
+				TavilyKey:            "",
 			},
 		},
 		{
 			name: "only anthropic",
-			args: map[string]string{flagAnthropicKey: "ak"},
+			args: map[string]string{
+				flagAnthropicKey:         "ak",
+				flagAnthropicWorkspaceID: "workspace-id",
+			},
 			want: agents.ProviderConfig{
-				AnthropicKey: "ak",
-				OpenAIKey:    "",
-				GoogleKey:    "",
-				BraveKey:     "",
-				TavilyKey:    "",
+				AnthropicKey:         "ak",
+				AnthropicWorkspaceID: "workspace-id",
+				OpenAIKey:            "",
+				GoogleKey:            "",
+				BraveKey:             "",
+				TavilyKey:            "",
 			},
 		},
 		{
-			name: "all five",
+			name: "all six",
 			args: map[string]string{
-				flagAnthropicKey: "ak",
-				flagOpenAIKey:    "ok",
-				flagGoogleKey:    "gk",
-				flagBraveKey:     "bk",
-				flagTavilyKey:    "tk",
+				flagAnthropicKey:         "ak",
+				flagAnthropicWorkspaceID: "workspace-id",
+				flagOpenAIKey:            "ok",
+				flagGoogleKey:            "gk",
+				flagBraveKey:             "bk",
+				flagTavilyKey:            "tk",
 			},
 			want: agents.ProviderConfig{
-				AnthropicKey: "ak",
-				OpenAIKey:    "ok",
-				GoogleKey:    "gk",
-				BraveKey:     "bk",
-				TavilyKey:    "tk",
+				AnthropicKey:         "ak",
+				AnthropicWorkspaceID: "workspace-id",
+				OpenAIKey:            "ok",
+				GoogleKey:            "gk",
+				BraveKey:             "bk",
+				TavilyKey:            "tk",
 			},
 		},
 	}
@@ -95,8 +103,7 @@ func TestBuildProviderConfig(t *testing.T) {
 }
 
 // TestBuildProviderConfigEnvVarBindings verifies that the production serve
-// command's env-var bindings (ANTHROPIC_API_KEY, GOOGLE_AI_API_KEY,
-// BRAVE_API_KEY, TAVILY_API_KEY) flow through urfave/cli into ProviderConfig.
+// command's provider env-var bindings flow through urfave/cli into ProviderConfig.
 // A rename of any of these env vars would otherwise silently disable the agent
 // service in production. This test cannot run in parallel because t.Setenv
 // mutates process env.
@@ -110,6 +117,11 @@ func TestBuildProviderConfigEnvVarBindings(t *testing.T) {
 			name:   "ANTHROPIC_API_KEY",
 			envVar: "ANTHROPIC_API_KEY",
 			field:  func(c agents.ProviderConfig) string { return c.AnthropicKey },
+		},
+		{
+			name:   "ANTHROPIC_WORKSPACE_ID",
+			envVar: "ANTHROPIC_WORKSPACE_ID",
+			field:  func(c agents.ProviderConfig) string { return c.AnthropicWorkspaceID },
 		},
 		{
 			name:   "GOOGLE_AI_API_KEY",

--- a/services/ai/cmd/serve_internal_test.go
+++ b/services/ai/cmd/serve_internal_test.go
@@ -2,17 +2,19 @@ package cmd
 
 import (
 	"flag"
+	"slices"
 	"testing"
 
 	"github.com/google/go-cmp/cmp"
 	"github.com/nhost/nhost/services/ai/agents"
+	"github.com/nhost/nhost/services/ai/agents/provider"
 	"github.com/urfave/cli/v2"
 )
 
-// newProviderConfigContext stages a urfave/cli context populated with the
-// agent-provider flags. The flag names mirror the action's registered flags;
+// newAgentConfigContext stages a urfave/cli context populated with the agent
+// provider and tool flags. The flag names mirror the action's registered flags;
 // a typo would surface here rather than at runtime.
-func newProviderConfigContext(t *testing.T, values map[string]string) *cli.Context {
+func newAgentConfigContext(t *testing.T, values map[string]string) *cli.Context {
 	t.Helper()
 
 	set := flag.NewFlagSet("test", flag.ContinueOnError)
@@ -23,34 +25,31 @@ func newProviderConfigContext(t *testing.T, values map[string]string) *cli.Conte
 	set.String(flagBraveKey, "", "")
 	set.String(flagTavilyKey, "", "")
 
-	for k, v := range values {
-		if err := set.Set(k, v); err != nil {
-			t.Fatalf("failed to set flag %q: %v", k, err)
+	for key, value := range values {
+		if err := set.Set(key, value); err != nil {
+			t.Fatalf("failed to set flag %q: %v", key, err)
 		}
 	}
 
 	return cli.NewContext(nil, set, nil)
 }
 
-func TestBuildProviderConfig(t *testing.T) {
+func TestBuildAgentProviders(t *testing.T) {
 	t.Parallel()
 
 	cases := []struct {
-		name string
-		args map[string]string
-		want agents.ProviderConfig
+		name          string
+		args          map[string]string
+		wantProviders []provider.Name
+		wantAnthropic provider.AnthropicConfig
+		wantTools     agents.ToolConfig
 	}{
 		{
-			name: "no flags set",
-			args: nil,
-			want: agents.ProviderConfig{
-				AnthropicKey:         "",
-				AnthropicWorkspaceID: "",
-				OpenAIKey:            "",
-				GoogleKey:            "",
-				BraveKey:             "",
-				TavilyKey:            "",
-			},
+			name:          "no flags set",
+			args:          nil,
+			wantProviders: nil,
+			wantAnthropic: provider.AnthropicConfig{APIKey: "", WorkspaceID: ""},
+			wantTools:     agents.ToolConfig{BraveKey: "", TavilyKey: ""},
 		},
 		{
 			name: "only anthropic",
@@ -58,17 +57,15 @@ func TestBuildProviderConfig(t *testing.T) {
 				flagAnthropicKey:         "ak",
 				flagAnthropicWorkspaceID: "workspace-id",
 			},
-			want: agents.ProviderConfig{
-				AnthropicKey:         "ak",
-				AnthropicWorkspaceID: "workspace-id",
-				OpenAIKey:            "",
-				GoogleKey:            "",
-				BraveKey:             "",
-				TavilyKey:            "",
+			wantProviders: []provider.Name{provider.ProviderAnthropic},
+			wantAnthropic: provider.AnthropicConfig{
+				APIKey:      "ak",
+				WorkspaceID: "workspace-id",
 			},
+			wantTools: agents.ToolConfig{BraveKey: "", TavilyKey: ""},
 		},
 		{
-			name: "all six",
+			name: "all providers and tools",
 			args: map[string]string{
 				flagAnthropicKey:         "ak",
 				flagAnthropicWorkspaceID: "workspace-id",
@@ -77,14 +74,16 @@ func TestBuildProviderConfig(t *testing.T) {
 				flagBraveKey:             "bk",
 				flagTavilyKey:            "tk",
 			},
-			want: agents.ProviderConfig{
-				AnthropicKey:         "ak",
-				AnthropicWorkspaceID: "workspace-id",
-				OpenAIKey:            "ok",
-				GoogleKey:            "gk",
-				BraveKey:             "bk",
-				TavilyKey:            "tk",
+			wantProviders: []provider.Name{
+				provider.ProviderAnthropic,
+				provider.ProviderGoogle,
+				provider.ProviderOpenAI,
 			},
+			wantAnthropic: provider.AnthropicConfig{
+				APIKey:      "ak",
+				WorkspaceID: "workspace-id",
+			},
+			wantTools: agents.ToolConfig{BraveKey: "bk", TavilyKey: "tk"},
 		},
 	}
 
@@ -92,64 +91,123 @@ func TestBuildProviderConfig(t *testing.T) {
 		t.Run(tc.name, func(t *testing.T) {
 			t.Parallel()
 
-			ctx := newProviderConfigContext(t, tc.args)
+			ctx := newAgentConfigContext(t, tc.args)
 
-			got := buildProviderConfig(ctx)
-			if diff := cmp.Diff(tc.want, got); diff != "" {
-				t.Errorf("buildProviderConfig() mismatch (-want +got):\n%s", diff)
+			gotProviders, err := buildAgentProviders(t.Context(), ctx)
+			if err != nil {
+				t.Fatalf("buildAgentProviders() returned an error: %v", err)
+			}
+
+			var gotNames []provider.Name
+			for name := range gotProviders {
+				gotNames = append(gotNames, name)
+			}
+
+			slices.Sort(gotNames)
+
+			if diff := cmp.Diff(tc.wantProviders, gotNames); diff != "" {
+				t.Errorf("provider names mismatch (-want +got):\n%s", diff)
+			}
+
+			if diff := cmp.Diff(tc.wantAnthropic, buildAnthropicConfig(ctx)); diff != "" {
+				t.Errorf("Anthropic config mismatch (-want +got):\n%s", diff)
+			}
+
+			if diff := cmp.Diff(tc.wantTools, buildAgentToolConfig(ctx)); diff != "" {
+				t.Errorf("tool config mismatch (-want +got):\n%s", diff)
 			}
 		})
 	}
 }
 
-// TestBuildProviderConfigEnvVarBindings verifies that the production serve
-// command's provider env-var bindings flow through urfave/cli into ProviderConfig.
-// A rename of any of these env vars would otherwise silently disable the agent
-// service in production. This test cannot run in parallel because t.Setenv
-// mutates process env.
-func TestBuildProviderConfigEnvVarBindings(t *testing.T) {
+// TestAgentConfigEnvVarBindings verifies that the production serve command's
+// environment bindings flow into provider construction and tool configuration.
+// A rename would otherwise silently disable the integration in production.
+func TestAgentConfigEnvVarBindings(t *testing.T) {
+	envVars := []string{
+		"ANTHROPIC_API_KEY",
+		"ANTHROPIC_WORKSPACE_ID",
+		"OPENAI_API_KEY",
+		"GOOGLE_AI_API_KEY",
+		"BRAVE_API_KEY",
+		"TAVILY_API_KEY",
+	}
+
 	cases := []struct {
 		name   string
 		envVar string
-		field  func(c agents.ProviderConfig) string
+		check  func(*testing.T, *cli.Context)
 	}{
 		{
 			name:   "ANTHROPIC_API_KEY",
 			envVar: "ANTHROPIC_API_KEY",
-			field:  func(c agents.ProviderConfig) string { return c.AnthropicKey },
+			check: func(t *testing.T, cCtx *cli.Context) {
+				t.Helper()
+				assertProviderConfigured(t, cCtx, provider.ProviderAnthropic)
+			},
 		},
 		{
 			name:   "ANTHROPIC_WORKSPACE_ID",
 			envVar: "ANTHROPIC_WORKSPACE_ID",
-			field:  func(c agents.ProviderConfig) string { return c.AnthropicWorkspaceID },
+			check: func(t *testing.T, cCtx *cli.Context) {
+				t.Helper()
+
+				if got := buildAnthropicConfig(cCtx).WorkspaceID; got != "from-env" {
+					t.Errorf("workspace ID = %q, want %q", got, "from-env")
+				}
+			},
+		},
+		{
+			name:   "OPENAI_API_KEY",
+			envVar: "OPENAI_API_KEY",
+			check: func(t *testing.T, cCtx *cli.Context) {
+				t.Helper()
+				assertProviderConfigured(t, cCtx, provider.ProviderOpenAI)
+			},
 		},
 		{
 			name:   "GOOGLE_AI_API_KEY",
 			envVar: "GOOGLE_AI_API_KEY",
-			field:  func(c agents.ProviderConfig) string { return c.GoogleKey },
+			check: func(t *testing.T, cCtx *cli.Context) {
+				t.Helper()
+				assertProviderConfigured(t, cCtx, provider.ProviderGoogle)
+			},
 		},
 		{
 			name:   "BRAVE_API_KEY",
 			envVar: "BRAVE_API_KEY",
-			field:  func(c agents.ProviderConfig) string { return c.BraveKey },
+			check: func(t *testing.T, cCtx *cli.Context) {
+				t.Helper()
+
+				if got := buildAgentToolConfig(cCtx).BraveKey; got != "from-env" {
+					t.Errorf("Brave API key = %q, want %q", got, "from-env")
+				}
+			},
 		},
 		{
 			name:   "TAVILY_API_KEY",
 			envVar: "TAVILY_API_KEY",
-			field:  func(c agents.ProviderConfig) string { return c.TavilyKey },
+			check: func(t *testing.T, cCtx *cli.Context) {
+				t.Helper()
+
+				if got := buildAgentToolConfig(cCtx).TavilyKey; got != "from-env" {
+					t.Errorf("Tavily API key = %q, want %q", got, "from-env")
+				}
+			},
 		},
 	}
 
 	for _, tc := range cases {
 		t.Run(tc.name, func(t *testing.T) {
+			for _, envVar := range envVars {
+				t.Setenv(envVar, "")
+			}
+
 			t.Setenv(tc.envVar, "from-env")
 
 			cmd := CommandServe()
 			cmd.Action = func(cCtx *cli.Context) error {
-				cfg := buildProviderConfig(cCtx)
-				if got := tc.field(cfg); got != "from-env" {
-					t.Errorf("expected env value 'from-env', got %q", got)
-				}
+				tc.check(t, cCtx)
 
 				return nil
 			}
@@ -161,5 +219,18 @@ func TestBuildProviderConfigEnvVarBindings(t *testing.T) {
 				t.Fatalf("app.Run failed: %v", err)
 			}
 		})
+	}
+}
+
+func assertProviderConfigured(t *testing.T, cCtx *cli.Context, name provider.Name) {
+	t.Helper()
+
+	providers, err := buildAgentProviders(t.Context(), cCtx)
+	if err != nil {
+		t.Fatalf("buildAgentProviders() returned an error: %v", err)
+	}
+
+	if _, ok := providers[name]; !ok {
+		t.Errorf("provider %q is not configured", name)
 	}
 }

--- a/services/ai/migrations/hasura.go
+++ b/services/ai/migrations/hasura.go
@@ -9,15 +9,13 @@ import (
 	"github.com/nhost/nhost/services/ai/hasura"
 )
 
-const aiSchema = "ai"
-
 func tableAutoEmbeddingsConfiguration(ctx context.Context, cl *hasura.Client) error {
 	table := &hasura.TrackTableRequest{
 		Type: "pg_track_table",
 		Args: hasura.TrackTableRequestArgs{
 			Source: "default",
 			Table: hasura.TrackTableRequestArgsTable{
-				Schema: aiSchema,
+				Schema: schemaName,
 				Name:   "auto_embeddings_configuration",
 			},
 			Configuration: hasura.TrackTableRequestArgsConfiguration{
@@ -129,7 +127,7 @@ func tableAgentProviders(ctx context.Context, cl *hasura.Client) error {
 		Args: hasura.TrackEnumTableArgs{
 			Source: "default",
 			Table: hasura.TrackTableRequestArgsTable{
-				Schema: aiSchema,
+				Schema: schemaName,
 				Name:   "agent_providers",
 			},
 			IsEnum: true,
@@ -169,7 +167,7 @@ func tableAgents(ctx context.Context, cl *hasura.Client) error {
 		Args: hasura.TrackTableRequestArgs{
 			Source: "default",
 			Table: hasura.TrackTableRequestArgsTable{
-				Schema: aiSchema,
+				Schema: schemaName,
 				Name:   "agents",
 			},
 			Configuration: hasura.TrackTableRequestArgsConfiguration{
@@ -216,7 +214,7 @@ func tableAgentSessions(ctx context.Context, cl *hasura.Client) error {
 		Args: hasura.TrackTableRequestArgs{
 			Source: "default",
 			Table: hasura.TrackTableRequestArgsTable{
-				Schema: aiSchema,
+				Schema: schemaName,
 				Name:   "agent_sessions",
 			},
 			Configuration: hasura.TrackTableRequestArgsConfiguration{
@@ -254,7 +252,7 @@ func tableAgentSessions(ctx context.Context, cl *hasura.Client) error {
 
 func agentSessionsRelationships(ctx context.Context, cl *hasura.Client) error {
 	agentSessionsTable := hasura.TrackTableRequestArgsTable{
-		Schema: aiSchema,
+		Schema: schemaName,
 		Name:   "agent_sessions",
 	}
 
@@ -299,7 +297,7 @@ func agentSessionsRelationships(ctx context.Context, cl *hasura.Client) error {
 			Using: hasura.RelationshipUsing{
 				ForeignKeyConstraintOn: hasura.ArrayRelationshipForeignKey{
 					Table: hasura.TrackTableRequestArgsTable{
-						Schema: aiSchema,
+						Schema: schemaName,
 						Name:   "agent_messages",
 					},
 					Column: "session_id",
@@ -321,7 +319,7 @@ func tableAgentMessages(ctx context.Context, cl *hasura.Client) error {
 		Args: hasura.TrackTableRequestArgs{
 			Source: "default",
 			Table: hasura.TrackTableRequestArgsTable{
-				Schema: aiSchema,
+				Schema: schemaName,
 				Name:   "agent_messages",
 			},
 			Configuration: hasura.TrackTableRequestArgsConfiguration{
@@ -366,7 +364,7 @@ func agentMessagesRelationships(ctx context.Context, cl *hasura.Client) error {
 		Type: "pg_create_object_relationship",
 		Args: hasura.CreateRelationshipArgs{
 			Table: hasura.TrackTableRequestArgsTable{
-				Schema: aiSchema,
+				Schema: schemaName,
 				Name:   "agent_messages",
 			},
 			Name:   "agentSession",
@@ -410,7 +408,7 @@ func ApplyHasuraMetadata(
 		{"auto-embeddings event", func() error {
 			return createEvent(
 				ctx, cl, "auto_embeddings_configuration",
-				aiSchema, aiBaseURL, "auto-embeddings-configuration",
+				schemaName, aiBaseURL, "auto-embeddings-configuration",
 			)
 		}},
 	}


### PR DESCRIPTION
<!-- pi-reviewer:start -->
### **What this change solves**
Refactors AI agent provider setup so configured clients are created once at service startup and reused across requests, while model selection remains request-scoped. It also adds Anthropic workspace routing and keeps provider configuration, metadata, streaming, tests, and documentation aligned with the new lifecycle.

___

### **Change Type**
Refactoring

___

### **Description**
- Replace per-request provider construction with a cloned registry of reusable Anthropic, OpenAI, and Google clients.
- Introduce request-scoped provider stream configuration and validate model selection at the streaming boundary.
- Build provider clients from CLI environment configuration, including optional Anthropic workspace routing.
- Update agent loops, approval resumption, SSE handling, Hasura metadata, tests, and service documentation for the new provider lifecycle.

___

### Diagram Walkthrough

```mermaid
flowchart LR
  A["Service environment"] --> B["Provider registry"]
  B --> C["Agent service"]
  D["Agent provider configuration"] --> C
  C --> E["Request-scoped model selection"]
  E --> F["Reusable provider client"]
  F --> G["SSE response stream"]
```

<details> <summary><h3> File Walkthrough</h3></summary>

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody>
<tr><td><strong>Agent orchestration</strong></td><td><details><summary>10 files</summary><table>
<tr><td><strong>services/ai/agents/agents.go</strong><dd><code>Store a cloned provider registry and separate optional tool credentials in the agent service.</code></dd></td><td>+15/-23</td></tr>
<tr><td><strong>services/ai/agents/agents_internal_test.go</strong><dd><code>Verify the service clones the configured provider registry.</code></dd></td><td>+42/-0</td></tr>
<tr><td><strong>services/ai/agents/agents_test.go</strong><dd><code>Cover service construction with empty and configured registries.</code></dd></td><td>+58/-0</td></tr>
<tr><td><strong>services/ai/agents/approval.go</strong><dd><code>Resume approved tool calls with the request-selected provider client.</code></dd></td><td>+2/-1</td></tr>
<tr><td><strong>services/ai/agents/approval_internal_test.go</strong><dd><code>Update approval-resumption tests for registry-based providers and missing-provider errors.</code></dd></td><td>+41/-6</td></tr>
<tr><td><strong>services/ai/agents/handlers_internal_test.go</strong><dd><code>Adapt HTTP and SSE handler tests to preconfigured provider mocks.</code></dd></td><td>+7/-30</td></tr>
<tr><td><strong>services/ai/agents/loop.go</strong><dd><code>Send request-scoped model and conversation data through the provider stream request.</code></dd></td><td>+16/-1</td></tr>
<tr><td><strong>services/ai/agents/loop_internal_test.go</strong><dd><code>Expand loop coverage for stream request contents and validation behavior.</code></dd></td><td>+103/-25</td></tr>
<tr><td><strong>services/ai/agents/sse.go</strong><dd><code>Resolve configured providers from the registry and simplify stream persistence plumbing.</code></dd></td><td>+27/-54</td></tr>
<tr><td><strong>services/ai/agents/sse_internal_test.go</strong><dd><code>Update SSE conversion and provider-selection tests for the revised service contract.</code></dd></td><td>+68/-70</td></tr>
</table></details></td></tr>
<tr><td><strong>Provider adapters</strong></td><td><details><summary>7 files</summary><table>
<tr><td><strong>services/ai/agents/provider/anthropic.go</strong><dd><code>Add static Anthropic client configuration, workspace headers, and request-scoped streaming.</code></dd></td><td>+40/-15</td></tr>
<tr><td><strong>services/ai/agents/provider/google.go</strong><dd><code>Make the Google client reusable while moving model selection into each stream request.</code></dd></td><td>+33/-22</td></tr>
<tr><td><strong>services/ai/agents/provider/google_internal_test.go</strong><dd><code>Construct Google providers through the new static configuration type.</code></dd></td><td>+1/-1</td></tr>
<tr><td><strong>services/ai/agents/provider/openai.go</strong><dd><code>Validate static OpenAI configuration and use request-scoped model selection.</code></dd></td><td>+26/-14</td></tr>
<tr><td><strong>services/ai/agents/provider/openai_internal_test.go</strong><dd><code>Update OpenAI streaming tests for the new stream request.</code></dd></td><td>+6/-4</td></tr>
<tr><td><strong>services/ai/agents/provider/provider.go</strong><dd><code>Define provider registries and validated request-scoped stream input.</code></dd></td><td>+44/-46</td></tr>
<tr><td><strong>services/ai/agents/provider/provider_test.go</strong><dd><code>Expand black-box coverage for constructors, registries, and stream validation.</code></dd></td><td>+419/-67</td></tr>
</table></details></td></tr>
<tr><td><strong>Service startup</strong></td><td><details><summary>2 files</summary><table>
<tr><td><strong>services/ai/cmd/serve.go</strong><dd><code>Build reusable provider clients from environment-backed CLI configuration.</code></dd></td><td>+67/-13</td></tr>
<tr><td><strong>services/ai/cmd/serve_internal_test.go</strong><dd><code>Cover provider registry construction, environment bindings, and configuration errors.</code></dd></td><td>+141/-58</td></tr>
</table></details></td></tr>
<tr><td><strong>Metadata and documentation</strong></td><td><details><summary>2 files</summary><table>
<tr><td><strong>services/ai/migrations/hasura.go</strong><dd><code>Adjust agent provider metadata configuration for service-managed credentials.</code></dd></td><td>+9/-11</td></tr>
<tr><td><strong>services/ai/README.md</strong><dd><code>Document Anthropic API key and optional workspace configuration.</code></dd></td><td>+3/-0</td></tr>
</table></details></td></tr>
</tbody></table>

</details>

___

<!-- pi-reviewer:end -->