### PR TITLE
fix(codegen): emit nullable schemas as `T | null` in the typescript plugin

### DIFF
--- a/docs/src/content/docs/reference/javascript/nhost-js/auth.md
+++ b/docs/src/content/docs/reference/javascript/nhost-js/auth.md
@@ -4303,10 +4303,10 @@ locale: string;
 #### metadata
 
 ```ts
-metadata: Record<string, unknown>;
+metadata: Record<string, unknown> | null;
 ```
 
-(`Record<string, unknown>`) - Custom metadata associated with the user
+(`Record<string, unknown> | null`) - Custom metadata associated with the user
 
 - Example - `{"firstName":"John","lastName":"Smith"}`
 

--- a/packages/nhost-js/src/auth/client.ts
+++ b/packages/nhost-js/src/auth/client.ts
@@ -42,7 +42,7 @@ export interface AuthenticationExtensionsClientOutputs {
  @property clientDataJSON (`string`) - Base64url encoded client data JSON
  @property authenticatorData (`string`) - Base64url encoded authenticator data
  @property signature (`string`) - Base64url encoded assertion signature
- @property userHandle? (`string | null`) - Base64url encoded user handle*/
+ @property userHandle? (`string`) - Base64url encoded user handle*/
 export interface AuthenticatorAssertionResponse {
   /**
    * Base64url encoded client data JSON
@@ -59,7 +59,7 @@ export interface AuthenticatorAssertionResponse {
   /**
    * Base64url encoded user handle
    */
-  userHandle?: string | null;
+  userHandle?: string;
 }
 
 /**
@@ -621,7 +621,7 @@ export interface PublicKeyCredentialRequestOptions {
  @property expiresAt (`string`) - Timestamp when the access token expires
     *    Example - `"2024-12-31T23:59:59Z"`
     *    Format - date-time
- @property refreshToken? (`string | null`) - OAuth2 provider refresh token for obtaining new access tokens (if provided by the provider)
+ @property refreshToken? (`string`) - OAuth2 provider refresh token for obtaining new access tokens (if provided by the provider)
     *    Example - `"1//0gK8..."`*/
 export interface ProviderSession {
   /**
@@ -644,7 +644,7 @@ export interface ProviderSession {
    * OAuth2 provider refresh token for obtaining new access tokens (if provided by the provider)
    *    Example - `"1//0gK8..."`
    */
-  refreshToken?: string | null;
+  refreshToken?: string;
 }
 
 /**
@@ -1378,7 +1378,7 @@ export type URLEncodedBase64 = string;
     *    Example - `false`
  @property roles (`string[]`) - List of roles assigned to the user
     *    Example - `["user","customer"]`
- @property activeMfaType? (`string | null`) - Active MFA type for the user*/
+ @property activeMfaType? (`string`) - Active MFA type for the user*/
 export interface User {
   /**
    * URL to the user's profile picture
@@ -1453,7 +1453,7 @@ export interface User {
   /**
    * Active MFA type for the user
    */
-  activeMfaType?: string | null;
+  activeMfaType?: string;
 }
 
 /**
@@ -1889,13 +1889,13 @@ export type OAuth2TokenRequestGrant_type =
 /**
  * 
  @property grant_type (`OAuth2TokenRequestGrant_type`) - 
- @property code? (`string | null`) - 
- @property redirect_uri? (`string | null`) - 
- @property client_id? (`string | null`) - 
- @property client_secret? (`string | null`) - 
- @property code_verifier? (`string | null`) - 
- @property refresh_token? (`string | null`) - 
- @property resource? (`string | null`) - */
+ @property code? (`string`) - 
+ @property redirect_uri? (`string`) - 
+ @property client_id? (`string`) - 
+ @property client_secret? (`string`) - 
+ @property code_verifier? (`string`) - 
+ @property refresh_token? (`string`) - 
+ @property resource? (`string`) - */
 export interface OAuth2TokenRequest {
   /**
    *
@@ -1904,31 +1904,31 @@ export interface OAuth2TokenRequest {
   /**
    *
    */
-  code?: string | null;
+  code?: string;
   /**
    *
    */
-  redirect_uri?: string | null;
+  redirect_uri?: string;
   /**
    *
    */
-  client_id?: string | null;
+  client_id?: string;
   /**
    *
    */
-  client_secret?: string | null;
+  client_secret?: string;
   /**
    *
    */
-  code_verifier?: string | null;
+  code_verifier?: string;
   /**
    *
    */
-  refresh_token?: string | null;
+  refresh_token?: string;
   /**
    *
    */
-  resource?: string | null;
+  resource?: string;
 }
 
 /**
@@ -2031,9 +2031,9 @@ export type OAuth2RevokeRequestToken_type_hint =
 /**
  * 
  @property token (`string`) - 
- @property token_type_hint? (`OAuth2RevokeRequestToken_type_hint | null`) - 
- @property client_id? (`string | null`) - 
- @property client_secret? (`string | null`) - */
+ @property token_type_hint? (`OAuth2RevokeRequestToken_type_hint`) - 
+ @property client_id? (`string`) - 
+ @property client_secret? (`string`) - */
 export interface OAuth2RevokeRequest {
   /**
    *
@@ -2042,15 +2042,15 @@ export interface OAuth2RevokeRequest {
   /**
    *
    */
-  token_type_hint?: OAuth2RevokeRequestToken_type_hint | null;
+  token_type_hint?: OAuth2RevokeRequestToken_type_hint;
   /**
    *
    */
-  client_id?: string | null;
+  client_id?: string;
   /**
    *
    */
-  client_secret?: string | null;
+  client_secret?: string;
 }
 
 /**
@@ -2063,9 +2063,9 @@ export type OAuth2IntrospectRequestToken_type_hint =
 /**
  * 
  @property token (`string`) - 
- @property token_type_hint? (`OAuth2IntrospectRequestToken_type_hint | null`) - 
- @property client_id? (`string | null`) - 
- @property client_secret? (`string | null`) - */
+ @property token_type_hint? (`OAuth2IntrospectRequestToken_type_hint`) - 
+ @property client_id? (`string`) - 
+ @property client_secret? (`string`) - */
 export interface OAuth2IntrospectRequest {
   /**
    *
@@ -2074,15 +2074,15 @@ export interface OAuth2IntrospectRequest {
   /**
    *
    */
-  token_type_hint?: OAuth2IntrospectRequestToken_type_hint | null;
+  token_type_hint?: OAuth2IntrospectRequestToken_type_hint;
   /**
    *
    */
-  client_id?: string | null;
+  client_id?: string;
   /**
    *
    */
-  client_secret?: string | null;
+  client_secret?: string;
 }
 
 /**
@@ -2243,13 +2243,13 @@ export type GetCode_challenge_method = 'S256';
  @property client_id (`string`) - 
  @property redirect_uri (`string`) - 
  @property response_type (`string`) - 
- @property scope? (`string | null`) - 
- @property state? (`string | null`) - 
- @property nonce? (`string | null`) - 
- @property code_challenge? (`string | null`) - 
- @property code_challenge_method? (`string | null`) - Only S256 is supported. The plain method is not allowed.
- @property resource? (`string | null`) - 
- @property prompt? (`string | null`) - */
+ @property scope? (`string`) - 
+ @property state? (`string`) - 
+ @property nonce? (`string`) - 
+ @property code_challenge? (`string`) - 
+ @property code_challenge_method? (`string`) - Only S256 is supported. The plain method is not allowed.
+ @property resource? (`string`) - 
+ @property prompt? (`string`) - */
 export interface Oauth2AuthorizePostBody {
   /**
    *
@@ -2266,31 +2266,31 @@ export interface Oauth2AuthorizePostBody {
   /**
    *
    */
-  scope?: string | null;
+  scope?: string;
   /**
    *
    */
-  state?: string | null;
+  state?: string;
   /**
    *
    */
-  nonce?: string | null;
+  nonce?: string;
   /**
    *
    */
-  code_challenge?: string | null;
+  code_challenge?: string;
   /**
    * Only S256 is supported. The plain method is not allowed.
    */
-  code_challenge_method?: string | null;
+  code_challenge_method?: string;
   /**
    *
    */
-  resource?: string | null;
+  resource?: string;
   /**
    *
    */
-  prompt?: string | null;
+  prompt?: string;
 }
 
 /**
@@ -3950,6 +3950,9 @@ export const createAPIClient = (
       params &&
       Object.entries(params)
         .flatMap(([key, value]) => {
+          if (value === null || value === undefined) {
+            return [];
+          }
           if (key === 'providerSpecificParams') {
             // Object with explode: true - each property as separate parameter
             if (
@@ -4376,6 +4379,9 @@ export const createAPIClient = (
       params &&
       Object.entries(params)
         .flatMap(([key, value]) => {
+          if (value === null || value === undefined) {
+            return [];
+          }
           if (key === 'providerSpecificParams') {
             // Object with explode: true - each property as separate parameter
             if (
@@ -4955,6 +4961,9 @@ export const createAPIClient = (
       params &&
       Object.entries(params)
         .flatMap(([key, value]) => {
+          if (value === null || value === undefined) {
+            return [];
+          }
           // Default handling (scalars or explode: false)
           const stringValue = Array.isArray(value)
             ? value.join(',')
@@ -5072,6 +5081,9 @@ export const createAPIClient = (
       params &&
       Object.entries(params)
         .flatMap(([key, value]) => {
+          if (value === null || value === undefined) {
+            return [];
+          }
           // Default handling (scalars or explode: false)
           const stringValue = Array.isArray(value)
             ? value.join(',')
@@ -5099,28 +5111,28 @@ export const createAPIClient = (
   ): Promise<FetchResponse<OAuth2TokenResponse>> => {
     const url = `${baseURL}/oauth2/token`;
     const params = new URLSearchParams();
-    if (body['grant_type'] !== undefined) {
+    if (body['grant_type'] !== undefined && body['grant_type'] !== null) {
       params.append('grant_type', String(body['grant_type']));
     }
-    if (body['code'] !== undefined) {
+    if (body['code'] !== undefined && body['code'] !== null) {
       params.append('code', String(body['code']));
     }
-    if (body['redirect_uri'] !== undefined) {
+    if (body['redirect_uri'] !== undefined && body['redirect_uri'] !== null) {
       params.append('redirect_uri', String(body['redirect_uri']));
     }
-    if (body['client_id'] !== undefined) {
+    if (body['client_id'] !== undefined && body['client_id'] !== null) {
       params.append('client_id', String(body['client_id']));
     }
-    if (body['client_secret'] !== undefined) {
+    if (body['client_secret'] !== undefined && body['client_secret'] !== null) {
       params.append('client_secret', String(body['client_secret']));
     }
-    if (body['code_verifier'] !== undefined) {
+    if (body['code_verifier'] !== undefined && body['code_verifier'] !== null) {
       params.append('code_verifier', String(body['code_verifier']));
     }
-    if (body['refresh_token'] !== undefined) {
+    if (body['refresh_token'] !== undefined && body['refresh_token'] !== null) {
       params.append('refresh_token', String(body['refresh_token']));
     }
-    if (body['resource'] !== undefined) {
+    if (body['resource'] !== undefined && body['resource'] !== null) {
       params.append('resource', String(body['resource']));
     }
 
@@ -5256,16 +5268,19 @@ export const createAPIClient = (
   ): Promise<FetchResponse<void>> => {
     const url = `${baseURL}/oauth2/revoke`;
     const params = new URLSearchParams();
-    if (body['token'] !== undefined) {
+    if (body['token'] !== undefined && body['token'] !== null) {
       params.append('token', String(body['token']));
     }
-    if (body['token_type_hint'] !== undefined) {
+    if (
+      body['token_type_hint'] !== undefined &&
+      body['token_type_hint'] !== null
+    ) {
       params.append('token_type_hint', String(body['token_type_hint']));
     }
-    if (body['client_id'] !== undefined) {
+    if (body['client_id'] !== undefined && body['client_id'] !== null) {
       params.append('client_id', String(body['client_id']));
     }
-    if (body['client_secret'] !== undefined) {
+    if (body['client_secret'] !== undefined && body['client_secret'] !== null) {
       params.append('client_secret', String(body['client_secret']));
     }
 
@@ -5300,16 +5315,19 @@ export const createAPIClient = (
   ): Promise<FetchResponse<OAuth2IntrospectResponse>> => {
     const url = `${baseURL}/oauth2/introspect`;
     const params = new URLSearchParams();
-    if (body['token'] !== undefined) {
+    if (body['token'] !== undefined && body['token'] !== null) {
       params.append('token', String(body['token']));
     }
-    if (body['token_type_hint'] !== undefined) {
+    if (
+      body['token_type_hint'] !== undefined &&
+      body['token_type_hint'] !== null
+    ) {
       params.append('token_type_hint', String(body['token_type_hint']));
     }
-    if (body['client_id'] !== undefined) {
+    if (body['client_id'] !== undefined && body['client_id'] !== null) {
       params.append('client_id', String(body['client_id']));
     }
-    if (body['client_secret'] !== undefined) {
+    if (body['client_secret'] !== undefined && body['client_secret'] !== null) {
       params.append('client_secret', String(body['client_secret']));
     }
 
@@ -5351,6 +5369,9 @@ export const createAPIClient = (
       params &&
       Object.entries(params)
         .flatMap(([key, value]) => {
+          if (value === null || value === undefined) {
+            return [];
+          }
           // Default handling (scalars or explode: false)
           const stringValue = Array.isArray(value)
             ? value.join(',')

--- a/packages/nhost-js/src/auth/client.ts
+++ b/packages/nhost-js/src/auth/client.ts
@@ -42,7 +42,7 @@ export interface AuthenticationExtensionsClientOutputs {
  @property clientDataJSON (`string`) - Base64url encoded client data JSON
  @property authenticatorData (`string`) - Base64url encoded authenticator data
  @property signature (`string`) - Base64url encoded assertion signature
- @property userHandle? (`string`) - Base64url encoded user handle*/
+ @property userHandle? (`string | null`) - Base64url encoded user handle*/
 export interface AuthenticatorAssertionResponse {
   /**
    * Base64url encoded client data JSON
@@ -59,7 +59,7 @@ export interface AuthenticatorAssertionResponse {
   /**
    * Base64url encoded user handle
    */
-  userHandle?: string;
+  userHandle?: string | null;
 }
 
 /**
@@ -621,7 +621,7 @@ export interface PublicKeyCredentialRequestOptions {
  @property expiresAt (`string`) - Timestamp when the access token expires
     *    Example - `"2024-12-31T23:59:59Z"`
     *    Format - date-time
- @property refreshToken? (`string`) - OAuth2 provider refresh token for obtaining new access tokens (if provided by the provider)
+ @property refreshToken? (`string | null`) - OAuth2 provider refresh token for obtaining new access tokens (if provided by the provider)
     *    Example - `"1//0gK8..."`*/
 export interface ProviderSession {
   /**
@@ -644,7 +644,7 @@ export interface ProviderSession {
    * OAuth2 provider refresh token for obtaining new access tokens (if provided by the provider)
    *    Example - `"1//0gK8..."`
    */
-  refreshToken?: string;
+  refreshToken?: string | null;
 }
 
 /**
@@ -1370,7 +1370,7 @@ export type URLEncodedBase64 = string;
     *    Example - `"en"`
     *    MinLength - 2
     *    MaxLength - 3
- @property metadata (`Record<string, unknown>`) - Custom metadata associated with the user
+ @property metadata (`Record<string, unknown> | null`) - Custom metadata associated with the user
     *    Example - `{"firstName":"John","lastName":"Smith"}`
  @property phoneNumber? (`string`) - User's phone number
     *    Example - `"+12025550123"`
@@ -1378,7 +1378,7 @@ export type URLEncodedBase64 = string;
     *    Example - `false`
  @property roles (`string[]`) - List of roles assigned to the user
     *    Example - `["user","customer"]`
- @property activeMfaType? (`string`) - Active MFA type for the user*/
+ @property activeMfaType? (`string | null`) - Active MFA type for the user*/
 export interface User {
   /**
    * URL to the user's profile picture
@@ -1434,7 +1434,7 @@ export interface User {
    * Custom metadata associated with the user
    *    Example - `{"firstName":"John","lastName":"Smith"}`
    */
-  metadata: Record<string, unknown>;
+  metadata: Record<string, unknown> | null;
   /**
    * User's phone number
    *    Example - `"+12025550123"`
@@ -1453,7 +1453,7 @@ export interface User {
   /**
    * Active MFA type for the user
    */
-  activeMfaType?: string;
+  activeMfaType?: string | null;
 }
 
 /**
@@ -1889,13 +1889,13 @@ export type OAuth2TokenRequestGrant_type =
 /**
  * 
  @property grant_type (`OAuth2TokenRequestGrant_type`) - 
- @property code? (`string`) - 
- @property redirect_uri? (`string`) - 
- @property client_id? (`string`) - 
- @property client_secret? (`string`) - 
- @property code_verifier? (`string`) - 
- @property refresh_token? (`string`) - 
- @property resource? (`string`) - */
+ @property code? (`string | null`) - 
+ @property redirect_uri? (`string | null`) - 
+ @property client_id? (`string | null`) - 
+ @property client_secret? (`string | null`) - 
+ @property code_verifier? (`string | null`) - 
+ @property refresh_token? (`string | null`) - 
+ @property resource? (`string | null`) - */
 export interface OAuth2TokenRequest {
   /**
    *
@@ -1904,31 +1904,31 @@ export interface OAuth2TokenRequest {
   /**
    *
    */
-  code?: string;
+  code?: string | null;
   /**
    *
    */
-  redirect_uri?: string;
+  redirect_uri?: string | null;
   /**
    *
    */
-  client_id?: string;
+  client_id?: string | null;
   /**
    *
    */
-  client_secret?: string;
+  client_secret?: string | null;
   /**
    *
    */
-  code_verifier?: string;
+  code_verifier?: string | null;
   /**
    *
    */
-  refresh_token?: string;
+  refresh_token?: string | null;
   /**
    *
    */
-  resource?: string;
+  resource?: string | null;
 }
 
 /**
@@ -2031,9 +2031,9 @@ export type OAuth2RevokeRequestToken_type_hint =
 /**
  * 
  @property token (`string`) - 
- @property token_type_hint? (`OAuth2RevokeRequestToken_type_hint`) - 
- @property client_id? (`string`) - 
- @property client_secret? (`string`) - */
+ @property token_type_hint? (`OAuth2RevokeRequestToken_type_hint | null`) - 
+ @property client_id? (`string | null`) - 
+ @property client_secret? (`string | null`) - */
 export interface OAuth2RevokeRequest {
   /**
    *
@@ -2042,15 +2042,15 @@ export interface OAuth2RevokeRequest {
   /**
    *
    */
-  token_type_hint?: OAuth2RevokeRequestToken_type_hint;
+  token_type_hint?: OAuth2RevokeRequestToken_type_hint | null;
   /**
    *
    */
-  client_id?: string;
+  client_id?: string | null;
   /**
    *
    */
-  client_secret?: string;
+  client_secret?: string | null;
 }
 
 /**
@@ -2063,9 +2063,9 @@ export type OAuth2IntrospectRequestToken_type_hint =
 /**
  * 
  @property token (`string`) - 
- @property token_type_hint? (`OAuth2IntrospectRequestToken_type_hint`) - 
- @property client_id? (`string`) - 
- @property client_secret? (`string`) - */
+ @property token_type_hint? (`OAuth2IntrospectRequestToken_type_hint | null`) - 
+ @property client_id? (`string | null`) - 
+ @property client_secret? (`string | null`) - */
 export interface OAuth2IntrospectRequest {
   /**
    *
@@ -2074,15 +2074,15 @@ export interface OAuth2IntrospectRequest {
   /**
    *
    */
-  token_type_hint?: OAuth2IntrospectRequestToken_type_hint;
+  token_type_hint?: OAuth2IntrospectRequestToken_type_hint | null;
   /**
    *
    */
-  client_id?: string;
+  client_id?: string | null;
   /**
    *
    */
-  client_secret?: string;
+  client_secret?: string | null;
 }
 
 /**
@@ -2243,13 +2243,13 @@ export type GetCode_challenge_method = 'S256';
  @property client_id (`string`) - 
  @property redirect_uri (`string`) - 
  @property response_type (`string`) - 
- @property scope? (`string`) - 
- @property state? (`string`) - 
- @property nonce? (`string`) - 
- @property code_challenge? (`string`) - 
- @property code_challenge_method? (`string`) - Only S256 is supported. The plain method is not allowed.
- @property resource? (`string`) - 
- @property prompt? (`string`) - */
+ @property scope? (`string | null`) - 
+ @property state? (`string | null`) - 
+ @property nonce? (`string | null`) - 
+ @property code_challenge? (`string | null`) - 
+ @property code_challenge_method? (`string | null`) - Only S256 is supported. The plain method is not allowed.
+ @property resource? (`string | null`) - 
+ @property prompt? (`string | null`) - */
 export interface Oauth2AuthorizePostBody {
   /**
    *
@@ -2266,31 +2266,31 @@ export interface Oauth2AuthorizePostBody {
   /**
    *
    */
-  scope?: string;
+  scope?: string | null;
   /**
    *
    */
-  state?: string;
+  state?: string | null;
   /**
    *
    */
-  nonce?: string;
+  nonce?: string | null;
   /**
    *
    */
-  code_challenge?: string;
+  code_challenge?: string | null;
   /**
    * Only S256 is supported. The plain method is not allowed.
    */
-  code_challenge_method?: string;
+  code_challenge_method?: string | null;
   /**
    *
    */
-  resource?: string;
+  resource?: string | null;
   /**
    *
    */
-  prompt?: string;
+  prompt?: string | null;
 }
 
 /**

--- a/packages/nhost-js/src/storage/client.ts
+++ b/packages/nhost-js/src/storage/client.ts
@@ -636,10 +636,10 @@ export const createAPIClient = (
     const isReactNative =
       typeof navigator !== 'undefined' &&
       (navigator as { product?: string }).product === 'ReactNative';
-    if (body['bucket-id'] !== undefined) {
+    if (body['bucket-id'] !== undefined && body['bucket-id'] !== null) {
       formData.append('bucket-id', body['bucket-id']);
     }
-    if (body['metadata[]'] !== undefined) {
+    if (body['metadata[]'] !== undefined && body['metadata[]'] !== null) {
       body['metadata[]'].forEach((value) => {
         if (isReactNative) {
           formData.append('metadata[]', {
@@ -656,7 +656,7 @@ export const createAPIClient = (
         }
       });
     }
-    if (body['file[]'] !== undefined) {
+    if (body['file[]'] !== undefined && body['file[]'] !== null) {
       body['file[]'].forEach((value) => {
         formData.append('file[]', value);
       });
@@ -822,7 +822,7 @@ export const createAPIClient = (
     const isReactNative =
       typeof navigator !== 'undefined' &&
       (navigator as { product?: string }).product === 'ReactNative';
-    if (body['metadata'] !== undefined) {
+    if (body['metadata'] !== undefined && body['metadata'] !== null) {
       if (isReactNative) {
         formData.append('metadata', {
           string: JSON.stringify(body['metadata']),
@@ -839,7 +839,7 @@ export const createAPIClient = (
         );
       }
     }
-    if (body['file'] !== undefined) {
+    if (body['file'] !== undefined && body['file'] !== null) {
       formData.append('file', body['file']);
     }
 

--- a/packages/nhost-js/src/storage/client.ts
+++ b/packages/nhost-js/src/storage/client.ts
@@ -725,6 +725,9 @@ export const createAPIClient = (
       params &&
       Object.entries(params)
         .flatMap(([key, value]) => {
+          if (value === null || value === undefined) {
+            return [];
+          }
           // Default handling (scalars or explode: false)
           const stringValue = Array.isArray(value)
             ? value.join(',')
@@ -770,6 +773,9 @@ export const createAPIClient = (
       params &&
       Object.entries(params)
         .flatMap(([key, value]) => {
+          if (value === null || value === undefined) {
+            return [];
+          }
           // Default handling (scalars or explode: false)
           const stringValue = Array.isArray(value)
             ? value.join(',')

--- a/tools/codegen/processor/intermediate.go
+++ b/tools/codegen/processor/intermediate.go
@@ -178,11 +178,12 @@ func (ir *InterMediateRepresentation) Render(out io.Writer) error {
 	}
 
 	funcs := template.FuncMap{
-		"title":   format.Title,
-		"join":    strings.Join,
-		"example": templateFnExample,
-		"pattern": templateFnPattern,
-		"format":  templateFnFormat,
+		"title":    format.Title,
+		"join":     strings.Join,
+		"example":  templateFnExample,
+		"pattern":  templateFnPattern,
+		"format":   templateFnFormat,
+		"nullable": templateFnNullable,
 	}
 	maps.Copy(funcs, ir.plugin.GetFuncMap())
 
@@ -226,4 +227,29 @@ func templateFnPattern(obj getSchemaer) string {
 
 func templateFnFormat(obj getSchemaer) string {
 	return obj.Schema().Schema().Format
+}
+
+// SchemaNullable reports whether the schema is declared nullable (OpenAPI 3.0
+// `nullable: true`), so generators can widen the type with an explicit null
+// (e.g. `T | null`). The server marshals such fields as `null` rather than
+// omitting them, so runtime-validating clients need the union.
+//
+// Plugins use this directly to widen container element/value types, which the
+// templates cannot reach: a container renders through a single `.Type.Name`,
+// so nullability declared on an array item or on `additionalProperties` is only
+// visible while building that name.
+func SchemaNullable(schema *base.SchemaProxy) bool {
+	if schema == nil {
+		return false
+	}
+
+	s := schema.Schema()
+
+	return s != nil && s.Nullable != nil && *s.Nullable
+}
+
+// templateFnNullable exposes SchemaNullable to templates for property-level
+// nullability.
+func templateFnNullable(obj getSchemaer) bool {
+	return SchemaNullable(obj.Schema())
 }

--- a/tools/codegen/processor/intermediate.go
+++ b/tools/codegen/processor/intermediate.go
@@ -232,7 +232,9 @@ func templateFnFormat(obj getSchemaer) string {
 // SchemaNullable reports whether the schema is declared nullable (OpenAPI 3.0
 // `nullable: true`), so generators can widen the type with an explicit null
 // (e.g. `T | null`). The server marshals such fields as `null` rather than
-// omitting them, so runtime-validating clients need the union.
+// omitting them, so runtime-validating clients need the union. Top-level schema
+// nullability is deliberately widened only for object properties and query
+// parameters, not component declarations or response/body types.
 //
 // Plugins use this directly to widen container element/value types, which the
 // templates cannot reach: a container renders through a single `.Type.Name`,

--- a/tools/codegen/processor/intermediate.go
+++ b/tools/codegen/processor/intermediate.go
@@ -229,12 +229,9 @@ func templateFnFormat(obj getSchemaer) string {
 	return obj.Schema().Schema().Format
 }
 
-// SchemaNullable reports whether the schema is declared nullable (OpenAPI 3.0
-// `nullable: true`), so generators can widen the type with an explicit null
-// (e.g. `T | null`). The server marshals such fields as `null` rather than
-// omitting them, so runtime-validating clients need the union. Top-level schema
-// nullability is deliberately widened only for object properties and query
-// parameters, not component declarations or response/body types.
+// SchemaNullable reports whether the schema declares OpenAPI 3.0
+// `nullable: true`. It does not decide whether a generated top-level type should
+// be widened; callers apply the target-specific policy for their context.
 //
 // Plugins use this directly to widen container element/value types, which the
 // templates cannot reach: a container renders through a single `.Type.Name`,
@@ -250,8 +247,8 @@ func SchemaNullable(schema *base.SchemaProxy) bool {
 	return s != nil && s.Nullable != nil && *s.Nullable
 }
 
-// templateFnNullable exposes SchemaNullable to templates for property-level
-// nullability.
+// templateFnNullable exposes SchemaNullable to templates. Templates apply it
+// only in contexts where their output contract represents explicit null.
 func templateFnNullable(obj getSchemaer) bool {
 	return SchemaNullable(obj.Schema())
 }

--- a/tools/codegen/processor/testdata/content.yaml
+++ b/tools/codegen/processor/testdata/content.yaml
@@ -30,6 +30,13 @@ paths:
           schema:
             type: string
             example: user
+        - name: filter
+          in: query
+          required: false
+          description: Nullable query parameter; the caller may send an explicit null
+          schema:
+            type: string
+            nullable: true
         - name: displayName
           in: query
           required: false

--- a/tools/codegen/processor/testdata/content.yaml
+++ b/tools/codegen/processor/testdata/content.yaml
@@ -33,7 +33,7 @@ paths:
         - name: filter
           in: query
           required: false
-          description: Nullable query parameter; the caller may send an explicit null
+          description: Optional query parameter declared nullable in OpenAPI
           schema:
             type: string
             nullable: true

--- a/tools/codegen/processor/testdata/content.yaml.ts
+++ b/tools/codegen/processor/testdata/content.yaml.ts
@@ -56,7 +56,7 @@ export type SignInProvider = "apple" | "github" | "google" | "linkedin" | "disco
   
     @property defaultRole? (string) - Default role for the user
   
-    @property filter? (string | null) - Nullable query parameter; the caller may send an explicit null
+    @property filter? (string) - Optional query parameter declared nullable in OpenAPI
   
     @property displayName? (string) - Display name for the user
   
@@ -82,10 +82,10 @@ export interface SignInProviderParams {
    */
   defaultRole?: string;
   /**
-   * Nullable query parameter; the caller may send an explicit null
+   * Optional query parameter declared nullable in OpenAPI
   
    */
-  filter?: string | null;
+  filter?: string;
   /**
    * Display name for the user
   

--- a/tools/codegen/processor/testdata/content.yaml.ts
+++ b/tools/codegen/processor/testdata/content.yaml.ts
@@ -56,6 +56,8 @@ export type SignInProvider = "apple" | "github" | "google" | "linkedin" | "disco
   
     @property defaultRole? (string) - Default role for the user
   
+    @property filter? (string | null) - Nullable query parameter; the caller may send an explicit null
+  
     @property displayName? (string) - Display name for the user
   
     @property locale? (string) - A two-characters locale
@@ -79,6 +81,11 @@ export interface SignInProviderParams {
   
    */
   defaultRole?: string;
+  /**
+   * Nullable query parameter; the caller may send an explicit null
+  
+   */
+  filter?: string | null;
   /**
    * Display name for the user
   

--- a/tools/codegen/processor/testdata/content.yaml.ts
+++ b/tools/codegen/processor/testdata/content.yaml.ts
@@ -158,6 +158,9 @@ export const createAPIClient = (
     params &&
     Object.entries(params)
       .flatMap(([key, value]) => {
+        if (value === null || value === undefined) {
+          return []
+        }
         if (key === "providerSpecificParams") {
           // Object with explode: true - each property as separate parameter
           if (typeof value === 'object' && value !== null && !Array.isArray(value)) {

--- a/tools/codegen/processor/testdata/deepobject-map.yaml.ts
+++ b/tools/codegen/processor/testdata/deepobject-map.yaml.ts
@@ -63,6 +63,9 @@ export const createAPIClient = (
     params &&
     Object.entries(params)
       .flatMap(([key, value]) => {
+        if (value === null || value === undefined) {
+          return []
+        }
         if (key === "upstreamParams") {
           // deepObject with explode: true - upstreamParams[prop]=value
           if (typeof value === 'object' && value !== null && !Array.isArray(value)) {

--- a/tools/codegen/processor/testdata/form-url-encoded.yaml
+++ b/tools/codegen/processor/testdata/form-url-encoded.yaml
@@ -35,12 +35,15 @@ components:
           type: string
           enum: [access_token, refresh_token]
           nullable: true
+          description: Optional token type hint declared nullable in OpenAPI.
         client_id:
           type: string
           nullable: true
+          description: Optional client identifier declared nullable in OpenAPI.
         client_secret:
           type: string
           nullable: true
+          description: Optional client secret declared nullable in OpenAPI.
       required:
         - token
 

--- a/tools/codegen/processor/testdata/form-url-encoded.yaml.ts
+++ b/tools/codegen/processor/testdata/form-url-encoded.yaml.ts
@@ -91,16 +91,16 @@ export const createAPIClient = (
   ): Promise<FetchResponse<void>> => {
     const url = `${ baseURL }/oauth2/revoke`;
     const params = new URLSearchParams();
-    if (body["token"] !== undefined) {
+    if (body["token"] !== undefined && body["token"] !== null) {
       params.append("token", String(body["token"]));
     }
-    if (body["token_type_hint"] !== undefined) {
+    if (body["token_type_hint"] !== undefined && body["token_type_hint"] !== null) {
       params.append("token_type_hint", String(body["token_type_hint"]));
     }
-    if (body["client_id"] !== undefined) {
+    if (body["client_id"] !== undefined && body["client_id"] !== null) {
       params.append("client_id", String(body["client_id"]));
     }
-    if (body["client_secret"] !== undefined) {
+    if (body["client_secret"] !== undefined && body["client_secret"] !== null) {
       params.append("client_secret", String(body["client_secret"]));
     }
 

--- a/tools/codegen/processor/testdata/form-url-encoded.yaml.ts
+++ b/tools/codegen/processor/testdata/form-url-encoded.yaml.ts
@@ -14,9 +14,9 @@ export type OAuth2RevokeRequestToken_type_hint = "access_token" | "refresh_token
 /**
  * 
  @property token (`string`) - 
- @property token_type_hint? (`OAuth2RevokeRequestToken_type_hint`) - 
- @property client_id? (`string`) - 
- @property client_secret? (`string`) - */
+ @property token_type_hint? (`OAuth2RevokeRequestToken_type_hint | null`) - 
+ @property client_id? (`string | null`) - 
+ @property client_secret? (`string | null`) - */
 export interface OAuth2RevokeRequest {
   /**
    * 
@@ -25,15 +25,15 @@ export interface OAuth2RevokeRequest {
   /**
    * 
    */
-  token_type_hint?: OAuth2RevokeRequestToken_type_hint,
+  token_type_hint?: OAuth2RevokeRequestToken_type_hint | null,
   /**
    * 
    */
-  client_id?: string,
+  client_id?: string | null,
   /**
    * 
    */
-  client_secret?: string,
+  client_secret?: string | null,
 };
 
 

--- a/tools/codegen/processor/testdata/form-url-encoded.yaml.ts
+++ b/tools/codegen/processor/testdata/form-url-encoded.yaml.ts
@@ -6,7 +6,7 @@ import type { ChainFunction, FetchResponse } from "../fetch";
 import { createEnhancedFetch, FetchError } from "../fetch";
 
 /**
- * 
+ * Optional token type hint declared nullable in OpenAPI.
  */
 export type OAuth2RevokeRequestToken_type_hint = "access_token" | "refresh_token";
 
@@ -14,26 +14,26 @@ export type OAuth2RevokeRequestToken_type_hint = "access_token" | "refresh_token
 /**
  * 
  @property token (`string`) - 
- @property token_type_hint? (`OAuth2RevokeRequestToken_type_hint | null`) - 
- @property client_id? (`string | null`) - 
- @property client_secret? (`string | null`) - */
+ @property token_type_hint? (`OAuth2RevokeRequestToken_type_hint`) - Optional token type hint declared nullable in OpenAPI.
+ @property client_id? (`string`) - Optional client identifier declared nullable in OpenAPI.
+ @property client_secret? (`string`) - Optional client secret declared nullable in OpenAPI.*/
 export interface OAuth2RevokeRequest {
   /**
    * 
    */
   token: string,
   /**
-   * 
+   * Optional token type hint declared nullable in OpenAPI.
    */
-  token_type_hint?: OAuth2RevokeRequestToken_type_hint | null,
+  token_type_hint?: OAuth2RevokeRequestToken_type_hint,
   /**
-   * 
+   * Optional client identifier declared nullable in OpenAPI.
    */
-  client_id?: string | null,
+  client_id?: string,
   /**
-   * 
+   * Optional client secret declared nullable in OpenAPI.
    */
-  client_secret?: string | null,
+  client_secret?: string,
 };
 
 

--- a/tools/codegen/processor/testdata/methods_ref.yaml
+++ b/tools/codegen/processor/testdata/methods_ref.yaml
@@ -48,6 +48,24 @@ paths:
                   type: string
                   description: "Target bucket identifier where files will be stored."
                   example: "user-uploads"
+                nullable-note:
+                  type: string
+                  nullable: true
+                  description: "Required multipart string that may be null."
+                nullable-tags:
+                  type: array
+                  nullable: true
+                  description: "Required multipart array that may be null."
+                  items:
+                    type: string
+                nullable-metadata:
+                  type: object
+                  nullable: true
+                  description: "Required multipart object that may be null."
+                  properties:
+                    label:
+                      type: string
+                      description: "Label stored with the upload."
                 metadata[]:
                   type: array
                   description: "Optional custom metadata for each uploaded file. Must match the order of the file[] array."
@@ -61,6 +79,9 @@ paths:
                     format: binary
               required:
                 - file[]
+                - nullable-note
+                - nullable-tags
+                - nullable-metadata
             encoding:
               file[]:
                 contentType: application/octet-stream

--- a/tools/codegen/processor/testdata/methods_ref.yaml.ts
+++ b/tools/codegen/processor/testdata/methods_ref.yaml.ts
@@ -834,6 +834,9 @@ export const createAPIClient = (
     params &&
     Object.entries(params)
       .flatMap(([key, value]) => {
+        if (value === null || value === undefined) {
+          return []
+        }
         // Default handling (scalars or explode: false)
         const stringValue = Array.isArray(value)
           ? value.join(',')
@@ -882,6 +885,9 @@ export const createAPIClient = (
     params &&
     Object.entries(params)
       .flatMap(([key, value]) => {
+        if (value === null || value === undefined) {
+          return []
+        }
         // Default handling (scalars or explode: false)
         const stringValue = Array.isArray(value)
           ? value.join(',')
@@ -1014,6 +1020,9 @@ export const createAPIClient = (
     params &&
     Object.entries(params)
       .flatMap(([key, value]) => {
+        if (value === null || value === undefined) {
+          return []
+        }
         // Default handling (scalars or explode: false)
         const stringValue = Array.isArray(value)
           ? value.join(',')

--- a/tools/codegen/processor/testdata/methods_ref.yaml.ts
+++ b/tools/codegen/processor/testdata/methods_ref.yaml.ts
@@ -456,9 +456,23 @@ export type RedirectToQuery = string;
 
 
 /**
+ * Required multipart object that may be null.
+ @property label? (`string`) - Label stored with the upload.*/
+export interface UploadFilesBodyNullableMetadata {
+  /**
+   * Label stored with the upload.
+   */
+  label?: string,
+};
+
+
+/**
  * 
  @property bucket-id? (`string`) - Target bucket identifier where files will be stored.
     *    Example - `"user-uploads"`
+ @property nullable-note (`string | null`) - Required multipart string that may be null.
+ @property nullable-tags (`string[] | null`) - Required multipart array that may be null.
+ @property nullable-metadata (`UploadFilesBodyNullableMetadata | null`) - Required multipart object that may be null.
  @property metadata[]? (`FileMetadata[]`) - Optional custom metadata for each uploaded file. Must match the order of the file[] array.
  @property file[] (`Blob[]`) - Array of files to upload.*/
 export interface UploadFilesBody {
@@ -467,6 +481,18 @@ export interface UploadFilesBody {
     *    Example - `"user-uploads"`
    */
   "bucket-id"?: string,
+  /**
+   * Required multipart string that may be null.
+   */
+  "nullable-note": string | null,
+  /**
+   * Required multipart array that may be null.
+   */
+  "nullable-tags": string[] | null,
+  /**
+   * Required multipart object that may be null.
+   */
+  "nullable-metadata": UploadFilesBodyNullableMetadata | null,
   /**
    * Optional custom metadata for each uploaded file. Must match the order of the file[] array.
    */
@@ -770,10 +796,37 @@ export const createAPIClient = (
     const isReactNative =
       typeof navigator !== "undefined" &&
       (navigator as { product?: string }).product === "ReactNative";
-    if (body["bucket-id"] !== undefined) {
+    if (body["bucket-id"] !== undefined && body["bucket-id"] !== null) {
       formData.append("bucket-id", body["bucket-id"]);
     }
-    if (body["metadata[]"] !== undefined) {
+    if (body["nullable-note"] !== undefined && body["nullable-note"] !== null) {
+      formData.append("nullable-note", body["nullable-note"]);
+    }
+    if (body["nullable-tags"] !== undefined && body["nullable-tags"] !== null) {
+      body["nullable-tags"].forEach((value) => {
+          formData.append("nullable-tags", value)
+        }
+      );
+    }
+    if (body["nullable-metadata"] !== undefined && body["nullable-metadata"] !== null) {
+      if (isReactNative) {
+        formData.append(
+          "nullable-metadata",
+          {
+            string: JSON.stringify(body["nullable-metadata"]),
+            type: "application/json",
+            name: "",
+          } as unknown as Blob,
+        );
+      } else {
+        formData.append(
+        "nullable-metadata",
+          new Blob([JSON.stringify(body["nullable-metadata"])], { type: "application/json" }),
+          "",
+        );
+      }
+    }
+    if (body["metadata[]"] !== undefined && body["metadata[]"] !== null) {
       body["metadata[]"].forEach((value) => {
           if (isReactNative) {
             formData.append(
@@ -794,7 +847,7 @@ export const createAPIClient = (
         }
       );
     }
-    if (body["file[]"] !== undefined) {
+    if (body["file[]"] !== undefined && body["file[]"] !== null) {
       body["file[]"].forEach((value) => {
           formData.append("file[]", value)
         }
@@ -937,7 +990,7 @@ export const createAPIClient = (
     const isReactNative =
       typeof navigator !== "undefined" &&
       (navigator as { product?: string }).product === "ReactNative";
-    if (body["metadata"] !== undefined) {
+    if (body["metadata"] !== undefined && body["metadata"] !== null) {
       if (isReactNative) {
         formData.append(
           "metadata",
@@ -955,7 +1008,7 @@ export const createAPIClient = (
         );
       }
     }
-    if (body["file"] !== undefined) {
+    if (body["file"] !== undefined && body["file"] !== null) {
       formData.append("file", body["file"]);
     }
 

--- a/tools/codegen/processor/testdata/types.yaml
+++ b/tools/codegen/processor/testdata/types.yaml
@@ -36,6 +36,33 @@ components:
           additionalProperties: true
           description: "Custom metadata associated with the file."
           example: { "alt": "Profile picture", "category": "avatar" }
+        nickname:
+          type: string
+          nullable: true
+          description: "Optional nickname; server returns null when unset."
+        extra:
+          type: object
+          additionalProperties: true
+          nullable: true
+          description: "Nullable free-form object."
+        aliases:
+          type: array
+          description: "Array whose individual items may be null."
+          items:
+            type: string
+            nullable: true
+        labels:
+          type: object
+          description: "Typed map whose values may be null."
+          additionalProperties:
+            type: string
+            nullable: true
+        nullableTags:
+          type: array
+          nullable: true
+          description: "Whole array may be null, items may not."
+          items:
+            type: string
         data:
           type: string
           format: binary

--- a/tools/codegen/processor/testdata/types.yaml
+++ b/tools/codegen/processor/testdata/types.yaml
@@ -36,6 +36,15 @@ components:
           additionalProperties: true
           description: "Custom metadata associated with the file."
           example: { "alt": "Profile picture", "category": "avatar" }
+        requiredNullableMetadata:
+          type: object
+          additionalProperties: true
+          nullable: true
+          description: "Always-present metadata that may be null."
+        requiredNullableString:
+          type: string
+          nullable: true
+          description: "Always-present string that may be null."
         nickname:
           type: string
           nullable: true
@@ -121,5 +130,7 @@ components:
         - age
         - createdAt
         - metadata
+        - requiredNullableMetadata
+        - requiredNullableString
         - data
       additionalProperties: false

--- a/tools/codegen/processor/testdata/types.yaml
+++ b/tools/codegen/processor/testdata/types.yaml
@@ -45,15 +45,21 @@ components:
           type: string
           nullable: true
           description: "Always-present string that may be null."
+        requiredNullableArray:
+          type: array
+          nullable: true
+          description: "Always-present array that may be null."
+          items:
+            type: string
         nickname:
           type: string
           nullable: true
-          description: "Optional nickname; server returns null when unset."
+          description: "Optional nickname declared nullable in OpenAPI."
         extra:
           type: object
           additionalProperties: true
           nullable: true
-          description: "Nullable free-form object."
+          description: "Optional free-form object declared nullable in OpenAPI."
         aliases:
           type: array
           description: "Array whose individual items may be null."
@@ -69,7 +75,7 @@ components:
         nullableTags:
           type: array
           nullable: true
-          description: "Whole array may be null, items may not."
+          description: "Optional array declared nullable in OpenAPI."
           items:
             type: string
         data:
@@ -132,5 +138,6 @@ components:
         - metadata
         - requiredNullableMetadata
         - requiredNullableString
+        - requiredNullableArray
         - data
       additionalProperties: false

--- a/tools/codegen/processor/testdata/types.yaml.ts
+++ b/tools/codegen/processor/testdata/types.yaml.ts
@@ -64,11 +64,12 @@ export interface SimpleObjectNested {
     *    Example - `{"alt":"Profile picture","category":"avatar"}`
  @property requiredNullableMetadata (`Record<string, unknown> | null`) - Always-present metadata that may be null.
  @property requiredNullableString (`string | null`) - Always-present string that may be null.
- @property nickname? (`string | null`) - Optional nickname; server returns null when unset.
- @property extra? (`Record<string, unknown> | null`) - Nullable free-form object.
+ @property requiredNullableArray (`string[] | null`) - Always-present array that may be null.
+ @property nickname? (`string`) - Optional nickname declared nullable in OpenAPI.
+ @property extra? (`Record<string, unknown>`) - Optional free-form object declared nullable in OpenAPI.
  @property aliases? (`(string | null)[]`) - Array whose individual items may be null.
  @property labels? (`Record<string, string | null>`) - Typed map whose values may be null.
- @property nullableTags? (`string[] | null`) - Whole array may be null, items may not.
+ @property nullableTags? (`string[]`) - Optional array declared nullable in OpenAPI.
  @property data (`Blob`) - Base64 encoded data of the file.
     *    Format - binary
  @property tags? (`string[]`) - List of tags associated with the object.
@@ -116,13 +117,17 @@ export interface SimpleObject {
    */
   requiredNullableString: string | null,
   /**
-   * Optional nickname; server returns null when unset.
+   * Always-present array that may be null.
    */
-  nickname?: string | null,
+  requiredNullableArray: string[] | null,
   /**
-   * Nullable free-form object.
+   * Optional nickname declared nullable in OpenAPI.
    */
-  extra?: Record<string, unknown> | null,
+  nickname?: string,
+  /**
+   * Optional free-form object declared nullable in OpenAPI.
+   */
+  extra?: Record<string, unknown>,
   /**
    * Array whose individual items may be null.
    */
@@ -132,9 +137,9 @@ export interface SimpleObject {
    */
   labels?: Record<string, string | null>,
   /**
-   * Whole array may be null, items may not.
+   * Optional array declared nullable in OpenAPI.
    */
-  nullableTags?: string[] | null,
+  nullableTags?: string[],
   /**
    * Base64 encoded data of the file.
     *    Format - binary

--- a/tools/codegen/processor/testdata/types.yaml.ts
+++ b/tools/codegen/processor/testdata/types.yaml.ts
@@ -62,6 +62,11 @@ export interface SimpleObjectNested {
     *    Format - date-time
  @property metadata (`Record<string, unknown>`) - Custom metadata associated with the file.
     *    Example - `{"alt":"Profile picture","category":"avatar"}`
+ @property nickname? (`string | null`) - Optional nickname; server returns null when unset.
+ @property extra? (`Record<string, unknown> | null`) - Nullable free-form object.
+ @property aliases? (`(string | null)[]`) - Array whose individual items may be null.
+ @property labels? (`Record<string, string | null>`) - Typed map whose values may be null.
+ @property nullableTags? (`string[] | null`) - Whole array may be null, items may not.
  @property data (`Blob`) - Base64 encoded data of the file.
     *    Format - binary
  @property tags? (`string[]`) - List of tags associated with the object.
@@ -100,6 +105,26 @@ export interface SimpleObject {
     *    Example - `{"alt":"Profile picture","category":"avatar"}`
    */
   metadata: Record<string, unknown>,
+  /**
+   * Optional nickname; server returns null when unset.
+   */
+  nickname?: string | null,
+  /**
+   * Nullable free-form object.
+   */
+  extra?: Record<string, unknown> | null,
+  /**
+   * Array whose individual items may be null.
+   */
+  aliases?: (string | null)[],
+  /**
+   * Typed map whose values may be null.
+   */
+  labels?: Record<string, string | null>,
+  /**
+   * Whole array may be null, items may not.
+   */
+  nullableTags?: string[] | null,
   /**
    * Base64 encoded data of the file.
     *    Format - binary

--- a/tools/codegen/processor/testdata/types.yaml.ts
+++ b/tools/codegen/processor/testdata/types.yaml.ts
@@ -62,6 +62,8 @@ export interface SimpleObjectNested {
     *    Format - date-time
  @property metadata (`Record<string, unknown>`) - Custom metadata associated with the file.
     *    Example - `{"alt":"Profile picture","category":"avatar"}`
+ @property requiredNullableMetadata (`Record<string, unknown> | null`) - Always-present metadata that may be null.
+ @property requiredNullableString (`string | null`) - Always-present string that may be null.
  @property nickname? (`string | null`) - Optional nickname; server returns null when unset.
  @property extra? (`Record<string, unknown> | null`) - Nullable free-form object.
  @property aliases? (`(string | null)[]`) - Array whose individual items may be null.
@@ -105,6 +107,14 @@ export interface SimpleObject {
     *    Example - `{"alt":"Profile picture","category":"avatar"}`
    */
   metadata: Record<string, unknown>,
+  /**
+   * Always-present metadata that may be null.
+   */
+  requiredNullableMetadata: Record<string, unknown> | null,
+  /**
+   * Always-present string that may be null.
+   */
+  requiredNullableString: string | null,
   /**
    * Optional nickname; server returns null when unset.
    */

--- a/tools/codegen/processor/typescript/templates/client.tmpl
+++ b/tools/codegen/processor/typescript/templates/client.tmpl
@@ -166,11 +166,11 @@ export const createAPIClient = (
 
     {{- range .RequestFormData.Properties }}
     {{- if eq .Type.Kind "scalar" }}
-    if (body["{{ .Name }}"] !== undefined) {
+    if (body["{{ .Name }}"] !== undefined && body["{{ .Name }}"] !== null) {
       formData.append("{{ .Name }}", body["{{ .Name }}"]);
     }
     {{- else if eq .Type.Kind "array" }}
-    if (body["{{ .Name }}"] !== undefined) {
+    if (body["{{ .Name }}"] !== undefined && body["{{ .Name }}"] !== null) {
       body["{{ .Name }}"].forEach((value) => {
         {{- if eq .Type.Item.Kind "scalar" }}
           formData.append("{{ .Name }}", value)
@@ -198,7 +198,7 @@ export const createAPIClient = (
       );
     }
     {{- else if eq .Type.Kind "object" }}
-    if (body["{{ .Name }}"] !== undefined) {
+    if (body["{{ .Name }}"] !== undefined && body["{{ .Name }}"] !== null) {
       if (isReactNative) {
         formData.append(
           "{{ .Name }}",

--- a/tools/codegen/processor/typescript/templates/client.tmpl
+++ b/tools/codegen/processor/typescript/templates/client.tmpl
@@ -95,6 +95,9 @@ export const createAPIClient = (
     params &&
     Object.entries(params)
       .flatMap(([key, value]) => {
+        if (value === null || value === undefined) {
+          return []
+        }
         {{- range .QueryParameters }}
         {{- if .Explode }}
         {{- if eq .Style "deepObject" }}
@@ -227,13 +230,13 @@ export const createAPIClient = (
     const params = new URLSearchParams();
     {{- range .RequestFormURLEncoded.Properties }}
     {{- if eq .Type.Kind "array" }}
-    if (body["{{ .Name }}"] !== undefined) {
+    if (body["{{ .Name }}"] !== undefined && body["{{ .Name }}"] !== null) {
       body["{{ .Name }}"].forEach((value) => {
         params.append("{{ .Name }}", String(value));
       });
     }
     {{- else }}
-    if (body["{{ .Name }}"] !== undefined) {
+    if (body["{{ .Name }}"] !== undefined && body["{{ .Name }}"] !== null) {
       params.append("{{ .Name }}", String(body["{{ .Name }}"]));
     }
     {{- end }}

--- a/tools/codegen/processor/typescript/templates/main.tmpl
+++ b/tools/codegen/processor/typescript/templates/main.tmpl
@@ -29,7 +29,7 @@ export type {{ .Name }} = {{ .Alias.Name }};
 /**
  * Parameters for the {{ .Name }} method.
 {{- range .QueryParameters }}
-    @property {{ .Name }}{{ if not .Required}}?{{ end }} ({{ .Type.Name }}) - {{ template "renderParamAttributeHelp" .Parameter }}
+    @property {{ .Name }}{{ if not .Required}}?{{ end }} ({{ .Type.Name }}{{ if nullable .Type }} | null{{ end }}) - {{ template "renderParamAttributeHelp" .Parameter }}
 {{- end -}}
  */
 export interface {{ title .Name }}Params {
@@ -37,7 +37,7 @@ export interface {{ title .Name }}Params {
   /**
    * {{ template "renderParamAttributeHelp" .Parameter }}
    */
-  {{ .Name }}{{ if not .Required}}?{{ end }}: {{ .Type.Name }};
+  {{ .Name }}{{ if not .Required}}?{{ end }}: {{ .Type.Name }}{{ if nullable .Type }} | null{{ end }};
 {{- end }}
 }
 {{- end }}

--- a/tools/codegen/processor/typescript/templates/main.tmpl
+++ b/tools/codegen/processor/typescript/templates/main.tmpl
@@ -29,7 +29,7 @@ export type {{ .Name }} = {{ .Alias.Name }};
 /**
  * Parameters for the {{ .Name }} method.
 {{- range .QueryParameters }}
-    @property {{ .Name }}{{ if not .Required}}?{{ end }} ({{ .Type.Name }}{{ if nullable .Type }} | null{{ end }}) - {{ template "renderParamAttributeHelp" .Parameter }}
+    @property {{ .Name }}{{ if not .Required}}?{{ end }} ({{ .Type.Name }}) - {{ template "renderParamAttributeHelp" .Parameter }}
 {{- end -}}
  */
 export interface {{ title .Name }}Params {
@@ -37,7 +37,7 @@ export interface {{ title .Name }}Params {
   /**
    * {{ template "renderParamAttributeHelp" .Parameter }}
    */
-  {{ .Name }}{{ if not .Required}}?{{ end }}: {{ .Type.Name }}{{ if nullable .Type }} | null{{ end }};
+  {{ .Name }}{{ if not .Required}}?{{ end }}: {{ .Type.Name }};
 {{- end }}
 }
 {{- end }}

--- a/tools/codegen/processor/typescript/templates/types.tmpl
+++ b/tools/codegen/processor/typescript/templates/types.tmpl
@@ -30,7 +30,7 @@
 /**
  * {{ .Schema.Schema.Description }}
 {{- range .Properties }}
- @property {{ .Name }}{{ if not .Required}}?{{ end }} (`{{ .Type.Name }}{{ if nullable .Type }} | null{{ end }}`) - {{ template "renderObjectAttributeHelp" .Type }}
+ @property {{ .Name }}{{ if not .Required}}?{{ end }} (`{{ .Type.Name }}{{ if and .Required (nullable .Type) }} | null{{ end }}`) - {{ template "renderObjectAttributeHelp" .Type }}
  {{- end -}}
  */
 export interface {{ .Name }} {
@@ -38,7 +38,7 @@ export interface {{ .Name }} {
   /**
    * {{ template "renderObjectAttributeHelp" .Type }}
    */
-  {{ quotePropertyIfNeeded .Name }}{{ if not .Required }}?{{ end }}: {{ .Type.Name }}{{ if nullable .Type }} | null{{ end }},
+  {{ quotePropertyIfNeeded .Name }}{{ if not .Required }}?{{ end }}: {{ .Type.Name }}{{ if and .Required (nullable .Type) }} | null{{ end }},
 {{- end }}
 };
 {{- end }}

--- a/tools/codegen/processor/typescript/templates/types.tmpl
+++ b/tools/codegen/processor/typescript/templates/types.tmpl
@@ -30,7 +30,7 @@
 /**
  * {{ .Schema.Schema.Description }}
 {{- range .Properties }}
- @property {{ .Name }}{{ if not .Required}}?{{ end }} (`{{ .Type.Name }}`) - {{ template "renderObjectAttributeHelp" .Type }}
+ @property {{ .Name }}{{ if not .Required}}?{{ end }} (`{{ .Type.Name }}{{ if nullable .Type }} | null{{ end }}`) - {{ template "renderObjectAttributeHelp" .Type }}
  {{- end -}}
  */
 export interface {{ .Name }} {
@@ -38,7 +38,7 @@ export interface {{ .Name }} {
   /**
    * {{ template "renderObjectAttributeHelp" .Type }}
    */
-  {{ quotePropertyIfNeeded .Name }}{{ if not .Required }}?{{ end }}: {{ .Type.Name }},
+  {{ quotePropertyIfNeeded .Name }}{{ if not .Required }}?{{ end }}: {{ .Type.Name }}{{ if nullable .Type }} | null{{ end }},
 {{- end }}
 };
 {{- end }}

--- a/tools/codegen/processor/typescript/typescript.go
+++ b/tools/codegen/processor/typescript/typescript.go
@@ -53,6 +53,12 @@ func (t *Typescript) TypeScalarName(scalar *processor.TypeScalar) string {
 }
 
 func (t *Typescript) TypeArrayName(array *processor.TypeArray) string {
+	// A nullable item must be parenthesised: `(string | null)[]` is an array of
+	// nullable strings, whereas `string | null[]` would parse as a union.
+	if processor.SchemaNullable(array.Item.Schema()) {
+		return fmt.Sprintf("(%s | null)[]", array.Item.Name())
+	}
+
 	return array.Item.Name() + "[]"
 }
 
@@ -89,7 +95,12 @@ func (t *Typescript) TypeMapName(schema *processor.TypeMap) string {
 		valueType, _, err := processor.GetType(ap.A, "", t, false)
 		if err == nil &&
 			(ap.A.IsReference() || valueType.Kind() == processor.KindIdentifierScalar) {
-			return fmt.Sprintf("Record<string, %s>", valueType.Name())
+			valueName := valueType.Name()
+			if processor.SchemaNullable(ap.A) {
+				valueName += " | null"
+			}
+
+			return fmt.Sprintf("Record<string, %s>", valueName)
 		}
 	}
 

--- a/tools/codegen/processor/typescript/typescript.go
+++ b/tools/codegen/processor/typescript/typescript.go
@@ -10,6 +10,8 @@ import (
 	"github.com/nhost/nhost/tools/codegen/processor"
 )
 
+// extCustomType values are emitted verbatim and must be safe on the left of `|`;
+// nullable function types therefore need parentheses in the extension value.
 const extCustomType = "x-ts-type"
 
 //go:embed templates/*.tmpl


### PR DESCRIPTION
### Checklist

- [x] No breaking changes
- [x] Tests pass
- [x] New features have new tests
- [x] Documentation is updated (if applicable)
- [x] Title of the PR is in the correct format (see below)

<!-- pi-reviewer:start -->
### **What this change solves**
The TypeScript codegen plugin ignored OpenAPI 3.0 `nullable: true`, so generated client types promised non-null values for fields the server legitimately serialises as `null`. This change threads schema nullability into the TypeScript emitter so properties, query parameters, array items, and typed map values render as `T | null`, keeping runtime-validating clients in agreement with the API contract.

___

### **Change Type**
Bug fix

___

### **Description**
- Add an exported `processor.SchemaNullable` helper plus a `nullable` template function to the intermediate representation's func map, so both templates and plugins can read OpenAPI 3.0 `nullable: true`.
- Widen object properties and query parameters to `T | null` in the TypeScript `types.tmpl` and `main.tmpl` templates, preserving the existing optional (`?`) marker independently of nullability.
- Handle container-nested nullability in the TypeScript plugin: nullable array items render as `(T | null)[]` (parenthesised to avoid `T | null[]` mis-parsing) and nullable typed `additionalProperties` render as `Record<string, T | null>`.
- Extend processor testdata with nullable fixtures — a nullable query parameter, a nullable scalar, a nullable free-form object, nullable array items, nullable map values, and a wholly nullable array — and refresh the affected `.ts` goldens.

___

<details> <summary><h3> File Walkthrough</h3></summary>


  | Relevant files
-- | --
Codegen core | 1 files    intermediate.goAdds exported SchemaNullable helper and registers the nullable template function   +31/-5 | intermediate.goAdds exported SchemaNullable helper and registers the nullable template function | +31/-5
intermediate.goAdds exported SchemaNullable helper and registers the nullable template function | +31/-5
TypeScript plugin | 3 files    typescript.goWidens nullable array items to (T \| null)[] and nullable map values to Record<string, T \| null>   +12/-1     templates/types.tmplAppends \| null to nullable object property JSDoc and interface fields   +2/-2     templates/main.tmplAppends \| null to nullable query parameter JSDoc and interface fields   +2/-2 | typescript.goWidens nullable array items to (T \| null)[] and nullable map values to Record<string, T \| null> | +12/-1 | templates/types.tmplAppends \| null to nullable object property JSDoc and interface fields | +2/-2 | templates/main.tmplAppends \| null to nullable query parameter JSDoc and interface fields | +2/-2
typescript.goWidens nullable array items to (T \| null)[] and nullable map values to Record<string, T \| null> | +12/-1
templates/types.tmplAppends \| null to nullable object property JSDoc and interface fields | +2/-2
templates/main.tmplAppends \| null to nullable query parameter JSDoc and interface fields | +2/-2
Test fixtures and goldens | 5 files    testdata/types.yamlAdds nullable scalar, nullable object, nullable array items, nullable map values, and nullable array fixtures   +27/-0     testdata/types.yaml.tsGolden output for the new nullable type fixtures   +25/-0     testdata/content.yamlAdds a nullable query parameter fixture   +7/-0     testdata/content.yaml.tsGolden output for the nullable query parameter   +7/-0     testdata/form-url-encoded.yaml.tsGolden refresh: pre-existing nullable form fields now render as T \| null   +6/-6 | testdata/types.yamlAdds nullable scalar, nullable object, nullable array items, nullable map values, and nullable array fixtures | +27/-0 | testdata/types.yaml.tsGolden output for the new nullable type fixtures | +25/-0 | testdata/content.yamlAdds a nullable query parameter fixture | +7/-0 | testdata/content.yaml.tsGolden output for the nullable query parameter | +7/-0 | testdata/form-url-encoded.yaml.tsGolden refresh: pre-existing nullable form fields now render as T \| null | +6/-6
testdata/types.yamlAdds nullable scalar, nullable object, nullable array items, nullable map values, and nullable array fixtures | +27/-0
testdata/types.yaml.tsGolden output for the new nullable type fixtures | +25/-0
testdata/content.yamlAdds a nullable query parameter fixture | +7/-0
testdata/content.yaml.tsGolden output for the nullable query parameter | +7/-0
testdata/form-url-encoded.yaml.tsGolden refresh: pre-existing nullable form fields now render as T \| null | +6/-6



</details>

___

<!-- pi-reviewer:end -->