### PR TITLE
fix(nhost-js): regenerate SDK with updated specs and codegen

### DIFF
--- a/docs/src/content/docs/reference/javascript/nhost-js/auth.md
+++ b/docs/src/content/docs/reference/javascript/nhost-js/auth.md
@@ -4224,10 +4224,10 @@ locale: string;
 #### metadata
 
 ```ts
-metadata: Record<string, unknown>;
+metadata: Record<string, unknown> | null;
 ```
 
-(`Record<string, unknown>`) - Custom metadata associated with the user
+(`Record<string, unknown> | null`) - Custom metadata associated with the user
 
 - Example - `{"firstName":"John","lastName":"Smith"}`
 

--- a/packages/nhost-js/src/auth/client.ts
+++ b/packages/nhost-js/src/auth/client.ts
@@ -42,7 +42,7 @@ export interface AuthenticationExtensionsClientOutputs {
  @property clientDataJSON (`string`) - Base64url encoded client data JSON
  @property authenticatorData (`string`) - Base64url encoded authenticator data
  @property signature (`string`) - Base64url encoded assertion signature
- @property userHandle? (`string`) - Base64url encoded user handle*/
+ @property userHandle? (`string | null`) - Base64url encoded user handle*/
 export interface AuthenticatorAssertionResponse {
   /**
    * Base64url encoded client data JSON
@@ -59,7 +59,7 @@ export interface AuthenticatorAssertionResponse {
   /**
    * Base64url encoded user handle
    */
-  userHandle?: string;
+  userHandle?: string | null;
 }
 
 /**
@@ -621,7 +621,7 @@ export interface PublicKeyCredentialRequestOptions {
  @property expiresAt (`string`) - Timestamp when the access token expires
     *    Example - `"2024-12-31T23:59:59Z"`
     *    Format - date-time
- @property refreshToken? (`string`) - OAuth2 provider refresh token for obtaining new access tokens (if provided by the provider)
+ @property refreshToken? (`string | null`) - OAuth2 provider refresh token for obtaining new access tokens (if provided by the provider)
     *    Example - `"1//0gK8..."`*/
 export interface ProviderSession {
   /**
@@ -644,7 +644,7 @@ export interface ProviderSession {
    * OAuth2 provider refresh token for obtaining new access tokens (if provided by the provider)
    *    Example - `"1//0gK8..."`
    */
-  refreshToken?: string;
+  refreshToken?: string | null;
 }
 
 /**
@@ -1370,7 +1370,7 @@ export type URLEncodedBase64 = string;
     *    Example - `"en"`
     *    MinLength - 2
     *    MaxLength - 3
- @property metadata (`Record<string, unknown>`) - Custom metadata associated with the user
+ @property metadata (`Record<string, unknown> | null`) - Custom metadata associated with the user
     *    Example - `{"firstName":"John","lastName":"Smith"}`
  @property phoneNumber? (`string`) - User's phone number
     *    Example - `"+12025550123"`
@@ -1378,7 +1378,7 @@ export type URLEncodedBase64 = string;
     *    Example - `false`
  @property roles (`string[]`) - List of roles assigned to the user
     *    Example - `["user","customer"]`
- @property activeMfaType? (`string`) - Active MFA type for the user*/
+ @property activeMfaType? (`string | null`) - Active MFA type for the user*/
 export interface User {
   /**
    * URL to the user's profile picture
@@ -1434,7 +1434,7 @@ export interface User {
    * Custom metadata associated with the user
    *    Example - `{"firstName":"John","lastName":"Smith"}`
    */
-  metadata: Record<string, unknown>;
+  metadata: Record<string, unknown> | null;
   /**
    * User's phone number
    *    Example - `"+12025550123"`
@@ -1453,7 +1453,7 @@ export interface User {
   /**
    * Active MFA type for the user
    */
-  activeMfaType?: string;
+  activeMfaType?: string | null;
 }
 
 /**
@@ -1841,13 +1841,13 @@ export type OAuth2TokenRequestGrant_type =
 /**
  * 
  @property grant_type (`OAuth2TokenRequestGrant_type`) - 
- @property code? (`string`) - 
- @property redirect_uri? (`string`) - 
- @property client_id? (`string`) - 
- @property client_secret? (`string`) - 
- @property code_verifier? (`string`) - 
- @property refresh_token? (`string`) - 
- @property resource? (`string`) - */
+ @property code? (`string | null`) - 
+ @property redirect_uri? (`string | null`) - 
+ @property client_id? (`string | null`) - 
+ @property client_secret? (`string | null`) - 
+ @property code_verifier? (`string | null`) - 
+ @property refresh_token? (`string | null`) - 
+ @property resource? (`string | null`) - */
 export interface OAuth2TokenRequest {
   /**
    *
@@ -1856,31 +1856,31 @@ export interface OAuth2TokenRequest {
   /**
    *
    */
-  code?: string;
+  code?: string | null;
   /**
    *
    */
-  redirect_uri?: string;
+  redirect_uri?: string | null;
   /**
    *
    */
-  client_id?: string;
+  client_id?: string | null;
   /**
    *
    */
-  client_secret?: string;
+  client_secret?: string | null;
   /**
    *
    */
-  code_verifier?: string;
+  code_verifier?: string | null;
   /**
    *
    */
-  refresh_token?: string;
+  refresh_token?: string | null;
   /**
    *
    */
-  resource?: string;
+  resource?: string | null;
 }
 
 /**
@@ -1983,9 +1983,9 @@ export type OAuth2RevokeRequestToken_type_hint =
 /**
  * 
  @property token (`string`) - 
- @property token_type_hint? (`OAuth2RevokeRequestToken_type_hint`) - 
- @property client_id? (`string`) - 
- @property client_secret? (`string`) - */
+ @property token_type_hint? (`OAuth2RevokeRequestToken_type_hint | null`) - 
+ @property client_id? (`string | null`) - 
+ @property client_secret? (`string | null`) - */
 export interface OAuth2RevokeRequest {
   /**
    *
@@ -1994,15 +1994,15 @@ export interface OAuth2RevokeRequest {
   /**
    *
    */
-  token_type_hint?: OAuth2RevokeRequestToken_type_hint;
+  token_type_hint?: OAuth2RevokeRequestToken_type_hint | null;
   /**
    *
    */
-  client_id?: string;
+  client_id?: string | null;
   /**
    *
    */
-  client_secret?: string;
+  client_secret?: string | null;
 }
 
 /**
@@ -2015,9 +2015,9 @@ export type OAuth2IntrospectRequestToken_type_hint =
 /**
  * 
  @property token (`string`) - 
- @property token_type_hint? (`OAuth2IntrospectRequestToken_type_hint`) - 
- @property client_id? (`string`) - 
- @property client_secret? (`string`) - */
+ @property token_type_hint? (`OAuth2IntrospectRequestToken_type_hint | null`) - 
+ @property client_id? (`string | null`) - 
+ @property client_secret? (`string | null`) - */
 export interface OAuth2IntrospectRequest {
   /**
    *
@@ -2026,15 +2026,15 @@ export interface OAuth2IntrospectRequest {
   /**
    *
    */
-  token_type_hint?: OAuth2IntrospectRequestToken_type_hint;
+  token_type_hint?: OAuth2IntrospectRequestToken_type_hint | null;
   /**
    *
    */
-  client_id?: string;
+  client_id?: string | null;
   /**
    *
    */
-  client_secret?: string;
+  client_secret?: string | null;
 }
 
 /**
@@ -2195,13 +2195,13 @@ export type GetCode_challenge_method = 'S256';
  @property client_id (`string`) - 
  @property redirect_uri (`string`) - 
  @property response_type (`string`) - 
- @property scope? (`string`) - 
- @property state? (`string`) - 
- @property nonce? (`string`) - 
- @property code_challenge? (`string`) - 
- @property code_challenge_method? (`string`) - Only S256 is supported. The plain method is not allowed.
- @property resource? (`string`) - 
- @property prompt? (`string`) - */
+ @property scope? (`string | null`) - 
+ @property state? (`string | null`) - 
+ @property nonce? (`string | null`) - 
+ @property code_challenge? (`string | null`) - 
+ @property code_challenge_method? (`string | null`) - Only S256 is supported. The plain method is not allowed.
+ @property resource? (`string | null`) - 
+ @property prompt? (`string | null`) - */
 export interface Oauth2AuthorizePostBody {
   /**
    *
@@ -2218,31 +2218,31 @@ export interface Oauth2AuthorizePostBody {
   /**
    *
    */
-  scope?: string;
+  scope?: string | null;
   /**
    *
    */
-  state?: string;
+  state?: string | null;
   /**
    *
    */
-  nonce?: string;
+  nonce?: string | null;
   /**
    *
    */
-  code_challenge?: string;
+  code_challenge?: string | null;
   /**
    * Only S256 is supported. The plain method is not allowed.
    */
-  code_challenge_method?: string;
+  code_challenge_method?: string | null;
   /**
    *
    */
-  resource?: string;
+  resource?: string | null;
   /**
    *
    */
-  prompt?: string;
+  prompt?: string | null;
 }
 
 /**

--- a/packages/nhost-js/src/auth/client.ts
+++ b/packages/nhost-js/src/auth/client.ts
@@ -42,7 +42,7 @@ export interface AuthenticationExtensionsClientOutputs {
  @property clientDataJSON (`string`) - Base64url encoded client data JSON
  @property authenticatorData (`string`) - Base64url encoded authenticator data
  @property signature (`string`) - Base64url encoded assertion signature
- @property userHandle? (`string | null`) - Base64url encoded user handle*/
+ @property userHandle? (`string`) - Base64url encoded user handle*/
 export interface AuthenticatorAssertionResponse {
   /**
    * Base64url encoded client data JSON
@@ -59,7 +59,7 @@ export interface AuthenticatorAssertionResponse {
   /**
    * Base64url encoded user handle
    */
-  userHandle?: string | null;
+  userHandle?: string;
 }
 
 /**
@@ -621,7 +621,7 @@ export interface PublicKeyCredentialRequestOptions {
  @property expiresAt (`string`) - Timestamp when the access token expires
     *    Example - `"2024-12-31T23:59:59Z"`
     *    Format - date-time
- @property refreshToken? (`string | null`) - OAuth2 provider refresh token for obtaining new access tokens (if provided by the provider)
+ @property refreshToken? (`string`) - OAuth2 provider refresh token for obtaining new access tokens (if provided by the provider)
     *    Example - `"1//0gK8..."`*/
 export interface ProviderSession {
   /**
@@ -644,7 +644,7 @@ export interface ProviderSession {
    * OAuth2 provider refresh token for obtaining new access tokens (if provided by the provider)
    *    Example - `"1//0gK8..."`
    */
-  refreshToken?: string | null;
+  refreshToken?: string;
 }
 
 /**
@@ -1378,7 +1378,7 @@ export type URLEncodedBase64 = string;
     *    Example - `false`
  @property roles (`string[]`) - List of roles assigned to the user
     *    Example - `["user","customer"]`
- @property activeMfaType? (`string | null`) - Active MFA type for the user*/
+ @property activeMfaType? (`string`) - Active MFA type for the user*/
 export interface User {
   /**
    * URL to the user's profile picture
@@ -1453,7 +1453,7 @@ export interface User {
   /**
    * Active MFA type for the user
    */
-  activeMfaType?: string | null;
+  activeMfaType?: string;
 }
 
 /**
@@ -1841,13 +1841,13 @@ export type OAuth2TokenRequestGrant_type =
 /**
  * 
  @property grant_type (`OAuth2TokenRequestGrant_type`) - 
- @property code? (`string | null`) - 
- @property redirect_uri? (`string | null`) - 
- @property client_id? (`string | null`) - 
- @property client_secret? (`string | null`) - 
- @property code_verifier? (`string | null`) - 
- @property refresh_token? (`string | null`) - 
- @property resource? (`string | null`) - */
+ @property code? (`string`) - 
+ @property redirect_uri? (`string`) - 
+ @property client_id? (`string`) - 
+ @property client_secret? (`string`) - 
+ @property code_verifier? (`string`) - 
+ @property refresh_token? (`string`) - 
+ @property resource? (`string`) - */
 export interface OAuth2TokenRequest {
   /**
    *
@@ -1856,31 +1856,31 @@ export interface OAuth2TokenRequest {
   /**
    *
    */
-  code?: string | null;
+  code?: string;
   /**
    *
    */
-  redirect_uri?: string | null;
+  redirect_uri?: string;
   /**
    *
    */
-  client_id?: string | null;
+  client_id?: string;
   /**
    *
    */
-  client_secret?: string | null;
+  client_secret?: string;
   /**
    *
    */
-  code_verifier?: string | null;
+  code_verifier?: string;
   /**
    *
    */
-  refresh_token?: string | null;
+  refresh_token?: string;
   /**
    *
    */
-  resource?: string | null;
+  resource?: string;
 }
 
 /**
@@ -1983,9 +1983,9 @@ export type OAuth2RevokeRequestToken_type_hint =
 /**
  * 
  @property token (`string`) - 
- @property token_type_hint? (`OAuth2RevokeRequestToken_type_hint | null`) - 
- @property client_id? (`string | null`) - 
- @property client_secret? (`string | null`) - */
+ @property token_type_hint? (`OAuth2RevokeRequestToken_type_hint`) - 
+ @property client_id? (`string`) - 
+ @property client_secret? (`string`) - */
 export interface OAuth2RevokeRequest {
   /**
    *
@@ -1994,15 +1994,15 @@ export interface OAuth2RevokeRequest {
   /**
    *
    */
-  token_type_hint?: OAuth2RevokeRequestToken_type_hint | null;
+  token_type_hint?: OAuth2RevokeRequestToken_type_hint;
   /**
    *
    */
-  client_id?: string | null;
+  client_id?: string;
   /**
    *
    */
-  client_secret?: string | null;
+  client_secret?: string;
 }
 
 /**
@@ -2015,9 +2015,9 @@ export type OAuth2IntrospectRequestToken_type_hint =
 /**
  * 
  @property token (`string`) - 
- @property token_type_hint? (`OAuth2IntrospectRequestToken_type_hint | null`) - 
- @property client_id? (`string | null`) - 
- @property client_secret? (`string | null`) - */
+ @property token_type_hint? (`OAuth2IntrospectRequestToken_type_hint`) - 
+ @property client_id? (`string`) - 
+ @property client_secret? (`string`) - */
 export interface OAuth2IntrospectRequest {
   /**
    *
@@ -2026,15 +2026,15 @@ export interface OAuth2IntrospectRequest {
   /**
    *
    */
-  token_type_hint?: OAuth2IntrospectRequestToken_type_hint | null;
+  token_type_hint?: OAuth2IntrospectRequestToken_type_hint;
   /**
    *
    */
-  client_id?: string | null;
+  client_id?: string;
   /**
    *
    */
-  client_secret?: string | null;
+  client_secret?: string;
 }
 
 /**
@@ -2195,13 +2195,13 @@ export type GetCode_challenge_method = 'S256';
  @property client_id (`string`) - 
  @property redirect_uri (`string`) - 
  @property response_type (`string`) - 
- @property scope? (`string | null`) - 
- @property state? (`string | null`) - 
- @property nonce? (`string | null`) - 
- @property code_challenge? (`string | null`) - 
- @property code_challenge_method? (`string | null`) - Only S256 is supported. The plain method is not allowed.
- @property resource? (`string | null`) - 
- @property prompt? (`string | null`) - */
+ @property scope? (`string`) - 
+ @property state? (`string`) - 
+ @property nonce? (`string`) - 
+ @property code_challenge? (`string`) - 
+ @property code_challenge_method? (`string`) - Only S256 is supported. The plain method is not allowed.
+ @property resource? (`string`) - 
+ @property prompt? (`string`) - */
 export interface Oauth2AuthorizePostBody {
   /**
    *
@@ -2218,31 +2218,31 @@ export interface Oauth2AuthorizePostBody {
   /**
    *
    */
-  scope?: string | null;
+  scope?: string;
   /**
    *
    */
-  state?: string | null;
+  state?: string;
   /**
    *
    */
-  nonce?: string | null;
+  nonce?: string;
   /**
    *
    */
-  code_challenge?: string | null;
+  code_challenge?: string;
   /**
    * Only S256 is supported. The plain method is not allowed.
    */
-  code_challenge_method?: string | null;
+  code_challenge_method?: string;
   /**
    *
    */
-  resource?: string | null;
+  resource?: string;
   /**
    *
    */
-  prompt?: string | null;
+  prompt?: string;
 }
 
 /**
@@ -3856,6 +3856,9 @@ export const createAPIClient = (
       params &&
       Object.entries(params)
         .flatMap(([key, value]) => {
+          if (value === null || value === undefined) {
+            return [];
+          }
           if (key === 'providerSpecificParams') {
             // Object with explode: true - each property as separate parameter
             if (
@@ -4282,6 +4285,9 @@ export const createAPIClient = (
       params &&
       Object.entries(params)
         .flatMap(([key, value]) => {
+          if (value === null || value === undefined) {
+            return [];
+          }
           if (key === 'providerSpecificParams') {
             // Object with explode: true - each property as separate parameter
             if (
@@ -4762,6 +4768,9 @@ export const createAPIClient = (
       params &&
       Object.entries(params)
         .flatMap(([key, value]) => {
+          if (value === null || value === undefined) {
+            return [];
+          }
           // Default handling (scalars or explode: false)
           const stringValue = Array.isArray(value)
             ? value.join(',')
@@ -4879,6 +4888,9 @@ export const createAPIClient = (
       params &&
       Object.entries(params)
         .flatMap(([key, value]) => {
+          if (value === null || value === undefined) {
+            return [];
+          }
           // Default handling (scalars or explode: false)
           const stringValue = Array.isArray(value)
             ? value.join(',')
@@ -4906,28 +4918,28 @@ export const createAPIClient = (
   ): Promise<FetchResponse<OAuth2TokenResponse>> => {
     const url = `${baseURL}/oauth2/token`;
     const params = new URLSearchParams();
-    if (body['grant_type'] !== undefined) {
+    if (body['grant_type'] !== undefined && body['grant_type'] !== null) {
       params.append('grant_type', String(body['grant_type']));
     }
-    if (body['code'] !== undefined) {
+    if (body['code'] !== undefined && body['code'] !== null) {
       params.append('code', String(body['code']));
     }
-    if (body['redirect_uri'] !== undefined) {
+    if (body['redirect_uri'] !== undefined && body['redirect_uri'] !== null) {
       params.append('redirect_uri', String(body['redirect_uri']));
     }
-    if (body['client_id'] !== undefined) {
+    if (body['client_id'] !== undefined && body['client_id'] !== null) {
       params.append('client_id', String(body['client_id']));
     }
-    if (body['client_secret'] !== undefined) {
+    if (body['client_secret'] !== undefined && body['client_secret'] !== null) {
       params.append('client_secret', String(body['client_secret']));
     }
-    if (body['code_verifier'] !== undefined) {
+    if (body['code_verifier'] !== undefined && body['code_verifier'] !== null) {
       params.append('code_verifier', String(body['code_verifier']));
     }
-    if (body['refresh_token'] !== undefined) {
+    if (body['refresh_token'] !== undefined && body['refresh_token'] !== null) {
       params.append('refresh_token', String(body['refresh_token']));
     }
-    if (body['resource'] !== undefined) {
+    if (body['resource'] !== undefined && body['resource'] !== null) {
       params.append('resource', String(body['resource']));
     }
 
@@ -5063,16 +5075,19 @@ export const createAPIClient = (
   ): Promise<FetchResponse<void>> => {
     const url = `${baseURL}/oauth2/revoke`;
     const params = new URLSearchParams();
-    if (body['token'] !== undefined) {
+    if (body['token'] !== undefined && body['token'] !== null) {
       params.append('token', String(body['token']));
     }
-    if (body['token_type_hint'] !== undefined) {
+    if (
+      body['token_type_hint'] !== undefined &&
+      body['token_type_hint'] !== null
+    ) {
       params.append('token_type_hint', String(body['token_type_hint']));
     }
-    if (body['client_id'] !== undefined) {
+    if (body['client_id'] !== undefined && body['client_id'] !== null) {
       params.append('client_id', String(body['client_id']));
     }
-    if (body['client_secret'] !== undefined) {
+    if (body['client_secret'] !== undefined && body['client_secret'] !== null) {
       params.append('client_secret', String(body['client_secret']));
     }
 
@@ -5107,16 +5122,19 @@ export const createAPIClient = (
   ): Promise<FetchResponse<OAuth2IntrospectResponse>> => {
     const url = `${baseURL}/oauth2/introspect`;
     const params = new URLSearchParams();
-    if (body['token'] !== undefined) {
+    if (body['token'] !== undefined && body['token'] !== null) {
       params.append('token', String(body['token']));
     }
-    if (body['token_type_hint'] !== undefined) {
+    if (
+      body['token_type_hint'] !== undefined &&
+      body['token_type_hint'] !== null
+    ) {
       params.append('token_type_hint', String(body['token_type_hint']));
     }
-    if (body['client_id'] !== undefined) {
+    if (body['client_id'] !== undefined && body['client_id'] !== null) {
       params.append('client_id', String(body['client_id']));
     }
-    if (body['client_secret'] !== undefined) {
+    if (body['client_secret'] !== undefined && body['client_secret'] !== null) {
       params.append('client_secret', String(body['client_secret']));
     }
 
@@ -5158,6 +5176,9 @@ export const createAPIClient = (
       params &&
       Object.entries(params)
         .flatMap(([key, value]) => {
+          if (value === null || value === undefined) {
+            return [];
+          }
           // Default handling (scalars or explode: false)
           const stringValue = Array.isArray(value)
             ? value.join(',')

--- a/packages/nhost-js/src/storage/client.ts
+++ b/packages/nhost-js/src/storage/client.ts
@@ -725,6 +725,9 @@ export const createAPIClient = (
       params &&
       Object.entries(params)
         .flatMap(([key, value]) => {
+          if (value === null || value === undefined) {
+            return [];
+          }
           // Default handling (scalars or explode: false)
           const stringValue = Array.isArray(value)
             ? value.join(',')
@@ -770,6 +773,9 @@ export const createAPIClient = (
       params &&
       Object.entries(params)
         .flatMap(([key, value]) => {
+          if (value === null || value === undefined) {
+            return [];
+          }
           // Default handling (scalars or explode: false)
           const stringValue = Array.isArray(value)
             ? value.join(',')


### PR DESCRIPTION
### Checklist

- [ ] No breaking changes
- [ ] Tests pass
- [ ] New features have new tests
- [ ] Documentation is updated (if applicable)
- [ ] Title of the PR is in the correct format (see below)

<!-- pi-reviewer:start -->
### **What this change solves**
The generated `@nhost/nhost-js` auth client typed `User.metadata` as non-nullable even though the server may return `null`, giving consumers a runtime surprise instead of a type-level signal. It also serialized explicit `null`/`undefined` parameter values into outgoing query strings and form bodies as the literal strings `"null"`/`"undefined"`. This regenerates both clients so nullable fields are typed `T | null` and null-ish values are omitted from the wire format.

___

### **Change Type**
Bug fix

___

### **Description**
- Widen `User.metadata` to `Record<string, unknown> | null` in the generated auth client, with the matching docstring update.
- Add an early `null`/`undefined` guard to every `Object.entries(params).flatMap(...)` query-parameter serializer so null-ish values are dropped rather than stringified — 5 sites in the auth client, 2 in the storage client.
- Extend the `!== undefined` checks on the OAuth2 `token`, `revoke`, and `introspect` form-urlencoded bodies to also reject `null`, covering 16 `params.append` call sites.
- Both files are generator output (`codegen gen --plugin typescript` via `packages/nhost-js/gen.sh`); the nullable-aware generator itself lives in the base branch `feat/nhost-js-codegen`.

<details> <summary><h3> File Walkthrough</h3></summary>


  | Relevant files
-- | --
Generated client | 2 files    packages/nhost-js/src/auth/client.tsNullable User.metadata type plus null/undefined guards in 5 query serializers and 16 OAuth2 form-body appends   +39/-18     packages/nhost-js/src/storage/client.tsNull/undefined guard added to 2 query-parameter serializers; no type changes   +6/-0 | packages/nhost-js/src/auth/client.tsNullable User.metadata type plus null/undefined guards in 5 query serializers and 16 OAuth2 form-body appends | +39/-18 | packages/nhost-js/src/storage/client.tsNull/undefined guard added to 2 query-parameter serializers; no type changes | +6/-0
packages/nhost-js/src/auth/client.tsNullable User.metadata type plus null/undefined guards in 5 query serializers and 16 OAuth2 form-body appends | +39/-18
packages/nhost-js/src/storage/client.tsNull/undefined guard added to 2 query-parameter serializers; no type changes | +6/-0



</details>

___

<!-- pi-reviewer:end -->
