### PR TITLE
fix(dashboard): Exclude generated columns from validation

### DIFF
--- a/dashboard/src/features/orgs/projects/database/dataGrid/utils/validationSchemaHelpers/validationSchemaHelpers.test.ts
+++ b/dashboard/src/features/orgs/projects/database/dataGrid/utils/validationSchemaHelpers/validationSchemaHelpers.test.ts
@@ -30,6 +30,20 @@ function makeColumn(
   } as DataBrowserColumnMetadata;
 }
 
+describe('generated columns', () => {
+  it('does not require non-nullable generated columns without defaults', async () => {
+    const schema = createDynamicValidationSchema([
+      makeColumn('text', {
+        isNullable: false,
+        isGenerated: true,
+        defaultValue: null,
+      }),
+    ]);
+
+    await expect(schema.validate({ col: null })).resolves.toBeTruthy();
+  });
+});
+
 describe('interval columns', () => {
   it('accepts valid PostgreSQL interval syntax', async () => {
     const schema = createDynamicValidationSchema([makeColumn('interval')]);

--- a/dashboard/src/features/orgs/projects/database/dataGrid/utils/validationSchemaHelpers/validationSchemaHelpers.ts
+++ b/dashboard/src/features/orgs/projects/database/dataGrid/utils/validationSchemaHelpers/validationSchemaHelpers.ts
@@ -106,6 +106,10 @@ export function createDynamicValidationSchema(
   columns: DataBrowserColumnMetadata[],
 ) {
   const schema = columns.reduce((currentSchema, column) => {
+    if (column.isGenerated) {
+      return currentSchema;
+    }
+
     const isNullable = column.isNullable;
     const isIdentity = column.isIdentity;
 


### PR DESCRIPTION
### Checklist

- [x] No breaking changes
- [x] Tests pass
- [x] New features have new tests
- [ ] Documentation is updated (if applicable)
- [x] Title of the PR is in the correct format (see below)

<!-- pi-reviewer:start -->
### **What this change solves**
Generated PostgreSQL columns are omitted from database record forms, but their metadata was still included in dynamic Yup validation. This change keeps generated columns out of validation so create, clone, and edit record flows do not require hidden generated fields.

___

### **Change Type**
Bug fix

___

### **Description**
- Skip generated columns while building the data browser's dynamic validation schema.
- Add regression coverage for a non-nullable generated column without a default value.

___

<details> <summary><h3> File Walkthrough</h3></summary>

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody>
<tr><td><strong>Dashboard validation</strong></td><td><details><summary>2 files</summary><table>
<tr>
  <td><strong>validationSchemaHelpers.ts</strong><dd><code>Skips generated columns before assigning per-column Yup validators.</code></dd></td>
  <td>+4/-0</td>
</tr>
<tr>
  <td><strong>validationSchemaHelpers.test.ts</strong><dd><code>Adds regression coverage for non-nullable generated columns without defaults.</code></dd></td>
  <td>+14/-0</td>
</tr>
</table></details></td></tr>
</tbody></table>

</details>

___

<!-- pi-reviewer:end -->
