### PR TITLE
fix(auth,storage,constellation): handle SIGTERM for graceful shutdown

### DIFF
--- a/services/auth/go/cmd/serve.go
+++ b/services/auth/go/cmd/serve.go
@@ -6,6 +6,8 @@ import (
 	"fmt"
 	"log/slog"
 	"net/http"
+	"os/signal"
+	"syscall"
 	"time"
 
 	"github.com/bradfitz/gomemcache/memcache"
@@ -1602,8 +1604,8 @@ func serve(ctx context.Context, cmd *cli.Command) error {
 	logger.InfoContext(ctx, cmd.Root().Name+" v"+cmd.Root().Version)
 	logFlags(ctx, logger, cmd)
 
-	servCtx, cancel := context.WithCancel(ctx)
-	defer cancel()
+	servCtx, stop := signal.NotifyContext(ctx, syscall.SIGINT, syscall.SIGTERM)
+	defer stop()
 
 	pool, err := getDBPool(ctx, cmd)
 	if err != nil {
@@ -1627,7 +1629,7 @@ func serve(ctx context.Context, cmd *cli.Command) error {
 	}
 
 	go func() {
-		defer cancel()
+		defer stop()
 
 		logger.InfoContext(
 			ctx, "starting server", slog.String("port", cmd.String(flagPort)),

--- a/services/constellation/cmd/serve.go
+++ b/services/constellation/cmd/serve.go
@@ -10,7 +10,9 @@ import (
 	"log/slog"
 	"net/http"
 	_ "net/http/pprof" //nolint:gosec // pprof is gated behind a CLI flag
+	"os/signal"
 	"strings"
+	"syscall"
 	"time"
 
 	"github.com/99designs/gqlgen/graphql/playground"
@@ -561,12 +563,13 @@ func runServer(
 		return fmt.Errorf("configuring HTTP server: %w", err)
 	}
 
-	ctx, cancel := context.WithCancel(ctx)
+	ctx, stop := signal.NotifyContext(ctx, syscall.SIGINT, syscall.SIGTERM)
+	defer stop()
 
 	profileServer := startProfileServer(ctx, cmd.String(flagProfileAddress), logger)
 
 	go func() {
-		defer cancel()
+		defer stop()
 
 		logger.InfoContext(ctx, "starting controller")
 		ctrl.Run(ctx, logger)
@@ -574,7 +577,7 @@ func runServer(
 	}()
 
 	go func() {
-		defer cancel()
+		defer stop()
 
 		logger.InfoContext(ctx, "starting server", slog.String("address", server.Addr))
 

--- a/services/storage/cmd/serve.go
+++ b/services/storage/cmd/serve.go
@@ -7,7 +7,9 @@ import (
 	"log/slog"
 	"net/http"
 	_ "net/http/pprof" //nolint:gosec
+	"os/signal"
 	"runtime"
+	"syscall"
 	"time"
 
 	"github.com/aws/aws-sdk-go-v2/aws"
@@ -499,8 +501,8 @@ func serve(ctx context.Context, cmd *cli.Command) error { //nolint:funlen
 	)
 	defer imageTransformer.Shutdown()
 
-	servCtx, cancel := context.WithCancel(ctx)
-	defer cancel()
+	servCtx, stop := signal.NotifyContext(ctx, syscall.SIGINT, syscall.SIGTERM)
+	defer stop()
 
 	contentStorage := getContentStorage(
 		servCtx,
@@ -545,7 +547,7 @@ func serve(ctx context.Context, cmd *cli.Command) error { //nolint:funlen
 	startPprofServer(servCtx, cmd.String(flagPprofBind), logger)
 
 	go func() {
-		defer cancel()
+		defer stop()
 
 		logger.InfoContext(servCtx, "starting server")
 
@@ -558,7 +560,12 @@ func serve(ctx context.Context, cmd *cli.Command) error { //nolint:funlen
 
 	logger.InfoContext(ctx, "shutting down server")
 
-	if err := server.Shutdown(ctx); err != nil {
+	shutdownCtx, shutdownCancel := context.WithTimeout(
+		context.Background(), 30*time.Second, //nolint:mnd
+	)
+	defer shutdownCancel()
+
+	if err := server.Shutdown(shutdownCtx); err != nil {
 		logger.ErrorContext(ctx, "problem shutting down server", slog.String("error", err.Error()))
 	}
 


### PR DESCRIPTION
Fixes #4943.

I run multi-tenant workloads on Kubernetes and noticed these three services never observe SIGTERM. kubelet sends SIGTERM on every rollout/scale-down, then SIGKILL after the grace period. Without signal handling the process runs until SIGKILL, killing in-flight auth flows, uploads and GraphQL queries and skipping cleanup (pool.Close, transformer shutdown, connector close).

Change:
- auth, storage, constellation serve loops now use signal.NotifyContext for SIGINT/SIGTERM, same pattern already used in services/mcp/server/server.go.
- storage shutdown now uses a 30s timeout context like auth instead of the parent context.

Verified:
- go vet ./services/auth/go/cmd/... clean.
- storage vet only fails on missing system libvips (pre-existing, unrelated).
- gofmt clean on all three files.
- Compared against mcp positive control.