### PR TITLE
fix(auth,storage): set http read/write/idle timeouts

### DIFF
--- a/services/auth/go/cmd/serve.go
+++ b/services/auth/go/cmd/serve.go
@@ -1514,7 +1514,10 @@ func getGoServer(
 	server := &http.Server{ //nolint:exhaustruct
 		Addr:              ":" + cmd.String(flagPort),
 		Handler:           router,
-		ReadHeaderTimeout: 5 * time.Second, //nolint:mnd
+		ReadHeaderTimeout: 5 * time.Second,   //nolint:mnd
+		ReadTimeout:       30 * time.Second,  //nolint:mnd
+		WriteTimeout:      5 * time.Minute,   //nolint:mnd
+		IdleTimeout:       120 * time.Second, //nolint:mnd
 	}
 
 	return server, nil

--- a/services/storage/cmd/serve.go
+++ b/services/storage/cmd/serve.go
@@ -167,7 +167,10 @@ func getServer(
 	server := &http.Server{ //nolint:exhaustruct
 		Addr:              cmd.String(flagBind),
 		Handler:           router,
-		ReadHeaderTimeout: 5 * time.Second, //nolint:mnd
+		ReadHeaderTimeout: 5 * time.Second,   //nolint:mnd
+		ReadTimeout:       30 * time.Second,  //nolint:mnd
+		WriteTimeout:      5 * time.Minute,   //nolint:mnd
+		IdleTimeout:       120 * time.Second, //nolint:mnd
 	}
 
 	return server, nil


### PR DESCRIPTION
Fixes #4945.

auth and storage only set ReadHeaderTimeout, so slow POSTs and slow download readers can pin workers with no upper bound. Storage is the worst case because downloads can trigger CPU-bound image transforms. Constellation already sets full timeouts in newHTTPServer, this copies the same values (30s read, 5m write, 120s idle) for consistency.

Verified:
- go vet ./services/auth/go/cmd/... clean.
- gofmt clean.
- Values match services/constellation/cmd/serve.go newHTTPServer defaults.