### PR TITLE
fix(server): add Read, Write, and Idle timeouts to auth and storage http.Server

### DIFF
--- a/services/auth/go/cmd/serve.go
+++ b/services/auth/go/cmd/serve.go
@@ -1514,7 +1514,10 @@ func getGoServer(
 	server := &http.Server{ //nolint:exhaustruct
 		Addr:              ":" + cmd.String(flagPort),
 		Handler:           router,
-		ReadHeaderTimeout: 5 * time.Second, //nolint:mnd
+		ReadHeaderTimeout: 5 * time.Second,  //nolint:mnd
+		ReadTimeout:       30 * time.Second, //nolint:mnd
+		WriteTimeout:      30 * time.Second, //nolint:mnd
+		IdleTimeout:       120 * time.Second, //nolint:mnd
 	}
 
 	return server, nil

--- a/services/storage/cmd/serve.go
+++ b/services/storage/cmd/serve.go
@@ -167,7 +167,10 @@ func getServer(
 	server := &http.Server{ //nolint:exhaustruct
 		Addr:              cmd.String(flagBind),
 		Handler:           router,
-		ReadHeaderTimeout: 5 * time.Second, //nolint:mnd
+		ReadHeaderTimeout: 5 * time.Second,  //nolint:mnd
+		ReadTimeout:       30 * time.Second, //nolint:mnd
+		WriteTimeout:      5 * time.Minute,  //nolint:mnd
+		IdleTimeout:       120 * time.Second, //nolint:mnd
 	}
 
 	return server, nil


### PR DESCRIPTION
### Summary
Adds explicit \ReadTimeout\ (30s), \WriteTimeout\ (30s/5m), and \IdleTimeout\ (120s) to \http.Server\ instances in auth (\services/auth/go/cmd/serve.go\) and storage (\services/storage/cmd/serve.go\).

### Rationale
Previously, auth and storage set only \ReadHeaderTimeout: 5s\. Without \ReadTimeout\, \WriteTimeout\, and \IdleTimeout\, slow connections (e.g. slow-loris POST requests or slow clients on storage downloads) could hold worker connections indefinitely. Setting these timeouts aligns auth and storage with the configuration standard used in Constellation (\
ewHTTPServer\) and prevents worker thread exhaustion under slow client scenarios.

Closes #4945