### PR TITLE
fix(auth): do not panic when signin/webauthn is called without a body

### DIFF
--- a/services/auth/go/controller/sign_in_webauthn.go
+++ b/services/auth/go/controller/sign_in_webauthn.go
@@ -61,7 +61,7 @@ func (ctrl *Controller) SignInWebauthn( //nolint:ireturn
 		return ctrl.sendError(ErrDisabledEndpoint), nil
 	}
 
-	if request.Body.Email == nil {
+	if request.Body == nil || request.Body.Email == nil {
 		return ctrl.postSigninWebauthnDiscoverableLogin(ctx, logger)
 	}
 

--- a/services/auth/go/controller/sign_in_webauthn_test.go
+++ b/services/auth/go/controller/sign_in_webauthn_test.go
@@ -14,7 +14,7 @@ import (
 	"go.uber.org/mock/gomock"
 )
 
-func TestSignInWebauthn(t *testing.T) {
+func TestSignInWebauthn(t *testing.T) { //nolint:maintidx
 	t.Parallel()
 
 	userID := uuid.MustParse("DB477732-48FA-4289-B694-2886A646B6EB")
@@ -234,6 +234,33 @@ func TestSignInWebauthn(t *testing.T) {
 				Body: &api.SignInWebauthnJSONRequestBody{
 					Email: nil,
 				},
+			},
+			expectedResponse: api.SignInWebauthn200JSONResponse(
+				protocol.PublicKeyCredentialRequestOptions{
+					Challenge:          protocol.URLEncodedBase64("ignoreme"),
+					Timeout:            60000,
+					RelyingPartyID:     "react-apollo.example.nhost.io",
+					AllowedCredentials: nil,
+					UserVerification:   "preferred",
+					Hints:              nil,
+					Extensions:         nil,
+				},
+			),
+			expectedJWT:       nil,
+			jwtTokenFn:        nil,
+			getControllerOpts: []getControllerOptsFunc{},
+		},
+
+		{
+			name:   "success discoverable login without a body",
+			config: getConfig,
+			db: func(ctrl *gomock.Controller) controller.DBClient {
+				mock := mock.NewMockDBClient(ctrl)
+
+				return mock
+			},
+			request: api.SignInWebauthnRequestObject{
+				Body: nil,
 			},
 			expectedResponse: api.SignInWebauthn200JSONResponse(
 				protocol.PublicKeyCredentialRequestOptions{


### PR DESCRIPTION
### Checklist

- [x] No breaking changes
- [x] Tests pass
- [x] New features have new tests
- [x] Documentation is updated (if applicable)
- [x] Title of the PR is in the correct format (see below)