### PR TITLE
feat(dashboard): split UnauthenticatedLayout into AuthFlowLayout and GuestGuard

### DIFF
--- a/dashboard/src/components/layout/AuthFlowLayout/AuthFlowLayout.tsx
+++ b/dashboard/src/components/layout/AuthFlowLayout/AuthFlowLayout.tsx
@@ -1,60 +1,26 @@
 import Image from 'next/image';
-import { useRouter } from 'next/router';
-import { useEffect } from 'react';
-import type { BaseLayoutProps } from '@/components/layout/BaseLayout';
-import { BaseLayout } from '@/components/layout/BaseLayout';
+import type { ReactNode } from 'react';
+import {
+  BaseLayout,
+  type BaseLayoutProps,
+} from '@/components/layout/BaseLayout';
 import { Container } from '@/components/layout/Container';
-import { LoadingScreen } from '@/components/presentational/LoadingScreen';
 import { RetryableErrorBoundary } from '@/components/presentational/RetryableErrorBoundary';
-import { useIsPlatform } from '@/features/orgs/projects/common/hooks/useIsPlatform';
-import { useAuth } from '@/providers/Auth';
 
-export interface UnauthenticatedLayoutProps extends BaseLayoutProps {
-  rightColumnContent?: React.ReactNode;
+export interface AuthFlowLayoutProps extends Omit<BaseLayoutProps, 'className'> {
+  rightColumnContent?: ReactNode;
 }
 
-export default function UnauthenticatedLayout({
+/**
+ * The sign-in / sign-up / verification flow: forced dark, full viewport, the
+ * form on the left and the brand column on the right. Whether the visitor may
+ * see it is `GuestGuard`'s business.
+ */
+export default function AuthFlowLayout({
   children,
   rightColumnContent,
   ...props
-}: UnauthenticatedLayoutProps) {
-  const router = useRouter();
-  const isPlatform = useIsPlatform();
-  const { isAuthenticated, isLoading } = useAuth();
-  const isOnResetPassword = router.route === '/password/reset';
-
-  useEffect(() => {
-    if (!isPlatform || (!isLoading && isAuthenticated)) {
-      // we do not want to redirect if the user tries to reset their password
-      if (!isOnResetPassword) {
-        const redirectQuery =
-          typeof router.query.redirect === 'string' &&
-          router.query.redirect.startsWith('/')
-            ? router.query.redirect
-            : null;
-        const storedRedirect = sessionStorage.getItem('postSignInRedirect');
-        const redirectTarget =
-          redirectQuery ||
-          (storedRedirect?.startsWith('/') ? storedRedirect : null) ||
-          '/';
-
-        if (storedRedirect) {
-          sessionStorage.removeItem('postSignInRedirect');
-        }
-
-        router.push(redirectTarget);
-      }
-    }
-  }, [isLoading, isAuthenticated, router, isPlatform, isOnResetPassword]);
-
-  if ((!isPlatform || isLoading || isAuthenticated) && !isOnResetPassword) {
-    return (
-      <BaseLayout {...props}>
-        <LoadingScreen className="bg-background" />
-      </BaseLayout>
-    );
-  }
-
+}: AuthFlowLayoutProps) {
   return (
     <BaseLayout {...props}>
       <div className="dark h-screen overflow-auto bg-black text-foreground">

--- a/dashboard/src/components/layout/AuthFlowLayout/index.ts
+++ b/dashboard/src/components/layout/AuthFlowLayout/index.ts
@@ -1,0 +1,2 @@
+export type { AuthFlowLayoutProps } from '@/components/layout/AuthFlowLayout/AuthFlowLayout';
+export { default as AuthFlowLayout } from '@/components/layout/AuthFlowLayout/AuthFlowLayout';

--- a/dashboard/src/components/layout/UnauthenticatedLayout/index.ts
+++ b/dashboard/src/components/layout/UnauthenticatedLayout/index.ts
@@ -1,2 +1,0 @@
-export * from './UnauthenticatedLayout';
-export { default as UnauthenticatedLayout } from './UnauthenticatedLayout';

--- a/dashboard/src/features/auth/GuestGuard/GuestGuard.tsx
+++ b/dashboard/src/features/auth/GuestGuard/GuestGuard.tsx
@@ -1,0 +1,49 @@
+import { useRouter } from 'next/router';
+import { type PropsWithChildren, useEffect } from 'react';
+import { Spinner } from '@/components/ui/v3/spinner';
+import { useIsPlatform } from '@/features/orgs/projects/common/hooks/useIsPlatform';
+import { useAuth } from '@/providers/Auth';
+
+/**
+ * Renders its children only for visitors who are not signed in. A signed-in
+ * visitor is sent to where they were headed before sign-in (the `redirect`
+ * query param or the stored target), falling back to the dashboard root.
+ */
+export default function GuestGuard({ children }: PropsWithChildren) {
+  const router = useRouter();
+  const isPlatform = useIsPlatform();
+  const { isAuthenticated, isLoading } = useAuth();
+
+  useEffect(() => {
+    if (isPlatform && (isLoading || !isAuthenticated)) {
+      return;
+    }
+
+    const redirectQuery =
+      typeof router.query.redirect === 'string' &&
+      router.query.redirect.startsWith('/')
+        ? router.query.redirect
+        : null;
+    const storedRedirect = sessionStorage.getItem('postSignInRedirect');
+    const redirectTarget =
+      redirectQuery ||
+      (storedRedirect?.startsWith('/') ? storedRedirect : null) ||
+      '/';
+
+    if (storedRedirect) {
+      sessionStorage.removeItem('postSignInRedirect');
+    }
+
+    router.push(redirectTarget);
+  }, [isLoading, isAuthenticated, router, isPlatform]);
+
+  if (!isPlatform || isLoading || isAuthenticated) {
+    return (
+      <div className="flex min-h-64 items-center justify-center">
+        <Spinner />
+      </div>
+    );
+  }
+
+  return children;
+}

--- a/dashboard/src/features/auth/GuestGuard/index.ts
+++ b/dashboard/src/features/auth/GuestGuard/index.ts
@@ -1,0 +1,1 @@
+export { default as GuestGuard } from '@/features/auth/GuestGuard/GuestGuard';

--- a/dashboard/src/pages/email/verify.tsx
+++ b/dashboard/src/pages/email/verify.tsx
@@ -1,8 +1,9 @@
 import { useRouter } from 'next/router';
 import type { ReactElement } from 'react';
 import { NavLink } from '@/components/common/NavLink';
-import { UnauthenticatedLayout } from '@/components/layout/UnauthenticatedLayout';
+import { AuthFlowLayout } from '@/components/layout/AuthFlowLayout';
 import { ButtonWithLoading } from '@/components/ui/v3/button';
+import { GuestGuard } from '@/features/auth/GuestGuard';
 import SendVerificationEmailForm from '@/features/auth/SignIn/SignInWithEmailAndPassword/components/SendVerificationEmailForm';
 import useResendVerificationEmail from '@/features/auth/SignIn/SignInWithEmailAndPassword/hooks/useResendVerificationEmail';
 
@@ -63,8 +64,8 @@ export default function VerifyEmailPage() {
 
 VerifyEmailPage.getLayout = function getLayout(page: ReactElement) {
   return (
-    <UnauthenticatedLayout title="Verify your email">
-      {page}
-    </UnauthenticatedLayout>
+    <AuthFlowLayout title="Verify your email">
+      <GuestGuard>{page}</GuestGuard>
+    </AuthFlowLayout>
   );
 };

--- a/dashboard/src/pages/oauth2/authorize.tsx
+++ b/dashboard/src/pages/oauth2/authorize.tsx
@@ -45,7 +45,7 @@ export default function OAuth2AuthorizePage() {
       const consentPath = requestId
         ? `/oauth2/authorize?request_id=${encodeURIComponent(requestId)}`
         : '/oauth2/authorize';
-      // Both are needed: the query param is used by UnauthenticatedLayout for
+      // Both are needed: the query param is used by GuestGuard for
       // email/password sign-in, while sessionStorage is used by AuthProvider for
       // OAuth sign-in (where the redirect to the external provider loses the query param).
       sessionStorage.setItem('postSignInRedirect', consentPath);

--- a/dashboard/src/pages/password/new.tsx
+++ b/dashboard/src/pages/password/new.tsx
@@ -7,8 +7,9 @@ import * as Yup from 'yup';
 import { NavLink } from '@/components/common/NavLink';
 import { Form } from '@/components/form/Form';
 import { FormInput } from '@/components/form/FormInput';
-import { UnauthenticatedLayout } from '@/components/layout/UnauthenticatedLayout';
+import { AuthFlowLayout } from '@/components/layout/AuthFlowLayout';
 import { ButtonWithLoading } from '@/components/ui/v3/button';
+import { GuestGuard } from '@/features/auth/GuestGuard';
 import { appendPkceId, generateAndStorePKCE } from '@/lib/pkce';
 import { useNhostClient } from '@/providers/nhost';
 import { getToastStyleProps } from '@/utils/constants/settings';
@@ -157,8 +158,8 @@ export default function NewPasswordPage() {
 
 NewPasswordPage.getLayout = function getLayout(page: ReactElement) {
   return (
-    <UnauthenticatedLayout title="Request Password Reset">
-      {page}
-    </UnauthenticatedLayout>
+    <AuthFlowLayout title="Request Password Reset">
+      <GuestGuard>{page}</GuestGuard>
+    </AuthFlowLayout>
   );
 };

--- a/dashboard/src/pages/password/reset.tsx
+++ b/dashboard/src/pages/password/reset.tsx
@@ -6,7 +6,7 @@ import * as Yup from 'yup';
 import { NavLink } from '@/components/common/NavLink';
 import { Form } from '@/components/form/Form';
 import { FormInput } from '@/components/form/FormInput';
-import { UnauthenticatedLayout } from '@/components/layout/UnauthenticatedLayout';
+import { AuthFlowLayout } from '@/components/layout/AuthFlowLayout';
 import { ButtonWithLoading } from '@/components/ui/v3/button';
 import useActionWithElevatedPermissions from '@/features/account/settings/hooks/useActionWithElevatedPermissions';
 import { useNhostClient } from '@/providers/nhost';
@@ -106,8 +106,8 @@ export default function ResetPasswordPage() {
 
 ResetPasswordPage.getLayout = function getLayout(page: ReactElement) {
   return (
-    <UnauthenticatedLayout title="Request Password Reset">
+    <AuthFlowLayout title="Request Password Reset">
       {page}
-    </UnauthenticatedLayout>
+    </AuthFlowLayout>
   );
 };

--- a/dashboard/src/pages/signin.tsx
+++ b/dashboard/src/pages/signin.tsx
@@ -1,9 +1,10 @@
 import NextLink from 'next/link';
 import { type ReactElement, useEffect } from 'react';
 import { SignInRightColumn } from '@/components/auth/SignInRightColumn';
-import { UnauthenticatedLayout } from '@/components/layout/UnauthenticatedLayout';
+import { AuthFlowLayout } from '@/components/layout/AuthFlowLayout';
 import { Button } from '@/components/ui/v3/button';
 import { Separator } from '@/components/ui/v3/separator';
+import { GuestGuard } from '@/features/auth/GuestGuard';
 import { SignInWithSecurityKey } from '@/features/auth/SignIn/SecurityKey';
 import { SignInWithGithub } from '@/features/auth/SignIn/SignInWithGithub';
 import { useAuth } from '@/providers/Auth';
@@ -80,11 +81,11 @@ export default function SigninPage() {
 
 SigninPage.getLayout = function getLayout(page: ReactElement) {
   return (
-    <UnauthenticatedLayout
+    <AuthFlowLayout
       title="Sign In"
       rightColumnContent={<SignInRightColumn />}
     >
-      {page}
-    </UnauthenticatedLayout>
+      <GuestGuard>{page}</GuestGuard>
+    </AuthFlowLayout>
   );
 };

--- a/dashboard/src/pages/signin/email.tsx
+++ b/dashboard/src/pages/signin/email.tsx
@@ -1,7 +1,8 @@
 import type { ReactElement } from 'react';
 import { SignInRightColumn } from '@/components/auth/SignInRightColumn';
 import { NavLink } from '@/components/common/NavLink';
-import { UnauthenticatedLayout } from '@/components/layout/UnauthenticatedLayout';
+import { AuthFlowLayout } from '@/components/layout/AuthFlowLayout';
+import { GuestGuard } from '@/features/auth/GuestGuard';
 import { SignInWithEmailAndPassword } from '@/features/auth/SignIn/SignInWithEmailAndPassword';
 
 function SigninPage() {
@@ -32,12 +33,12 @@ function SigninPage() {
 
 SigninPage.getLayout = function getLayout(page: ReactElement) {
   return (
-    <UnauthenticatedLayout
+    <AuthFlowLayout
       title="Sign In"
       rightColumnContent={<SignInRightColumn />}
     >
-      {page}
-    </UnauthenticatedLayout>
+      <GuestGuard>{page}</GuestGuard>
+    </AuthFlowLayout>
   );
 };
 

--- a/dashboard/src/pages/signup.tsx
+++ b/dashboard/src/pages/signup.tsx
@@ -3,8 +3,9 @@ import NextLink from 'next/link';
 import type { ReactElement } from 'react';
 import { useCallback } from 'react';
 import { CookieConsent } from '@/components/common/CookieConsent';
-import { UnauthenticatedLayout } from '@/components/layout/UnauthenticatedLayout';
+import { AuthFlowLayout } from '@/components/layout/AuthFlowLayout';
 import { Separator } from '@/components/ui/v3/separator';
+import { GuestGuard } from '@/features/auth/GuestGuard';
 import { SignUpTabs } from '@/features/auth/SignUp/SignUpTabs';
 import { SignUpWithGithub } from '@/features/auth/SignUp/SignUpWithGithub';
 
@@ -183,11 +184,11 @@ export default function SignUpPage() {
 
 SignUpPage.getLayout = function getLayout(page: ReactElement) {
   return (
-    <UnauthenticatedLayout
+    <AuthFlowLayout
       title="Sign Up"
       rightColumnContent={rightColumnContent}
     >
-      {page}
-    </UnauthenticatedLayout>
+      <GuestGuard>{page}</GuestGuard>
+    </AuthFlowLayout>
   );
 };


### PR DESCRIPTION
Summary:
- `AuthFlowLayout` is the dark two-column sign-in shell and nothing else.
- `GuestGuard` redirects signed-in visitors to their post-sign-in target and shows a spinner while the session resolves.
- `/password/reset` renders without the guard instead of the layout checking `router.route`, since it is reached while signed in via the reset token.

Behaviour change to check: while the session resolves, the auth shell renders with a spinner in the form column instead of a full-screen loading screen.

### Checklist

- [ ] No breaking changes
- [ ] Tests pass
- [ ] New features have new tests

🤖 Generated with [Claude Code](https://claude.com/claude-code)
