### PR TITLE
fix(dashboard): toggle MultiSelect values from the controlled prop

### DIFF
--- a/dashboard/src/components/ui/v3/multi-select.tsx
+++ b/dashboard/src/components/ui/v3/multi-select.tsx
@@ -61,24 +61,26 @@ export function MultiSelect({
   onValuesChange?: (values: string[]) => void;
 }) {
   const [open, setOpen] = useState(false);
-  const [selectedValues, setSelectedValues] = useState(
-    new Set<string>(values ?? defaultValues),
+  const [internalValues, setInternalValues] = useState(
+    new Set<string>(defaultValues),
   );
   const [items, setItems] = useState<Map<string, ReactNode>>(new Map());
 
+  const selectedValues = useMemo(
+    () => (values ? new Set(values) : internalValues),
+    [values, internalValues],
+  );
+
   const toggleValue = useCallback(
     (toggledValue: string) => {
-      const getNewSet = (prev: Set<string>) => {
-        const newSet = new Set(prev);
-        if (newSet.has(toggledValue)) {
-          newSet.delete(toggledValue);
-        } else {
-          newSet.add(toggledValue);
-        }
-        return newSet;
-      };
-      setSelectedValues(getNewSet);
-      onValuesChange?.([...getNewSet(selectedValues)]);
+      const newSet = new Set(selectedValues);
+      if (newSet.has(toggledValue)) {
+        newSet.delete(toggledValue);
+      } else {
+        newSet.add(toggledValue);
+      }
+      setInternalValues(newSet);
+      onValuesChange?.([...newSet]);
     },
     [onValuesChange, selectedValues],
   );
@@ -96,12 +98,12 @@ export function MultiSelect({
     () => ({
       open,
       setOpen,
-      selectedValues: values ? new Set(values) : selectedValues,
+      selectedValues,
       toggleValue,
       items,
       onItemAdded,
     }),
-    [open, values, items, toggleValue, onItemAdded, selectedValues],
+    [open, selectedValues, items, toggleValue, onItemAdded],
   );
 
   return (


### PR DESCRIPTION
### Checklist

- [ ] No breaking changes
- [ ] Tests pass
- [ ] New features have new tests
- [ ] Documentation is updated (if applicable)
- [ ] Title of the PR is in the correct format (see below)

<!-- pi-reviewer:start -->
### **What this change solves**
Ensures `MultiSelect` toggles options from the current controlled `values` prop when provided. This prevents stale internal selection state from driving `onValuesChange` in controlled usage and adds regression coverage for controlled and uncontrolled selection updates.

___

### **Change Type**
Bug fix

___

### **Description**
- Separate uncontrolled/default selection state from the controlled `values` prop.
- Derive `selectedValues` from `values` when supplied, otherwise from internal state.
- Toggle against the derived selection set, emit the resulting value list through `onValuesChange`, and cover controlled hydration/removal plus uncontrolled defaults in tests.

___

<details> <summary><h3> File Walkthrough</h3></summary>

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody>
<tr><td><strong>Dashboard UI</strong></td><td><details><summary>2 files</summary><table>
<tr>
  <td><strong>dashboard/src/components/ui/v3/multi-select.tsx</strong><dd><code>Updates MultiSelect selection state derivation and toggle handling for controlled usage.</code></dd></td>
  <td>+17/-15</td>
</tr>
<tr>
  <td><strong>dashboard/src/components/ui/v3/multi-select.test.tsx</strong><dd><code>Adds regression tests for controlled hydration, controlled removal, and uncontrolled default value toggling.</code></dd></td>
  <td>+117/-0</td>
</tr>
</table></details></td></tr>
</tbody></table>

</details>

___

<!-- pi-reviewer:end -->
