### PR TITLE
fix(cli): pull minio image from quay.io instead of Docker Hub

### DIFF
--- a/cli/dockercompose/compose.go
+++ b/cli/dockercompose/compose.go
@@ -349,7 +349,7 @@ func traefik(
 
 func minio(volumeName string) *Service {
 	return &Service{
-		Image:      "minio/minio:RELEASE.2025-02-28T09-55-16Z",
+		Image:      "quay.io/minio/minio:RELEASE.2025-02-28T09-55-16Z",
 		DependsOn:  nil,
 		EntryPoint: []string{"/bin/sh"},
 		Command: []string{


### PR DESCRIPTION
## Problem
`nhost up` currently fails outright because Docker Hub no longer serves the `minio/minio` repository - pulling it now returns:

```
minio Error pull access denied for minio/minio, repository does not exist or may require 'docker login': denied: requested access to the resource is denied
```

Because docker compose aborts the whole stack when any one image fails to pull, this takes down every other service too (postgres, auth, storage, etc.), not just minio. This is currently breaking `nhost up` in CI and local dev for anyone relying on the CLI's local development environment.

I can reproduce this directly against Docker Hub's own API right now (independent of the CLI):
```
$ curl -s https://hub.docker.com/v2/repositories/minio/minio/
{"message":"object not found"}
```

## Solution
`quay.io` still serves the exact same pinned tag (`RELEASE.2025-02-28T09-55-16Z`) that `cli/dockercompose/compose.go` already hardcodes, so this points the minio service at `quay.io/minio/minio` instead of the now-unavailable Docker Hub repo. No behavior change beyond the registry the image is pulled from.

## Test plan
- [x] Verified `quay.io/minio/minio:RELEASE.2025-02-28T09-55-16Z` returns a valid manifest (HTTP 200)
- [x] Verified `minio/minio` on Docker Hub returns 404 for the same tag and for the repository itself
- [ ] Would appreciate a maintainer confirming `nhost up` starts cleanly with this change in CI, since I don't have a full dev setup for this monorepo